### PR TITLE
[tests] Issue 2639: NullPointerException at closing consumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -693,6 +693,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
         ClientCnx cnx = cnx();
+        if (null == cnx) {
+            // no connection already
+            closeFuture.complete(null);
+            return closeFuture;
+        }
         cnx.sendRequestWithId(cmd, requestId).handle((v, exception) -> {
             cnx.removeConsumer(consumerId);
             if (exception == null || !cnx.ctx().channel().isActive()) {


### PR DESCRIPTION
*Motivation*

Connection can be null when closing consumer.

*Changes*

Check if the connection is null or not during closing.

