### PR TITLE
Avoid NullPointerException in ZK server stats collection

### DIFF
--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperServerAspect.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperServerAspect.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.zookeeper;
 
 import io.prometheus.client.Gauge;
 
+import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -71,7 +72,12 @@ public class ZooKeeperServerAspect {
                 .setChild(new Gauge.Child() {
                     @Override
                     public double get() {
-                        return zkServer.serverStats().getNumAliveClientConnections();
+                        ServerCnxnFactory cnxFactory = zkServer.getServerCnxnFactory();
+                        if (cnxFactory != null) {
+                            return cnxFactory.getNumAliveConnections();
+                        } else {
+                            return -1;
+                        }
                     }
                 }).register();
 


### PR DESCRIPTION
### Motivation

The call to `serverStats().getNumAliveClientConnections()` inside ZK server is throwing NPE in some cases where the `ServerCnxnFactory` is null. 

```
22:07:04.269 [qtp33419717-17] WARN  org.eclipse.jetty.servlet.ServletHandler - /metrics
java.lang.NullPointerException: null
	at org.apache.zookeeper.server.ZooKeeperServer.getNumAliveConnections(ZooKeeperServer.java:883) ~[org.apache.pulsar-pulsar-broker-2.2.0-streamlio-4.jar:2.2.0-streamlio-4]
	at org.apache.zookeeper.server.ServerStats.getNumAliveClientConnections(ServerStats.java:90) ~[org.apache.pulsar-pulsar-broker-2.2.0-streamlio-4.jar:2.2.0-streamlio-4]
	at org.apache.pulsar.zookeeper.ZooKeeperServerAspect$3.get(ZooKeeperServerAspect.java:74) ~[org.apache.pulsar-pulsar-zookeeper-2.2.0-streamlio-4.jar:2.2.0-streamlio-4]
	at io.prometheus.client.Gauge.collect(Gauge.java:295) ~[io.prometheus-simpleclient-0.0.23.jar:?]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:180) ~[io.prometheus-simpleclient-0.0.23.jar:?]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:213) ~[io.prometheus-simpleclient-0.0.23.jar:?]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:134) ~[io.prometheus-simpleclient-0.0.23.jar:?]
	at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:22) ~[io.prometheus-simpleclient_common-0.0.23.jar:?]
	at io.prometheus.client.exporter.MetricsServlet.doGet(MetricsServlet.java:43) ~[io.prometheus-simpleclient_servlet-0.0.23.jar:?]
```

This also break the metrics output since it won't print any more metrics after this exception.

### Modifications

Bypass the `ServerStats` object and directly get the info on the `ServerCnxnFactory`, validating that it's not null.