### PR TITLE
Fix Bug of ConsumerInterceptor on method onAcknowledge()

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -459,6 +459,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
             } else {
                 // other messages in batch are still pending ack.
+                if (ackType == AckType.Individual) {
+                    onAcknowledge(messageId, null);
+                } else if (ackType == AckType.Cumulative) {
+                    onAcknowledgeCumulative(messageId, null);
+                }
                 return CompletableFuture.completedFuture(null);
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -426,6 +426,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 && !batchMessageId.getAcker().isPrevBatchCumulativelyAcked()) {
                 sendAcknowledge(batchMessageId.prevBatchMessageId(), AckType.Cumulative, properties);
                 batchMessageId.getAcker().setPrevBatchCumulativelyAcked(true);
+            } else {
+                onAcknowledge(batchMessageId, null);
             }
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] cannot ack message to broker {}, acktype {}, pending acks - {}", subscription,
@@ -459,11 +461,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
             } else {
                 // other messages in batch are still pending ack.
-                if (ackType == AckType.Individual) {
-                    onAcknowledge(messageId, null);
-                } else if (ackType == AckType.Cumulative) {
-                    onAcknowledgeCumulative(messageId, null);
-                }
                 return CompletableFuture.completedFuture(null);
             }
         }


### PR DESCRIPTION
### Motivation

To fix bug for issue [issue-2655](https://github.com/apache/pulsar/issues/2655)

### Modifications

Add call interceptor logic in markAckForBatchMessage method.

### Result

Consumer acknowledge the batch message will call onAcknowledge() for every messages in batch message.
