### PR TITLE
Apply make format into Python C++ wrapper client

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -210,6 +210,8 @@ add_custom_target(format ${BUILD_SUPPORT_DIR}/run_clang_format.py
         ${CMAKE_SOURCE_DIR}/lib
         ${CMAKE_SOURCE_DIR}/tests
         ${CMAKE_SOURCE_DIR}/python/src
+        ${CMAKE_SOURCE_DIR}/examples
+        ${CMAKE_SOURCE_DIR}/wireshark
         ${CMAKE_SOURCE_DIR}/include)
 
 # `make check-format` option (for CI test)

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -209,6 +209,7 @@ add_custom_target(format ${BUILD_SUPPORT_DIR}/run_clang_format.py
         ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
         ${CMAKE_SOURCE_DIR}/lib
         ${CMAKE_SOURCE_DIR}/tests
+        ${CMAKE_SOURCE_DIR}/python/src
         ${CMAKE_SOURCE_DIR}/include)
 
 # `make check-format` option (for CI test)

--- a/pulsar-client-cpp/examples/SampleAsyncProducer.cc
+++ b/pulsar-client-cpp/examples/SampleAsyncProducer.cc
@@ -28,9 +28,7 @@ DECLARE_LOG_OBJECT()
 
 using namespace pulsar;
 
