### PR TITLE
Avoid problem that topic becomes unavailable due to failure of cursor…

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -348,10 +348,15 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (!ledger.ledgerExists(position.getLedgerId())) {
             Long nextExistingLedger = ledger.getNextValidLedger(position.getLedgerId());
             if (nextExistingLedger == null) {
-                log.info("[{}-{}] Couldn't find next next valid ledger for recovery {}", ledger.getName(), name,
+                log.info("[{}] [{}] Couldn't find next next valid ledger for recovery {}", ledger.getName(), name,
                         position);
             }
             position = nextExistingLedger != null ? PositionImpl.get(nextExistingLedger, -1) : position;
+        }
+        if (position.compareTo(ledger.getLastPosition()) > 0) {
+            log.warn("[{}] [{}] Current position {} is ahead of last position {}", ledger.getName(), name, position,
+                    ledger.getLastPosition());
+            position = PositionImpl.get(ledger.getLastPosition());
         }
         log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, position);
 


### PR DESCRIPTION
… recovery

### Motivation

This is a change to avoid https://github.com/apache/pulsar/issues/2666.

If a topic is under the following condition and the broker is restarted, that topic becomes unavailable and we can not send or receive messages.

- The managed ledger contains two ledgers and the newer ledger is empty
```
ledgerInfo {
  ledgerId: 65425
  entries: 2
  size: 238
  timestamp: 1506510325426
}
ledgerInfo {
  ledgerId: 1952728
  timestamp: 0
}
```
- `cursorsLedgerId` included in the managed cursor info is -1
- `markDeleteLedgerId` is between the two ledgers contained in the managed ledger
```
cursorsLedgerId: -1
markDeleteLedgerId: 1952575
markDeleteEntryId: -1
```

This is because `position` gets ahead of the last position of the managed ledger, and `IllegalArgumentException` occurs in the following line.
https://github.com/apache/pulsar/blob/d5e88c1ec16df557655e42c9f648a2fd3343d759/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L358

### Modifications

If `position` gets ahead of the last position of the managed ledger when recovering the cursor, `position` is adjusted to the last position.

### Result

Even a topic with metadata as described above, the cursor will be recovered successfully.