### PR TITLE
Function Serverside Validation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -80,10 +80,11 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                                      final @FormDataParam("data") InputStream uploadedInputStream,
                                      final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                      final @FormDataParam("url") String functionPkgUrl,
-                                     final @FormDataParam("functionDetails") String functionDetailsJson) {
+                                     final @FormDataParam("functionDetails") String functionDetailsJson,
+                                     final @FormDataParam("functionConfig") String functionConfigJson) {
 
         return functions.registerFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, functionConfigJson, clientAppId());
     }
 
     @PUT
@@ -101,10 +102,11 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                                    final @FormDataParam("data") InputStream uploadedInputStream,
                                    final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                    final @FormDataParam("url") String functionPkgUrl,
-                                   final @FormDataParam("functionDetails") String functionDetailsJson) {
+                                   final @FormDataParam("functionDetails") String functionDetailsJson,
+                                   final @FormDataParam("functionConfig") String functionConfigJson) {
 
         return functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, functionConfigJson, clientAppId());
 
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -330,10 +330,8 @@ public class CmdFunctions extends CmdBase {
             if (!StringUtils.isBlank(DEPRECATED_className)) className = DEPRECATED_className;
             if (!StringUtils.isBlank(DEPRECATED_topicsPattern)) topicsPattern = DEPRECATED_topicsPattern;
             if (!StringUtils.isBlank(DEPRECATED_logTopic)) logTopic = DEPRECATED_logTopic;
-            if (!StringUtils.isBlank(DEPRECATED_outputSerdeClassName))
-                outputSerdeClassName = DEPRECATED_outputSerdeClassName;
-            if (!StringUtils.isBlank(DEPRECATED_customSerdeInputString))
-                customSerdeInputString = DEPRECATED_customSerdeInputString;
+            if (!StringUtils.isBlank(DEPRECATED_outputSerdeClassName)) outputSerdeClassName = DEPRECATED_outputSerdeClassName;
+            if (!StringUtils.isBlank(DEPRECATED_customSerdeInputString)) customSerdeInputString = DEPRECATED_customSerdeInputString;
 
             if (!StringUtils.isBlank(DEPRECATED_fnConfigFile)) fnConfigFile = DEPRECATED_fnConfigFile;
             if (DEPRECATED_processingGuarantees != null) processingGuarantees = DEPRECATED_processingGuarantees;
@@ -342,8 +340,7 @@ public class CmdFunctions extends CmdBase {
             if (DEPRECATED_windowLengthCount != null) windowLengthCount = DEPRECATED_windowLengthCount;
             if (DEPRECATED_windowLengthDurationMs != null) windowLengthDurationMs = DEPRECATED_windowLengthDurationMs;
             if (DEPRECATED_slidingIntervalCount != null) slidingIntervalCount = DEPRECATED_slidingIntervalCount;
-            if (DEPRECATED_slidingIntervalDurationMs != null)
-                slidingIntervalDurationMs = DEPRECATED_slidingIntervalDurationMs;
+            if (DEPRECATED_slidingIntervalDurationMs != null) slidingIntervalDurationMs = DEPRECATED_slidingIntervalDurationMs;
             if (DEPRECATED_autoAck != null) autoAck = DEPRECATED_autoAck;
             if (DEPRECATED_timeoutMs != null) timeoutMs = DEPRECATED_timeoutMs;
         }
@@ -380,14 +377,12 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setInputs(inputTopics);
             }
             if (null != customSerdeInputString) {
-                Type type = new TypeToken<Map<String, String>>() {
-                }.getType();
+                Type type = new TypeToken<Map<String, String>>() {}.getType();
                 Map<String, String> customSerdeInputMap = new Gson().fromJson(customSerdeInputString, type);
                 functionConfig.setCustomSerdeInputs(customSerdeInputMap);
             }
             if (null != customSchemaInputString) {
-                Type type = new TypeToken<Map<String, String>>() {
-                }.getType();
+                Type type = new TypeToken<Map<String, String>>() {}.getType();
                 Map<String, String> customschemaInputMap = new Gson().fromJson(customSchemaInputString, type);
                 functionConfig.setCustomSchemaInputs(customschemaInputMap);
             }
@@ -421,8 +416,7 @@ public class CmdFunctions extends CmdBase {
             }
 
             if (null != userConfigString) {
-                Type type = new TypeToken<Map<String, String>>() {
-                }.getType();
+                Type type = new TypeToken<Map<String, String>>() {}.getType();
                 Map<String, Object> userConfigMap = new Gson().fromJson(userConfigString, type);
                 functionConfig.setUserConfig(userConfigMap);
             }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
@@ -435,7 +435,7 @@ public class TestCmdSinks {
         );
     }
 
-    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Connector from .*.pulsar-io-twitter.nar has error: The 'twitter' connector does not provide a sink implementation")
+    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "The 'twitter' connector does not provide a sink implementation")
     public void testInvalidJarWithNoSource() throws Exception {
         SinkConfig sinkConfig = getSinkConfig();
         sinkConfig.setArchive(WRONG_JAR_PATH);
@@ -783,7 +783,7 @@ public class TestCmdSinks {
         testCmdSinkConfigFile(testSinkConfig, expectedSinkConfig);
     }
 
-    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Connector from .*.pulsar-io-twitter.nar has error: The 'twitter' connector does not provide a sink implementation")
+    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "The 'twitter' connector does not provide a sink implementation")
     public void testCmdSinkConfigFileInvalidJarNoSink() throws Exception {
         SinkConfig testSinkConfig = getSinkConfig();
         testSinkConfig.setArchive(WRONG_JAR_PATH);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
@@ -355,7 +355,7 @@ public class TestCmdSources {
         );
     }
 
