### PR TITLE
Fix the variable name for getting current topic name

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -75,7 +75,7 @@ class ContextImpl(pulsar.Context):
     return self.current_message_id
 
   def get_current_message_topic_name(self):
-    return self.current_topic_name
+    return self.current_input_topic_name
 
   def get_function_name(self):
     return self.instance_config.function_details.name


### PR DESCRIPTION
### Motivation

The actual name of the variable representing topic name is current_input_topic_name

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
