### PR TITLE
CPP add receiveAsync API

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -100,6 +100,19 @@ class Consumer {
     Result receive(Message& msg, int timeoutMs);
 
     /**
+     * Receive a single message
+     * <p>
+     * Retrieves a message when it will be available and completes callback with received message.
+     * </p>
+     * <p>
+     * receiveAsync() should be called subsequently once callback gets completed with received message.
+     * Else it creates <i> backlog of receive requests </i> in the application.
+     * </p>
+     * @param ReceiveCallback will be completed when message is available
+     */
+    void receiveAsync(ReceiveCallback callback);
+
+    /**
      * Acknowledge the reception of a single message.
      *
      * This method will block until an acknowledgement is sent to the broker. After

--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -36,6 +36,7 @@ class PulsarWrapper;
 
 /// Callback definition for non-data operation
 typedef boost::function<void(Result result)> ResultCallback;
+typedef boost::function<void(Result, const Message& msg)> ReceiveCallback;
 
 /// Callback definition for MessageListener
 typedef boost::function<void(Consumer consumer, const Message& msg)> MessageListener;

--- a/pulsar-client-cpp/lib/Consumer.cc
+++ b/pulsar-client-cpp/lib/Consumer.cc
@@ -73,6 +73,15 @@ Result Consumer::receive(Message& msg, int timeoutMs) {
     return impl_->receive(msg, timeoutMs);
 }
 
+void Consumer::receiveAsync(ReceiveCallback callback) {
+    if (!impl_) {
+        Message msg;
+        callback(ResultConsumerNotInitialized, msg);
+        return;
+    }
+    impl_->receiveAsync(callback);
+}
+
 Result Consumer::acknowledge(const Message& message) { return acknowledge(message.getMessageId()); }
 
 Result Consumer::acknowledge(const MessageId& messageId) {

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -48,6 +48,7 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
       startMessageId_(startMessageId),
       // This is the initial capacity of the queue
       incomingMessages_(std::max(config_.getReceiverQueueSize(), 1)),
+      pendingReceives_(),
       availablePermits_(conf.getReceiverQueueSize()),
       consumerId_(client->newConsumerId()),
       consumerName_(config_.getConsumerName()),
@@ -290,6 +291,22 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
         Lock lock(mutex_);
         numOfMessageReceived = receiveIndividualMessagesFromBatch(cnx, m);
     } else {
+        Lock lock(pendingReceiveMutex_);
+        // if asyncReceive is waiting then notify callback without adding to incomingMessages queue
+        bool asyncReceivedWaiting = !pendingReceives_.empty();
+        ReceiveCallback callback;
+        if (asyncReceivedWaiting) {
+            callback = pendingReceives_.front();
+            pendingReceives_.pop();
+        }
+        lock.unlock();
+
+        if (asyncReceivedWaiting) {
+            listenerExecutor_->postWork(boost::bind(&ConsumerImpl::notifyPendingReceivedCallback,
+                                                    shared_from_this(), ResultOk, m, callback));
+            return;
+        }
+
         // config_.getReceiverQueueSize() != 0 or waiting For ZeroQueueSize Message`
         if (config_.getReceiverQueueSize() != 0 ||
             (config_.getReceiverQueueSize() == 0 && messageListener_)) {
@@ -314,6 +331,27 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
             listenerExecutor_->postWork(boost::bind(&ConsumerImpl::internalListener, shared_from_this()));
         }
     }
+}
+
+void ConsumerImpl::failPendingReceiveCallback() {
+    Message msg;
+    Lock lock(pendingReceiveMutex_);
+    while (!pendingReceives_.empty()) {
+        ReceiveCallback callback = pendingReceives_.front();
+        pendingReceives_.pop();
+        listenerExecutor_->postWork(boost::bind(&ConsumerImpl::notifyPendingReceivedCallback,
+                                                shared_from_this(), ResultAlreadyClosed, msg, callback));
+    }
+    lock.unlock();
+}
+
+void ConsumerImpl::notifyPendingReceivedCallback(Result result, Message& msg,
+                                                 const ReceiveCallback& callback) {
+    if (result == ResultOk && config_.getReceiverQueueSize() != 0) {
+        messageProcessed(msg);
+        unAckedMessageTrackerPtr_->add(msg.getMessageId());
+    }
+    callback(result, msg);
 }
 
 // Zero Queue size is not supported with Batch Messages
@@ -345,8 +383,19 @@ uint32_t ConsumerImpl::receiveIndividualMessagesFromBatch(const ClientConnection
             }
         }
 
-        // Regular path, append individual message to incoming messages queue
-        incomingMessages_.push(msg);
+        //
+        Lock lock(pendingReceiveMutex_);
+        if (!pendingReceives_.empty()) {
+            ReceiveCallback callback = pendingReceives_.front();
+            pendingReceives_.pop();
+            lock.unlock();
+            listenerExecutor_->postWork(boost::bind(&ConsumerImpl::notifyPendingReceivedCallback,
+                                                    shared_from_this(), ResultOk, msg, callback));
+        } else {
+            // Regular path, append individual message to incoming messages queue
+            incomingMessages_.push(msg);
+            lock.unlock();
+        }
     }
 
     if (skippedMessages > 0) {
@@ -507,6 +556,37 @@ Result ConsumerImpl::receive(Message& msg) {
     Result res = receiveHelper(msg);
     consumerStatsBasePtr_->receivedMessage(msg, res);
     return res;
+}
+
+void ConsumerImpl::receiveAsync(ReceiveCallback& callback) {
+    Message msg;
+
+    // fail the callback if consumer is closing or closed
+    Lock stateLock(mutex_);
+    if (state_ == Closing || state_ == Closed) {
+        callback(ResultAlreadyClosed, msg);
+        return;
+    }
+    stateLock.unlock();
+
+    Lock lock(pendingReceiveMutex_);
+    if (incomingMessages_.pop(msg, milliseconds(0))) {
+        lock.unlock();
+        messageProcessed(msg);
+        unAckedMessageTrackerPtr_->add(msg.getMessageId());
+        callback(ResultOk, msg);
+    } else {
+        pendingReceives_.push(callback);
+        lock.unlock();
+
+        if (config_.getReceiverQueueSize() == 0) {
+            ClientConnectionPtr currentCnx = getCnx().lock();
+            if (currentCnx) {
+                LOG_DEBUG(getName() << "Send more permits: " << 1);
+                receiveMessages(currentCnx, 1);
+            }
+        }
+    }
 }
 
 Result ConsumerImpl::receiveHelper(Message& msg) {
@@ -747,6 +827,9 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     if (!callback.empty()) {
         future.addListener(boost::bind(&ConsumerImpl::handleClose, shared_from_this(), _1, callback));
     }
+
+    // fail pendingReceive callback
+    failPendingReceiveCallback();
 }
 
 void ConsumerImpl::handleClose(Result result, ResultCallback callback) {

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -35,6 +35,7 @@ class ConsumerImplBase {
     virtual const std::string& getTopic() const = 0;
     virtual Result receive(Message& msg) = 0;
     virtual Result receive(Message& msg, int timeout) = 0;
+    virtual void receiveAsync(ReceiveCallback& callback) = 0;
     virtual void unsubscribeAsync(ResultCallback callback) = 0;
     virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback) = 0;
     virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) = 0;

--- a/pulsar-client-cpp/lib/HandlerBase.h
+++ b/pulsar-client-cpp/lib/HandlerBase.h
@@ -91,6 +91,7 @@ class HandlerBase {
     const std::string topic_;
     ClientConnectionWeakPtr connection_;
     boost::mutex mutex_;
+    boost::mutex pendingReceiveMutex_;
     ptime creationTimestamp_;
 
     const TimeDuration operationTimeut_;

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -34,6 +34,7 @@ MultiTopicsConsumerImpl::MultiTopicsConsumerImpl(ClientImplPtr client, const std
       messages_(1000),
       listenerExecutor_(client->getListenerExecutorProvider()->get()),
       messageListener_(conf.getMessageListener()),
+      pendingReceives_(),
       namespaceName_(topicName ? topicName->getNamespaceName() : boost::shared_ptr<NamespaceName>()),
       lookupServicePtr_(lookupServicePtr),
       numberTopicPartitions_(boost::make_shared<std::atomic<int>>(0)),
@@ -385,6 +386,9 @@ void MultiTopicsConsumerImpl::closeAsync(ResultCallback callback) {
         consumerPtr->closeAsync(boost::bind(&MultiTopicsConsumerImpl::handleSingleConsumerClose,
                                             shared_from_this(), _1, topicPartitionName, callback));
     }
+
+    // fail pending recieve
+    failPendingReceiveCallback();
 }
 
 void MultiTopicsConsumerImpl::handleSingleConsumerClose(Result result, std::string& topicPartitionName,
@@ -429,11 +433,23 @@ void MultiTopicsConsumerImpl::messageReceived(Consumer consumer, const Message& 
                                                           << " message:" << msg.getDataAsString());
     const std::string& topicPartitionName = consumer.getTopic();
     msg.impl_->setTopicName(topicPartitionName);
-    messages_.push(msg);
 
-    if (messageListener_) {
-        listenerExecutor_->postWork(
-            boost::bind(&MultiTopicsConsumerImpl::internalListener, shared_from_this(), consumer));
+    Lock lock(pendingReceiveMutex_);
+    if (!pendingReceives_.empty()) {
+        ReceiveCallback callback = pendingReceives_.front();
+        pendingReceives_.pop();
+        lock.unlock();
+        unAckedMessageTrackerPtr_->add(msg.getMessageId());
+        listenerExecutor_->postWork(boost::bind(callback, ResultOk, msg));
+    } else {
+        if (messages_.full()) {
+            lock.unlock();
+        }
+        messages_.push(msg);
+        if (messageListener_) {
+            listenerExecutor_->postWork(
+                boost::bind(&MultiTopicsConsumerImpl::internalListener, shared_from_this(), consumer));
+        }
     }
 }
 
@@ -487,6 +503,38 @@ Result MultiTopicsConsumerImpl::receive(Message& msg, int timeout) {
     } else {
         return ResultTimeout;
     }
+}
+
+void MultiTopicsConsumerImpl::receiveAsync(ReceiveCallback& callback) {
+    Message msg;
+
+    // fail the callback if consumer is closing or closed
+    Lock stateLock(mutex_);
+    if (state_ == Closing || state_ == Closed) {
+        callback(ResultAlreadyClosed, msg);
+        return;
+    }
+    stateLock.unlock();
+
+    Lock lock(pendingReceiveMutex_);
+    if (messages_.pop(msg, milliseconds(0))) {
+        lock.unlock();
+        unAckedMessageTrackerPtr_->add(msg.getMessageId());
+        callback(ResultOk, msg);
+    } else {
+        pendingReceives_.push(callback);
+    }
+}
+
+void MultiTopicsConsumerImpl::failPendingReceiveCallback() {
+    Message msg;
+    Lock lock(pendingReceiveMutex_);
+    while (!pendingReceives_.empty()) {
+        ReceiveCallback callback = pendingReceives_.front();
+        pendingReceives_.pop();
+        listenerExecutor_->postWork(boost::bind(callback, ResultAlreadyClosed, msg));
+    }
+    lock.unlock();
 }
 
 void MultiTopicsConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCallback callback) {

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -21,6 +21,7 @@
 #include "ConsumerImpl.h"
 #include "ClientImpl.h"
 #include <vector>
+#include <queue>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include "boost/enable_shared_from_this.hpp"
@@ -52,6 +53,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     virtual const std::string& getTopic() const;
     virtual Result receive(Message& msg);
     virtual Result receive(Message& msg, int timeout);
+    virtual void receiveAsync(ReceiveCallback& callback);
     virtual void unsubscribeAsync(ResultCallback callback);
     virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback);
     virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback);
@@ -80,6 +82,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     typedef std::vector<ConsumerImplPtr> ConsumerList;
     ConsumerList consumers_;
     boost::mutex mutex_;
+    boost::mutex pendingReceiveMutex_;
     PartitionedConsumerState state_;
     unsigned int unsubscribedSoFar_;
     BlockingQueue<Message> messages_;
@@ -99,8 +102,10 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     void messageReceived(Consumer consumer, const Message& msg);
     void internalListener(Consumer consumer);
     void receiveMessages();
+    void failPendingReceiveCallback();
     Promise<Result, ConsumerImplBaseWeakPtr> partitionedConsumerCreatedPromise_;
     UnAckedMessageTrackerScopedPtr unAckedMessageTrackerPtr_;
+    std::queue<ReceiveCallback> pendingReceives_;
 };
 typedef boost::weak_ptr<PartitionedConsumerImpl> PartitionedConsumerImplWeakPtr;
 typedef boost::shared_ptr<PartitionedConsumerImpl> PartitionedConsumerImplPtr;


### PR DESCRIPTION
### Motivation

Sometimes, client wants to receive a message async to complete specific depending task or request. eg. java-client library has [receiveAsync](https://github.com/apache/incubator-pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java#L89) api  which is used by proxy to receive msg async and completes pending proxy request on message-received. CPP-client library doesn't have `receiveAsync` api.

### Modifications

Add `receiveAsync` api to cpp-client library.
