### PR TITLE
 [python] MessageId.serialize() should return bytes instead of str 

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -107,6 +107,7 @@ from pulsar.functions.serde import SerDe, IdentitySerDe, PickleSerDe
 import re
 _retype = type(re.compile('x'))
 
+
 class MessageId:
     """
     Represents a message id
@@ -120,18 +121,18 @@ class MessageId:
 
     def serialize(self):
         """
-        Returns a string representation of the message id.
-        This string can be stored and later deserialized.
+        Returns a bytes representation of the message id.
+        This bytes sequence can be stored and later deserialized.
         """
         return self._msg_id.serialize()
 
     @staticmethod
-    def deserialize(message_id_str):
+    def deserialize(message_id_bytes):
         """
         Deserialize a message id object from a previously
-        serialized string.
+        serialized bytes sequence.
         """
-        return _pulsar.MessageId.deserialize(message_id_str)
+        return _pulsar.MessageId.deserialize(message_id_bytes)
 
 
 class Message:

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -753,6 +753,12 @@ class PulsarTest(TestCase):
             pass
         client.close()
 
+    def test_message_id(self):
+        s = MessageId.earliest.serialize()
+        self.assertEqual(MessageId.deserialize(s), MessageId.earliest)
+
+        s = MessageId.latest.serialize()
+        self.assertEqual(MessageId.deserialize(s), MessageId.latest)
 
     def _check_value_error(self, fun):
         try:

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -26,10 +26,10 @@ std::string MessageId_str(const MessageId& msgId) {
     return ss.str();
 }
 
-std::string MessageId_serialize(const MessageId& msgId) {
+boost::python::object MessageId_serialize(const MessageId& msgId) {
     std::string serialized;
     msgId.serialize(serialized);
-    return serialized;
+    return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize(serialized.c_str(), serialized.length())));
 }
 
 std::string Message_str(const Message& msg) {

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -26,6 +26,30 @@ std::string MessageId_str(const MessageId& msgId) {
     return ss.str();
 }
 
+bool MessageId_eq(const MessageId& a, const MessageId& b) {
+    return a == b;
+}
+
+bool MessageId_ne(const MessageId& a, const MessageId& b) {
+    return a != b;
+}
+
+bool MessageId_lt(const MessageId& a, const MessageId& b) {
+    return a < b;
+}
+
+bool MessageId_le(const MessageId& a, const MessageId& b) {
+    return a <= b;
+}
+
+bool MessageId_gt(const MessageId& a, const MessageId& b) {
+    return a > b;
+}
+
+bool MessageId_ge(const MessageId& a, const MessageId& b) {
+    return a >= b;
+}
+
 boost::python::object MessageId_serialize(const MessageId& msgId) {
     std::string serialized;
     msgId.serialize(serialized);
@@ -72,6 +96,12 @@ void export_message() {
 
     class_<MessageId>("MessageId")
             .def("__str__", &MessageId_str)
+            .def("__eq__", &MessageId_eq)
+            .def("__ne__", &MessageId_ne)
+            .def("__le__", &MessageId_le)
+            .def("__lt__", &MessageId_lt)
+            .def("__ge__", &MessageId_ge)
+            .def("__gt__", &MessageId_gt)
             .add_static_property("earliest", make_getter(&_MessageId_earliest))
             .add_static_property("latest", make_getter(&_MessageId_latest))
             .def("serialize", &MessageId_serialize)


### PR DESCRIPTION
### Motivation

Fixes #2708

`MessageId.serialize()` is returning a `str` object but it Python 3 that should be a `bytes` object since the the string is not ascii but binary protobuf.