### PR TITLE
Fixed link and spacing for python docs

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -337,6 +337,7 @@ class Client:
           The topic name
 
         **Options**
+
         * `producer_name`:
            Specify a name for the producer. If not assigned,
            the system will generate a globally unique name which can be accessed

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -39,7 +39,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python]({{site.baseUrl}}/api/python).
+The complete Python API reference is available at [api/python](/api/python).
 
 ## Examples
 


### PR DESCRIPTION
### Motivation

Fixed a broken link and added extra line so the producer docs formatting will not get messed up.