### PR TITLE
Gracefully shutdown function worker service

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -23,9 +23,12 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * A starter to start function worker.
  */
+@Slf4j
 public class FunctionWorkerStarter {
 
     private static class WorkerArguments {
@@ -60,6 +63,16 @@ public class FunctionWorkerStarter {
         }
 
         final Worker worker = new Worker(workerConfig);
-        worker.startAsync();
+        try {
+            worker.start();
+        }catch(Exception e){
+            log.error("Failed to start function worker", e);
+            worker.stop();
+            System.exit(-1);
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Stopping function worker service ..");
+            worker.stop();
+        }));
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -34,7 +34,7 @@ import java.net.URI;
 import java.util.HashSet;
 
 @Slf4j
-public class Worker extends AbstractService {
+public class Worker {
 
     private final WorkerConfig workerConfig;
     private final WorkerService workerService;
@@ -45,19 +45,7 @@ public class Worker extends AbstractService {
         this.workerService = new WorkerService(workerConfig);
     }
 
-    @Override
-    protected void doStart() {
-        try {
-            doStartImpl();
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            log.error("Interrupted at starting worker", ie);
-        } catch (Throwable t) {
-            log.error("Failed to start worker", t);
-        }
-    }
-
-    protected void doStartImpl() throws Exception {
+    protected void start() throws Exception {
         URI dlogUri = initialize(this.workerConfig);
 
         workerService.start(dlogUri);
@@ -146,11 +134,15 @@ public class Worker extends AbstractService {
         }
     }
 
-    @Override
-    protected void doStop() {
-        if (null != this.server) {
-            this.server.stop();
+    protected void stop() {
+        try {
+            if (null != this.server) {
+                this.server.stop();
+            }
+            workerService.stop();    
+        }catch(Exception e) {
+            log.warn("Failed to gracefully stop worker service ", e);
         }
-        workerService.stop();
+        
     }
 }


### PR DESCRIPTION
### Motivation

Right now, if broker is down when function service starts, it fails to start worker and keeps the process hanging in a failure state. Also, function-worker doesn't close resource on sigterm or while shutting down.
```

	19:26:56.037 [main] ERROR org.apache.pulsar.functions.worker.Worker - Failed to start worker
java.lang.RuntimeException: java.lang.RuntimeException: org.apache.pulsar.client.api.PulsarClientException$TimeoutException: 0 lookup request timedout after ms 1
	at org.apache.pulsar.functions.worker.WorkerService.start(WorkerService.java:184) ~[classes/:?]
	at org.apache.pulsar.functions.worker.Worker.doStartImpl(Worker.java:64) ~[classes/:?]
	at org.apache.pulsar.functions.worker.Worker.doStart(Worker.java:52) [classes/:?]
	at com.google.common.util.concurrent.AbstractService.startAsync(AbstractService.java:211) [guava-21.0.jar:?]
	at org.apache.pulsar.functions.worker.FunctionWorkerStarter.main(FunctionWorkerStarter.java:64) [classes/:?]
```
### Modifications

- shutdown worker if it fails to start
- gracefully shutdown worker service.

