### PR TITLE
fix: parent mvn version for presto artifact

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -68,5 +68,12 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>2.10</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -169,5 +169,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh-external</artifactId>
+                <version>2.10</version>
+            </extension>
+        </extensions>
     </build>
 </project>


### PR DESCRIPTION
### Motivation

fixed incorrect parent version for presto artifact which can cause below error while uploading artifacts to maven repo

```
05:00:45 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project pulsar-presto-distribution: Failed to deploy artifacts/metadata: Cannot access scpexe://maven.repo/ with type default using the available connector factories: BasicRepositoryConnectorFactory: Cannot access scpexe://maven.repo/ using the registered transporter factories: WagonTransporterFactory: java.util.NoSuchElementException
05:00:45 [ERROR] role: org.apache.maven.wagon.Wagon
05:00:45 [ERROR] roleHint: scpexe
```