### PR TITLE
In ZK 3.4.13 the elapsed time is not anymore based on System.currentTimeMillis()

### DIFF
--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/FinalRequestProcessorAspect.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/FinalRequestProcessorAspect.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.zookeeper.ZooDefs.OpCode;
+import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.Request;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -90,7 +91,7 @@ public class FinalRequestProcessorAspect {
         String type = requestTypeMap.getOrDefault(request.type, "unknown");
         requests.labels(type).inc();
 
-        long latencyMs = System.currentTimeMillis() - request.createTime;
+        long latencyMs = Time.currentElapsedTime() - request.createTime;
         String latencyLabel = isWriteRequest(request.type) ? "write" : "read";
         requestsLatency.labels(latencyLabel).observe(latencyMs);
     }


### PR DESCRIPTION
### Motivation

In ZK dashboard, the latency metrics are showing wrong values (eg: 48 years). 

The problem is that we rely on AspectJ to get access to ZK internals and add instrumentation. The "request start" timestamp in ZK 3.4.13 has been changed from using `System.currentTimeMillis()` to `System.nanoTime() / 100000`. 

We need to change the timestamp we use for end operation as well.
