### PR TITLE
Add types comment in Prometheus stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -24,8 +24,11 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
+import org.eclipse.jetty.util.ConcurrentHashSet;
 
 import io.netty.util.concurrent.FastThreadLocal;
+
+import java.util.Set;
 
 public class NamespaceStatsAggregator {
 
@@ -43,6 +46,8 @@ public class NamespaceStatsAggregator {
         }
     };
 
+    private static Set<String> METRIC_TYPES = new ConcurrentHashSet<>();
+
     public static void generate(PulsarService pulsar, boolean includeTopicMetrics, boolean includeConsumerMetrics, SimpleTextOutputStream stream) {
         String cluster = pulsar.getConfiguration().getClusterName();
         AggregatedNamespaceStats namespaceStats = localNamespaceStats.get();
@@ -50,6 +55,8 @@ public class NamespaceStatsAggregator {
 
         pulsar.getBrokerService().getMultiLayerTopicMap().forEach((namespace, bundlesMap) -> {
             namespaceStats.reset();
+
+            METRIC_TYPES.forEach(metric -> TopicStats.metricType(stream, metric));
 
             bundlesMap.forEach((bundle, topicsMap) -> {
                 topicsMap.forEach((name, topic) -> {
@@ -218,20 +225,35 @@ public class NamespaceStatsAggregator {
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String name,
                                long value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            TopicStats.metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String name,
                                double value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            TopicStats.metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metricWithRemoteCluster(SimpleTextOutputStream stream, String cluster, String namespace,
                                                 String name, String remoteCluster, double value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace);
-        stream.write("\", remote_cluster=\"").write(remoteCluster).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            TopicStats.metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace);
+        stream.write("\",remote_cluster=\"").write(remoteCluster).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -86,12 +86,16 @@ public class PrometheusMetricsGenerator {
         while (metricFamilySamples.hasMoreElements()) {
             MetricFamilySamples metricFamily = metricFamilySamples.nextElement();
 
+            // Write type of metric
+            stream.write("# TYPE ").write(metricFamily.name).write(' ')
+                    .write(getTypeStr(metricFamily.type)).write('\n');
+
             for (int i = 0; i < metricFamily.samples.size(); i++) {
                 Sample sample = metricFamily.samples.get(i);
                 stream.write(sample.name);
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
-                    stream.write(", ");
+                    stream.write(",");
                     stream.write(sample.labelNames.get(j));
                     stream.write("=\"");
                     stream.write(sample.labelValues.get(j));
@@ -104,4 +108,21 @@ public class PrometheusMetricsGenerator {
             }
         }
     }
+
+    static String getTypeStr(Collector.Type type) {
+        switch (type) {
+        case COUNTER:
+            return "counter";
+        case GAUGE:
+            return "gauge";
+        case SUMMARY        :
+            return "summary";
+        case HISTOGRAM:
+            return "histogram";
+        case UNTYPED:
+        default:
+            return "untyped";
+        }
+    }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.broker.stats.prometheus;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.bookkeeper.mledger.util.StatsBuckets;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
-
-import java.util.HashMap;
-import java.util.Map;
+import org.eclipse.jetty.util.ConcurrentHashSet;
 
 class TopicStats {
 
@@ -45,6 +47,7 @@ class TopicStats {
 
     Map<String, AggregatedReplicationStats> replicationStats = new HashMap<>();
     Map<String, AggregatedSubscriptionStats> subscriptionStats = new HashMap<>();
+    private static Set<String> METRIC_TYPES = new ConcurrentHashSet<>();
 
     public void reset() {
         subscriptionsCount = 0;
@@ -68,6 +71,8 @@ class TopicStats {
 
     static void printTopicStats(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
                                 TopicStats stats) {
+
+        METRIC_TYPES.forEach(metric -> metricType(stream, metric));
 
         metric(stream, cluster, namespace, topic, "pulsar_subscriptions_count", stats.subscriptionsCount);
         metric(stream, cluster, namespace, topic, "pulsar_producers_count", stats.producersCount);
@@ -129,40 +134,69 @@ class TopicStats {
 
     }
 
+    static void metricType(SimpleTextOutputStream stream, String name) {
+        stream.write("# TYPE ").write(name).write(" gauge\n");
+    }
+
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
                                String name, double value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace)
-                .write("\", topic=\"").write(topic).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace)
+                .write("\",topic=\"").write(topic).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic, String subscription,
                                String name, long value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace)
-                .write("\", topic=\"").write(topic).write("\", subscription=\"").write(subscription).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace)
+                .write("\",topic=\"").write(topic).write("\",subscription=\"").write(subscription).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic, String subscription,
                                String name, double value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace)
-                .write("\", topic=\"").write(topic).write("\", subscription=\"").write(subscription).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace)
+                .write("\",topic=\"").write(topic).write("\",subscription=\"").write(subscription).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic, String subscription,
                                String consumerName, long consumerId, String name, long value) {
+        if (!METRIC_TYPES.contains(name)) {
+            metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
         stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace)
-                .write("\", topic=\"").write(topic).write("\", subscription=\"").write(subscription)
-                .write("\", consumer_name=\"").write(consumerName).write("\", consumer_id=\"").write(consumerId).write("\"} ");
+                .write("\",topic=\"").write(topic).write("\",subscription=\"").write(subscription)
+                .write("\",consumer_name=\"").write(consumerName).write("\",consumer_id=\"").write(consumerId).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic, String subscription,
                                String consumerName, long consumerId, String name, double value) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\", namespace=\"").write(namespace)
-                .write("\", topic=\"").write(topic).write("\", subscription=\"").write(subscription)
-                .write("\", consumer_name=\"").write(consumerName).write("\", consumer_id=\"").write(consumerId).write("\"} ");
+        if (!METRIC_TYPES.contains(name)) {
+            metricType(stream, name);
+            METRIC_TYPES.add(name);
+        }
+
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace)
+                .write("\",topic=\"").write(topic).write("\",subscription=\"").write(subscription)
+                .write("\",consumer_name=\"").write(consumerName).write("\",consumer_id=\"").write(consumerId).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -150,7 +150,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Splitter.on("\n").split(metrics).forEach(line -> {
-            if (line.isEmpty()) {
+            if (line.isEmpty() || line.startsWith("#")) {
                 return;
             }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
@@ -168,7 +168,7 @@ public class FunctionStatsGeneratorTest {
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Arrays.asList(metrics.split("\n")).forEach(line -> {
-            if (line.isEmpty()) {
+            if (line.isEmpty() || line.startsWith("#")) {
                 return;
             }
             Matcher matcher = pattern.matcher(line);


### PR DESCRIPTION
### Motivation

While metrics types are optional in the Prometheus format (and ignored by Prometheus server), some external tools (eg: DataDog) are failing to ingest the metrics exported by Pulsar broker in Prometheus format. 

The reason is that we use a custom exporter and we don't mark the metrics types, such as the Prometheus regular libraries are doing.

### Modifications

 * Ensure metric type is printed, once, before the metric is printed
 * Removed space after comma in labels. While this is parsed correctly by all implementation, the spec doesn't actually allow a space in that position.
