### PR TITLE
Allow bk-client to support old bk-protocol

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -289,6 +289,9 @@ bookkeeperClientTimeoutInSeconds=30
 # Using a value of 0, is disabling the speculative reads
 bookkeeperClientSpeculativeReadTimeoutInMillis=0
 
+# Use older Bookkeeper wire protocol with bookie
+bookkeeperUseV2WireProtocol=true
+
 # Enable bookies health check. Bookies that have more than the configured number of failure within
 # the interval will be quarantined for some time. During this period, new ledgers won't be created
 # on these bookies

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -286,6 +286,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Speculative reads are initiated if a read request doesn't complete within
     // a certain time Using a value of 0, is disabling the speculative reads
     private int bookkeeperClientSpeculativeReadTimeoutInMillis = 0;
+    // Use older Bookkeeper wire protocol with bookie
+    private boolean bookkeeperUseV2WireProtocol = true;
     // Enable bookies health check. Bookies that have more than the configured
     // number of failure within the interval will be quarantined for some time.
     // During this period, new ledgers won't be created on these bookies
@@ -1095,6 +1097,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setBookkeeperClientSpeculativeReadTimeoutInMillis(int bookkeeperClientSpeculativeReadTimeoutInMillis) {
         this.bookkeeperClientSpeculativeReadTimeoutInMillis = bookkeeperClientSpeculativeReadTimeoutInMillis;
+    }
+
+    public boolean isBookkeeperUseV2WireProtocol() {
+        return bookkeeperUseV2WireProtocol;
+    }
+
+    public void setBookkeeperUseV2WireProtocol(boolean bookkeeperUseV2WireProtocol) {
+        this.bookkeeperUseV2WireProtocol = bookkeeperUseV2WireProtocol;
     }
 
     public boolean isBookkeeperClientHealthCheckEnabled() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -53,7 +53,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setReadEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setSpeculativeReadTimeout(conf.getBookkeeperClientSpeculativeReadTimeoutInMillis());
         bkConf.setNumChannelsPerBookie(16);
-        bkConf.setUseV2WireProtocol(true);
+        bkConf.setUseV2WireProtocol(conf.isBookkeeperUseV2WireProtocol());
         bkConf.setEnableDigestTypeAutodetection(true);
         bkConf.setLedgerManagerFactoryClassName(HierarchicalLedgerManagerFactory.class.getName());
         if (conf.isBookkeeperClientHealthCheckEnabled()) {


### PR DESCRIPTION
### Motivation

Need this config due to two reasons:
1. This config is useful in migration process where bk-client and bookies are on different versions.
2. It seems there is some issue with BK-4.7 with authentication-enable
a. Bookie sends [BookkeeperProtocol.Response](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java#L200) to BK-Client but BK-Client doesn't add [PacketHeader](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java#L242) as bookie-response is [not-type of BookieProtocol](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java#L237) therefore, BK-client [fails to parse](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java#L279) bookie response with below failure and this can be prevent by using `bookkeeperUseV2WireProtocol` flag.
```
07:03:06.008 [bookkeeper-io-12-7] INFO  org.apache.bookkeeper.proto.PerChannelBookieClient - Successfully connected to bookie: 74.6.168.37:3181
07:03:06.081 [bookkeeper-io-12-7] ERROR org.apache.bookkeeper.proto.PerChannelBookieClient - Unexpected exception caught by bookie client channel handler
java.lang.IllegalStateException: Received unknown response : op code = 6
        at org.apache.bookkeeper.proto.BookieProtoEncoding$ResponseEnDeCoderPreV3.decode(BookieProtoEncoding.java:303) ~[bookkeeper-server-4.7.0.24-yahoo.jar:4.7.0.24-yahoo]
        at org.apache.bookkeeper.proto.BookieProtoEncoding$ResponseDecoder.channelRead(BookieProtoEncoding.java:502) ~[bookkeeper-server-4.7.0.24-yahoo.jar:4.7.0.24-yahoo]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-codec-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [netty-codec-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:945) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:806) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:404) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [netty-common-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.22.Final.jar:4.1.22.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```

### Modifications

add `bookkeeperUseV2WireProtocol` flag which can be used in migration process.
