### PR TITLE
Added missing brokerServiceURL config keys in proxy.conf

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -23,6 +23,14 @@ zookeeperServers=
 # Configuration store connection string (as a comma-separated list)
 configurationStoreServers=
 
+# if Service Discovery is Disabled this url should point to the discovery service provider.
+brokerServiceURL=
+brokerServiceURLTLS=
+
+# These settings are unnecessary if `zookeeperServers` is specified
+brokerWebServiceURL=
+brokerWebServiceURLTLS=
+
 # If function workers are setup in a separate cluster, configure the following 2 settings
 # to point to the function workers cluster
 functionWorkerWebServiceURL=


### PR DESCRIPTION
### Motivation

Few keys were missing from `proxy.conf` and it makes it harder to override this values in the Kubernetes spec files.