### PR TITLE
Add Presto Sql Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,11 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>cassandra-driver-core</artifactId>
         <version>${cassandra.version}</version>
       </dependency>
+      <dependency>
+    	<groupId>org.assertj</groupId>
+    	<artifactId>assertj-core</artifactId>
+    	<version>3.11.1</version>
+	  </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -878,6 +883,12 @@ flexible messaging model and an intuitive client API.</description>
       <artifactId>powermock-module-testng</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+    	<groupId>org.assertj</groupId>
+    	<artifactId>assertj-core</artifactId>
+    	<scope>test</scope>
+	 </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/tests/docker-images/latest-version-image/conf/presto_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/presto_worker.conf
@@ -17,19 +17,10 @@
 # under the License.
 #
 
-FROM apachepulsar/pulsar-all:latest
-
-RUN apt-get update && apt-get install -y supervisor
-
-RUN mkdir -p /var/log/pulsar && mkdir -p /var/run/supervisor/ && mkdir -p /pulsar/ssl
-
-COPY conf/supervisord.conf /etc/supervisord.conf
-COPY conf/global-zk.conf conf/local-zk.conf conf/bookie.conf conf/broker.conf conf/functions_worker.conf \
-     conf/proxy.conf conf/presto_worker.conf /etc/supervisord/conf.d/
-
-COPY ssl/ca.cert.pem ssl/broker.key-pk8.pem ssl/broker.cert.pem \
-     ssl/admin.key-pk8.pem ssl/admin.cert.pem /pulsar/ssl/
-
-COPY scripts/init-cluster.sh scripts/run-global-zk.sh scripts/run-local-zk.sh \
-     scripts/run-bookie.sh scripts/run-broker.sh scripts/run-functions-worker.sh scripts/run-proxy.sh scripts/run-presto-worker.sh \
-     /pulsar/bin/
+[program:presto-worker]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/presto_worker.log
+directory=/pulsar
+environment=PULSAR_MEM=-Xms128M
+command=/pulsar/bin/pulsar sql-worker start

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -77,6 +77,12 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -116,6 +116,7 @@
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
@@ -127,7 +128,7 @@
   	  <artifactId>elasticsearch-rest-high-level-client</artifactId>
   	  <version>6.3.2</version>
   	</dependency>
-  	
+
   </dependencies>
 
   <build>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
