### PR TITLE
Fix sink-record to get topic name

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -38,6 +38,11 @@ public class SinkRecord<T> implements Record<T> {
     }
 
     @Override
+    public Optional<String> getTopicName() {
+        return sourceRecord.getTopicName();
+    }
+
+    @Override
     public Optional<String> getKey() {
         return sourceRecord.getKey();
     }


### PR DESCRIPTION
### Motivation

Right now, many times Sink requires topic-name to compute partitioned key if the record doesn't have any key setup. But right now, `record.getTopicName()` always returns empty as method is not implemented into SinkRecord.

### Modifications

implement `SinkRecord::getTopicName`