### PR TITLE
Added script to change the project version in 1 command

### DIFF
--- a/protobuf-shaded/pom.xml
+++ b/protobuf-shaded/pom.xml
@@ -32,6 +32,7 @@
 
   <artifactId>protobuf-shaded</artifactId>
   <name>Apache Pulsar :: Protobuf shaded</name>
+  <version>2.3.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -31,7 +31,7 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-presto-distribution</artifactId>
     <name>Pulsar SQL :: Pulsar Presto Distribution</name>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
 
     <properties>
         <presto.version>0.206</presto.version>

--- a/src/set-project-version.sh
+++ b/src/set-project-version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Required argument with new project version"
+    exit 1
+fi
+
+NEW_VERSION=$1
+
+# Go to top level project directory
+pushd $(dirname "$0")/..
+
+mvn versions:set -DnewVersion=$NEW_VERSION
+mvn versions:set -DnewVersion=$NEW_VERSION -pl buildtools
+mvn versions:set -DnewVersion=$NEW_VERSION -pl pulsar-sql/presto-distribution
+mvn versions:set -DnewVersion=$NEW_VERSION -f protobuf-shaded/pom.xml
+
+popd


### PR DESCRIPTION
### Motivation

The release instructions in wiki page did not contain a couple of commands to update the project version. 

Since we have multiple poms to update now (to avoid inheriting all the dependencies from parent pom), it's better to have a script to have a single command to run.