### PR TITLE
Upgrade kinesis version to fix extract binary in memory

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.12.8</version>
+      <version>0.12.9</version>
     </dependency>
 	<!-- /kinesis dependencies -->
 


### PR DESCRIPTION
### Motivation

Kinesis old version had a major bug to copy native-files into main memory which can cause outofmemory if multiple concurrent kinesis-producers are created at same time. and it has been fixed in `0.12.9`.
aws-kinesis: https://github.com/awslabs/amazon-kinesis-producer/pull/198

Upgrade kinesis version: `0.12.9`
