### PR TITLE
Make Pulsar Docker have very short ttl cache time

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -36,6 +36,7 @@ COPY scripts/install-pulsar-client.sh /pulsar/bin
 
 ADD target/python-client/ /pulsar/pulsar-client
 RUN /pulsar/bin/install-pulsar-client.sh
+RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/jre/lib/security/java.security
 
 WORKDIR /pulsar
 


### PR DESCRIPTION
### Motivation
Bookie restarts in a container environment will change the ip but may not change the hostname. In these scenarios we need to make sure that brokers react to the dns changes very quickly