### PR TITLE
Issue #2638: com.fasterxml.jackson.databind.JsonMappingException: Infinite recursion

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -36,6 +36,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
     private String serviceUrl;
+    @JsonIgnore
     private ServiceUrlProvider serviceUrlProvider;
 
     @JsonIgnore


### PR DESCRIPTION


*Motivation*

Fixes #2638.

```
22:58:30.363 [pulsar-client-io-58-1:org.apache.pulsar.client.impl.ProducerStatsRecorderImpl@104] ERROR org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - Failed to dump config info: {}
com.fasterxml.jackson.databind.JsonMappingException: Infinite recursion (StackOverflowError) (through reference chain: org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]->org.apache.pulsar.client.impl.conf.ClientConfigurationData["serviceUrlProvider"]->org.apache.pulsar.client.api.ServiceUrlProviderTest$AutoChangedServiceUrlProvider["pulsarClient"]->org.apache.pulsar.client.impl.PulsarClientImpl["conf"]-
```

The problem is in the TestServiceUrlProvider it includes PulsarClient again, which will cause recursive reference.

*Changes*

Add `@JsonIgnore` to ignore serviceUrlProvider


