### PR TITLE
Remove `install_usercode_dependencies` from java instance main

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -95,9 +95,6 @@ public class JavaInstanceMain implements AutoCloseable {
     @Parameter(names = "--expected_healthcheck_interval", description = "Expected interval in seconds between healtchecks", required = true)
     protected int expectedHealthCheckInterval;
 
-    @Parameter(names = "--install_usercode_dependencies", description = "Do we need to explictly install any user code dependencies(Does not apply to Java", required = false)
-    protected Boolean installUsercodeDependencies;
-
     private Server server;
     private RuntimeSpawner runtimeSpawner;
     private ThreadRuntimeFactory containerFactory;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -85,6 +85,11 @@ class RuntimeUtils {
             args.add(logDirectory);
             args.add("--logging_file");
             args.add(instanceConfig.getFunctionDetails().getName());
+            // `installUserCodeDependencies` is only valid for python runtime
+            if (installUserCodeDepdendencies != null && installUserCodeDepdendencies) {
+                args.add("--install_usercode_dependencies");
+                args.add("True");
+            }
             // TODO:- Find a platform independent way of controlling memory for a python application
         }
         args.add("--instance_id");
@@ -131,10 +136,6 @@ class RuntimeUtils {
         }
         args.add("--expected_healthcheck_interval");
         args.add(String.valueOf(expectedHealthCheckInterval));
-        if (installUserCodeDepdendencies != null && installUserCodeDepdendencies) {
-            args.add("--install_usercode_dependencies");
-            args.add("True");
-        }
         return args;
     }
 }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -121,7 +121,7 @@ public class KubernetesRuntimeTest {
 
         KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, 30l);
         List<String> args = container.getProcessArgs();
-        assertEquals(args.size(), 30);
+        assertEquals(args.size(), 28);
         String expectedArgs = "java -cp " + javaInstanceJarFile
                 + " -Dpulsar.functions.java.instance.jar=" + javaInstanceJarFile
                 + " -Dlog4j.configurationFile=/pulsar/conf/log4j2.yaml "
@@ -135,7 +135,7 @@ public class KubernetesRuntimeTest {
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
                 + " --max_buffered_tuples 1024 --port " + args.get(23)
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
-                + " --expected_healthcheck_interval -1 --install_usercode_dependencies True";
+                + " --expected_healthcheck_interval -1";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 
@@ -147,14 +147,17 @@ public class KubernetesRuntimeTest {
         List<String> args = container.getProcessArgs();
         assertEquals(args.size(), 26);
         String expectedArgs = "python " + pythonInstanceFile
-                + " --py " + pulsarRootDir + "/" + userJarFile + " --logging_directory "
-                + logDirectory + " --logging_file " + config.getFunctionDetails().getName() + " --instance_id "
-                + "$SHARD_ID" + " --function_id " + config.getFunctionId()
+                + " --py " + pulsarRootDir + "/" + userJarFile
+                + " --logging_directory " + logDirectory
+                + " --logging_file " + config.getFunctionDetails().getName()
+                + " --install_usercode_dependencies True"
+                + " --instance_id " + "$SHARD_ID"
+                + " --function_id " + config.getFunctionId()
                 + " --function_version " + config.getFunctionVersion()
                 + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(21)
-                + " --expected_healthcheck_interval -1 --install_usercode_dependencies True";
+                + " --max_buffered_tuples 1024 --port " + args.get(23)
+                + " --expected_healthcheck_interval -1";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 


### PR DESCRIPTION
`installUserCodeDependencies` is only valid for python instance; and python and java have different behaviors on
handling command args. so remove it from java instance to avoid confusion and problems

