### PR TITLE
clear old function failure exception from stats

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -108,9 +108,9 @@ public class RuntimeSpawner implements AutoCloseable {
         return runtime.getFunctionStatus().thenApply(f -> {
            FunctionStatus.Builder builder = FunctionStatus.newBuilder();
            builder.mergeFrom(f).setNumRestarts(numRestarts).setInstanceId(instanceConfig.getInstanceId());
-           if (runtimeDeathException != null) {
-               builder.setFailureException(runtimeDeathException.getMessage());
-           }
+            if (!f.getRunning() && runtimeDeathException != null) {
+                builder.setFailureException(runtimeDeathException.getMessage());
+            }
            return builder.build();
         });
     }


### PR DESCRIPTION
### Motivation

Right now, if function fails first time and then starts and runs successfully then still function-stats shows old exception in stats which confuses user regarding function current state.

### Modifications

Hide old exception if function started successfully.

