### PR TITLE
Fix: Race condition while initializing PatternMultiTopicsConsumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -54,7 +54,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                           ExecutorService listenerExecutor,
                                           CompletableFuture<Consumer<T>> subscribeFuture,
                                           Schema<T> schema, Mode subscriptionMode, ConsumerInterceptors<T> interceptors) {
-        super(client, conf, listenerExecutor, subscribeFuture, schema, interceptors);
+        super(client, conf, listenerExecutor, subscribeFuture, schema, interceptors, false);
         this.topicsPattern = topicsPattern;
         this.subscriptionMode = subscriptionMode;
 
@@ -65,6 +65,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
 
         this.topicsChangeListener = new PatternTopicsChangedListener();
         recheckPatternTimeout = client.timer().newTimeout(this, Math.min(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.MINUTES);
+        super.init();
     }
 
     public static NamespaceName getNameSpaceFromPattern(Pattern pattern) {


### PR DESCRIPTION
### Motivation

Saw below failure for `PatternTopicsConsumerImplTest::testStartEmptyPatternConsumer` which generally happens when `Parent-MultiTopicsConsumerImpl` completes subscribe-future before `PatternMultiTopicsConsumer` initialize constructor and initialize variables. And if client tries to access any getters before consumer-init then it gives NPE.

```
java.lang.AssertionError: expected [null] but found [persistent://my-property/my-ns/pattern-topic.*]
    at org.testng.Assert.fail(Assert.java:96)
    at org.testng.Assert.failNotSame(Assert.java:772)
    at org.testng.Assert.assertSame(Assert.java:723)
    at org.testng.Assert.assertSame(Assert.java:733)
    at org.apache.pulsar.client.impl.PatternTopicsConsumerImplTest.testStartEmptyPatternConsumer(PatternTopicsConsumerImplTest.java:487)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
    at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
    at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

### Modification
Completes subscribe-future after initializing consumer variables