-void callback(Result code, const Message& msg) {
-    LOG_INFO("Received code: " << code << " -- Msg: " << msg);
-}
+void callback(Result code, const Message& msg) { LOG_INFO("Received code: " << code << " -- Msg: " << msg); }
 
 int main() {
     Client client("pulsar://localhost:6650");

--- a/pulsar-client-cpp/examples/SampleConsumer.cc
+++ b/pulsar-client-cpp/examples/SampleConsumer.cc
@@ -27,7 +27,6 @@ DECLARE_LOG_OBJECT()
 using namespace pulsar;
 
 int main() {
-
     Client client("pulsar://localhost:6650");
 
     Consumer consumer;

--- a/pulsar-client-cpp/python/src/authentication.cc
+++ b/pulsar-client-cpp/python/src/authentication.cc
@@ -26,6 +26,5 @@ AuthenticationWrapper::AuthenticationWrapper(const std::string& dynamicLibPath,
 void export_authentication() {
     using namespace boost::python;
 
-    class_<AuthenticationWrapper>("Authentication", init<const std::string&, const std::string&>())
-            ;
+    class_<AuthenticationWrapper>("Authentication", init<const std::string&, const std::string&>());
 }

--- a/pulsar-client-cpp/python/src/client.cc
+++ b/pulsar-client-cpp/python/src/client.cc
@@ -22,9 +22,9 @@ Producer Client_createProducer(Client& client, const std::string& topic, const P
     Producer producer;
     Result res;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = client.createProducer(topic, conf, producer);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
     return producer;
@@ -35,23 +35,22 @@ Consumer Client_subscribe(Client& client, const std::string& topic, const std::s
     Consumer consumer;
     Result res;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = client.subscribe(topic, subscriptionName, conf, consumer);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
     return consumer;
 }
 
-Reader Client_createReader(Client& client, const std::string& topic,
-                           const BatchMessageId& startMessageId,
+Reader Client_createReader(Client& client, const std::string& topic, const BatchMessageId& startMessageId,
                            const ReaderConfiguration& conf) {
     Reader reader;
     Result res;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = client.createReader(topic, startMessageId, conf, reader);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
     return reader;
@@ -60,9 +59,9 @@ Reader Client_createReader(Client& client, const std::string& topic,
 void Client_close(Client& client) {
     Result res;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = client.close();
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
@@ -70,11 +69,10 @@ void Client_close(Client& client) {
 void export_client() {
     using namespace boost::python;
 
-    class_<Client>("Client", init<const std::string&, const ClientConfiguration& >())
-            .def("create_producer", &Client_createProducer)
-            .def("subscribe", &Client_subscribe)
-            .def("create_reader", &Client_createReader)
-            .def("close", &Client_close)
-            .def("shutdown", &Client::shutdown)
-            ;
+    class_<Client>("Client", init<const std::string&, const ClientConfiguration&>())
+        .def("create_producer", &Client_createProducer)
+        .def("subscribe", &Client_subscribe)
+        .def("create_reader", &Client_createReader)
+        .def("close", &Client_close)
+        .def("shutdown", &Client::shutdown);
 }

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -18,14 +18,11 @@
  */
 #include "utils.h"
 
-template<typename T>
+template <typename T>
 struct ListenerWrapper {
     PyObject* _pyListener;
 
-    ListenerWrapper(py::object pyListener) :
-        _pyListener(pyListener.ptr()) {
-        Py_XINCREF(_pyListener);
-    }
+    ListenerWrapper(py::object pyListener) : _pyListener(pyListener.ptr()) { Py_XINCREF(_pyListener); }
 
     ListenerWrapper(const ListenerWrapper& other) {
         _pyListener = other._pyListener;
@@ -38,9 +35,7 @@ struct ListenerWrapper {
         return *this;
     }
 
-    virtual ~ListenerWrapper() {
-        Py_XDECREF(_pyListener);
-    }
+    virtual ~ListenerWrapper() { Py_XDECREF(_pyListener); }
 
     void operator()(T consumer, const Message& msg) {
         PyGILState_STATE state = PyGILState_Ensure();
@@ -62,7 +57,7 @@ static ConsumerConfiguration& ConsumerConfiguration_setMessageListener(ConsumerC
 }
 
 static ReaderConfiguration& ReaderConfiguration_setReaderListener(ReaderConfiguration& conf,
-                                                                   py::object pyListener) {
+                                                                  py::object pyListener) {
     conf.setReaderListener(ListenerWrapper<Reader>(pyListener));
     return conf;
 }
@@ -78,69 +73,77 @@ void export_config() {
     using namespace boost::python;
 
     class_<ClientConfiguration>("ClientConfiguration")
-            .def("authentication", &ClientConfiguration_setAuthentication, return_self<>())
-            .def("operation_timeout_seconds", &ClientConfiguration::getOperationTimeoutSeconds)
-            .def("operation_timeout_seconds", &ClientConfiguration::setOperationTimeoutSeconds, return_self<>())
-            .def("io_threads", &ClientConfiguration::getIOThreads)
-            .def("io_threads", &ClientConfiguration::setIOThreads, return_self<>())
-            .def("message_listener_threads", &ClientConfiguration::getMessageListenerThreads)
-            .def("message_listener_threads", &ClientConfiguration::setMessageListenerThreads, return_self<>())
-            .def("concurrent_lookup_requests", &ClientConfiguration::getConcurrentLookupRequest)
-            .def("concurrent_lookup_requests", &ClientConfiguration::setConcurrentLookupRequest, return_self<>())
-            .def("log_conf_file_path", &ClientConfiguration::getLogConfFilePath, return_value_policy<copy_const_reference>())
-            .def("log_conf_file_path", &ClientConfiguration::setLogConfFilePath, return_self<>())
-            .def("use_tls", &ClientConfiguration::isUseTls)
-            .def("use_tls", &ClientConfiguration::setUseTls, return_self<>())
-            .def("tls_trust_certs_file_path", &ClientConfiguration::getTlsTrustCertsFilePath)
-            .def("tls_trust_certs_file_path", &ClientConfiguration::setTlsTrustCertsFilePath, return_self<>())
-            .def("tls_allow_insecure_connection", &ClientConfiguration::isTlsAllowInsecureConnection)
-            .def("tls_allow_insecure_connection", &ClientConfiguration::setTlsAllowInsecureConnection, return_self<>())
-            ;
+        .def("authentication", &ClientConfiguration_setAuthentication, return_self<>())
+        .def("operation_timeout_seconds", &ClientConfiguration::getOperationTimeoutSeconds)
+        .def("operation_timeout_seconds", &ClientConfiguration::setOperationTimeoutSeconds, return_self<>())
+        .def("io_threads", &ClientConfiguration::getIOThreads)
+        .def("io_threads", &ClientConfiguration::setIOThreads, return_self<>())
+        .def("message_listener_threads", &ClientConfiguration::getMessageListenerThreads)
+        .def("message_listener_threads", &ClientConfiguration::setMessageListenerThreads, return_self<>())
+        .def("concurrent_lookup_requests", &ClientConfiguration::getConcurrentLookupRequest)
+        .def("concurrent_lookup_requests", &ClientConfiguration::setConcurrentLookupRequest, return_self<>())
+        .def("log_conf_file_path", &ClientConfiguration::getLogConfFilePath,
+             return_value_policy<copy_const_reference>())
+        .def("log_conf_file_path", &ClientConfiguration::setLogConfFilePath, return_self<>())
+        .def("use_tls", &ClientConfiguration::isUseTls)
+        .def("use_tls", &ClientConfiguration::setUseTls, return_self<>())
+        .def("tls_trust_certs_file_path", &ClientConfiguration::getTlsTrustCertsFilePath)
+        .def("tls_trust_certs_file_path", &ClientConfiguration::setTlsTrustCertsFilePath, return_self<>())
+        .def("tls_allow_insecure_connection", &ClientConfiguration::isTlsAllowInsecureConnection)
+        .def("tls_allow_insecure_connection", &ClientConfiguration::setTlsAllowInsecureConnection,
+             return_self<>());
 
     class_<ProducerConfiguration>("ProducerConfiguration")
-            .def("producer_name", &ProducerConfiguration::getProducerName, return_value_policy<copy_const_reference>())
-            .def("producer_name", &ProducerConfiguration::setProducerName, return_self<>())
-            .def("send_timeout_millis", &ProducerConfiguration::getSendTimeout)
-            .def("send_timeout_millis", &ProducerConfiguration::setSendTimeout, return_self<>())
-            .def("initial_sequence_id", &ProducerConfiguration::getInitialSequenceId)
-            .def("initial_sequence_id", &ProducerConfiguration::setInitialSequenceId, return_self<>())
-            .def("compression_type", &ProducerConfiguration::getCompressionType)
-            .def("compression_type", &ProducerConfiguration::setCompressionType, return_self<>())
-            .def("max_pending_messages", &ProducerConfiguration::getMaxPendingMessages)
-            .def("max_pending_messages", &ProducerConfiguration::setMaxPendingMessages, return_self<>())
-            .def("block_if_queue_full", &ProducerConfiguration::getBlockIfQueueFull)
-            .def("block_if_queue_full", &ProducerConfiguration::setBlockIfQueueFull, return_self<>())
-            .def("partitions_routing_mode", &ProducerConfiguration::getPartitionsRoutingMode)
-            .def("partitions_routing_mode", &ProducerConfiguration::setPartitionsRoutingMode, return_self<>())
-            .def("batching_enabled", &ProducerConfiguration::getBatchingEnabled, return_value_policy<copy_const_reference>())
-            .def("batching_enabled", &ProducerConfiguration::setBatchingEnabled, return_self<>())
-            .def("batching_max_messages", &ProducerConfiguration::getBatchingMaxMessages, return_value_policy<copy_const_reference>())
-            .def("batching_max_messages", &ProducerConfiguration::setBatchingMaxMessages, return_self<>())
-            .def("batching_max_allowed_size_in_bytes", &ProducerConfiguration::getBatchingMaxAllowedSizeInBytes, return_value_policy<copy_const_reference>())
-            .def("batching_max_allowed_size_in_bytes", &ProducerConfiguration::setBatchingMaxAllowedSizeInBytes, return_self<>())
-            .def("batching_max_publish_delay_ms", &ProducerConfiguration::getBatchingMaxPublishDelayMs, return_value_policy<copy_const_reference>())
-            .def("batching_max_publish_delay_ms", &ProducerConfiguration::setBatchingMaxPublishDelayMs, return_self<>())
-            ;
+        .def("producer_name", &ProducerConfiguration::getProducerName,
+             return_value_policy<copy_const_reference>())
+        .def("producer_name", &ProducerConfiguration::setProducerName, return_self<>())
+        .def("send_timeout_millis", &ProducerConfiguration::getSendTimeout)
+        .def("send_timeout_millis", &ProducerConfiguration::setSendTimeout, return_self<>())
+        .def("initial_sequence_id", &ProducerConfiguration::getInitialSequenceId)
+        .def("initial_sequence_id", &ProducerConfiguration::setInitialSequenceId, return_self<>())
+        .def("compression_type", &ProducerConfiguration::getCompressionType)
+        .def("compression_type", &ProducerConfiguration::setCompressionType, return_self<>())
+        .def("max_pending_messages", &ProducerConfiguration::getMaxPendingMessages)
+        .def("max_pending_messages", &ProducerConfiguration::setMaxPendingMessages, return_self<>())
+        .def("block_if_queue_full", &ProducerConfiguration::getBlockIfQueueFull)
+        .def("block_if_queue_full", &ProducerConfiguration::setBlockIfQueueFull, return_self<>())
+        .def("partitions_routing_mode", &ProducerConfiguration::getPartitionsRoutingMode)
+        .def("partitions_routing_mode", &ProducerConfiguration::setPartitionsRoutingMode, return_self<>())
+        .def("batching_enabled", &ProducerConfiguration::getBatchingEnabled,
+             return_value_policy<copy_const_reference>())
+        .def("batching_enabled", &ProducerConfiguration::setBatchingEnabled, return_self<>())
+        .def("batching_max_messages", &ProducerConfiguration::getBatchingMaxMessages,
+             return_value_policy<copy_const_reference>())
+        .def("batching_max_messages", &ProducerConfiguration::setBatchingMaxMessages, return_self<>())
+        .def("batching_max_allowed_size_in_bytes", &ProducerConfiguration::getBatchingMaxAllowedSizeInBytes,
+             return_value_policy<copy_const_reference>())
+        .def("batching_max_allowed_size_in_bytes", &ProducerConfiguration::setBatchingMaxAllowedSizeInBytes,
+             return_self<>())
+        .def("batching_max_publish_delay_ms", &ProducerConfiguration::getBatchingMaxPublishDelayMs,
+             return_value_policy<copy_const_reference>())
+        .def("batching_max_publish_delay_ms", &ProducerConfiguration::setBatchingMaxPublishDelayMs,
+             return_self<>());
 
     class_<ConsumerConfiguration>("ConsumerConfiguration")
-            .def("consumer_type", &ConsumerConfiguration::getConsumerType)
-            .def("consumer_type", &ConsumerConfiguration::setConsumerType, return_self<>())
-            .def("message_listener", &ConsumerConfiguration_setMessageListener, return_self<>())
-            .def("receiver_queue_size", &ConsumerConfiguration::getReceiverQueueSize)
-            .def("receiver_queue_size", &ConsumerConfiguration::setReceiverQueueSize)
-            .def("consumer_name", &ConsumerConfiguration::getConsumerName, return_value_policy<copy_const_reference>())
-            .def("consumer_name", &ConsumerConfiguration::setConsumerName)
-            .def("unacked_messages_timeout_ms", &ConsumerConfiguration::getUnAckedMessagesTimeoutMs)
-            .def("unacked_messages_timeout_ms", &ConsumerConfiguration::setUnAckedMessagesTimeoutMs)
-            .def("broker_consumer_stats_cache_time_ms", &ConsumerConfiguration::getBrokerConsumerStatsCacheTimeInMs)
-            .def("broker_consumer_stats_cache_time_ms", &ConsumerConfiguration::setBrokerConsumerStatsCacheTimeInMs)
-            ;
+        .def("consumer_type", &ConsumerConfiguration::getConsumerType)
+        .def("consumer_type", &ConsumerConfiguration::setConsumerType, return_self<>())
+        .def("message_listener", &ConsumerConfiguration_setMessageListener, return_self<>())
+        .def("receiver_queue_size", &ConsumerConfiguration::getReceiverQueueSize)
+        .def("receiver_queue_size", &ConsumerConfiguration::setReceiverQueueSize)
+        .def("consumer_name", &ConsumerConfiguration::getConsumerName,
+             return_value_policy<copy_const_reference>())
+        .def("consumer_name", &ConsumerConfiguration::setConsumerName)
+        .def("unacked_messages_timeout_ms", &ConsumerConfiguration::getUnAckedMessagesTimeoutMs)
+        .def("unacked_messages_timeout_ms", &ConsumerConfiguration::setUnAckedMessagesTimeoutMs)
+        .def("broker_consumer_stats_cache_time_ms",
+             &ConsumerConfiguration::getBrokerConsumerStatsCacheTimeInMs)
+        .def("broker_consumer_stats_cache_time_ms",
+             &ConsumerConfiguration::setBrokerConsumerStatsCacheTimeInMs);
 
     class_<ReaderConfiguration>("ReaderConfiguration")
-            .def("message_listener", &ReaderConfiguration_setReaderListener, return_self<>())
-            .def("receiver_queue_size", &ReaderConfiguration::getReceiverQueueSize)
-            .def("receiver_queue_size", &ReaderConfiguration::setReceiverQueueSize)
-            .def("reader_name", &ReaderConfiguration::getReaderName, return_value_policy<copy_const_reference>())
-            .def("reader_name", &ReaderConfiguration::setReaderName)
-            ;
+        .def("message_listener", &ReaderConfiguration_setReaderListener, return_self<>())
+        .def("receiver_queue_size", &ReaderConfiguration::getReceiverQueueSize)
+        .def("receiver_queue_size", &ReaderConfiguration::setReceiverQueueSize)
+        .def("reader_name", &ReaderConfiguration::getReaderName, return_value_policy<copy_const_reference>())
+        .def("reader_name", &ReaderConfiguration::setReaderName);
 }

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -20,9 +20,9 @@
 
 void Consumer_unsubscribe(Consumer& consumer) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.unsubscribe();
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
@@ -32,11 +32,11 @@ Message Consumer_receive(Consumer& consumer) {
     Result res;
 
     while (true) {
-        Py_BEGIN_ALLOW_THREADS
+        Py_BEGIN_ALLOW_THREADS;
         // Use 100ms timeout to periodically check whether the
         // interpreter was interrupted
         res = consumer.receive(msg, 100);
-        Py_END_ALLOW_THREADS
+        Py_END_ALLOW_THREADS;
 
         if (res != ResultTimeout) {
             // In case of timeout we keep calling receive() to simulate a
@@ -58,9 +58,9 @@ Message Consumer_receive(Consumer& consumer) {
 Message Consumer_receive_timeout(Consumer& consumer, int timeoutMs) {
     Message msg;
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.receive(msg, timeoutMs);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
     return msg;
@@ -68,74 +68,69 @@ Message Consumer_receive_timeout(Consumer& consumer, int timeoutMs) {
 
 void Consumer_acknowledge(Consumer& consumer, const Message& msg) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.acknowledge(msg);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
 
 void Consumer_acknowledge_message_id(Consumer& consumer, const MessageId& msgId) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.acknowledge(msgId);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
 
 void Consumer_acknowledge_cumulative(Consumer& consumer, const Message& msg) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.acknowledgeCumulative(msg);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
 
 void Consumer_acknowledge_cumulative_message_id(Consumer& consumer, const MessageId& msgId) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.acknowledgeCumulative(msgId);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
 
 void Consumer_close(Consumer& consumer) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = consumer.close();
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
 
-void Consumer_pauseMessageListener(Consumer& consumer) {
-    CHECK_RESULT(consumer.pauseMessageListener());
-}
+void Consumer_pauseMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.pauseMessageListener()); }
 
-void Consumer_resumeMessageListener(Consumer& consumer) {
-    CHECK_RESULT(consumer.resumeMessageListener());
-}
+void Consumer_resumeMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.resumeMessageListener()); }
 
 void export_consumer() {
     using namespace boost::python;
 
     class_<Consumer>("Consumer", no_init)
-            .def("topic", &Consumer::getTopic, "return the topic this consumer is subscribed to",
-                 return_value_policy<copy_const_reference>())
-            .def("subscription_name", &Consumer::getSubscriptionName, return_value_policy<copy_const_reference>())
-            .def("unsubscribe", &Consumer_unsubscribe)
-            .def("receive", &Consumer_receive)
-            .def("receive", &Consumer_receive_timeout)
-            .def("acknowledge", &Consumer_acknowledge)
-            .def("acknowledge", &Consumer_acknowledge_message_id)
-            .def("acknowledge_cumulative", &Consumer_acknowledge_cumulative)
-            .def("acknowledge_cumulative", &Consumer_acknowledge_cumulative_message_id)
-            .def("close", &Consumer_close)
-            .def("pause_message_listener", &Consumer_pauseMessageListener)
-            .def("resume_message_listener", &Consumer_resumeMessageListener)
-            .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages)
-            ;
+        .def("topic", &Consumer::getTopic, "return the topic this consumer is subscribed to",
+             return_value_policy<copy_const_reference>())
+        .def("subscription_name", &Consumer::getSubscriptionName, return_value_policy<copy_const_reference>())
+        .def("unsubscribe", &Consumer_unsubscribe)
+        .def("receive", &Consumer_receive)
+        .def("receive", &Consumer_receive_timeout)
+        .def("acknowledge", &Consumer_acknowledge)
+        .def("acknowledge", &Consumer_acknowledge_message_id)
+        .def("acknowledge_cumulative", &Consumer_acknowledge_cumulative)
+        .def("acknowledge_cumulative", &Consumer_acknowledge_cumulative_message_id)
+        .def("close", &Consumer_close)
+        .def("pause_message_listener", &Consumer_pauseMessageListener)
+        .def("resume_message_listener", &Consumer_resumeMessageListener)
+        .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages);
 }

--- a/pulsar-client-cpp/python/src/enums.cc
+++ b/pulsar-client-cpp/python/src/enums.cc
@@ -18,61 +18,55 @@
  */
 #include "utils.h"
 
-
 void export_enums() {
     using namespace boost::python;
 
     enum_<ProducerConfiguration::PartitionsRoutingMode>("PartitionsRoutingMode")
-            .value("UseSinglePartition", ProducerConfiguration::UseSinglePartition)
-            .value("RoundRobinDistribution", ProducerConfiguration::RoundRobinDistribution)
-            .value("CustomPartition", ProducerConfiguration::CustomPartition)
-            ;
+        .value("UseSinglePartition", ProducerConfiguration::UseSinglePartition)
+        .value("RoundRobinDistribution", ProducerConfiguration::RoundRobinDistribution)
+        .value("CustomPartition", ProducerConfiguration::CustomPartition);
 
     enum_<CompressionType>("CompressionType")
-            .value("NONE", CompressionNone) // Don't use 'None' since it's a keyword in py3
-            .value("LZ4", CompressionLZ4)
-            .value("ZLib", CompressionZLib)
-            ;
+        .value("NONE", CompressionNone)  // Don't use 'None' since it's a keyword in py3
+        .value("LZ4", CompressionLZ4)
+        .value("ZLib", CompressionZLib);
 
     enum_<ConsumerType>("ConsumerType")
-            .value("Exclusive", ConsumerExclusive)
-            .value("Shared", ConsumerShared)
-            .value("Failover", ConsumerFailover)
-            ;
+        .value("Exclusive", ConsumerExclusive)
+        .value("Shared", ConsumerShared)
+        .value("Failover", ConsumerFailover);
 
-    enum_<Result >("Result", "Collection of return codes")
-            .value("Ok", ResultOk)
-            .value("UnknownError", ResultUnknownError)
-            .value("InvalidConfiguration", ResultInvalidConfiguration)
-            .value("Timeout", ResultTimeout)
-            .value("LookupError", ResultLookupError)
-            .value("ConnectError", ResultConnectError)
-            .value("ReadError", ResultReadError)
-            .value("AuthenticationError", ResultAuthenticationError)
-            .value("AuthorizationError", ResultAuthorizationError)
-            .value("ErrorGettingAuthenticationData", ResultErrorGettingAuthenticationData)
-            .value("BrokerMetadataError", ResultBrokerMetadataError)
-            .value("BrokerPersistenceError", ResultBrokerPersistenceError)
-            .value("ChecksumError", ResultChecksumError)
-            .value("ConsumerBusy", ResultConsumerBusy)
-            .value("NotConnected", ResultNotConnected)
-            .value("AlreadyClosed", ResultAlreadyClosed)
-            .value("InvalidMessage", ResultInvalidMessage)
-            .value("ConsumerNotInitialized", ResultConsumerNotInitialized)
-            .value("ProducerNotInitialized", ResultProducerNotInitialized)
-            .value("TooManyLookupRequestException", ResultTooManyLookupRequestException)
-            .value("InvalidTopicName", ResultInvalidTopicName)
-            .value("InvalidUrl", ResultInvalidUrl)
-            .value("ServiceUnitNotReady", ResultServiceUnitNotReady)
-            .value("OperationNotSupported", ResultOperationNotSupported)
-            .value("ProducerBlockedQuotaExceededError", ResultProducerBlockedQuotaExceededError)
-            .value("ProducerBlockedQuotaExceededException", ResultProducerBlockedQuotaExceededException)
-            .value("ProducerQueueIsFull", ResultProducerQueueIsFull)
-            .value("MessageTooBig", ResultMessageTooBig)
-            .value("TopicNotFound", ResultTopicNotFound)
-            .value("SubscriptionNotFound", ResultSubscriptionNotFound)
-            .value("ConsumerNotFound", ResultConsumerNotFound)
-            .value("UnsupportedVersionError", ResultUnsupportedVersionError)
-            ;
-
+    enum_<Result>("Result", "Collection of return codes")
+        .value("Ok", ResultOk)
+        .value("UnknownError", ResultUnknownError)
+        .value("InvalidConfiguration", ResultInvalidConfiguration)
+        .value("Timeout", ResultTimeout)
+        .value("LookupError", ResultLookupError)
+        .value("ConnectError", ResultConnectError)
+        .value("ReadError", ResultReadError)
+        .value("AuthenticationError", ResultAuthenticationError)
+        .value("AuthorizationError", ResultAuthorizationError)
+        .value("ErrorGettingAuthenticationData", ResultErrorGettingAuthenticationData)
+        .value("BrokerMetadataError", ResultBrokerMetadataError)
+        .value("BrokerPersistenceError", ResultBrokerPersistenceError)
+        .value("ChecksumError", ResultChecksumError)
+        .value("ConsumerBusy", ResultConsumerBusy)
+        .value("NotConnected", ResultNotConnected)
+        .value("AlreadyClosed", ResultAlreadyClosed)
+        .value("InvalidMessage", ResultInvalidMessage)
+        .value("ConsumerNotInitialized", ResultConsumerNotInitialized)
+        .value("ProducerNotInitialized", ResultProducerNotInitialized)
+        .value("TooManyLookupRequestException", ResultTooManyLookupRequestException)
+        .value("InvalidTopicName", ResultInvalidTopicName)
+        .value("InvalidUrl", ResultInvalidUrl)
+        .value("ServiceUnitNotReady", ResultServiceUnitNotReady)
+        .value("OperationNotSupported", ResultOperationNotSupported)
+        .value("ProducerBlockedQuotaExceededError", ResultProducerBlockedQuotaExceededError)
+        .value("ProducerBlockedQuotaExceededException", ResultProducerBlockedQuotaExceededException)
+        .value("ProducerQueueIsFull", ResultProducerQueueIsFull)
+        .value("MessageTooBig", ResultMessageTooBig)
+        .value("TopicNotFound", ResultTopicNotFound)
+        .value("SubscriptionNotFound", ResultSubscriptionNotFound)
+        .value("ConsumerNotFound", ResultConsumerNotFound)
+        .value("UnsupportedVersionError", ResultUnsupportedVersionError);
 }

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -39,7 +39,8 @@ std::string Message_str(const Message& msg) {
 }
 
 boost::python::object Message_data(const Message& msg) {
-    return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
+    return boost::python::object(
+        boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
 }
 
 const BatchMessageId& Message_getMessageId(const Message& msg) {
@@ -49,43 +50,41 @@ const BatchMessageId& Message_getMessageId(const Message& msg) {
 void export_message() {
     using namespace boost::python;
 
-    MessageBuilder& (MessageBuilder::*MessageBuilderSetContentString)(const std::string&) = &MessageBuilder::setContent;
+    MessageBuilder& (MessageBuilder::*MessageBuilderSetContentString)(const std::string&) =
+        &MessageBuilder::setContent;
 
     class_<MessageBuilder, boost::noncopyable>("MessageBuilder")
-            .def("content", MessageBuilderSetContentString, return_self<>())
-            .def("property", &MessageBuilder::setProperty, return_self<>())
-            .def("properties", &MessageBuilder::setProperties, return_self<>())
-            .def("sequence_id", &MessageBuilder::setSequenceId, return_self<>())
-            .def("partition_key", &MessageBuilder::setPartitionKey, return_self<>())
-            .def("event_timestamp", &MessageBuilder::setEventTimestamp, return_self<>())
-            .def("replication_clusters", &MessageBuilder::setReplicationClusters, return_self<>())
-            .def("disable_replication", &MessageBuilder::disableReplication, return_self<>())
-            .def("build", &MessageBuilder::build)
-            ;
+        .def("content", MessageBuilderSetContentString, return_self<>())
+        .def("property", &MessageBuilder::setProperty, return_self<>())
+        .def("properties", &MessageBuilder::setProperties, return_self<>())
+        .def("sequence_id", &MessageBuilder::setSequenceId, return_self<>())
+        .def("partition_key", &MessageBuilder::setPartitionKey, return_self<>())
+        .def("event_timestamp", &MessageBuilder::setEventTimestamp, return_self<>())
+        .def("replication_clusters", &MessageBuilder::setReplicationClusters, return_self<>())
+        .def("disable_replication", &MessageBuilder::disableReplication, return_self<>())
+        .def("build", &MessageBuilder::build);
 
-    class_<Message::StringMap>("MessageStringMap")
-            .def(map_indexing_suite<Message::StringMap>())
-            ;
+    class_<Message::StringMap>("MessageStringMap").def(map_indexing_suite<Message::StringMap>());
 
-    static const BatchMessageId& _MessageId_earliest = static_cast<const BatchMessageId&>(MessageId::earliest());
+    static const BatchMessageId& _MessageId_earliest =
+        static_cast<const BatchMessageId&>(MessageId::earliest());
     static const BatchMessageId& _MessageId_latest = static_cast<const BatchMessageId&>(MessageId::latest());
 
     class_<BatchMessageId, boost::shared_ptr<BatchMessageId> >("MessageId")
-            .def("__str__", &MessageId_str)
-            .add_static_property("earliest", make_getter(&_MessageId_earliest))
-            .add_static_property("latest", make_getter(&_MessageId_latest))
-            .def("serialize", &MessageId_serialize)
-            .def("deserialize", &MessageId::deserialize).staticmethod("deserialize")
-            ;
+        .def("__str__", &MessageId_str)
+        .add_static_property("earliest", make_getter(&_MessageId_earliest))
+        .add_static_property("latest", make_getter(&_MessageId_latest))
+        .def("serialize", &MessageId_serialize)
+        .def("deserialize", &MessageId::deserialize)
+        .staticmethod("deserialize");
 
     class_<Message>("Message")
-            .def("properties", &Message::getProperties, return_value_policy<copy_const_reference>())
-            .def("data", &Message_data)
-            .def("length", &Message::getLength)
-            .def("partition_key", &Message::getPartitionKey, return_value_policy<copy_const_reference>())
-            .def("publish_timestamp", &Message::getPublishTimestamp)
-            .def("event_timestamp", &Message::getEventTimestamp)
-            .def("message_id", &Message_getMessageId, return_value_policy<copy_const_reference>())
-            .def("__str__", &Message_str)
-            ;
+        .def("properties", &Message::getProperties, return_value_policy<copy_const_reference>())
+        .def("data", &Message_data)
+        .def("length", &Message::getLength)
+        .def("partition_key", &Message::getPartitionKey, return_value_policy<copy_const_reference>())
+        .def("publish_timestamp", &Message::getPublishTimestamp)
+        .def("event_timestamp", &Message::getEventTimestamp)
+        .def("message_id", &Message_getMessageId, return_value_policy<copy_const_reference>())
+        .def("__str__", &Message_str);
 }

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -20,9 +20,9 @@
 
 void Producer_send(Producer& producer, const Message& message) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = producer.send(message);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
@@ -48,16 +48,16 @@ void Producer_sendAsync(Producer& producer, const Message& message, py::object c
     PyObject* pyCallback = callback.ptr();
     Py_XINCREF(pyCallback);
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     producer.sendAsync(message, boost::bind(Producer_sendAsyncCallback, pyCallback, _1, _2));
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 }
 
 void Producer_close(Producer& producer) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = producer.close();
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
@@ -66,26 +66,26 @@ void export_producer() {
     using namespace boost::python;
 
     class_<Producer>("Producer", no_init)
-            .def("topic", &Producer::getTopic, "return the topic to which producer is publishing to",
-                 return_value_policy<copy_const_reference>())
-            .def("producer_name", &Producer::getProducerName,
-                 "return the producer name which could have been assigned by the system or specified by the client",
-                 return_value_policy<copy_const_reference>())
-            .def("last_sequence_id", &Producer::getLastSequenceId)
-            .def("send", &Producer_send,
-                 "Publish a message on the topic associated with this Producer.\n"
-                         "\n"
-                         "This method will block until the message will be accepted and persisted\n"
-                         "by the broker. In case of errors, the client library will try to\n"
-                         "automatically recover and use a different broker.\n"
-                         "\n"
-                         "If it wasn't possible to successfully publish the message within the sendTimeout,\n"
-                         "an error will be returned.\n"
-                         "\n"
-                         "This method is equivalent to asyncSend() and wait until the callback is triggered.\n"
-                         "\n"
-                         "@param msg message to publish\n")
-            .def("send_async", &Producer_sendAsync)
-            .def("close", &Producer_close)
-            ;
+        .def("topic", &Producer::getTopic, "return the topic to which producer is publishing to",
+             return_value_policy<copy_const_reference>())
+        .def("producer_name", &Producer::getProducerName,
+             "return the producer name which could have been assigned by the system or specified by the "
+             "client",
+             return_value_policy<copy_const_reference>())
+        .def("last_sequence_id", &Producer::getLastSequenceId)
+        .def("send", &Producer_send,
+             "Publish a message on the topic associated with this Producer.\n"
+             "\n"
+             "This method will block until the message will be accepted and persisted\n"
+             "by the broker. In case of errors, the client library will try to\n"
+             "automatically recover and use a different broker.\n"
+             "\n"
+             "If it wasn't possible to successfully publish the message within the sendTimeout,\n"
+             "an error will be returned.\n"
+             "\n"
+             "This method is equivalent to asyncSend() and wait until the callback is triggered.\n"
+             "\n"
+             "@param msg message to publish\n")
+        .def("send_async", &Producer_sendAsync)
+        .def("close", &Producer_close);
 }

--- a/pulsar-client-cpp/python/src/pulsar.cc
+++ b/pulsar-client-cpp/python/src/pulsar.cc
@@ -27,7 +27,6 @@ void export_config();
 void export_enums();
 void export_authentication();
 
-
 static void translateException(const PulsarException& ex) {
     std::string err = "Pulsar error: ";
     err += strResult(ex._result);
@@ -35,8 +34,7 @@ static void translateException(const PulsarException& ex) {
     PyErr_SetString(PyExc_Exception, err.c_str());
 }
 
-BOOST_PYTHON_MODULE(_pulsar)
-{
+BOOST_PYTHON_MODULE(_pulsar) {
     py::register_exception_translator<PulsarException>(translateException);
 
     // Initialize thread support so that we can grab the GIL mutex

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -23,11 +23,11 @@ Message Reader_readNext(Reader& reader) {
     Result res;
 
     while (true) {
-        Py_BEGIN_ALLOW_THREADS
+        Py_BEGIN_ALLOW_THREADS;
         // Use 100ms timeout to periodically check whether the
         // interpreter was interrupted
         res = reader.readNext(msg, 100);
-        Py_END_ALLOW_THREADS
+        Py_END_ALLOW_THREADS;
 
         if (res != ResultTimeout) {
             // In case of timeout we keep calling receive() to simulate a
@@ -49,9 +49,9 @@ Message Reader_readNext(Reader& reader) {
 Message Reader_readNextTimeout(Reader& reader, int timeoutMs) {
     Message msg;
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = reader.readNext(msg, timeoutMs);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
     return msg;
@@ -59,9 +59,9 @@ Message Reader_readNextTimeout(Reader& reader, int timeoutMs) {
 
 void Reader_close(Reader& reader) {
     Result res;
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     res = reader.close();
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     CHECK_RESULT(res);
 }
@@ -70,9 +70,8 @@ void export_reader() {
     using namespace boost::python;
 
     class_<Reader>("Reader", no_init)
-            .def("topic", &Reader::getTopic, return_value_policy<copy_const_reference>())
-            .def("read_next", &Reader_readNext)
-            .def("read_next", &Reader_readNextTimeout)
-            .def("close", &Reader_close)
-            ;
+        .def("topic", &Reader::getTopic, return_value_policy<copy_const_reference>())
+        .def("read_next", &Reader_readNext)
+        .def("read_next", &Reader_readNextTimeout)
+        .def("close", &Reader_close);
 }

--- a/pulsar-client-cpp/python/src/utils.h
+++ b/pulsar-client-cpp/python/src/utils.h
@@ -26,8 +26,7 @@ namespace py = boost::python;
 
 struct PulsarException {
     Result _result;
-    PulsarException(Result res) :
-            _result(res) {}
+    PulsarException(Result res) : _result(res) {}
 };
 
 inline void CHECK_RESULT(Result res) {

--- a/pulsar-client-cpp/wireshark/moduleinfo.h
+++ b/pulsar-client-cpp/wireshark/moduleinfo.h
@@ -25,7 +25,6 @@
 /* Name of package */
 #define PACKAGE "|pulsar|"
 
-
 #ifdef VERSION
 #undef VERSION
 #endif

--- a/pulsar-client-cpp/wireshark/pulsarDissector.cc
+++ b/pulsar-client-cpp/wireshark/pulsarDissector.cc
@@ -79,56 +79,62 @@ static pulsar::proto::BaseCommand command;
 
 using namespace pulsar::proto;
 
-static const value_string pulsar_cmd_names[] = {  //
-        { BaseCommand::CONNECT, "Connect" },  //
-                { BaseCommand::CONNECTED, "Connected" },  //
-                { BaseCommand::SUBSCRIBE, "Subscribe" },  //
-                { BaseCommand::PRODUCER, "Producer" },  //
-                { BaseCommand::SEND, "Send" },  //
-                { BaseCommand::SEND_RECEIPT, "SendReceipt" },  //
-                { BaseCommand::SEND_ERROR, "SendError" },  //
-                { BaseCommand::MESSAGE, "Message" },  //
-                { BaseCommand::ACK, "Ack" },  //
-                { BaseCommand::FLOW, "Flow" },  //
-                { BaseCommand::UNSUBSCRIBE, "Unsubscribe" },  //
-                { BaseCommand::SUCCESS, "Success" },  //
-                { BaseCommand::ERROR, "Error" },  //
-                { BaseCommand::CLOSE_PRODUCER, "CloseProducer" },  //
-                { BaseCommand::CLOSE_CONSUMER, "CloseConsumer" },  //
-                { BaseCommand::PRODUCER_SUCCESS, "ProducerSuccess" },  //
-                { BaseCommand::PING, "Ping" },  //
-                { BaseCommand::PONG, "Pong" },  //
-        };
-
-static const value_string auth_methods_vs[] = { { AuthMethodNone, "None" },  //
-        { AuthMethodYcaV1, "YCAv1" },  //
-        { AuthMethodAthens, "Athens" }  //
+static const value_string pulsar_cmd_names[] = {
+    //
+    {BaseCommand::CONNECT, "Connect"},                   //
+    {BaseCommand::CONNECTED, "Connected"},               //
+    {BaseCommand::SUBSCRIBE, "Subscribe"},               //
+    {BaseCommand::PRODUCER, "Producer"},                 //
+    {BaseCommand::SEND, "Send"},                         //
+    {BaseCommand::SEND_RECEIPT, "SendReceipt"},          //
+    {BaseCommand::SEND_ERROR, "SendError"},              //
+    {BaseCommand::MESSAGE, "Message"},                   //
+    {BaseCommand::ACK, "Ack"},                           //
+    {BaseCommand::FLOW, "Flow"},                         //
+    {BaseCommand::UNSUBSCRIBE, "Unsubscribe"},           //
+    {BaseCommand::SUCCESS, "Success"},                   //
+    {BaseCommand::ERROR, "Error"},                       //
+    {BaseCommand::CLOSE_PRODUCER, "CloseProducer"},      //
+    {BaseCommand::CLOSE_CONSUMER, "CloseConsumer"},      //
+    {BaseCommand::PRODUCER_SUCCESS, "ProducerSuccess"},  //
+    {BaseCommand::PING, "Ping"},                         //
+    {BaseCommand::PONG, "Pong"},                         //
 };
 
-static const value_string server_errors_vs[] = { { UnknownError, "UnknownError" },  //
-        { MetadataError, "MetadataError" },  //
-        { PersistenceError, "PersistenceError" },  //
-        { AuthenticationError, "AuthenticationError" },  //
-        { AuthorizationError, "AuthorizationError" },  //
-        { ConsumerBusy, "ConsumerBusy" },  //
-        { ServiceNotReady, "ServiceNotReady" },  //
-        { ProducerBlockedQuotaExceededError, "ProducerBlockedQuotaExceededError" },  //
-        { ProducerBlockedQuotaExceededException, "ProducerBlockedQuotaExceededException" }  //
+static const value_string auth_methods_vs[] = {
+    {AuthMethodNone, "None"},     //
+    {AuthMethodYcaV1, "YCAv1"},   //
+    {AuthMethodAthens, "Athens"}  //
 };
 
-static const value_string ack_type_vs[] = { { CommandAck::Individual, "Individual" },  //
-        { CommandAck::Cumulative, "Cumulative" }  //
+static const value_string server_errors_vs[] = {
+    {UnknownError, "UnknownError"},                                                   //
+    {MetadataError, "MetadataError"},                                                 //
+    {PersistenceError, "PersistenceError"},                                           //
+    {AuthenticationError, "AuthenticationError"},                                     //
+    {AuthorizationError, "AuthorizationError"},                                       //
+    {ConsumerBusy, "ConsumerBusy"},                                                   //
+    {ServiceNotReady, "ServiceNotReady"},                                             //
+    {ProducerBlockedQuotaExceededError, "ProducerBlockedQuotaExceededError"},         //
+    {ProducerBlockedQuotaExceededException, "ProducerBlockedQuotaExceededException"}  //
 };
 
-static const value_string protocol_version_vs[] = { { v0, "v0" },  //
-        { v1, "v1" }  //
+static const value_string ack_type_vs[] = {
+    {CommandAck::Individual, "Individual"},  //
+    {CommandAck::Cumulative, "Cumulative"}   //
 };
 
-static const value_string sub_type_names_vs[] = {  //
-        { CommandSubscribe::Exclusive, "Exclusive" },  //
-                { CommandSubscribe::Shared, "Shared" },  //
-                { CommandSubscribe::Failover, "Failover" }  //
-        };
+static const value_string protocol_version_vs[] = {
+    {v0, "v0"},  //
+    {v1, "v1"}   //
+};
+
+static const value_string sub_type_names_vs[] = {
+    //
+    {CommandSubscribe::Exclusive, "Exclusive"},  //
+    {CommandSubscribe::Shared, "Shared"},        //
+    {CommandSubscribe::Failover, "Failover"}     //
+};
 
 static const char* to_str(int value, const value_string* values) {
     return val_to_str(value, values, "Unknown (%d)");
@@ -152,10 +158,7 @@ struct RequestData {
     uint32_t ackFrame;
     nstime_t ackTimestamp;
 
-    RequestData()
-            : requestFrame(UINT32_MAX),
-              ackFrame(UINT32_MAX) {
-    }
+    RequestData() : requestFrame(UINT32_MAX), ackFrame(UINT32_MAX) {}
 };
 
 struct RequestResponseData : public RequestData {
@@ -185,10 +188,9 @@ struct ConnectionState {
     std::map<uint64_t, RequestResponseData> requests;
 };
 
-static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t *tvb, int offset,
-                                     int maxOffset) {
+static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t* tvb, int offset, int maxOffset) {
     // Decode message metadata
-    uint32_t metadataSize = (uint32_t) tvb_get_ntohl(tvb, offset);
+    uint32_t metadataSize = (uint32_t)tvb_get_ntohl(tvb, offset);
     offset += 4;
 
     if (offset + metadataSize > maxOffset) {
@@ -198,7 +200,7 @@ static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t *tvb, int 
     }
 
     static MessageMetadata msgMetadata;
-    uint8_t* ptr = (uint8_t*) tvb_get_ptr(tvb, offset, metadataSize);
+    uint8_t* ptr = (uint8_t*)tvb_get_ptr(tvb, offset, metadataSize);
 
     if (!msgMetadata.ParseFromArray(ptr, metadataSize)) {
         proto_tree_add_boolean_format(frame_tree, hf_pulsar_error, tvb, offset, metadataSize, true,
@@ -206,12 +208,9 @@ static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t *tvb, int 
         return;
     }
 
-    proto_item* md_tree = proto_tree_add_subtree_format(frame_tree, tvb, offset, metadataSize,
-                                                        ett_pulsar,
-                                                        NULL,
-                                                        "Message / %s / %llu",
-                                                        msgMetadata.producer_name().c_str(),
-                                                        msgMetadata.sequence_id());
+    proto_item* md_tree = proto_tree_add_subtree_format(
+        frame_tree, tvb, offset, metadataSize, ett_pulsar, NULL, "Message / %s / %llu",
+        msgMetadata.producer_name().c_str(), msgMetadata.sequence_id());
     proto_tree_add_string(md_tree, hf_pulsar_producer_name, tvb, offset, metadataSize,
                           msgMetadata.producer_name().c_str());
     proto_tree_add_uint64(md_tree, hf_pulsar_sequence_id, tvb, offset, metadataSize,
@@ -224,27 +223,21 @@ static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t *tvb, int 
     }
 
     if (msgMetadata.properties_size() > 0) {
-        proto_item* properties_tree = proto_tree_add_subtree_format(frame_tree, tvb, offset,
-                                                                    metadataSize, ett_pulsar,
-                                                                    NULL,
-                                                                    "Properties");
+        proto_item* properties_tree = proto_tree_add_subtree_format(frame_tree, tvb, offset, metadataSize,
+                                                                    ett_pulsar, NULL, "Properties");
         for (int i = 0; i < msgMetadata.properties_size(); i++) {
             const KeyValue& kv = msgMetadata.properties(i);
-            proto_tree_add_string_format(properties_tree, hf_pulsar_property, tvb, offset,
-                                         metadataSize, "", "%s : %s", kv.key().c_str(),
-                                         kv.value().c_str());
+            proto_tree_add_string_format(properties_tree, hf_pulsar_property, tvb, offset, metadataSize, "",
+                                         "%s : %s", kv.key().c_str(), kv.value().c_str());
         }
     }
 
     if (msgMetadata.replicate_to_size() > 0) {
-        proto_item* replicate_tree = proto_tree_add_subtree_format(frame_tree, tvb, offset,
-                                                                   metadataSize, ett_pulsar,
-                                                                   NULL,
-                                                                   "Replicate to");
+        proto_item* replicate_tree = proto_tree_add_subtree_format(frame_tree, tvb, offset, metadataSize,
+                                                                   ett_pulsar, NULL, "Replicate to");
         for (int i = 0; i < msgMetadata.replicate_to_size(); i++) {
-            proto_tree_add_string_format(replicate_tree, hf_pulsar_replicated_from, tvb, offset,
-                                         metadataSize, "", "%s",
-                                         msgMetadata.replicate_to(i).c_str());
+            proto_tree_add_string_format(replicate_tree, hf_pulsar_replicated_from, tvb, offset, metadataSize,
+                                         "", "%s", msgMetadata.replicate_to(i).c_str());
         }
     }
 
@@ -255,15 +248,15 @@ static void dissect_message_metadata(proto_tree* frame_tree, tvbuff_t *tvb, int 
 
     offset += metadataSize;
     uint32_t payloadSize = maxOffset - offset;
-    proto_tree_add_subtree_format(md_tree, tvb, offset, payloadSize, ett_pulsar, NULL,
-                                  "Payload / size=%u", payloadSize);
+    proto_tree_add_subtree_format(md_tree, tvb, offset, payloadSize, ett_pulsar, NULL, "Payload / size=%u",
+                                  payloadSize);
 }
 
 void link_to_request_frame(proto_tree* cmd_tree, tvbuff_t* tvb, int offset, int size,
                            const RequestData& reqData) {
     if (reqData.requestFrame != UINT32_MAX) {
-        proto_tree* item = proto_tree_add_uint(cmd_tree, hf_pulsar_request_in, tvb, offset, size,
-                                               reqData.requestFrame);
+        proto_tree* item =
+            proto_tree_add_uint(cmd_tree, hf_pulsar_request_in, tvb, offset, size, reqData.requestFrame);
         PROTO_ITEM_SET_GENERATED(item);
 
         nstime_t latency;
@@ -276,8 +269,8 @@ void link_to_request_frame(proto_tree* cmd_tree, tvbuff_t* tvb, int offset, int 
 void link_to_response_frame(proto_tree* cmd_tree, tvbuff_t* tvb, int offset, int size,
                             const RequestData& reqData) {
     if (reqData.ackFrame != UINT32_MAX) {
-        proto_tree* item = proto_tree_add_uint(cmd_tree, hf_pulsar_response_in, tvb, offset, size,
-                                               reqData.ackFrame);
+        proto_tree* item =
+            proto_tree_add_uint(cmd_tree, hf_pulsar_response_in, tvb, offset, size, reqData.ackFrame);
         PROTO_ITEM_SET_GENERATED(item);
 
         nstime_t latency;
@@ -290,13 +283,11 @@ void link_to_response_frame(proto_tree* cmd_tree, tvbuff_t* tvb, int offset, int
 //////////
 
 /* This method dissects fully reassembled messages */
-static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree* tree,
-                               void* data _U_) {
+static int dissect_pulsar_message(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data _U_) {
     col_set_str(pinfo->cinfo, COL_PROTOCOL, "yahoo-Pulsar");
 
     conversation_t* conversation = find_or_create_conversation(pinfo);
-    ConnectionState* state = (ConnectionState*) conversation_get_proto_data(conversation,
-                                                                            proto_pulsar);
+    ConnectionState* state = (ConnectionState*)conversation_get_proto_data(conversation, proto_pulsar);
     if (state == NULL) {
         state = new ConnectionState();
         conversation_add_proto_data(conversation, proto_pulsar, state);
@@ -305,7 +296,7 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
     uint32_t offset = FRAME_SIZE_LEN;
     int maxOffset = tvb_captured_length(tvb);
 
-    uint32_t cmdSize = (uint32_t) tvb_get_ntohl(tvb, offset);
+    uint32_t cmdSize = (uint32_t)tvb_get_ntohl(tvb, offset);
     offset += 4;
 
     if (offset + cmdSize > maxOffset) {
@@ -314,7 +305,7 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
         return maxOffset;
     }
 
-    uint8_t* ptr = (uint8_t*) tvb_get_ptr(tvb, offset, cmdSize);
+    uint8_t* ptr = (uint8_t*)tvb_get_ptr(tvb, offset, cmdSize);
     if (!command.ParseFromArray(ptr, cmdSize)) {
         proto_tree_add_boolean_format(tree, hf_pulsar_error, tvb, offset, cmdSize, true,
                                       "Error parsing protocol buffer command");
@@ -324,19 +315,16 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
     int cmdOffset = offset;
     offset += cmdSize;
 
-    col_add_str(pinfo->cinfo, COL_INFO,
-                val_to_str_const(command.type(), pulsar_cmd_names, "Unknown (%d)"));
+    col_add_str(pinfo->cinfo, COL_INFO, val_to_str_const(command.type(), pulsar_cmd_names, "Unknown (%d)"));
 
     proto_item* frame_tree = NULL;
     proto_item* cmd_tree = NULL;
     if (tree) { /* we are being asked for details */
-        proto_item *ti = proto_tree_add_item(tree, proto_pulsar, tvb, 0, -1, ENC_NA);
+        proto_item* ti = proto_tree_add_item(tree, proto_pulsar, tvb, 0, -1, ENC_NA);
         frame_tree = proto_item_add_subtree(ti, ett_pulsar);
         proto_tree_add_item(frame_tree, hf_pulsar_frame_size, tvb, 0, 4, ENC_BIG_ENDIAN);
         proto_tree_add_item(frame_tree, hf_pulsar_cmd_size, tvb, 4, 4, ENC_BIG_ENDIAN);
-        cmd_tree = proto_tree_add_subtree_format(frame_tree, tvb, 8, cmdSize, ett_pulsar,
-        NULL,
-                                                 "Command %s",
+        cmd_tree = proto_tree_add_subtree_format(frame_tree, tvb, 8, cmdSize, ett_pulsar, NULL, "Command %s",
                                                  to_str(command.type(), pulsar_cmd_names));
         proto_tree_add_string(cmd_tree, hf_pulsar_cmd_type, tvb, 8, cmdSize,
                               to_str(command.type(), pulsar_cmd_names));
@@ -385,9 +373,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
             consumerData.subType = subscribe.subtype();
 
             col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %s / %s / %s",
-                            to_str(subscribe.subtype(), sub_type_names_vs),
-                            subscribe.topic().c_str(), subscribe.subscription().c_str(),
-                            subscribe.consumer_name().c_str());
+                            to_str(subscribe.subtype(), sub_type_names_vs), subscribe.topic().c_str(),
+                            subscribe.subscription().c_str(), subscribe.consumer_name().c_str());
 
             if (tree) {
                 proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -401,13 +388,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_request_id, tvb, cmdOffset, cmdSize,
                                       subscribe.request_id());
                 proto_tree_add_string(
-                        cmd_tree,
-                        hf_pulsar_consumer_name,
-                        tvb,
-                        cmdOffset,
-                        cmdSize,
-                        subscribe.has_consumer_name() ?
-                                subscribe.consumer_name().c_str() : "<none>");
+                    cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset, cmdSize,
+                    subscribe.has_consumer_name() ? subscribe.consumer_name().c_str() : "<none>");
             }
             break;
         }
@@ -431,8 +413,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_request_id, tvb, cmdOffset, cmdSize,
                                       producer.request_id());
                 proto_tree_add_string(
-                        cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
-                        producer.has_producer_name() ? producer.producer_name().c_str() : "<none>");
+                    cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
+                    producer.has_producer_name() ? producer.producer_name().c_str() : "<none>");
 
                 link_to_response_frame(cmd_tree, tvb, cmdOffset, cmdSize, reqData);
             }
@@ -447,8 +429,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 
             ProducerData& producerData = state->producers[send.producer_id()];
 
-            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu",
-                            producerData.producerName.c_str(), send.sequence_id());
+            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu", producerData.producerName.c_str(),
+                            send.sequence_id());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_producer_id, tvb, cmdOffset, cmdSize,
@@ -459,8 +441,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 // Decode message metadata
                 dissect_message_metadata(cmd_tree, tvb, offset, maxOffset);
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset,
-                                             cmdSize, producerData.producerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
+                                             producerData.producerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -474,15 +456,15 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
         }
         case BaseCommand::SEND_RECEIPT: {
             const CommandSendReceipt& send_receipt = command.send_receipt();
-            RequestData & data = state->producers[send_receipt.producer_id()].messages[send_receipt
-                    .sequence_id()];
+            RequestData& data =
+                state->producers[send_receipt.producer_id()].messages[send_receipt.sequence_id()];
             data.ackFrame = pinfo->fd->num;
             data.ackTimestamp.secs = pinfo->fd->abs_ts.secs;
             data.ackTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
 
             ProducerData& producerData = state->producers[send_receipt.producer_id()];
-            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu",
-                            producerData.producerName.c_str(), send_receipt.sequence_id());
+            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu", producerData.producerName.c_str(),
+                            send_receipt.sequence_id());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_producer_id, tvb, cmdOffset, cmdSize,
@@ -491,13 +473,13 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                                       send_receipt.sequence_id());
                 if (send_receipt.has_message_id()) {
                     const MessageIdData& messageId = send_receipt.message_id();
-                    proto_tree_add_string_format(cmd_tree, hf_pulsar_message_id, tvb, cmdOffset,
-                                                 cmdSize, "", "Message Id: %llu:%llu",
-                                                 messageId.ledgerid(), messageId.entryid());
+                    proto_tree_add_string_format(cmd_tree, hf_pulsar_message_id, tvb, cmdOffset, cmdSize, "",
+                                                 "Message Id: %llu:%llu", messageId.ledgerid(),
+                                                 messageId.entryid());
                 }
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset,
-                                             cmdSize, producerData.producerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
+                                             producerData.producerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -510,19 +492,19 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
         }
         case BaseCommand::SEND_ERROR: {
             const CommandSendError& send_error = command.send_error();
-            RequestData & reqData = state->producers[send_error.producer_id()].messages[send_error
-                    .sequence_id()];
+            RequestData& reqData =
+                state->producers[send_error.producer_id()].messages[send_error.sequence_id()];
             reqData.ackFrame = pinfo->fd->num;
             reqData.ackTimestamp.secs = pinfo->fd->abs_ts.secs;
             reqData.ackTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
 
             ProducerData& producerData = state->producers[send_error.producer_id()];
-            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu",
-                            producerData.producerName.c_str(), send_error.sequence_id());
+            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu", producerData.producerName.c_str(),
+                            send_error.sequence_id());
 
             if (tree) {
-                proto_tree_add_boolean_format(frame_tree, hf_pulsar_error, tvb, cmdOffset, cmdSize,
-                                              true, "Error in sending operation");
+                proto_tree_add_boolean_format(frame_tree, hf_pulsar_error, tvb, cmdOffset, cmdSize, true,
+                                              "Error in sending operation");
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_producer_id, tvb, cmdOffset, cmdSize,
                                       send_error.producer_id());
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_sequence_id, tvb, cmdOffset, cmdSize,
@@ -531,8 +513,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_server_error, tvb, cmdOffset, cmdSize,
                                              to_str(send_error.error(), server_errors_vs));
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset,
-                                             cmdSize, producerData.producerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
+                                             producerData.producerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -546,17 +528,15 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
         }
         case BaseCommand::MESSAGE: {
             const CommandMessage& message = command.message();
-            RequestData& data =
-                    state->consumers[message.consumer_id()].messages[message.message_id()];
+            RequestData& data = state->consumers[message.consumer_id()].messages[message.message_id()];
             data.requestFrame = pinfo->fd->num;
             data.requestTimestamp.secs = pinfo->fd->abs_ts.secs;
             data.requestTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
 
             const ConsumerData& consumerData = state->consumers[message.consumer_id()];
 
-            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu:%llu",
-                            consumerData.consumerName.c_str(), message.message_id().ledgerid(),
-                            message.message_id().entryid());
+            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu:%llu", consumerData.consumerName.c_str(),
+                            message.message_id().ledgerid(), message.message_id().entryid());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_consumer_id, tvb, cmdOffset, cmdSize,
@@ -564,8 +544,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 
                 dissect_message_metadata(cmd_tree, tvb, offset, maxOffset);
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset,
-                                             cmdSize, consumerData.consumerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset, cmdSize,
+                                             consumerData.consumerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -586,9 +566,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 
             const ConsumerData& consumerData = state->consumers[ack.consumer_id()];
 
-            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu:%llu",
-                            consumerData.consumerName.c_str(), ack.message_id().ledgerid(),
-                            ack.message_id().entryid());
+            col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %llu:%llu", consumerData.consumerName.c_str(),
+                            ack.message_id().ledgerid(), ack.message_id().entryid());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_consumer_id, tvb, cmdOffset, cmdSize,
@@ -596,8 +575,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 proto_tree_add_string(cmd_tree, hf_pulsar_ack_type, tvb, cmdOffset, cmdSize,
                                       to_str(ack.ack_type(), ack_type_vs));
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset,
-                                             cmdSize, consumerData.consumerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset, cmdSize,
+                                             consumerData.consumerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -622,8 +601,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 proto_tree_add_uint(cmd_tree, hf_pulsar_message_permits, tvb, cmdOffset, cmdSize,
                                     flow.messagepermits());
 
-                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset,
-                                             cmdSize, consumerData.consumerName.c_str());
+                item = proto_tree_add_string(cmd_tree, hf_pulsar_consumer_name, tvb, cmdOffset, cmdSize,
+                                             consumerData.consumerName.c_str());
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -642,9 +621,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
             ConsumerData& consumerData = state->consumers[unsubscribe.consumer_id()];
 
             col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %s / %s / %s",
-                            to_str(consumerData.subType, sub_type_names_vs),
-                            consumerData.topic.c_str(), consumerData.subscriptionName.c_str(),
-                            consumerData.consumerName.c_str());
+                            to_str(consumerData.subType, sub_type_names_vs), consumerData.topic.c_str(),
+                            consumerData.subscriptionName.c_str(), consumerData.consumerName.c_str());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_consumer_id, tvb, cmdOffset, cmdSize,
@@ -672,7 +650,7 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 
         case BaseCommand::SUCCESS: {
             const CommandSuccess& success = command.success();
-            RequestResponseData & reqData = state->requests[success.request_id()];
+            RequestResponseData& reqData = state->requests[success.request_id()];
             reqData.ackFrame = pinfo->fd->num;
             reqData.ackTimestamp.secs = pinfo->fd->abs_ts.secs;
             reqData.ackTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
@@ -687,14 +665,14 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
         }
         case BaseCommand::ERROR: {
             const CommandError& error = command.error();
-            RequestResponseData & reqData = state->requests[error.request_id()];
+            RequestResponseData& reqData = state->requests[error.request_id()];
             reqData.ackFrame = pinfo->fd->num;
             reqData.ackTimestamp.secs = pinfo->fd->abs_ts.secs;
             reqData.ackTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
 
             if (tree) {
-                proto_tree_add_boolean_format(frame_tree, hf_pulsar_error, tvb, cmdOffset, cmdSize,
-                                              true, "Request failed");
+                proto_tree_add_boolean_format(frame_tree, hf_pulsar_error, tvb, cmdOffset, cmdSize, true,
+                                              "Request failed");
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_request_id, tvb, cmdOffset, cmdSize,
                                       error.request_id());
                 proto_tree_add_string(cmd_tree, hf_pulsar_server_error, tvb, cmdOffset, cmdSize,
@@ -745,9 +723,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
             ConsumerData& consumerData = state->consumers[close_consumer.consumer_id()];
 
             col_append_fstr(pinfo->cinfo, COL_INFO, " / %s / %s / %s / %s",
-                            to_str(consumerData.subType, sub_type_names_vs),
-                            consumerData.topic.c_str(), consumerData.subscriptionName.c_str(),
-                            consumerData.consumerName.c_str());
+                            to_str(consumerData.subType, sub_type_names_vs), consumerData.topic.c_str(),
+                            consumerData.subscriptionName.c_str(), consumerData.consumerName.c_str());
 
             if (tree) {
                 proto_tree_add_uint64(cmd_tree, hf_pulsar_consumer_id, tvb, cmdOffset, cmdSize,
@@ -775,7 +752,7 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 
         case BaseCommand::PRODUCER_SUCCESS: {
             const CommandProducerSuccess& success = command.producer_success();
-            RequestResponseData & reqData = state->requests[success.request_id()];
+            RequestResponseData& reqData = state->requests[success.request_id()];
             reqData.ackFrame = pinfo->fd->num;
             reqData.ackTimestamp.secs = pinfo->fd->abs_ts.secs;
             reqData.ackTimestamp.nsecs = pinfo->fd->abs_ts.nsecs;
@@ -789,8 +766,8 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
                 proto_tree_add_string(cmd_tree, hf_pulsar_producer_name, tvb, cmdOffset, cmdSize,
                                       success.producer_name().c_str());
 
-                proto_tree* item = proto_tree_add_uint64(cmd_tree, hf_pulsar_producer_id, tvb,
-                                                         cmdOffset, cmdSize, producerId);
+                proto_tree* item = proto_tree_add_uint64(cmd_tree, hf_pulsar_producer_id, tvb, cmdOffset,
+                                                         cmdSize, producerId);
                 PROTO_ITEM_SET_GENERATED(item);
 
                 item = proto_tree_add_string(cmd_tree, hf_pulsar_topic, tvb, cmdOffset, cmdSize,
@@ -811,112 +788,89 @@ static int dissect_pulsar_message(tvbuff_t *tvb, packet_info* pinfo, proto_tree*
 }
 
 /* determine PDU length of protocol Pulsar */
-static uint32_t get_pulsar_message_len(packet_info *pinfo _U_, tvbuff_t *tvb, int offset,
-                                    void *data _U_) {
-    uint32_t len = (uint32_t) tvb_get_ntohl(tvb, offset);
+static uint32_t get_pulsar_message_len(packet_info* pinfo _U_, tvbuff_t* tvb, int offset, void* data _U_) {
+    uint32_t len = (uint32_t)tvb_get_ntohl(tvb, offset);
     return FRAME_SIZE_LEN + len;
 }
 
-static int dissect_pulsar(tvbuff_t *tvb, packet_info* pinfo, proto_tree* tree, void* data _U_) {
+static int dissect_pulsar(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data _U_) {
     tcp_dissect_pdus(tvb, pinfo, tree, 1, FRAME_SIZE_LEN, get_pulsar_message_len, dissect_pulsar_message,
                      data);
     return tvb_captured_length(tvb);
 }
 
-static hf_register_info hf[] = {  //
-        { &hf_pulsar_error, { "Error", "yahoo.pulsar.error", FT_BOOLEAN, BASE_DEC,
-        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_error_message, { "Message", "yahoo.pulsar.error_message", FT_STRING, 0,
-                NULL, 0x0,
-                NULL, HFILL } },  //
-                { &hf_pulsar_cmd_type, { "Command Type", "yahoo.pulsar.cmd.type", FT_STRING, 0,
-                NULL, 0x0,
-                NULL, HFILL } },  //
-                { &hf_pulsar_frame_size, { "Frame size", "yahoo.pulsar.frame_size", FT_UINT32, BASE_DEC,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_cmd_size, { "Command size", "yahoo.pulsar.cmd_size", FT_UINT32, BASE_DEC,
-                NULL, 0x0,
-                NULL, HFILL } },  //
+static hf_register_info hf[] = {
+    //
+    {&hf_pulsar_error, {"Error", "yahoo.pulsar.error", FT_BOOLEAN, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_error_message,
+     {"Message", "yahoo.pulsar.error_message", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_cmd_type,
+     {"Command Type", "yahoo.pulsar.cmd.type", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_frame_size,
+     {"Frame size", "yahoo.pulsar.frame_size", FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_cmd_size,
+     {"Command size", "yahoo.pulsar.cmd_size", FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_client_version, { "Client version", "yahoo.pulsar.client_version", FT_STRING,
-                        0,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_auth_method, { "Auth method", "yahoo.pulsar.auth_method", FT_STRING, 0, NULL,
-                        0x0,
-                        NULL, HFILL } },  //
-                { &hf_pulsar_auth_data, { "Auth data", "yahoo.pulsar.auth_data", FT_STRING, 0,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_protocol_version, { "Protocol version", "yahoo.pulsar.protocol_version",
-                        FT_STRING, 0,
-                        NULL, 0x0, NULL, HFILL } },
+    {&hf_pulsar_client_version,
+     {"Client version", "yahoo.pulsar.client_version", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_auth_method,
+     {"Auth method", "yahoo.pulsar.auth_method", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},                    //
+    {&hf_pulsar_auth_data, {"Auth data", "yahoo.pulsar.auth_data", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_protocol_version,
+     {"Protocol version", "yahoo.pulsar.protocol_version", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},
 
-                { &hf_pulsar_server_version, { "Server version", "yahoo.pulsar.server_version", FT_STRING,
-                        0,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_topic, { "Topic", "yahoo.pulsar.topic", FT_STRING, 0, NULL, 0x0,
-                NULL, HFILL } },  //
-                { &hf_pulsar_subscription, { "Subscription", "yahoo.pulsar.subscription", FT_STRING, 0,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_subType, { "Subscription type:", "yahoo.pulsar.sub_type", FT_STRING, 0, NULL,
-                        0x0,
-                        NULL, HFILL } },  //
-                { &hf_pulsar_consumer_id, { "Consumer Id", "yahoo.pulsar.consumer_id", FT_UINT64,
-                        BASE_DEC,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_producer_id, { "Producer Id", "yahoo.pulsar.producer_id", FT_UINT64,
-                        BASE_DEC,
-                        NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_server_version,
+     {"Server version", "yahoo.pulsar.server_version", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_topic, {"Topic", "yahoo.pulsar.topic", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_subscription,
+     {"Subscription", "yahoo.pulsar.subscription", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_subType,
+     {"Subscription type:", "yahoo.pulsar.sub_type", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_consumer_id,
+     {"Consumer Id", "yahoo.pulsar.consumer_id", FT_UINT64, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_producer_id,
+     {"Producer Id", "yahoo.pulsar.producer_id", FT_UINT64, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_server_error, { "Server error", "yahoo.pulsar.server_error", FT_STRING, 0,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_ack_type, { "Ack type", "yahoo.pulsar.ack_type", FT_STRING, 0,
-                NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_server_error,
+     {"Server error", "yahoo.pulsar.server_error", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},               //
+    {&hf_pulsar_ack_type, {"Ack type", "yahoo.pulsar.ack_type", FT_STRING, 0, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_request_id, { "Request Id", "yahoo.pulsar.request_id", FT_UINT64, BASE_DEC,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_consumer_name, { "Consumer Name", "yahoo.pulsar.consumer_name", FT_STRING,
-                        BASE_NONE,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_producer_name, { "Producer Name", "yahoo.pulsar.producer_name", FT_STRING,
-                        BASE_NONE,
-                        NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_request_id,
+     {"Request Id", "yahoo.pulsar.request_id", FT_UINT64, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_consumer_name,
+     {"Consumer Name", "yahoo.pulsar.consumer_name", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_producer_name,
+     {"Producer Name", "yahoo.pulsar.producer_name", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_sequence_id, { "Sequence Id", "yahoo.pulsar.sequence_id", FT_UINT64,
-                        BASE_DEC,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_message_id, { "Message Id", "yahoo.pulsar.message_id", FT_STRING, BASE_NONE,
-                NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_message_permits, { "Message Permits", "yahoo.pulsar.message_permits",
-                        FT_UINT32, BASE_DEC,
-                        NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_sequence_id,
+     {"Sequence Id", "yahoo.pulsar.sequence_id", FT_UINT64, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_message_id,
+     {"Message Id", "yahoo.pulsar.message_id", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_message_permits,
+     {"Message Permits", "yahoo.pulsar.message_permits", FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_publish_time, { "Publish time", "yahoo.pulsar.publish_time", FT_UINT64,
-                        BASE_DEC,
-                        NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_publish_time,
+     {"Publish time", "yahoo.pulsar.publish_time", FT_UINT64, BASE_DEC, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_replicated_from, { "Replicated from", "yahoo.pulsar.replicated_from",
-                        FT_STRING, BASE_NONE,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_partition_key, { "Partition key", "yahoo.pulsar.partition_key", FT_STRING,
-                        BASE_NONE,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_replicate_to, { "Replicate to", "yahoo.pulsar.replicate_to", FT_STRING,
-                        BASE_NONE,
-                        NULL, 0x0, NULL, HFILL } },  //
-                { &hf_pulsar_property, { "Property", "yahoo.pulsar.property", FT_STRING, BASE_NONE,
-                NULL, 0x0, NULL, HFILL } },  //
+    {&hf_pulsar_replicated_from,
+     {"Replicated from", "yahoo.pulsar.replicated_from", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_partition_key,
+     {"Partition key", "yahoo.pulsar.partition_key", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_replicate_to,
+     {"Replicate to", "yahoo.pulsar.replicate_to", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
+    {&hf_pulsar_property,
+     {"Property", "yahoo.pulsar.property", FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL}},  //
 
-                { &hf_pulsar_request_in, { "Request in frame", "yahoo.pulsar.request_in", FT_FRAMENUM,
-                        BASE_NONE,
-                        NULL, 0, "This packet is a response to the packet with this number",
-                        HFILL } },  //
-                { &hf_pulsar_response_in, { "Response in frame", "yahoo.pulsar.response_in", FT_FRAMENUM,
-                        BASE_NONE,
-                        NULL, 0, "This packet will be responded in the packet with this number",
-                        HFILL } },  //
-                { &hf_pulsar_publish_latency, { "Latency", "yahoo.pulsar.publish_latency",
-                        FT_RELATIVE_TIME, BASE_NONE, NULL, 0x0,
-                        "How long time it took to ACK message", HFILL } }, };
+    {&hf_pulsar_request_in,
+     {"Request in frame", "yahoo.pulsar.request_in", FT_FRAMENUM, BASE_NONE, NULL, 0,
+      "This packet is a response to the packet with this number", HFILL}},  //
+    {&hf_pulsar_response_in,
+     {"Response in frame", "yahoo.pulsar.response_in", FT_FRAMENUM, BASE_NONE, NULL, 0,
+      "This packet will be responded in the packet with this number", HFILL}},  //
+    {&hf_pulsar_publish_latency,
+     {"Latency", "yahoo.pulsar.publish_latency", FT_RELATIVE_TIME, BASE_NONE, NULL, 0x0,
+      "How long time it took to ACK message", HFILL}},
+};
 
 ////////////////
 ///
@@ -924,12 +878,12 @@ void proto_register_pulsar() {
     // register the new protocol, protocol fields, and subtrees
 
     proto_pulsar = proto_register_protocol("Pulsar Wire Protocol", /* name       */
-                                        "Yahoo Pulsar", /* short name */
-                                        "yahoo.pulsar" /* abbrev     */
-                                        );
+                                           "Yahoo Pulsar",         /* short name */
+                                           "yahoo.pulsar"          /* abbrev     */
+    );
 
     /* Setup protocol subtree array */
-    static int *ett[] = { &ett_pulsar };
+    static int* ett[] = {&ett_pulsar};
 
     proto_register_field_array(proto_pulsar, hf, array_length(hf));
     proto_register_subtree_array(ett, array_length(ett));
@@ -953,8 +907,5 @@ G_MODULE_EXPORT void plugin_register(void) {
     }
 }
 
-G_MODULE_EXPORT void plugin_reg_handoff(void) {
-    proto_reg_handoff_pulsar();
-}
-
+G_MODULE_EXPORT void plugin_reg_handoff(void) { proto_reg_handoff_pulsar(); }
 }


### PR DESCRIPTION
### Motivation

This is the continuation of https://github.com/apache/incubator-pulsar/pull/1080.
I totally missed Python-C++ client wrapper.

### Modifications

- Add the Python-C++ client wrapper codes into `make format` target
- Apply `make format` into that

### Result

C++ codes are now totally clean!
