### PR TITLE
Add System Property Option for Athenz

### DIFF
--- a/pulsar-broker-auth-athenz/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenz.java
+++ b/pulsar-broker-auth-athenz/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenz.java
@@ -25,6 +25,7 @@ import java.security.PublicKey;
 
 import javax.naming.AuthenticationException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.slf4j.Logger;
@@ -39,14 +40,21 @@ public class AuthenticationProviderAthenz implements AuthenticationProvider {
 
     private static final String DOMAIN_NAME_LIST = "athenzDomainNames";
 
+    private static final String SYS_PROP_DOMAIN_NAME_LIST = "pulsar.athenz.domain.names";
+
     private List<String> domainNameList = null;
 
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {
-        if (config.getProperty(DOMAIN_NAME_LIST) == null) {
+        String domainNames;
+        if (config.getProperty(DOMAIN_NAME_LIST) != null) {
+            domainNames = (String) config.getProperty(DOMAIN_NAME_LIST);
+        } else if (!StringUtils.isEmpty(System.getProperty(SYS_PROP_DOMAIN_NAME_LIST))) {
+            domainNames = System.getProperty(SYS_PROP_DOMAIN_NAME_LIST);
+        } else {
             throw new IOException("No athenz domain name specified");
         }
-        String domainNames = (String) config.getProperty(DOMAIN_NAME_LIST);
+
         domainNameList = Lists.newArrayList(domainNames.split(","));
         log.info("Supported domain names for athenz: {}", domainNameList);
     }

--- a/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
+++ b/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.authentication;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
+
 import org.testng.annotations.Test;
 import org.testng.annotations.BeforeClass;
 
@@ -61,6 +62,20 @@ public class AuthenticationProviderAthenzTest {
 
         // Specify Athenz configuration file for AuthZpeClient which is used in AuthenticationProviderAthenz
         System.setProperty(ZpeConsts.ZPE_PROP_ATHENZ_CONF, "./src/test/resources/athenz.conf.test");
+    }
+
+    @Test
+    public void testInitilizeFromSystemPropeties() {
+        System.setProperty("pulsar.athenz.domain.names", "test_provider");
+        ServiceConfiguration emptyConf = new ServiceConfiguration();
+        Properties emptyProp = new Properties();
+        emptyConf.setProperties(emptyProp);
+        AuthenticationProviderAthenz sysPropProvider = new AuthenticationProviderAthenz();
+        try {
+            sysPropProvider.initialize(emptyConf);
+        } catch (Exception e) {
+            fail("Fail to Read pulsar.athenz.domain.names from System Properties");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation
 
I cannot use Athenz in functions worker because I cannot set athenzDomainNames.
I fixed to set Athenz option in system properties (not in conf file).
 
### Modifications
 
To get athenzDomainNames, I added system properties option `pulsar.athenz.domain.names`
 
### Result
 
We can use Athenz in functions worker.