### PR TITLE
Improve Go/macOS C++ client installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ $ bin/pulsar standalone
 
 Check https://pulsar.apache.org for documentation and examples.
 
+## Build Pulsar docs
+
+Refer to the docs [README](site2/README.md).
+
 ## Contact
 
 ##### Mailing lists

--- a/site2/README.md
+++ b/site2/README.md
@@ -23,6 +23,8 @@ yarn install
 yarn start
 ```
 
+Note that the `/docs/en/` path shows the documentation for the latest stable release of Pulsar.  Change it to `/docs/en/next/` to show your local changes, with live refresh.
+
 ## Contribute
 
 The website is comprised of two parts, one is documentation, while the other is website pages (including blog posts).

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -20,12 +20,10 @@ through [RPM](client-libraries-cpp.md#rpm), [Deb](client-libraries-cpp.md#deb) o
 
 ### Installing go package
 
-You can install the `pulsar` library locally using `go get`:
-
-> #### NOTE
+> #### Compatibility Warning
 > The version number of the Go client **must match** the version number of the Pulsar C++ client library.
-> Additionally, `go get` doesn't support fetching a specific tag - it will always pull in master's
-> version of the Go client - so you'll need a bleeding edge C++ client library to match.
+
+You can install the `pulsar` library locally using `go get`.  Note that `go get` doesn't support fetching a specific tag - it will always pull in master's version of the Go client.  You'll need a C++ client library that matches master.
 
 ```bash
 $ go get -u github.com/apache/pulsar/pulsar-client-go/pulsar

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -23,9 +23,9 @@ through [RPM](client-libraries-cpp.md#rpm), [Deb](client-libraries-cpp.md#deb) o
 You can install the `pulsar` library locally using `go get`:
 
 > #### NOTE
-> 
-> `go get` doesn't support fetching a specific tag. so it will always pull in pulsar go client
-> from latest master. You need to make sure you have installed the right pulsar cpp client library.
+> The version number of the Go client **must match** the version number of the Pulsar C++ client library.
+> Additionally, `go get` doesn't support fetching a specific tag - it will always pull in master's
+> version of the Go client - so you'll need a bleeding edge C++ client library to match.
 
 ```bash
 $ go get -u github.com/apache/pulsar/pulsar-client-go/pulsar


### PR DESCRIPTION
### Motivation

See #2703 

### Modifications

Reworded the warning.  Also added a link to the website readme to the main readme, documented how to view built docs.

### Result
Doc change

fixes  #2703