### PR TITLE
[website] update client references

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -10,6 +10,44 @@ The Pulsar C++ client has been successfully tested on **MacOS** and **Linux**.
 
 ## Linux
 
+### Install
+
+> Since 2.1.0 release, Pulsar ships pre-built RPM and Debian packages. You can choose download
+> and install those packages instead of building them yourself.
+
+#### RPM
+
+| Link | Crypto files |
+|------|--------------|
+| [client]({{pulsar:rpm:client}}) | [asc]({{pulsar:rpm:client}}.asc), [sha1]({{pulsar:rpm:client}}.sha1), [sha512]({{pulsar:rpm:client}}.sha512) |
+| [client-debuginfo]({{pulsar:rpm:client-debuginfo}}) | [asc]({{pulsar:rpm:client-debuginfo}}.asc), [sha1]({{pulsar:rpm:client-debuginfo}}.sha1), [sha512]({{pulsar:rpm:client-debuginfo}}.sha512) |
+| [client-devel]({{pulsar:rpm:client-devel}}) | [asc]({{pulsar:rpm:client-devel}}.asc), [sha1]({{pulsar:rpm:client-devel}}.sha1), [sha512]({{pulsar:rpm:client-devel}}.sha512) |
+
+To install a RPM package, down the RPM packages and install them using following command:
+
+```bash
+$ rpm -ivh apache-pulsar-client*.rpm
+```
+
+#### DEB
+
+| Link | Crypto files |
+|------|--------------|
+| [client]({{pulsar:deb:client}}) | [asc]({{pulsar:deb:client}}.asc), [sha1]({{pulsar:deb:client}}.sha1), [sha512]({{pulsar:deb:client}}.sha512) |
+| [client-devel]({{pulsar:deb:client-devel}}) | [asc]({{pulsar:deb:client-devel}}.asc), [sha1]({{pulsar:deb:client-devel}}.sha1), [sha512]({{pulsar:deb:client-devel}}.sha512) |
+
+To install a RPM package, down the DEB packages and install them using following command:
+
+```bash
+$ apt-install apache-pulsar-client*.deb
+```
+
+### Build
+
+> If you want to build RPM and Debian packages off latest master, you can follow the instructions
+> below to do so. All the instructions are run at the root directory of your cloned Pulsar
+> repo.
+
 There are recipes that build RPM and Debian packages containing a
 statically linked `libpulsar.so` / `libpulsar.a` with all the required
 dependencies.

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -16,14 +16,25 @@ The Pulsar Go client can be used to create Pulsar [producers](#producers), [cons
 
 Pulsar Go client library is based on the C++ client library. Follow
 the instructions for [C++ library](client-libraries-cpp.md) for installing the binaries
-through RPM, Deb or Homebrew packages.
+through [RPM](client-libraries-cpp.md#rpm), [Deb](client-libraries-cpp.md#deb) or [Homebrew packages](client-libraries-cpp.md#macos).
 
 ### Installing go package
 
 You can install the `pulsar` library locally using `go get`:
 
+> #### NOTE
+> 
+> `go get` doesn't support fetching a specific tag. so it will always pull in pulsar go client
+> from latest master. You need to make sure you have installed the right pulsar cpp client library.
+
 ```bash
 $ go get -u github.com/apache/incubator-pulsar/pulsar-client-go/pulsar
+```
+
+Or you can use [dep](https://github.com/golang/dep) for managing the dependencies.
+
+```bash
+$ dep ensure -add github.com/apache/incubator-pulsar/pulsar-client-go/pulsar@v{{pulsar.version}}
 ```
 
 Once installed locally, you can import it into your project:

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -15,7 +15,7 @@ You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client
 To install the `pulsar-client` library as a pre-built package using the [pip](https://pip.pypa.io/en/stable/) package manager:
 
 ```shell
-$ pip install pulsar-client --upgrade
+$ pip install pulsar-client=={{pulsar:version_number}}
 ```
 
 Installation via PyPi is available for the following Python versions:

--- a/site2/docs/getting-started-clients.md
+++ b/site2/docs/getting-started-clients.md
@@ -38,4 +38,4 @@ There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for
 
 For a tutorial on using the Pulsar C++ clent, see [The Pulsar C++ client](client-libraries-cpp.md).
 
-There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here]({{ site.baseurl }}api/cpp).
+There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](/api/cpp).

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -25,6 +25,15 @@ function binaryReleaseUrl(version) {
   return `http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-${version}/apache-pulsar-${version}-bin.tar.gz`
 }
 
+function rpmReleaseUrl(version, type) {
+  rpmVersion = version.replace('incubating', '1_incubating');
+  return `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}.x86_64.rpm`
+}
+
+function debReleaseUrl(version, type) {
+  return `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-${version}/DEB/apache-pulsar-client${type}.deb`
+}
+
 function doReplace(options) {
   replace(options)
     .then(changes => {
@@ -44,11 +53,16 @@ const versions = getVersions();
 const latestVersion = versions[0];
 
 const from = [
+  /{{pulsar:version_number}}/g,
   /{{pulsar:version}}/g, 
   /pulsar:binary_release_url/g,
   /pulsar:download_page_url/g,
+  /{{pulsar:rpm:client}}/g,
+  /{{pulsar:rpm:client-debuginfo}}/g,
+  /{{pulsar:rpm:client-devel}}/g,
+  /{{pulsar:deb:client}}/g,
+  /{{pulsar:deb:client-devel}}/g,
 ];
-
 
 const options = {
   files: [
@@ -58,9 +72,15 @@ const options = {
   ignore: versions.map(v => `${docsDir}/${v}/**/*`), // TODO add next and assets
   from: from,
   to: [
+    `${latestVersion}`, 
     `${latestVersion}-incubating`, 
     binaryReleaseUrl(`${latestVersion}-incubating`), 
-    downloadPageUrl()
+    downloadPageUrl(),
+    rpmReleaseUrl(`${latestVersion}-incubating`, ""),
+    rpmReleaseUrl(`${latestVersion}-incubating`, "-debuginfo"),
+    rpmReleaseUrl(`${latestVersion}-incubating`, "-devel"),
+    debReleaseUrl(`${latestVersion}-incubating`, ""),
+    debReleaseUrl(`${latestVersion}-incubating`, "-dev"),
   ],
   dry: false
 };
@@ -80,9 +100,15 @@ for (v of versions) {
     ],
     from: from,
     to: [
+      `${v}`, 
       `${v}-incubating`, 
       binaryReleaseUrl(`${v}-incubating`),
-      downloadPageUrl()
+      downloadPageUrl(),
+      rpmReleaseUrl(`${v}-incubating`, ""),
+      rpmReleaseUrl(`${v}-incubating`, "-debuginfo"),
+      rpmReleaseUrl(`${v}-incubating`, "-devel"),
+      debReleaseUrl(`${v}-incubating`, ""),
+      debReleaseUrl(`${v}-incubating`, "-dev"),
     ],
     dry: true
   };


### PR DESCRIPTION
 ### Changes

- add downloads for PRM and DEB packages
- specify version for python client (via `pip install`) and go client (via `dep`)
