### PR TITLE
[function] Fix expected health check interval

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeFactory.java
@@ -30,6 +30,8 @@ public interface RuntimeFactory extends AutoCloseable {
      * Create a function container to execute a java instance.
      *
      * @param instanceConfig java instance config
+     * @param codeFile code file
+     * @param expectedHealthCheckInterval expected health check interval in seconds
      * @return function container to start/stop instance
      */
     Runtime createContainer(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -69,7 +69,7 @@ public class RuntimeSpawner implements AutoCloseable {
                 details.getName(), this.instanceConfig.getInstanceId());
 
         runtime = runtimeFactory.createContainer(this.instanceConfig, codeFile,
-                instanceLivenessCheckFreqMs * 1000);
+                instanceLivenessCheckFreqMs / 1000);
         runtime.start();
 
         // monitor function runtime to make sure it is running.  If not, restart the function runtime


### PR DESCRIPTION
*Motivation*

Java instance main is expecting health check interval in seconds.

*Changes

Make sure the health check interval is passed in seconds.

*Tests*

It fixes following issue

```
14:36:29.528 [FunctionActionerThread] INFO  org.apache.pulsar.functions.runtime.ProcessRuntime - Started process successfully
Exception in thread "main" java.lang.IllegalArgumentException
	at java.util.concurrent.ScheduledThreadPoolExecutor.scheduleAtFixedRate(ScheduledThreadPoolExecutor.java:565)
	at java.util.concurrent.Executors$DelegatedScheduledExecutorService.scheduleAtFixedRate(Executors.java:735)
	at org.apache.pulsar.functions.runtime.JavaInstanceMain.start(JavaInstanceMain.java:154)
	at org.apache.pulsar.functions.runtime.JavaInstanceMain.main(JavaInstanceMain.java:185)
```
