### PR TITLE
Reduce thread executor pool sizes when running unit tests

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -79,9 +79,15 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final boolean isBookkeeperManaged;
     private final ZooKeeper zookeeper;
     private final ManagedLedgerFactoryConfig config;
-    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(16,
+
+    private static final int EXECUTOR_THREAD_COUNT = Integer
+            .parseInt(System.getProperty("pulsar.bookkeeper-ml-executor-thread-count", "16"));
+    private static final int WORKERS_EXECUTOR_THREAD_COUNT = Integer
+            .parseInt(System.getProperty("pulsar.bookkeeper-ml-workers-executor-thread-count", "16"));
+
+    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(EXECUTOR_THREAD_COUNT,
             new DefaultThreadFactory("bookkeeper-ml"));
-    private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(16, "bookkeeper-ml-workers");
+    private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(WORKERS_EXECUTOR_THREAD_COUNT, "bookkeeper-ml-workers");
 
     protected final ManagedLedgerFactoryMBeanImpl mbean;
 

--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,14 @@ flexible messaging model and an intuitive client API.</description>
             -Dorg.slf4j.simpleLogger.log.org.apache.zookeeper=off
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper=off
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper.mledger=info
+
+            -Dpulsar.executor-thread-count=1
+            -Dpulsar.cache-executor-thread-count=1
+            -Dpulsar.ordered-executor-thread-count=1
+            -Dpulsar.web-service-thread-count=2
+            -Dpulsar.bookkeeper-ml-executor-thread-count=1
+            -Dpulsar.bookkeeper-ml-workers-executor-thread-count=1
+            -Dpulsar.io-thread-count=1
           </argLine>
           <reuseForks>true</reuseForks>
           <forkCount>1</forkCount>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -78,6 +78,16 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  * Main class for Pulsar broker service
  */
 public class PulsarService implements AutoCloseable {
+
+    private static final int EXECUTOR_THREAD_COUNT = Integer
+            .parseInt(System.getProperty("pulsar.executor-thread-count", "20"));
+
+    private static final int CACHE_EXECUTOR_THREAD_COUNT = Integer
+            .parseInt(System.getProperty("pulsar.cache-executor-thread-count", "10"));
+
+    private static final int ORDERED_EXECUTOR_THREAD_COUNT = Integer
+            .parseInt(System.getProperty("pulsar.ordered-executor-thread-count", "8"));
+
     private static final Logger LOG = LoggerFactory.getLogger(PulsarService.class);
     private ServiceConfiguration config = null;
     private NamespaceService nsservice = null;
@@ -92,11 +102,12 @@ public class PulsarService implements AutoCloseable {
     private ZooKeeperCache localZkCache;
     private GlobalZooKeeperCache globalZkCache;
     private LocalZooKeeperConnectionService localZooKeeperConnectionProvider;
-    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(20,
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(EXECUTOR_THREAD_COUNT,
             new DefaultThreadFactory("pulsar"));
-    private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(10,
+    private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(CACHE_EXECUTOR_THREAD_COUNT,
             new DefaultThreadFactory("zk-cache-callback"));
-    private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(8, "pulsar-ordered");
+    private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(ORDERED_EXECUTOR_THREAD_COUNT,
+            "pulsar-ordered");
     private final ScheduledExecutorService loadManagerExecutor;
     private ScheduledFuture<?> loadReportTask = null;
     private ScheduledFuture<?> loadSheddingTask = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -76,7 +76,8 @@ public class WebService implements AutoCloseable {
     public static final String ATTRIBUTE_PULSAR_NAME = "pulsar";
     public static final String HANDLER_CACHE_CONTROL = "max-age=3600";
     public static final String HANDLER_REQUEST_LOG_TZ = "GMT";
-    public static final int NUM_ACCEPTORS = 32; // make it configurable?
+    public static final int NUM_ACCEPTORS = Integer
+            .parseInt(System.getProperty("pulsar.web-service-thread-count", "32"));
     public static final int MAX_CONCURRENT_REQUESTES = 1024; // make it configurable?
 
     private final PulsarService pulsar;
@@ -155,7 +156,7 @@ public class WebService implements AutoCloseable {
             context.addFilter(holder, MATCH_ALL, EnumSet.allOf(DispatcherType.class));
             log.info("Enabling ApiVersionFilter");
         }
-        
+
         FilterHolder responseFilter = new FilterHolder(new ResponseHandlerFilter(pulsar));
         context.addFilter(responseFilter, MATCH_ALL, EnumSet.allOf(DispatcherType.class));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -79,6 +79,7 @@ public abstract class MockedPulsarServiceBaseTest {
 
     public MockedPulsarServiceBaseTest() {
         this.conf = new ServiceConfiguration();
+        this.conf.setNumWorkerThreadsForNonPersistentTopic(1);
         this.conf.setBrokerServicePort(BROKER_PORT);
         this.conf.setBrokerServicePortTls(BROKER_PORT_TLS);
         this.conf.setWebServicePort(BROKER_WEBSERVICE_PORT);


### PR DESCRIPTION
### Motivation

Since we're starting and stopping the pulsar broker during the unit tests execution, we should reduce the amount of threads created.