-    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Connector from .*.pulsar-io-cassandra.nar has error: The 'cassandra' connector does not provide a source implementation")
+    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Failed to extract source class from archive")
     public void testInvalidJarWithNoSource() throws Exception {
         SourceConfig sourceConfig = getSourceConfig();
         sourceConfig.setArchive(WRONG_JAR_PATH);
@@ -650,7 +650,7 @@ public class TestCmdSources {
         testCmdSourceConfigFile(testSourceConfig, expectedSourceConfig);
     }
 
-    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Connector from .*.pulsar-io-cassandra.nar has error: The 'cassandra' connector does not provide a source implementation")
+    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Failed to extract source class from archive")
     public void testCmdSourceConfigFileInvalidJarNoSource() throws Exception {
         SourceConfig testSourceConfig = getSourceConfig();
         testSourceConfig.setArchive(WRONG_JAR_PATH);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -32,6 +32,7 @@ import lombok.ToString;
 import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 
+import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.NotNull;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isFileExists;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isImplementationOfClass;
@@ -98,7 +99,7 @@ public class FunctionConfig {
      */
     private String outputSchemaType;
 
-    @isImplementationOfClass(implementsClass = SerDe.class)
+    @ConfigValidationAnnotations.isValidSerde
     private String outputSerdeClassName;
     @isValidTopicName
     private String logTopic;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -163,7 +163,9 @@ public class FunctionConfigUtils {
         }
 
         Map<String, Object> configs = new HashMap<>();
-        configs.putAll(functionConfig.getUserConfig());
+        if (functionConfig.getUserConfig() != null) {
+            configs.putAll(functionConfig.getUserConfig());
+        }
 
         // windowing related
         WindowConfig windowConfig = functionConfig.getWindowConfig();

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -38,12 +38,7 @@ public class FunctionConfigUtils {
 
         Class<?>[] typeArgs = null;
         if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
-            if (functionConfig.getJar().startsWith(Utils.FILE)) {
-                // server derives the arg-type by loading a class
-                if (isBlank(functionConfig.getClassName())) {
-                    throw new IllegalArgumentException("Class-name must be present for jar with file-url");
-                }
-            } else {
+            if (classLoader != null) {
                 typeArgs = Utils.getFunctionTypes(functionConfig, classLoader);
             }
         }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.utils;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
+
+public class FunctionConfigUtils {
+
+    public static FunctionDetails convert(FunctionConfig functionConfig, ClassLoader classLoader)
+            throws IllegalArgumentException {
+
+        Class<?>[] typeArgs = null;
+        if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
+            if (functionConfig.getJar().startsWith(Utils.FILE)) {
+                // server derives the arg-type by loading a class
+                if (isBlank(functionConfig.getClassName())) {
+                    throw new IllegalArgumentException("Class-name must be present for jar with file-url");
+                }
+            } else {
+                typeArgs = Utils.getFunctionTypes(functionConfig, classLoader);
+            }
+        }
+
+        FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
+
+        // Setup source
+        Function.SourceSpec.Builder sourceSpecBuilder = Function.SourceSpec.newBuilder();
+        if (functionConfig.getInputs() != null) {
+            functionConfig.getInputs().forEach((topicName -> {
+                sourceSpecBuilder.putInputSpecs(topicName,
+                        Function.ConsumerSpec.newBuilder()
+                                .setIsRegexPattern(false)
+                                .build());
+            }));
+        }
+        if (functionConfig.getTopicsPattern() != null && !functionConfig.getTopicsPattern().isEmpty()) {
+            sourceSpecBuilder.putInputSpecs(functionConfig.getTopicsPattern(),
+                    Function.ConsumerSpec.newBuilder()
+                            .setIsRegexPattern(true)
+                            .build());
+        }
+        if (functionConfig.getCustomSerdeInputs() != null) {
+            functionConfig.getCustomSerdeInputs().forEach((topicName, serdeClassName) -> {
+                sourceSpecBuilder.putInputSpecs(topicName,
+                        Function.ConsumerSpec.newBuilder()
+                                .setSerdeClassName(serdeClassName)
+                                .setIsRegexPattern(false)
+                                .build());
+            });
+        }
+        if (functionConfig.getCustomSchemaInputs() != null) {
+            functionConfig.getCustomSchemaInputs().forEach((topicName, schemaType) -> {
+                sourceSpecBuilder.putInputSpecs(topicName,
+                        Function.ConsumerSpec.newBuilder()
+                                .setSchemaType(schemaType)
+                                .setIsRegexPattern(false)
+                                .build());
+            });
+        }
+        if (functionConfig.getInputSpecs() != null) {
+            functionConfig.getInputSpecs().forEach((topicName, consumerConf) -> {
+                Function.ConsumerSpec.Builder bldr = Function.ConsumerSpec.newBuilder()
+                        .setIsRegexPattern(consumerConf.isRegexPattern());
+                if (!StringUtils.isBlank(consumerConf.getSchemaType())) {
+                    bldr.setSchemaType(consumerConf.getSchemaType());
+                } else if (!StringUtils.isBlank(consumerConf.getSerdeClassName())) {
+                    bldr.setSerdeClassName(consumerConf.getSerdeClassName());
+                }
+                sourceSpecBuilder.putInputSpecs(topicName, bldr.build());
+            });
+        }
+
+        // Set subscription type based on ordering and EFFECTIVELY_ONCE semantics
+        Function.SubscriptionType subType = (functionConfig.isRetainOrdering()
+                || FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE.equals(functionConfig.getProcessingGuarantees()))
+                ? Function.SubscriptionType.FAILOVER
+                : Function.SubscriptionType.SHARED;
+        sourceSpecBuilder.setSubscriptionType(subType);
+
+        if (isNotBlank(functionConfig.getSubName())) {
+            sourceSpecBuilder.setSubscriptionName(functionConfig.getSubName());
+        }
+
+        if (typeArgs != null) {
+            sourceSpecBuilder.setTypeClassName(typeArgs[0].getName());
+        }
+        if (functionConfig.getTimeoutMs() != null) {
+            sourceSpecBuilder.setTimeoutMs(functionConfig.getTimeoutMs());
+        }
+        functionDetailsBuilder.setSource(sourceSpecBuilder);
+
+        // Setup sink
+        Function.SinkSpec.Builder sinkSpecBuilder = Function.SinkSpec.newBuilder();
+        if (functionConfig.getOutput() != null) {
+            sinkSpecBuilder.setTopic(functionConfig.getOutput());
+        }
+        if (!StringUtils.isBlank(functionConfig.getOutputSerdeClassName())) {
+            sinkSpecBuilder.setSerDeClassName(functionConfig.getOutputSerdeClassName());
+        }
+        if (!StringUtils.isBlank(functionConfig.getOutputSchemaType())) {
+            sinkSpecBuilder.setSchemaType(functionConfig.getOutputSchemaType());
+        }
+
+        if (typeArgs != null) {
+            sinkSpecBuilder.setTypeClassName(typeArgs[1].getName());
+        }
+        functionDetailsBuilder.setSink(sinkSpecBuilder);
+
+        if (functionConfig.getTenant() != null) {
+            functionDetailsBuilder.setTenant(functionConfig.getTenant());
+        }
+        if (functionConfig.getNamespace() != null) {
+            functionDetailsBuilder.setNamespace(functionConfig.getNamespace());
+        }
+        if (functionConfig.getName() != null) {
+            functionDetailsBuilder.setName(functionConfig.getName());
+        }
+        if (functionConfig.getLogTopic() != null) {
+            functionDetailsBuilder.setLogTopic(functionConfig.getLogTopic());
+        }
+        if (functionConfig.getRuntime() != null) {
+            functionDetailsBuilder.setRuntime(Utils.convertRuntime(functionConfig.getRuntime()));
+        }
+        if (functionConfig.getProcessingGuarantees() != null) {
+            functionDetailsBuilder.setProcessingGuarantees(
+                    Utils.convertProcessingGuarantee(functionConfig.getProcessingGuarantees()));
+        }
+
+        if (functionConfig.getMaxMessageRetries() >= 0) {
+            Function.RetryDetails.Builder retryBuilder = Function.RetryDetails.newBuilder();
+            retryBuilder.setMaxMessageRetries(functionConfig.getMaxMessageRetries());
+            if (isNotEmpty(functionConfig.getDeadLetterTopic())) {
+                retryBuilder.setDeadLetterTopic(functionConfig.getDeadLetterTopic());
+            }
+            functionDetailsBuilder.setRetryDetails(retryBuilder);
+        }
+
+        Map<String, Object> configs = new HashMap<>();
+        configs.putAll(functionConfig.getUserConfig());
+
+        // windowing related
+        WindowConfig windowConfig = functionConfig.getWindowConfig();
+        if (windowConfig != null) {
+            windowConfig.setActualWindowFunctionClassName(functionConfig.getClassName());
+            configs.put(WindowConfig.WINDOW_CONFIG_KEY, windowConfig);
+            // set class name to window function executor
+            functionDetailsBuilder.setClassName("org.apache.pulsar.functions.windowing.WindowFunctionExecutor");
+
+        } else {
+            if (functionConfig.getClassName() != null) {
+                functionDetailsBuilder.setClassName(functionConfig.getClassName());
+            }
+        }
+        if (!configs.isEmpty()) {
+            functionDetailsBuilder.setUserConfig(new Gson().toJson(configs));
+        }
+
+        functionDetailsBuilder.setAutoAck(functionConfig.isAutoAck());
+        functionDetailsBuilder.setParallelism(functionConfig.getParallelism());
+        if (functionConfig.getResources() != null) {
+            Function.Resources.Builder bldr = Function.Resources.newBuilder();
+            if (functionConfig.getResources().getCpu() != null) {
+                bldr.setCpu(functionConfig.getResources().getCpu());
+            }
+            if (functionConfig.getResources().getRam() != null) {
+                bldr.setRam(functionConfig.getResources().getRam());
+            }
+            if (functionConfig.getResources().getDisk() != null) {
+                bldr.setDisk(functionConfig.getResources().getDisk());
+            }
+            functionDetailsBuilder.setResources(bldr.build());
+        }
+        return functionDetailsBuilder.build();
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.utils;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.common.nar.NarClassLoader;
+import org.apache.pulsar.functions.api.utils.IdentityFunction;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.functions.utils.Utils.convertProcessingGuarantee;
+
+public class SinkConfigUtils {
+
+    public static FunctionDetails convert(SinkConfig sinkConfig) throws IOException {
+
+        String sinkClassName = null;
+        String typeArg = null;
+
+        FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
+
+        boolean isBuiltin = sinkConfig.getArchive().startsWith(Utils.BUILTIN);
+
+        if (!isBuiltin) {
+            if (sinkConfig.getArchive().startsWith(Utils.FILE)) {
+                if (isBlank(sinkConfig.getClassName())) {
+                    throw new IllegalArgumentException("Class-name must be present for archive with file-url");
+                }
+                sinkClassName = sinkConfig.getClassName(); // server derives the arg-type by loading a class
+            } else {
+                sinkClassName = ConnectorUtils.getIOSinkClass(sinkConfig.getArchive());
+                try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(sinkConfig.getArchive()),
+                        Collections.emptySet())) {
+                    typeArg = Utils.getSinkType(sinkClassName, ncl).getName();
+                }
+            }
+        }
+
+        if (sinkConfig.getTenant() != null) {
+            functionDetailsBuilder.setTenant(sinkConfig.getTenant());
+        }
+        if (sinkConfig.getNamespace() != null) {
+            functionDetailsBuilder.setNamespace(sinkConfig.getNamespace());
+        }
+        if (sinkConfig.getName() != null) {
+            functionDetailsBuilder.setName(sinkConfig.getName());
+        }
+        functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
+        functionDetailsBuilder.setParallelism(sinkConfig.getParallelism());
+        functionDetailsBuilder.setClassName(IdentityFunction.class.getName());
+        if (sinkConfig.getProcessingGuarantees() != null) {
+            functionDetailsBuilder.setProcessingGuarantees(
+                    convertProcessingGuarantee(sinkConfig.getProcessingGuarantees()));
+        }
+
+        // set source spec
+        // source spec classname should be empty so that the default pulsar source will be used
+        Function.SourceSpec.Builder sourceSpecBuilder = Function.SourceSpec.newBuilder();
+        sourceSpecBuilder.setSubscriptionType(Function.SubscriptionType.SHARED);
+        if (sinkConfig.getInputs() != null) {
+            sinkConfig.getInputs().forEach(topicName ->
+                    sourceSpecBuilder.putInputSpecs(topicName,
+                            Function.ConsumerSpec.newBuilder()
+                                    .setIsRegexPattern(false)
+                                    .build()));
+        }
+        if (!StringUtils.isEmpty(sinkConfig.getTopicsPattern())) {
+            sourceSpecBuilder.putInputSpecs(sinkConfig.getTopicsPattern(),
+                    Function.ConsumerSpec.newBuilder()
+                            .setIsRegexPattern(true)
+                            .build());
+        }
+        if (sinkConfig.getTopicToSerdeClassName() != null) {
+            sinkConfig.getTopicToSerdeClassName().forEach((topicName, serde) -> {
+                sourceSpecBuilder.putInputSpecs(topicName,
+                        Function.ConsumerSpec.newBuilder()
+                                .setSerdeClassName(serde == null ? "" : serde)
+                                .setIsRegexPattern(false)
+                                .build());
+            });
+        }
+        if (sinkConfig.getTopicToSchemaType() != null) {
+            sinkConfig.getTopicToSchemaType().forEach((topicName, schemaType) -> {
+                sourceSpecBuilder.putInputSpecs(topicName,
+                        Function.ConsumerSpec.newBuilder()
+                                .setSchemaType(schemaType == null ? "" : schemaType)
+                                .setIsRegexPattern(false)
+                                .build());
+            });
+        }
+        if (sinkConfig.getInputSpecs() != null) {
+            sinkConfig.getInputSpecs().forEach((topic, spec) -> {
+                sourceSpecBuilder.putInputSpecs(topic,
+                        Function.ConsumerSpec.newBuilder()
+                                .setSerdeClassName(spec.getSerdeClassName() != null ? spec.getSerdeClassName() : "")
+                                .setSchemaType(spec.getSchemaType() != null ? spec.getSchemaType() : "")
+                                .setIsRegexPattern(spec.isRegexPattern())
+                                .build());
+            });
+        }
+
+        if (typeArg != null) {
+            sourceSpecBuilder.setTypeClassName(typeArg);
+        }
+        if (isNotBlank(sinkConfig.getSourceSubscriptionName())) {
+            sourceSpecBuilder.setSubscriptionName(sinkConfig.getSourceSubscriptionName());
+        }
+
+        Function.SubscriptionType subType = (sinkConfig.isRetainOrdering()
+                || FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE.equals(sinkConfig.getProcessingGuarantees()))
+                ? Function.SubscriptionType.FAILOVER
+                : Function.SubscriptionType.SHARED;
+        sourceSpecBuilder.setSubscriptionType(subType);
+
+        functionDetailsBuilder.setAutoAck(sinkConfig.isAutoAck());
+        if (sinkConfig.getTimeoutMs() != null) {
+            sourceSpecBuilder.setTimeoutMs(sinkConfig.getTimeoutMs());
+        }
+
+        functionDetailsBuilder.setSource(sourceSpecBuilder);
+
+        // set up sink spec
+        Function.SinkSpec.Builder sinkSpecBuilder = Function.SinkSpec.newBuilder();
+        if (sinkClassName != null) {
+            sinkSpecBuilder.setClassName(sinkClassName);
+        }
+
+        if (isBuiltin) {
+            String builtin = sinkConfig.getArchive().replaceFirst("^builtin://", "");
+            sinkSpecBuilder.setBuiltin(builtin);
+        }
+
+        if (sinkConfig.getConfigs() != null) {
+            sinkSpecBuilder.setConfigs(new Gson().toJson(sinkConfig.getConfigs()));
+        }
+        if (typeArg != null) {
+            sinkSpecBuilder.setTypeClassName(typeArg);
+        }
+        functionDetailsBuilder.setSink(sinkSpecBuilder);
+
+        if (sinkConfig.getResources() != null) {
+            Function.Resources.Builder bldr = Function.Resources.newBuilder();
+            if (sinkConfig.getResources().getCpu() != null) {
+                bldr.setCpu(sinkConfig.getResources().getCpu());
+            }
+            if (sinkConfig.getResources().getRam() != null) {
+                bldr.setRam(sinkConfig.getResources().getRam());
+            }
+            if (sinkConfig.getResources().getDisk() != null) {
+                bldr.setDisk(sinkConfig.getResources().getDisk());
+            }
+            functionDetailsBuilder.setResources(bldr.build());
+        }
+        return functionDetailsBuilder.build();
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.utils;
+
+import com.google.gson.Gson;
+import org.apache.pulsar.common.nar.NarClassLoader;
+import org.apache.pulsar.functions.api.utils.IdentityFunction;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.apache.pulsar.functions.utils.Utils.convertProcessingGuarantee;
+import static org.apache.pulsar.functions.utils.Utils.getSourceType;
+
+public class SourceConfigUtils {
+
+    public static FunctionDetails convert(SourceConfig sourceConfig)
+            throws IllegalArgumentException, IOException {
+
+        String sourceClassName = null;
+        String typeArg = null;
+
+        FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
+
+        boolean isBuiltin = sourceConfig.getArchive().startsWith(Utils.BUILTIN);
+
+        if (!isBuiltin) {
+            if (sourceConfig.getArchive().startsWith(Utils.FILE)) {
+                if (org.apache.commons.lang3.StringUtils.isBlank(sourceConfig.getClassName())) {
+                    throw new IllegalArgumentException("Class-name must be present for archive with file-url");
+                }
+                sourceClassName = sourceConfig.getClassName(); // server derives the arg-type by loading a class
+            } else {
+                sourceClassName = ConnectorUtils.getIOSourceClass(sourceConfig.getArchive());
+
+                try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(sourceConfig.getArchive()),
+                        Collections.emptySet())) {
+                    typeArg = getSourceType(sourceClassName, ncl).getName();
+                }
+            }
+        }
+
+        if (sourceConfig.getTenant() != null) {
+            functionDetailsBuilder.setTenant(sourceConfig.getTenant());
+        }
+        if (sourceConfig.getNamespace() != null) {
+            functionDetailsBuilder.setNamespace(sourceConfig.getNamespace());
+        }
+        if (sourceConfig.getName() != null) {
+            functionDetailsBuilder.setName(sourceConfig.getName());
+        }
+        functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
+        functionDetailsBuilder.setParallelism(sourceConfig.getParallelism());
+        functionDetailsBuilder.setClassName(IdentityFunction.class.getName());
+        functionDetailsBuilder.setAutoAck(true);
+        if (sourceConfig.getProcessingGuarantees() != null) {
+            functionDetailsBuilder.setProcessingGuarantees(
+                    convertProcessingGuarantee(sourceConfig.getProcessingGuarantees()));
+        }
+
+        // set source spec
+        Function.SourceSpec.Builder sourceSpecBuilder = Function.SourceSpec.newBuilder();
+        if (sourceClassName != null) {
+            sourceSpecBuilder.setClassName(sourceClassName);
+        }
+
+        if (isBuiltin) {
+            String builtin = sourceConfig.getArchive().replaceFirst("^builtin://", "");
+            sourceSpecBuilder.setBuiltin(builtin);
+        }
+
+        if (sourceConfig.getConfigs() != null) {
+            sourceSpecBuilder.setConfigs(new Gson().toJson(sourceConfig.getConfigs()));
+        }
+
+        if (typeArg != null) {
+            sourceSpecBuilder.setTypeClassName(typeArg);
+        }
+        functionDetailsBuilder.setSource(sourceSpecBuilder);
+
+        // set up sink spec.
+        // Sink spec classname should be empty so that the default pulsar sink will be used
+        Function.SinkSpec.Builder sinkSpecBuilder = Function.SinkSpec.newBuilder();
+        if (!org.apache.commons.lang3.StringUtils.isEmpty(sourceConfig.getSchemaType())) {
+            sinkSpecBuilder.setSchemaType(sourceConfig.getSchemaType());
+        }
+        if (!org.apache.commons.lang3.StringUtils.isEmpty(sourceConfig.getSerdeClassName())) {
+            sinkSpecBuilder.setSerDeClassName(sourceConfig.getSerdeClassName());
+        }
+
+        sinkSpecBuilder.setTopic(sourceConfig.getTopicName());
+
+        if (typeArg != null) {
+            sinkSpecBuilder.setTypeClassName(typeArg);
+        }
+
+        functionDetailsBuilder.setSink(sinkSpecBuilder);
+
+        if (sourceConfig.getResources() != null) {
+            Function.Resources.Builder bldr = Function.Resources.newBuilder();
+            if (sourceConfig.getResources().getCpu() != null) {
+                bldr.setCpu(sourceConfig.getResources().getCpu());
+            }
+            if (sourceConfig.getResources().getRam() != null) {
+                bldr.setRam(sourceConfig.getResources().getRam());
+            }
+            if (sourceConfig.getResources().getDisk() != null) {
+                bldr.setDisk(sourceConfig.getResources().getDisk());
+            }
+            functionDetailsBuilder.setResources(bldr.build());
+        }
+
+        return functionDetailsBuilder.build();
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -101,9 +101,8 @@ public class Utils {
         }
     }
 
-    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig) {
-        Object userClass = createInstance(functionConfig.getClassName(),
-                Thread.currentThread().getContextClassLoader());
+    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig, ClassLoader classLoader) {
+        Object userClass = createInstance(functionConfig.getClassName(), classLoader);
         boolean isWindowConfigPresent = functionConfig.getWindowConfig() != null;
         return getFunctionTypes(userClass, isWindowConfigPresent);
     }
@@ -187,10 +186,6 @@ public class Utils {
         throw new RuntimeException("Unrecognized processing guarantee: " + processingGuarantees.name());
     }
 
-    public static Class<?> getSourceType(String className) {
-        return getSourceType(className, Thread.currentThread().getContextClassLoader());
-    }
-
     public static Class<?> getSourceType(String className, ClassLoader classloader) {
 
         Object userClass = Reflections.createInstance(className, classloader);
@@ -203,10 +198,6 @@ public class Utils {
         typeArg = TypeResolver.resolveRawArgument(Source.class, source.getClass());
 
         return typeArg;
-    }
-
-    public static Class<?> getSinkType(String className) {
-        return getSinkType(className, Thread.currentThread().getContextClassLoader());
     }
 
     public static Class<?> getSinkType(String className, ClassLoader classLoader) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ConfigValidation.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ConfigValidation.java
@@ -44,7 +44,7 @@ public class ConfigValidation {
         PYTHON
     }
 
-    public static void validateConfig(Object config, String runtimeType) {
+    public static void validateConfig(Object config, String runtimeType, ClassLoader classLoader) {
         for (Field field : config.getClass().getDeclaredFields()) {
             Object value;
             field.setAccessible(true);
@@ -53,12 +53,12 @@ public class ConfigValidation {
             } catch (IllegalAccessException e) {
                throw new RuntimeException(e);
             }
-            validateField(field, value, Runtime.valueOf(runtimeType));
+            validateField(field, value, Runtime.valueOf(runtimeType), classLoader);
         }
-        validateClass(config, Runtime.valueOf(runtimeType));
+        validateClass(config, Runtime.valueOf(runtimeType), classLoader);
     }
 
-    private static void validateClass(Object config, Runtime runtime) {
+    private static void validateClass(Object config, Runtime runtime, ClassLoader classLoader) {
 
         List<Annotation> annotationList = new LinkedList<>();
         Class<?>[] classes = ConfigValidationAnnotations.class.getDeclaredClasses();
@@ -70,10 +70,10 @@ public class ConfigValidation {
 
             }
         }
-        processAnnotations(annotationList, config.getClass().getName(), config, runtime);
+        processAnnotations(annotationList, config.getClass().getName(), config, runtime, classLoader);
     }
 
-    private static void validateField(Field field, Object value, Runtime runtime) {
+    private static void validateField(Field field, Object value, Runtime runtime, ClassLoader classLoader) {
         List<Annotation> annotationList = new LinkedList<>();
         Class<?>[] classes = ConfigValidationAnnotations.class.getDeclaredClasses();
         for (Class clazz : classes) {
@@ -84,11 +84,11 @@ public class ConfigValidation {
 
             }
         }
-        processAnnotations(annotationList, field.getName(), value, runtime);
+        processAnnotations(annotationList, field.getName(), value, runtime, classLoader);
     }
 
     private static void processAnnotations( List<Annotation> annotations, String fieldName, Object value,
-                                           Runtime runtime) {
+                                           Runtime runtime, ClassLoader classLoader) {
         try {
             for (Annotation annotation : annotations) {
 
@@ -127,7 +127,7 @@ public class ConfigValidation {
                         } else { //If not call default constructor
                             o = clazz.newInstance();
                         }
-                        o.validateField(fieldName, value);
+                        o.validateField(fieldName, value, classLoader);
                     }
                 }
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ConfigValidationAnnotations.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ConfigValidationAnnotations.java
@@ -178,6 +178,17 @@ public class ConfigValidationAnnotations {
     }
 
     /**
+     * checks if the topic name is valid
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface isValidSerde {
+        Class<?> validatorClass() default ValidatorImpls.SerdeValidator.class;
+
+        ConfigValidation.Runtime targetRuntime() default ConfigValidation.Runtime.JAVA;
+    }
+
+    /**
      * checks if window configs is valid
      */
     @Retention(RetentionPolicy.RUNTIME)

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/Validator.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/Validator.java
@@ -27,5 +27,5 @@ public abstract class Validator {
     public Validator() {
     }
 
-    public abstract void validateField(String name, Object o);
+    public abstract void validateField(String name, Object o, ClassLoader classLoader);
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
@@ -270,7 +270,7 @@ public class ValidatorImpls {
 
         @Override
         public void validateField(String name, Object o, ClassLoader classLoader) {
-            if (o.equals(DEFAULT_SERDE)) return;
+            if (o != null && o.equals(DEFAULT_SERDE)) return;
             new ValidatorImpls.ImplementsClassValidator(SerDe.class).validateField(name, o, classLoader);
         }
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
@@ -814,7 +814,7 @@ public class ValidatorImpls {
                     });
                 }
             } catch (IOException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalArgumentException(e.getMessage());
             }
         }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -970,6 +970,9 @@ public class FunctionsImpl {
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
                 clsLoader = extractClassLoader(functionPkgUrl, uploadedInputStreamAsFile);
             }
+            if (functionConfig.getRuntime() == null) {
+                throw new IllegalArgumentException("Function Runtime no specified");
+            }
             ConfigValidation.validateConfig(functionConfig, functionConfig.getRuntime().name(), clsLoader);
             return FunctionConfigUtils.convert(functionConfig, clsLoader);
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -162,14 +162,6 @@ public class FunctionsImpl {
                     .entity(new ErrorData(String.format("Function %s already exists", functionName))).build();
         }
 
-        try {
-            worker().getFunctionRuntimeManager().getRuntimeFactory().doAdmissionChecks(functionDetails);
-        } catch (Exception e) {
-            log.error("Function {}/{}/{} cannot be admitted by the runtime factory", tenant, namespace, functionName);
-            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(String.format("Function %s cannot be admitted:- %s", functionName, e.getMessage()))).build();
-        }
-
         FunctionDetails functionDetails;
         boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
         File uploadedInputStreamAsFile = null;
@@ -189,6 +181,14 @@ public class FunctionsImpl {
             log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
             return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
+        }
+
+        try {
+            worker().getFunctionRuntimeManager().getRuntimeFactory().doAdmissionChecks(functionDetails);
+        } catch (Exception e) {
+            log.error("Function {}/{}/{} cannot be admitted by the runtime factory", tenant, namespace, functionName);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(String.format("Function %s cannot be admitted:- %s", functionName, e.getMessage()))).build();
         }
 
         // function state
@@ -241,14 +241,6 @@ public class FunctionsImpl {
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
-        try {
-            worker().getFunctionRuntimeManager().getRuntimeFactory().doAdmissionChecks(functionDetails);
-        } catch (Exception e) {
-            log.error("Updated Function {}/{}/{} cannot be submitted to runtime factory", tenant, namespace, functionName);
-            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(String.format("Function %s cannot be admitted:- %s", functionName, e.getMessage()))).build();
-        }
-
         FunctionDetails functionDetails;
         boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
         File uploadedInputStreamAsFile = null;
@@ -268,6 +260,14 @@ public class FunctionsImpl {
             log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
             return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
+        }
+
+        try {
+            worker().getFunctionRuntimeManager().getRuntimeFactory().doAdmissionChecks(functionDetails);
+        } catch (Exception e) {
+            log.error("Updated Function {}/{}/{} cannot be submitted to runtime factory", tenant, namespace, functionName);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(String.format("Function %s cannot be admitted:- %s", functionName, e.getMessage()))).build();
         }
 
         // function state

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -971,55 +971,49 @@ public class FunctionsImpl {
             }
             return FunctionConfigUtils.convert(functionConfig, clsLoader);
         }
-        try {
-            FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
-            org.apache.pulsar.functions.utils.Utils.mergeJson(functionDetailsJson, functionDetailsBuilder);
-            if (isNotBlank(functionPkgUrl)) {
-                // set package-url if present
-                functionDetailsBuilder.setPackageUrl(functionPkgUrl);
-            }
-            ClassLoader clsLoader = null;
-            if (functionDetailsBuilder.getRuntime() == FunctionDetails.Runtime.JAVA) {
-                clsLoader = extractClassLoader(functionPkgUrl, uploadedInputStreamAsFile);
-            }
-            validateFunctionClassTypes(clsLoader, functionDetailsBuilder);
-
-            FunctionDetails functionDetails = functionDetailsBuilder.build();
-
-            List<String> missingFields = new LinkedList<>();
-            if (functionDetails.getTenant() == null || functionDetails.getTenant().isEmpty()) {
-                missingFields.add("Tenant");
-            }
-            if (functionDetails.getNamespace() == null || functionDetails.getNamespace().isEmpty()) {
-                missingFields.add("Namespace");
-            }
-            if (functionDetails.getName() == null || functionDetails.getName().isEmpty()) {
-                missingFields.add("Name");
-            }
-            if (functionDetails.getClassName() == null || functionDetails.getClassName().isEmpty()) {
-                missingFields.add("ClassName");
-            }
-            // TODO in the future add more check here for functions and connectors
-            if (!functionDetails.getSource().isInitialized()) {
-                missingFields.add("Source");
-            }
-            // TODO in the future add more check here for functions and connectors
-            if (!functionDetails.getSink().isInitialized()) {
-                missingFields.add("Sink");
-            }
-            if (!missingFields.isEmpty()) {
-                String errorMessage = join(missingFields, ",");
-                throw new IllegalArgumentException(errorMessage + " is not provided");
-            }
-            if (functionDetails.getParallelism() <= 0) {
-                throw new IllegalArgumentException("Parallelism needs to be set to a positive number");
-            }
-            return functionDetails;
-        } catch (IllegalArgumentException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            throw new IllegalArgumentException("Invalid FunctionDetails");
+        FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
+        org.apache.pulsar.functions.utils.Utils.mergeJson(functionDetailsJson, functionDetailsBuilder);
+        if (isNotBlank(functionPkgUrl)) {
+            // set package-url if present
+            functionDetailsBuilder.setPackageUrl(functionPkgUrl);
         }
+        ClassLoader clsLoader = null;
+        if (functionDetailsBuilder.getRuntime() == FunctionDetails.Runtime.JAVA) {
+            clsLoader = extractClassLoader(functionPkgUrl, uploadedInputStreamAsFile);
+        }
+        validateFunctionClassTypes(clsLoader, functionDetailsBuilder);
+
+        FunctionDetails functionDetails = functionDetailsBuilder.build();
+
+        List<String> missingFields = new LinkedList<>();
+        if (functionDetails.getTenant() == null || functionDetails.getTenant().isEmpty()) {
+            missingFields.add("Tenant");
+        }
+        if (functionDetails.getNamespace() == null || functionDetails.getNamespace().isEmpty()) {
+            missingFields.add("Namespace");
+        }
+        if (functionDetails.getName() == null || functionDetails.getName().isEmpty()) {
+            missingFields.add("Name");
+        }
+        if (functionDetails.getClassName() == null || functionDetails.getClassName().isEmpty()) {
+            missingFields.add("ClassName");
+        }
+        // TODO in the future add more check here for functions and connectors
+        if (!functionDetails.getSource().isInitialized()) {
+            missingFields.add("Source");
+        }
+        // TODO in the future add more check here for functions and connectors
+        if (!functionDetails.getSink().isInitialized()) {
+            missingFields.add("Sink");
+        }
+        if (!missingFields.isEmpty()) {
+            String errorMessage = join(missingFields, ",");
+            throw new IllegalArgumentException(errorMessage + " is not provided");
+        }
+        if (functionDetails.getParallelism() <= 0) {
+            throw new IllegalArgumentException("Parallelism needs to be set to a positive number");
+        }
+        return functionDetails;
     }
 
     private ClassLoader extractClassLoader(String functionPkgUrl, File uploadedInputStreamAsFile) throws URISyntaxException, IOException {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -153,6 +153,14 @@ public class FunctionsImpl {
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
+        FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
+
+        if (functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
+            log.error("Function {}/{}/{} already exists", tenant, namespace, functionName);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(String.format("Function %s already exists", functionName))).build();
+        }
+
         FunctionDetails functionDetails;
         boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
         File uploadedInputStreamAsFile = null;
@@ -172,14 +180,6 @@ public class FunctionsImpl {
             log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
             return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
-        }
-
-        FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
-
-        if (functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function {}/{}/{} already exists", tenant, namespace, functionName);
-            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(String.format("Function %s already exists", functionName))).build();
         }
 
         // function state
@@ -225,6 +225,13 @@ public class FunctionsImpl {
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
+        FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
+
+        if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
+        }
+
         FunctionDetails functionDetails;
         boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
         File uploadedInputStreamAsFile = null;
@@ -244,13 +251,6 @@ public class FunctionsImpl {
             log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
             return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
-        }
-
-        FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
-
-        if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
         // function state

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -91,6 +91,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
 import org.apache.pulsar.functions.utils.FunctionConfig;
 import org.apache.pulsar.functions.utils.FunctionConfigUtils;
 import org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders;
+import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.Utils;
@@ -969,6 +970,7 @@ public class FunctionsImpl {
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
                 clsLoader = extractClassLoader(functionPkgUrl, uploadedInputStreamAsFile);
             }
+            ConfigValidation.validateConfig(functionConfig, functionConfig.getRuntime().name(), clsLoader);
             return FunctionConfigUtils.convert(functionConfig, clsLoader);
         }
         FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