@@ -1,0 +1,21 @@
+package org.apache.pulsar.tests.integration.containers;
+
+/**
+ * A pulsar container that runs the presto worker
+ */
+public class PrestoWorkerContainer extends PulsarContainer<PrestoWorkerContainer> {
+
+    public static final String NAME = "presto-worker";
+    public static final int PRESTO_HTTP_PORT = 8081;
+
+    public PrestoWorkerContainer(String clusterName, String hostname) {
+        super(
+                clusterName,
+                hostname,
+                hostname,
+                "bin/run-presto-worker.sh",
+                -1,
+                PRESTO_HTTP_PORT,
+                "/v1/node");
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.tests.integration.containers;
 
 /**

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/Stock.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/Stock.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.presto;
+
+import java.util.Objects;
+
+public class Stock {
+
+    private int entryId;
+    private String symbol;
+    private double sharePrice;
+
+    public Stock(int entryId, String symbol, double sharePrice) {
+        this.entryId = entryId;
+        this.symbol = symbol;
+        this.sharePrice = sharePrice;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Stock stock = (Stock) o;
+        return entryId == stock.entryId &&
+                Double.compare(stock.sharePrice, sharePrice) == 0 &&
+                Objects.equals(symbol, stock.symbol);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol, sharePrice);
+    }
+
+    @Override
+    public String toString() {
+        return "Stock{" +
+                "entryId=" + entryId +
+                ", symbol='" + symbol + '\'' +
+                ", sharePrice=" + sharePrice +
+                '}';
+    }
+
+    public int getEntryId() {
+        return entryId;
+    }
+
+    public void setEntryId(int entryId) {
+        this.entryId = entryId;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public double getSharePrice() {
+        return sharePrice;
+    }
+
+    public void setSharePrice(double sharePrice) {
+        this.sharePrice = sharePrice;
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -1,6 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.tests.integration.presto;
 
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
@@ -16,6 +38,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 public class TestBasicPresto extends PulsarClusterTestBase {
+
+    private static final int NUM_OF_STOCKS = 10;
 
     @BeforeSuite
     @Override
@@ -45,6 +69,43 @@ public class TestBasicPresto extends PulsarClusterTestBase {
         ContainerExecResult containerExecResult = execQuery("show catalogs;");
         assertThat(containerExecResult.getExitCode()).isEqualTo(0);
         assertThat(containerExecResult.getStdout()).contains("pulsar", "system");
+    }
+
+    @Test
+    public void testSimpleSQLQuery() throws Exception {
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder()
+                                    .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
+                                    .build();
+
+        final String stocksTopic = "stocks";
+
+        @Cleanup
+        Producer<Stock> producer = pulsarClient.newProducer(JSONSchema.of(Stock.class))
+                .topic(stocksTopic)
+                .create();
+
+
+        for (int i = 0 ; i < NUM_OF_STOCKS; ++i) {
+            final Stock stock = new Stock(i,"STOCK_" + i , 100.0 + i * 10);
+            producer.send(stock);
+        }
+
+        ContainerExecResult containerExecResult = execQuery("select * from pulsar.\"public/default\".stocks order by entryid;");
+        assertThat(containerExecResult.getExitCode()).isEqualTo(0);
+        log.info("select sql query output \n{}", containerExecResult.getStdout());
+        String[] split = containerExecResult.getStdout().split("\n");
+        assertThat(split.length).isGreaterThan(NUM_OF_STOCKS - 2);
+
+        String[] split2 = containerExecResult.getStdout().split("\n|,");
+
+        for (int i = 0; i < NUM_OF_STOCKS - 2; ++i) {
+            assertThat(split2).contains("\"" + i + "\"");
+            assertThat(split2).contains("\"" + "STOCK_" + i + "\"");
+            assertThat(split2).contains("\"" + (100.0 + i * 10) + "\"");
+        }
+
     }
 
     @AfterSuite

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -1,0 +1,66 @@
+package org.apache.pulsar.tests.integration.presto;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class TestBasicPresto extends PulsarClusterTestBase {
+
+    @BeforeSuite
+    @Override
+    public void setupCluster() throws Exception {
+        final String clusterName = Stream.of(this.getClass().getSimpleName(), randomName(5))
+                .filter(s -> s != null && !s.isEmpty())
+                .collect(joining("-"));
+
+        PulsarClusterSpec spec = PulsarClusterSpec.builder()
+                .numBookies(2)
+                .numBrokers(1)
+                .enablePrestoWorker(true)
+                .clusterName(clusterName)
+                .build();
+
+        log.info("Setting up cluster {} with {} bookies, {} brokers",
+                spec.clusterName(), spec.numBookies(), spec.numBrokers());
+
+        pulsarCluster = PulsarCluster.forSpec(spec);
+        pulsarCluster.start();
+
+        log.info("Cluster {} is setup with presto worker", spec.clusterName());
+    }
+
+    @Test
+    public void testDefaultCatalog() throws Exception {
+        ContainerExecResult containerExecResult = execQuery("show catalogs;");
+        assertThat(containerExecResult.getExitCode()).isEqualTo(0);
+        assertThat(containerExecResult.getStdout()).contains("pulsar", "system");
+    }
+
+    @AfterSuite
+    @Override
+    public void tearDownCluster() {
+        super.tearDownCluster();
+    }
+
+    public static ContainerExecResult execQuery(final String query) throws Exception {
+        ContainerExecResult containerExecResult;
+
+        containerExecResult = pulsarCluster.getPrestoWorkerContainer()
+                .execCmd("/bin/bash", "-c", PulsarCluster.PULSAR_COMMAND_SCRIPT + " sql --execute " + "'" + query + "'");
+
+        return containerExecResult;
+
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
@@ -78,6 +78,15 @@ public class PulsarClusterSpec {
     @Default
     int numFunctionWorkers = 0;
 
+
+    /**
+     * Enable a Preto Worker Node
+     *
+     * @return the flag whether presto worker is eanbled
+     */
+    @Default
+    boolean enablePrestoWorker = false;
+
     /**
      * Returns the function runtime type.
      *


### PR DESCRIPTION
This is basic test for presto sql support in pulsar

We are adding Presto Test Container which can be instantiated to run queries.
Also added are supervisor config and presto worker init scripts, and mapping env variables to presto configs