### PR TITLE
Enable gzip for broker web service

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/WebService.java
@@ -42,7 +42,9 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.ExecutorThreadPool;
+import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.filter.EncodingFilter;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +127,7 @@ public class WebService implements AutoCloseable {
         ResourceConfig config = new ResourceConfig();
         config.packages("jersey.config.server.provider.packages", javaPackages);
         config.register(provider);
+        EncodingFilter.enableFor(config, GZipEncoder.class);
         ServletHolder servletHolder = new ServletHolder(new ServletContainer(config));
         servletHolder.setAsyncSupported(true);
         addServlet(basePath, servletHolder, requiresAuthentication);


### PR DESCRIPTION
Enable gzip compression on broker WebService, this would mostly benefit stats requests as they are very heavy and JSON is really compressible. 