### PR TITLE
Show stacktrace when Function fails

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
@@ -154,6 +154,7 @@ public class Reflections {
         try {
             return createInstance(userClassName, loadJar(jar));
         } catch (Exception ex) {
+            ex.printStackTrace();
             return null;
         }
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
@@ -153,9 +153,9 @@ public class Reflections {
     public static Object createInstance(String userClassName, java.io.File jar) {
         try {
             return createInstance(userClassName, loadJar(jar));
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return null;
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION


### Motivation

This is particularly handy when you are submiting your function and your
function fails, due to cases like Persistence.createEntityManagerFactory
can't find a persistent-unit and PersistenceException(RuntimeException)
is thrown.

### Modifications

Add printStackTrace() when createInstance() failed.

### Result
The following is added 
```
java.lang.RuntimeException: User class constructor throws exception
        at org.apache.pulsar.functions.utils.Reflections.createInstance(Reflections.java:113)
        at org.apache.pulsar.functions.utils.Reflections.createInstance(Reflections.java:157)
        at org.apache.pulsar.admin.cli.CmdFunctions$FunctionDetailsCommand.doJavaSubmitChecks(CmdFunctions.java:356)
        at org.apache.pulsar.admin.cli.CmdFunctions$FunctionDetailsCommand.processArguments(CmdFunctions.java:292)
        at org.apache.pulsar.admin.cli.CmdFunctions$BaseCommand.run(CmdFunctions.java:112)
        at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:61)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:167)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:217)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.apache.pulsar.functions.utils.Reflections.createInstance(Reflections.java:105)
        ... 7 more
Caused by: javax.persistence.PersistenceException: No Persistence provider for EntityManager named myunit
        at javax.persistence.Persistence.createEntityManagerFactory(Persistence.java:61)
        at javax.persistence.Persistence.createEntityManagerFactory(Persistence.java:39)
        ... 12 more
```
in addition to the original message
```
java.lang.IllegalArgumentException: The Java util function class MyContextFunction could not be instantiated from jar /myfunctions/pulsar-functions/target/pulsar-functions-LOCAL-SNAPSHOT-shaded.jar
        at org.apache.pulsar.admin.cli.CmdFunctions$FunctionDetailsCommand.doJavaSubmitChecks(CmdFunctions.java:370)
        at org.apache.pulsar.admin.cli.CmdFunctions$FunctionDetailsCommand.processArguments(CmdFunctions.java:292)
        at org.apache.pulsar.admin.cli.CmdFunctions$BaseCommand.run(CmdFunctions.java:112)
        at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:61)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:167)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:217)
```
