### PR TITLE
Fix: invalid function-java-instance proto args

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -93,7 +93,7 @@ class RuntimeUtils {
         args.add("--function_version");
         args.add(instanceConfig.getFunctionVersion());
         args.add("--function_details");
-        args.add("'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'");
+        args.add(JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()));
 
         args.add("--pulsar_serviceurl");
         args.add(pulsarServiceUrl);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -126,8 +126,8 @@ public class KubernetesRuntimeTest {
                 + " --jar " + userJarFile + " --instance_id "
                 + "$SHARD_ID" + " --function_id " + config.getFunctionId()
                 + " --function_version " + config.getFunctionVersion()
-                + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
-                + "' --pulsar_serviceurl " + pulsarServiceUrl
+                + " --function_details " + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
+                + " --pulsar_serviceurl " + pulsarServiceUrl
                 + " --max_buffered_tuples 1024 --port " + args.get(23)
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval -1";
@@ -146,8 +146,8 @@ public class KubernetesRuntimeTest {
                 + logDirectory + " --logging_file " + config.getFunctionDetails().getName() + " --instance_id "
                 + "$SHARD_ID" + " --function_id " + config.getFunctionId()
                 + " --function_version " + config.getFunctionVersion()
-                + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
-                + "' --pulsar_serviceurl " + pulsarServiceUrl
+                + " --function_details " + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
+                + " --pulsar_serviceurl " + pulsarServiceUrl
                 + " --max_buffered_tuples 1024 --port " + args.get(21)
                 + " --expected_healthcheck_interval -1";
         assertEquals(String.join(" ", args), expectedArgs);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -126,8 +126,8 @@ public class ProcessRuntimeTest {
                 + " --jar " + userJarFile + " --instance_id "
                 + config.getInstanceId() + " --function_id " + config.getFunctionId()
                 + " --function_version " + config.getFunctionVersion()
-                + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
-                + "' --pulsar_serviceurl " + pulsarServiceUrl
+                + " --function_details " + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
+                + " --pulsar_serviceurl " + pulsarServiceUrl
                 + " --max_buffered_tuples 1024 --port " + args.get(23)
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval 30";
@@ -146,8 +146,8 @@ public class ProcessRuntimeTest {
                 + logDirectory + "/functions" + " --logging_file " + config.getFunctionDetails().getName() + " --instance_id "
                 + config.getInstanceId() + " --function_id " + config.getFunctionId()
                 + " --function_version " + config.getFunctionVersion()
-                + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
-                + "' --pulsar_serviceurl " + pulsarServiceUrl
+                + " --function_details " + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
+                + " --pulsar_serviceurl " + pulsarServiceUrl
                 + " --max_buffered_tuples 1024 --port " + args.get(21)
                 + " --expected_healthcheck_interval 30";
         assertEquals(String.join(" ", args), expectedArgs);


### PR DESCRIPTION
### Motivation

Right now, with change in #1950, function-worker invokes java-instance process with invalid argument with invalid proto-format therefore, java-instance process fail with below exception
```
Exception in thread "main" org.apache.pulsar.functions.runtime.shaded.com.google.protobuf.InvalidProtocolBufferException: Expect message object but got: "{\"tenant\":\"test\",\"namespace\":\"test-namespace\",\"name\":\"example\",\"className\":\"org.apache.pulsar.functions.api.examples.ExclamationFunction\",\"userConfig\":\"{\"PublishTopic\":\"test_result\"}\",\"autoAck\":true,\"parallelism\":1,\"source\":{\"typeClassName\":\"java.lang.String\",\"inputSpecs\":{\"test_src\":{}}},\"sink\":{\"topic\":\"test_result\",\"typeClassName\":\"java.lang.String\"},\"resources\":{}}"
	at org.apache.pulsar.functions.runtime.shaded.com.google.protobuf.util.JsonFormat$ParserImpl.mergeMessage(JsonFormat.java:1296)
	at org.apache.pulsar.functions.runtime.shaded.com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1273)
	at org.apache.pulsar.functions.runtime.shaded.com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1155)
	at org.apache.pulsar.functions.runtime.shaded.com.google.protobuf.util.JsonFormat$Parser.merge(JsonFormat.java:338)
	at org.apache.pulsar.functions.runtime.JavaInstanceMain.start(JavaInstanceMain.java:114)
	at org.apache.pulsar.functions.runtime.JavaInstanceMain.main(JavaInstanceMain.java:186)
```

### Modifications

correct the java-args so, java-function-instance can start successfully.