@@ -56,10 +56,11 @@ public class FunctionApiV2Resource extends FunctionApiResource {
                                      final @FormDataParam("data") InputStream uploadedInputStream,
                                      final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                      final @FormDataParam("url") String functionPkgUrl,
-                                     final @FormDataParam("functionDetails") String functionDetailsJson) {
+                                     final @FormDataParam("functionDetails") String functionDetailsJson,
+                                     final @FormDataParam("functionConfig") String functionConfigJson) {
 
         return functions.registerFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, functionConfigJson, clientAppId());
 
     }
 
@@ -72,10 +73,11 @@ public class FunctionApiV2Resource extends FunctionApiResource {
                                    final @FormDataParam("data") InputStream uploadedInputStream,
                                    final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                    final @FormDataParam("url") String functionPkgUrl,
-                                   final @FormDataParam("functionDetails") String functionDetailsJson) {
+                                   final @FormDataParam("functionDetails") String functionDetailsJson,
+                                   final @FormDataParam("functionConfig") String functionConfigJson) {
 
         return functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, functionConfigJson, clientAppId());
 
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -315,6 +315,7 @@ public class FunctionApiV2ResourceTest {
                 details,
                 null,
                 org.apache.pulsar.functions.utils.Utils.printJson(functionDetails),
+                null,
                 null);
 
         assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -344,6 +345,7 @@ public class FunctionApiV2ResourceTest {
             mockedFormData,
             null,
             org.apache.pulsar.functions.utils.Utils.printJson(functionDetails),
+            null,
             null);
     }
 
