### PR TITLE
Use same shading prefix for functions instance

### DIFF
--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -109,79 +109,79 @@
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.google</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.netty</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.grpc</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.grpc</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.grpc</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.bookkeeper</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.bookkeeper</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.squareup</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.squareup</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.squareup</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>okio</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.okio</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.okio</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.inferred</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.inferred</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.inferred</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.jboss</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.jboss</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.jboss</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.fasterxml.jackson</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.beust</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.beust</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.beust</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>net.jodah</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.net.jodah</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.net.jodah</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.yaml</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.yaml</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.yaml</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.glassfish</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.glassfish</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.glassfish</shadedPattern>
                 </relocation>
                   <relocation>
                   <pattern>com.yahoo</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.yahoo</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.http</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.http</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.commons</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.jvnet</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.jvnet</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.jvnet</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.opencensus</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.opencensus</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.opencensus</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.eclipse</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.eclipse</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.eclipse</shadedPattern>
                 </relocation>
                 <!--
                     asynchttpclient can only be shaded to be under `org.apache.pulsar.shade`
@@ -194,21 +194,21 @@
                 </relocation>
                 <relocation>
                   <pattern>org.bouncycastle</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.bouncycastle</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.bouncycastle</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>jersey</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.jersey</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.jersey</shadedPattern>
                 </relocation>
                 <!-- DONT ever shade log4j, otherwise logging won't work anymore in running functions in process mode
                 <relocation>
                   <pattern>org.apache.logging</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.logging</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.logging</shadedPattern>
                 </relocation>
                 -->
                 <relocation>
                   <pattern>javassist</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javassist</shadedPattern>
+                  <shadedPattern>org.apache.pulsar.shade.javassist</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pulsar-functions/runtime/src/main/resources/java_instance_log4j2.yml
+++ b/pulsar-functions/runtime/src/main/resources/java_instance_log4j2.yml
@@ -98,7 +98,7 @@ Configuration:
   Loggers:
 
     Logger:
-      name: org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper
+      name: org.apache.pulsar.shade.org.apache.bookkeeper
       level: "${sys:bk.log.level}"
       additivity: false
       AppenderRef:


### PR DESCRIPTION
### Motivation

Since we are using 2 different shading prefixes for client lib and functions runtime, several of the classes are included twice in the `java_instace.jar`. 