### PR TITLE
Add backlog quota configuration on topic

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -284,6 +284,10 @@ replicatedSubscriptionsSnapshotTimeoutSeconds=30
 # Max number of snapshot to be cached per subscription.
 replicatedSubscriptionsSnapshotMaxCachedPerSubscription=10
 
+# Enable or disable topic level policy, default is disabled
+# WARN: Topic level policy will cause more load on zookeeper, please use it carefully.
+topicLevelPolicyEnable=false
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -188,6 +188,10 @@ maxConsumersPerTopic=0
 # Using a value of 0, is disabling maxConsumersPerSubscription-limit check.
 maxConsumersPerSubscription=0
 
+# Enalbe topic level policy, default is disabled
+# WARN: Topic level policy will cause more load on zookeeper, please use it carefully.
+topicLevelPolicyEnable=false
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -542,6 +542,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Max number of snapshot to be cached per subscription.")
     private int replicatedSubscriptionsSnapshotMaxCachedPerSubscription = 10;
 
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Enable or disable topic level policy, default is disabled.")
+    private boolean topicLevelPolicyEnable = false;
+
     /***** --- TLS --- ****/
     @FieldContext(
         category = CATEGORY_TLS,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -386,7 +386,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected BacklogQuota namespaceBacklogQuota(String namespace, String namespacePath) {
-        return pulsar().getBrokerService().getBacklogQuotaManager().getBacklogQuota(namespace, namespacePath);
+//        return pulsar().getBrokerService().getBacklogQuotaManager().getBacklogQuota(namespace, namespacePath);
     }
 
     protected DispatchRate dispatchRate() {
@@ -410,6 +410,17 @@ public abstract class AdminResource extends PulsarWebResource {
                 pulsar().getConfiguration().getSubscribeThrottlingRatePerConsumer(),
                 pulsar().getConfiguration().getSubscribeRatePeriodPerConsumerInSecond()
         );
+    }
+    protected Policies getTopicPolicies(TopicName topicName) {
+        try {
+            return policiesCache().get(AdminResource.path(POLICIES, topicName.getNamespace(), topicName.getLocalName()))
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Topic policy does not exist"));
+        } catch (RestException re) {
+            throw re;
+        } catch (Exception e) {
+            log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);
+            throw new RestException(e);
+        }
     }
 
     public static ObjectMapper jsonMapper() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -386,7 +386,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected BacklogQuota namespaceBacklogQuota(String namespace, String namespacePath) {
-//        return pulsar().getBrokerService().getBacklogQuotaManager().getBacklogQuota(namespace, namespacePath);
+        return pulsar().getBrokerService().getBacklogQuotaManager().getBacklogQuota(namespace, namespacePath);
     }
 
     protected DispatchRate dispatchRate() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -413,6 +413,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
     protected Policies getTopicPolicies(TopicName topicName) {
         try {
+            checkTopicLevelPolicyEnable();
             return policiesCache().get(AdminResource.path(POLICIES, topicName.getNamespace(), topicName.getLocalName()))
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Topic policy does not exist"));
         } catch (RestException re) {
@@ -420,6 +421,13 @@ public abstract class AdminResource extends PulsarWebResource {
         } catch (Exception e) {
             log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);
             throw new RestException(e);
+        }
+    }
+
+    protected void checkTopicLevelPolicyEnable() {
+        if (!config().isTopicLevelPolicyEnable()) {
+            throw new RestException(Status.METHOD_NOT_ALLOWED,
+                    "Topic level policy is disabled, to enable the topic level policy and retry.");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1423,6 +1423,7 @@ public class PersistentTopicsBase extends AdminResource {
         if (backlogQuotaType == null) {
             backlogQuotaType = BacklogQuotaType.destination_storage;
         }
+        checkTopicLevelPolicyEnable();
         try {
             Stat nodeStat = new Stat();
             String path = path(POLICIES, namespaceName.toString(), topicName.getLocalName());
@@ -1495,6 +1496,7 @@ public class PersistentTopicsBase extends AdminResource {
         if (backlogQuotaType == null) {
             backlogQuotaType = BacklogQuotaType.destination_storage;
         }
+        checkTopicLevelPolicyEnable();
         try {
             Stat nodeStat = new Stat();
             final String path = path(POLICIES, namespaceName.toString(), topicName.getLocalName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1013,7 +1013,8 @@ public class PersistentTopics extends PersistentTopicsBase {
     @Path("/{tenant}/{namespace}/{topic}/backlogQuotaMap")
     @ApiOperation(value = "Get backlog quota map on a topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
-            @ApiResponse(code = 404, message = "Topic policy does not exist") })
+            @ApiResponse(code = 404, message = "Topic policy does not exist"),
+            @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry")})
     public Map<BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(@PathParam("tenant") String tenant,
                                                                   @PathParam("namespace") String namespace,
                                                                   @PathParam("topic") @Encoded String encodedTopic) {
@@ -1028,6 +1029,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
             @ApiResponse(code = 412, message = "Specified backlog quota exceeds retention quota. Increase retention quota and retry request") })
     public void setBacklogQuota(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
                                 @PathParam("topic") @Encoded String encodedTopic,
@@ -1041,6 +1043,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     @ApiOperation(value = "Remove a backlog quota policy from a topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
+            @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
     public void removeBacklogQuota(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
                                    @PathParam("topic") @Encoded String encodedTopic,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -58,6 +58,18 @@ public class BacklogQuotaManager {
         return this.defaultQuota;
     }
 
+    public BacklogQuota getBacklogQuota(String namespace, String policyPath) {
+        try {
+            return zkCache.get(policyPath)
+                    .map(p -> p.backlog_quota_map.getOrDefault(BacklogQuotaType.destination_storage, defaultQuota))
+                    .orElse(defaultQuota);
+        } catch (Exception e) {
+            log.error(String.format("Failed to read policies data, will apply the default backlog quota: namespace=%s",
+                    namespace), e);
+            return this.defaultQuota;
+        }
+    }
+
     public BacklogQuota getBacklogQuota(TopicName topicName) {
         String policyPath = AdminResource.path(POLICIES, topicName.getNamespace(), topicName.getLocalName());
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -939,10 +939,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      */
     public boolean isBacklogExceeded(PersistentTopic topic) {
         TopicName topicName = TopicName.get(topic.getName());
-        long backlogQuotaLimitInBytes = getBacklogQuotaManager().getBacklogQuotaLimit(topicName.getNamespace());
+        long backlogQuotaLimitInBytes = getBacklogQuotaManager().getBacklogQuotaLimit(topicName);
         if (backlogQuotaLimitInBytes < 0) {
             return false;
         }
+
         if (log.isDebugEnabled()) {
             log.debug("[{}] - backlog quota limit = [{}]", topic.getName(), backlogQuotaLimitInBytes);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1628,11 +1628,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public BacklogQuota getBacklogQuota() {
         TopicName topicName = TopicName.get(this.getName());
-        String namespace = topicName.getNamespace();
-        String policyPath = AdminResource.path(POLICIES, namespace);
-
-        BacklogQuota backlogQuota = brokerService.getBacklogQuotaManager().getBacklogQuota(namespace, policyPath);
-        return backlogQuota;
+        return brokerService.getBacklogQuotaManager().getBacklogQuota(topicName);
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -1045,4 +1046,89 @@ public interface Topics {
      * @throws PulsarAdminException
      */
     MessageId getLastMessageId(String topic) throws PulsarAdminException;
+
+    /**
+     * Get backlog quota map on a topic.
+     * <p>
+     * Get backlog quota map on a topic.
+     * <p>
+     * Response example:
+     *
+     * <pre>
+     * <code>
+     *  {
+     *      "namespace_memory" : {
+     *          "limit" : "134217728",
+     *          "policy" : "consumer_backlog_eviction"
+     *      },
+     *      "destination_storage" : {
+     *          "limit" : "-1",
+     *          "policy" : "producer_exception"
+     *      }
+     *  }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Permission denied
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Map<BacklogQuota.BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic) throws PulsarAdminException;
+
+    /**
+     * Set a backlog quota for a topic.
+     * <p>
+     * Set a backlog quota on a topic.
+     * <p>
+     * The backlog quota can be set on this resource:
+     * <p>
+     * Request parameter example:
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "limit" : "134217728",
+     *     "policy" : "consumer_backlog_eviction"
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @param backlogQuota
+     *            the new BacklogQuota
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setBacklogQuota(String topic, BacklogQuota backlogQuota) throws PulsarAdminException;
+
+    /**
+     * Remove a backlog quota policy from a topic.
+     * <p>
+     * Remove a backlog quota policy from a topic.
+     * <p>
+     * The namespace backlog policy will fall back to the default.
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeBacklogQuota(String topic) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -70,6 +70,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
@@ -914,6 +915,41 @@ public class TopicsImpl extends BaseResource implements Topics {
             TopicName tn = validateTopic(topic);
             return request(topicPath(tn, "offload"))
                 .get(OffloadProcessStatus.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public Map<BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuotaMap");
+            return request(path).get(new GenericType<Map<BacklogQuotaType, BacklogQuota>>() {
+            });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void setBacklogQuota(String topic, BacklogQuota backlogQuota) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuota");
+            request(path).post(Entity.entity(backlogQuota, MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void removeBacklogQuota(String topic) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuota");
+            request(path.queryParam("backlogQuotaType", BacklogQuotaType.destination_storage.toString()))
+                    .delete(ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.admin.cli;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.CommaParameterSplitter;
 import com.google.common.collect.Lists;
@@ -32,6 +33,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -45,6 +47,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
@@ -95,6 +98,9 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("offload", new Offload());
         jcommander.addCommand("offload-status", new OffloadStatusCmd());
         jcommander.addCommand("last-message-id", new GetLastMessageId());
+        jcommander.addCommand("get-backlog-quotas", new GetBacklogQuotaMap());
+        jcommander.addCommand("set-backlog-quota", new SetBacklogQuota());
+        jcommander.addCommand("remove-backlog-quota", new RemoveBacklogQuota());
     }
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
@@ -738,8 +744,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
+
     @Parameters(commandDescription = "get the last commit message id of topic")
     private class GetLastMessageId extends CliCommand {
+
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
@@ -747,6 +755,61 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             print(topics.getLastMessageId(persistentTopic));
+        }
+    };
+
+    @Parameters(commandDescription = "Get the backlog quota policies for a topic")
+    private class GetBacklogQuotaMap extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            print(admin.topics().getBacklogQuotaMap(persistentTopic));
+        }
+    }
+
+    @Parameters(commandDescription = "Set a backlog quota policy for a topic")
+    private class SetBacklogQuota extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-l", "--limit" }, description = "Size limit (eg: 10M, 16G)", required = true)
+        private String limitStr;
+
+        @Parameter(names = { "-p", "--policy" }, description = "Retention policy to enforce when the limit is reached. "
+                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]", required = true)
+        private String policyStr;
+
+        @Override
+        void run() throws PulsarAdminException {
+            BacklogQuota.RetentionPolicy policy;
+            long limit;
+
+            try {
+                policy = BacklogQuota.RetentionPolicy.valueOf(policyStr);
+            } catch (IllegalArgumentException e) {
+                throw new ParameterException(String.format("Invalid retention policy type '%s'. Valid options are: %s",
+                        policyStr, Arrays.toString(BacklogQuota.RetentionPolicy.values())));
+            }
+
+            limit = validateSizeString(limitStr);
+
+            String persistentTopic = validatePersistentTopic(params);
+            admin.topics().setBacklogQuota(persistentTopic, new BacklogQuota(limit, policy));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove a backlog quota policy from a topic")
+    private class RemoveBacklogQuota extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            admin.topics().removeBacklogQuota(persistentTopic);
         }
     }
 }


### PR DESCRIPTION
### Motivation

Support set backlog quota on topic level.

### Modifications

Support `get-backlog-quotas` on topic level.
Support `set-backlog-quota` on topic level.
Support `remove-backlog-quota` on topic level.

### Results

If set backlog quota on a topic, backlog policy will use the backlog quota setting on topic， otherwise back to use backlog quota setting on namespace which topic belong to.