@@ -590,6 +592,7 @@ public class FunctionApiV2ResourceTest {
             details,
             null,
             org.apache.pulsar.functions.utils.Utils.printJson(functionDetails),
+            null,
             null);
 
         assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -619,6 +622,7 @@ public class FunctionApiV2ResourceTest {
             mockedFormData,
             null,
             org.apache.pulsar.functions.utils.Utils.printJson(functionDetails),
+            null,
             null);
     }
 
@@ -701,6 +705,7 @@ public class FunctionApiV2ResourceTest {
             null,
             filePackageUrl,
             org.apache.pulsar.functions.utils.Utils.printJson(functionDetails),
+            null,
             null);
 
         assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -1050,7 +1055,7 @@ public class FunctionApiV2ResourceTest {
                         .setSubscriptionType(subscriptionType).putAllTopicsToSerDeClassName(topicsToSerDeClassName))
                 .build();
         Response response = resource.registerFunction(tenant, namespace, function, null, null, filePackageUrl,
-                org.apache.pulsar.functions.utils.Utils.printJson(functionDetails), null);
+                org.apache.pulsar.functions.utils.Utils.printJson(functionDetails), null, null);
 
         assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
@@ -1075,7 +1080,7 @@ public class FunctionApiV2ResourceTest {
                         .setSubscriptionType(subscriptionType).putAllTopicsToSerDeClassName(topicsToSerDeClassName))
                 .build();
         Response response = resource.registerFunction(tenant, namespace, function, null, null, filePackageUrl,
-                org.apache.pulsar.functions.utils.Utils.printJson(functionDetails), null);
+                org.apache.pulsar.functions.utils.Utils.printJson(functionDetails), null, null);
 
         assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -65,6 +65,7 @@ import org.apache.pulsar.functions.proto.Function.SourceSpec;
 import org.apache.pulsar.functions.proto.Function.SubscriptionType;
 import org.apache.pulsar.functions.runtime.RuntimeFactory;
 import org.apache.pulsar.functions.source.TopicSchema;
+import org.apache.pulsar.functions.utils.FunctionConfig;
 import org.apache.pulsar.functions.worker.*;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.functions.worker.rest.api.FunctionsImpl;


### PR DESCRIPTION
### Motivation
Currently the cli does all the validation(about types, etc) before submitting to the worker, which does very little validation. This is problematic when clients other than pulsar cli are used to submit functions. 
The current function submission also suffers from poor abstraction. The main abstraction for the cli is the FunctionConfig interface, while for the rest interface its the FunctionDetails protobuf.
This pr is the first step in removing both of the above issues. In this pr, we allow users to specify a json version of the FunctionConfig and do validation on it. The current cli still uses the old style, we will change those in later prs.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
