### PR TITLE
Updated README to build cpp client.

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -73,8 +73,8 @@ Run unit tests:
 #### Install all dependencies:
 
 ```shell
-apt-get install g++ cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
-                libprotobuf-dev libboost-all-dev  libgtest-dev \
+apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
+                libprotobuf-dev libboost-all-dev  libgtest-dev google-mock \
                 libjsoncpp-dev libxml2-utils protobuf-compiler python-setuptools
 ```
 
@@ -82,6 +82,16 @@ apt-get install g++ cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
 
 ```shell
 cd /usr/src/gtest
+sudo cmake .
+sudo make
+sudo cp *.a /usr/lib
+```
+
+
+#### Compile and install Google Mock:
+
+```shell
+cd /usr/src/gmock
 sudo cmake .
 sudo make
 sudo cp *.a /usr/lib


### PR DESCRIPTION
### Motivation

I have encountered the problem to build `pulsar` on `Ubuntu 16.04` regarding `gmock`, and the proposed fix works.

### Modifications

Like `gtest`, install `gmock`.

### Result

I could build `pulsar` as expected..
