### PR TITLE
Fix invalid range error when getting number of entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -652,7 +652,15 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getNumberOfEntries() {
-        return getNumberOfEntries(Range.closedOpen(readPosition, ledger.getLastPosition().getNext()));
+        if (readPosition.compareTo(ledger.getLastPosition().getNext()) > 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Read position {} is ahead of last position {}. There are no entries to read",
+                        ledger.getName(), name, readPosition, ledger.getLastPosition());
+            }
+            return 0;
+        } else {
+            return getNumberOfEntries(Range.closedOpen(readPosition, ledger.getLastPosition().getNext()));
+        }
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2759,6 +2759,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             public void operationComplete() {
                 assertEquals(cursor.getMarkDeletedPosition(), lastPosition);
                 assertEquals(cursor.getReadPosition(), nextPosition);
+                assertEquals(cursor.getNumberOfEntries(), 0L);
             }
 
             @Override


### PR DESCRIPTION
For a topic with metadata similar to https://github.com/apache/pulsar/pull/2673, IllegalArgumentException may occur in the following line:
https://github.com/apache/pulsar/blob/b2484d92d5068d4f0699eb9c3d31640cb48f9dd0/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L655

This is the broker log when the exception has occurred:
[invalid_range_error.txt](https://github.com/apache/pulsar/files/2442924/invalid_range_error.txt)

It is because `readPosition` is ahead of `ledger.getLastPosition().getNext()`, so `ManagedCursorImpl#getNumberOfEntries()` should return 0 as the number of entries to read in that case.

I think this issue and https://github.com/apache/pulsar/pull/2673 are the result of that `ledger.getLastPosition()` is no longer the real last of the managed ledger because of https://github.com/apache/pulsar/pull/1550.