### PR TITLE
Support receiveAsync cancellation

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -291,6 +291,16 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
         return null;
     }
 
+    protected CompletableFuture<Message> getPendingReceive() {
+        while (!pendingReceives.isEmpty()) {
+            CompletableFuture<Message> f = pendingReceives.poll();
+            if (f != null && !f.isDone()) {
+                return f;
+            }
+        }
+        return null;
+    }
+
     abstract public boolean isConnected();
 
     abstract public int getAvailablePermits();


### PR DESCRIPTION
We should allow for futures returned by `receiveAsync` to be cancelled and remove the future from `pendingReceives` queue.
