### PR TITLE
fix NPE while setting stats

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -104,7 +104,10 @@ class ThreadRuntime implements Runtime {
         if (!isAlive()) {
             FunctionStatus.Builder functionStatusBuilder = FunctionStatus.newBuilder();
             functionStatusBuilder.setRunning(false);
-            functionStatusBuilder.setFailureException(getDeathException().getMessage());
+            Throwable ex = getDeathException();
+            if (ex != null && ex.getMessage() != null) {
+                functionStatusBuilder.setFailureException(ex.getMessage());
+            }
             statsFuture.complete(functionStatusBuilder.build());
             return statsFuture;
         }


### PR DESCRIPTION
### Motivation

It fixes below NPE
```
 java.lang.NullPointerException: null
	at org.apache.pulsar.functions.proto.InstanceCommunication$FunctionStatus$Builder.setFailureException(InstanceCommunication.java:2155) ~[classes/:?]
	at org.apache.pulsar.functions.runtime.ThreadRuntime.getFunctionStatus(ThreadRuntime.java:107) ~[classes/:?]
	at org.apache.pulsar.functions.runtime.RuntimeSpawner.getFunctionStatus(RuntimeSpawner.java:107) ~[classes/:?]
	at org.apache.pulsar.functions.worker.FunctionRuntimeManager.getFunctionInstanceStatus(FunctionRuntimeManager.java:260) ~[classes/:?]
	at org.apache.pulsar.functions.worker.FunctionRuntimeManager.getAllFunctionStatus(FunctionRuntimeManager.java:435) ~[classes/:?]
	at org.apache.pulsar.functions.worker.rest.api.FunctionsImpl.getFunctionStatus(FunctionsImpl.java:490) [classes/:?]
	at org.apache.pulsar.functions.worker.rest.api.v2.FunctionApiV2Resource.getFunctionStatus(FunctionApiV2Resource.java:115) [classes/:?]
```


