### PR TITLE
Removed organization affiliations from website

### DIFF
--- a/site2/website/data/team.js
+++ b/site2/website/data/team.js
@@ -4,121 +4,135 @@ module.exports = {
       name: 'Boyang Jerry Peng',
       apacheId: 'jerrypeng',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Brad McMillen',
       apacheId: 'bradtm',
       org: 'Yahoo',
-      roles: 'Committer, PPMC',
+      roles: 'Committer, PMC',
+    },
+    {
+      name: 'David Fisher',
+      apacheId: 'wave',
+      roles: 'Committer, PMC'
+    },
+    {
+      name: 'Francis Christopher Liu',
+      apacheId: 'toffer',
+      roles: 'Committer, PMC'
     },
     {
       name: 'Hiroyuki Sakai',
       apacheId: 'hrsakai',
       org: 'Yahoo Japan Corporation',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Ivan Brendan Kelly',
       apacheId: 'ivank',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Jai Asher',
       apacheId: 'jai1',
       org: 'Yahoo',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Jia Zhai',
       apacheId: 'zhaijia',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
+    },
+    {
+      name: 'Jim Jagielski',
+      apacheId: 'jim',
+      roles: 'Committer, PMC'
     },
     {
       name: 'Joe Francis',
       apacheId: 'joef',
       org: 'Yahoo',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Ludwig Pummer',
       apacheId: 'ludwigp',
       org: 'Yahoo',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Masahiro Sakamoto',
       apacheId: 'massakam',
       org: 'Yahoo Japan Corporation',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Masakazu Kitajo',
       apacheId: 'maskit',
       org: '',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Matteo Merli',
       apacheId: 'mmerli',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Nozomi Kurihara',
       apacheId: 'nkurihar',
       org: 'Yahoo Japan Corporation',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
+    },
+    {
+      name: 'P. Taylor Goetz',
+      apacheId: 'ptgoetz',
+      roles: 'Committer, PMC'
     },
     {
       name: 'Rajan Dhabalia',
       apacheId: 'rdhabalia',
       org: 'Yahoo',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Sahaya Andrews',
       apacheId: 'andrews',
       org: 'Yahoo',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Sanjeev Kulkarni',
       apacheId: 'sanjeevrk',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Sebastián Schepens',
       apacheId: 'sschepens',
       org: 'MercadoLibre',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Siddharth Boobna',
       apacheId: 'sboobna',
       org: 'Salesforce',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Sijie Guo',
       apacheId: 'sijie',
       org: 'Streamlio',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     },
     {
       name: 'Yuki Shiga',
       apacheId: 'yushiga',
       org: 'Yahoo Japan Corporation',
-      roles: 'Committer, PPMC'
+      roles: 'Committer, PMC'
     }
-  ],
-  mentors: [
-    {name: 'David Fisher', apacheId: 'wave'},
-    {name: 'Francis Christopher Liu', apacheId: 'toffer'},
-    {name: 'Jim Jagielski', apacheId: 'jim'},
-    {name: 'P. Taylor Goetz', apacheId: 'ptgoetz' }
   ]
 }

--- a/site2/website/pages/en/team.js
+++ b/site2/website/pages/en/team.js
@@ -57,7 +57,6 @@ class Team extends React.Component {
                 <tr>
                   <th><translate>Name</translate></th>
                   <th><translate>Apache Id</translate></th>
-                  <th><translate>Organization</translate></th>
                   <th><translate>Roles</translate></th>
                 </tr>
               </thead>
@@ -67,29 +66,7 @@ class Team extends React.Component {
                     <tr key={c.apacheId}>
                       <td>{c.name}</td>
                       <td>{c.apacheId}</td>
-                      <td>{c.org}</td>
                       <td>{c.roles}</td>
-                    </tr>
-                  )
-                )}
-              </tbody>
-            </table>
-
-            <h2><translate>Mentors</translate></h2>
-            <p><translate>The following people are the mentors of this incubator project</translate></p>
-            <table className="versions">
-              <thead>
-                <tr>
-                  <th><translate>Name</translate></th>
-                  <th><translate>Apache Id</translate></th>
-                </tr>
-              </thead>
-              <tbody>
-                {team.mentors.map(
-                  m => (
-                    <tr key={m.apacheId}>
-                      <td>{m.name}</td>
-                      <td>{m.apacheId}</td>
                     </tr>
                   )
                 )}


### PR DESCRIPTION
### Motivation

As pointed out, the ASF policy is to not indicate affiliations in team's page.