### PR TITLE
For externally managed functions, function worker should not do metrics management

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -650,6 +650,10 @@ public class FunctionRuntimeManager implements AutoCloseable{
     }
     
     public void updateRates() {
+        if (runtimeFactory.externallyManaged()) {
+            // We don't do metrics management for externally managed functions
+            return;
+        }
         for (Entry<String, FunctionRuntimeInfo> entry : this.functionRuntimeInfoMap.entrySet()) {
             RuntimeSpawner functionRuntimeSpawner = entry.getValue().getRuntimeSpawner();
             if (functionRuntimeSpawner != null) {


### PR DESCRIPTION

### Motivation

Externally managed functions have a different path for metrics management. Workers should not be doing resetMetrics in that environment

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
