### PR TITLE
Change access to public for method getProducers().

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -237,7 +237,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
     private static final Logger log = LoggerFactory.getLogger(PartitionedProducerImpl.class);
 
-    protected List<ProducerImpl<T>> getProducers() {
+    public List<ProducerImpl<T>> getProducers() {
         return producers.stream().collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Motivation

Need to get stats from producers in PartitionedProducerImpl.

### Modifications

Change access to public for method getProducers().

