### PR TITLE
[tests] Increase the wait duration for sink topic being created at PulsarWorkerAssignmentTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
@@ -46,8 +45,6 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
@@ -290,7 +287,7 @@ public abstract class MockedPulsarServiceBaseTest {
             if (predicate.test(null) || i == (retryCount - 1)) {
                 break;
             }
-            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
+            Thread.sleep(intSleepTimeInMillis);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -203,7 +203,7 @@ public class PulsarWorkerAssignmentTest {
             } catch (PulsarAdminException e) {
                 return false;
             }
-        }, 5, 150);
+        }, 500, 150);
         // validate 2 instances have been started
         assertEquals(admin.topics().getStats(sinkTopic).subscriptions.size(), 1);
         assertEquals(admin.topics().getStats(sinkTopic).subscriptions.values().iterator().next().consumers.size(), 2);
@@ -221,7 +221,7 @@ public class PulsarWorkerAssignmentTest {
             } catch (PulsarAdminException e) {
                 return false;
             }
-        }, 5, 150);
+        }, 500, 150);
         // validate pulsar sink consumer has started on the topic
         assertEquals(admin.topics().getStats(sinkTopic).subscriptions.values().iterator().next().consumers.size(), 1);
     }
@@ -262,7 +262,7 @@ public class PulsarWorkerAssignmentTest {
             } catch (Exception e) {
                 return false;
             }
-        }, 5, 150);
+        }, 500, 150);
 
         // Validate registered assignments
         Map<String, Assignment> assignments = runtimeManager.getCurrentAssignments().values().iterator().next();
@@ -292,7 +292,7 @@ public class PulsarWorkerAssignmentTest {
             } catch (Exception e) {
                 return false;
             }
-        }, 5, 150);
+        }, 500, 150);
 
         // Validate registered assignments
         assignments = runtimeManager.getCurrentAssignments().values().iterator().next();
@@ -311,7 +311,7 @@ public class PulsarWorkerAssignmentTest {
             } catch (Exception e) {
                 return false;
             }
-        }, 5, 150);
+        }, 500, 150);
 
         // Validate registered assignments
         assignments = runtimeManager2.getCurrentAssignments().values().iterator().next();


### PR DESCRIPTION
*Motivation*

Currently there is a wait strategy for sink topic being created. However the value is a bit small,
so if the jenkins becomes slow, the test will fail.

*Changes*

Increase the retry count which will increase the wait duration.

