### PR TITLE
Fix: apache-rat validation

### DIFF
--- a/conf/presto/jvm.config
+++ b/conf/presto/jvm.config
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 -server
 -Xmx16G
 -XX:+UseG1GC

--- a/distribution/server/src/assemble/src.xml
+++ b/distribution/server/src/assemble/src.xml
@@ -81,6 +81,7 @@
         <exclude>**/file:/**</exclude>
         <exclude>**/SecurityAuth.audit*</exclude>
         <exclude>**/site/**</exclude>
+        <exclude>**/site2/**</exclude>
         <exclude>**/.idea/**</exclude>
         <exclude>**/*.a</exclude>
         <exclude>**/*.so</exclude>


### PR DESCRIPTION
### Motivation

`mvn apache-rat:check` is failing:

```
2 Unknown Licenses

*******************************

Unapproved licenses:

  site2/README.md
  conf/presto/jvm.config

*******************************
```


