### PR TITLE
Allow user to configure proxy as reverse HTTP proxy

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -29,6 +29,7 @@
         <Root level="warn">
             <AppenderRef ref="Console" />
         </Root>
+        <Logger name="org.eclipse.jetty" level="info"/>
         <Logger name="org.apache.pulsar" level="info"/>
         <Logger name="org.apache.bookkeeper" level="info"/>
         <Logger name="org.apache.kafka" level="info"/>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -78,8 +78,15 @@ public class PulsarConfigurationLoader {
         }
     }
 
+    /**
+     * Creates PulsarConfiguration and loads it with populated attribute values from provided Properties object.
+     *
+     * @param properties The properties to populate the attributed from
+     * @throws IOException
+     * @throws IllegalArgumentException
+     */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    protected static <T extends PulsarConfiguration> T create(Properties properties,
+    public static <T extends PulsarConfiguration> T create(Properties properties,
             Class<? extends PulsarConfiguration> clazz) throws IOException, IllegalArgumentException {
         checkNotNull(properties);
         T configuration = null;

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -18,15 +18,25 @@
  */
 package org.apache.pulsar.proxy.server;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
 
 import com.google.common.collect.Sets;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ProxyConfiguration implements PulsarConfiguration {
+    private final static Logger log = LoggerFactory.getLogger(ProxyConfiguration.class);
 
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;
@@ -119,7 +129,10 @@ public class ProxyConfiguration implements PulsarConfiguration {
     // Specify whether Client certificates are required for TLS
     // Reject the Connection if the Client Certificate is not trusted.
     private boolean tlsRequireTrustedClientCertOnConnect = false;
-    
+
+    // Http redirects to redirect to non-pulsar services
+    private Set<HttpReverseProxyConfig> httpReverseProxyConfigs = Sets.newHashSet();
+
     private Properties properties = new Properties();
 
     public boolean forwardAuthorizationCredentials() {
@@ -370,6 +383,29 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     public void setProperties(Properties properties) {
         this.properties = properties;
+
+        Map<String, Map<String, String>> redirects = new HashMap<>();
+        Pattern redirectPattern = Pattern.compile("^httpReverseProxy\\.([^\\.]*)\\.(.+)$");
+        Map<String, List<Matcher>> groups = properties.stringPropertyNames().stream()
+            .map((s) -> redirectPattern.matcher(s))
+            .filter(Matcher::matches)
+            .collect(Collectors.groupingBy((m) -> m.group(1))); // group by name
+
+        groups.entrySet().forEach((e) -> {
+                Map<String, String> keyToFullKey = e.getValue().stream().collect(
+                        Collectors.toMap(m -> m.group(2), m -> m.group(0)));
+                if (!keyToFullKey.containsKey("path")) {
+                    throw new IllegalArgumentException(
+                            String.format("httpReverseProxy.%s.path must be specified exactly once", e.getKey()));
+                }
+                if (!keyToFullKey.containsKey("proxyTo")) {
+                    throw new IllegalArgumentException(
+                            String.format("httpReverseProxy.%s.proxyTo must be specified exactly once", e.getKey()));
+                }
+                httpReverseProxyConfigs.add(new HttpReverseProxyConfig(e.getKey(),
+                                                    properties.getProperty(keyToFullKey.get("path")),
+                                                    properties.getProperty(keyToFullKey.get("proxyTo"))));
+            });
     }
 
     public Set<String> getTlsProtocols() {
@@ -410,5 +446,42 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     public void setTlsRequireTrustedClientCertOnConnect(boolean tlsRequireTrustedClientCertOnConnect) {
         this.tlsRequireTrustedClientCertOnConnect = tlsRequireTrustedClientCertOnConnect;
+    }
+
+    public Set<HttpReverseProxyConfig> getHttpReverseProxyConfigs() {
+        return httpReverseProxyConfigs;
+    }
+
+    public void setHttpReverseProxyConfigs(Set<HttpReverseProxyConfig> reverseProxyConfigs) {
+        this.httpReverseProxyConfigs = reverseProxyConfigs;
+    }
+
+    public static class HttpReverseProxyConfig {
+        private final String name;
+        private final String path;
+        private final String proxyTo;
+
+        HttpReverseProxyConfig(String name, String path, String proxyTo) {
+            this.name = name;
+            this.path = path;
+            this.proxyTo = proxyTo;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getProxyTo() {
+            return proxyTo;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("HttpReverseProxyConfig(%s, path=%s, proxyTo=%s)", name, path, proxyTo);
+        }
     }
 }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
@@ -1,0 +1,299 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.logging.LoggingFeature;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ProxyIsAHttpProxyTest extends MockedPulsarServiceBaseTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ProxyIsAHttpProxyTest.class);
+
+    private Server backingServer1;
+    private Server backingServer2;
+    private Client client = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        internalSetup();
+
+        backingServer1 = new Server(0);
+        backingServer1.setHandler(newHandler("server1"));
+        backingServer1.start();
+
+        backingServer2 = new Server(0);
+        backingServer2.setHandler(newHandler("server2"));
+        backingServer2.start();
+    }
+
+    private static AbstractHandler newHandler(String text) {
+        return new AbstractHandler() {
+            @Override
+            public void handle(String target, Request baseRequest,
+                               HttpServletRequest request,HttpServletResponse response)
+                    throws IOException, ServletException {
+                response.setContentType("text/plain;charset=utf-8");
+                response.setStatus(HttpServletResponse.SC_OK);
+                baseRequest.setHandled(true);
+                response.getWriter().println(String.format("%s,%s", text, request.getRequestURI()));
+            }
+        };
+    }
+
+    @Override
+    @AfterClass
+    protected void cleanup() throws Exception {
+        internalCleanup();
+
+        backingServer1.stop();
+        backingServer2.stop();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRedirectNotSpecified() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("httpReverseProxy.foobar.path", "/ui");
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testPathNotSpecified() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("httpReverseProxy.foobar.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+    }
+
+    @Test
+    public void testSingleRedirect() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("httpReverseProxy.foobar.path", "/ui");
+        props.setProperty("httpReverseProxy.foobar.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r = client.target(webServer.getServiceUri()).path("/ui/foobar").request().get();
+            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r.readEntity(String.class).trim(), "server1,/foobar");
+        } finally {
+            webServer.stop();
+        }
+    }
+
+    @Test
+    public void testMultipleRedirect() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("httpReverseProxy.0.path", "/server1");
+        props.setProperty("httpReverseProxy.0.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("httpReverseProxy.1.path", "/server2");
+        props.setProperty("httpReverseProxy.1.proxyTo", backingServer2.getURI().toString());
+
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r1 = client.target(webServer.getServiceUri()).path("/server1/foobar").request().get();
+            Assert.assertEquals(r1.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r1.readEntity(String.class).trim(), "server1,/foobar");
+
+            Response r2 = client.target(webServer.getServiceUri()).path("/server2/blahblah").request().get();
+            Assert.assertEquals(r2.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r2.readEntity(String.class).trim(), "server2,/blahblah");
+
+        } finally {
+            webServer.stop();
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTryingToUseExistingPath() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("httpReverseProxy.foobar.path", "/admin");
+        props.setProperty("httpReverseProxy.foobar.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+
+    }
+
+    @Test
+    public void testLongPathInProxyTo() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("httpReverseProxy.foobar.path", "/ui");
+        props.setProperty("httpReverseProxy.foobar.proxyTo",
+                          backingServer1.getURI().resolve("/foo/bar/blah/yadda/yadda/yadda").toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r = client.target(webServer.getServiceUri()).path("/ui/foobar").request().get();
+            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r.readEntity(String.class).trim(), "server1,/foo/bar/blah/yadda/yadda/yadda/foobar");
+        } finally {
+            webServer.stop();
+        }
+
+    }
+
+    @Test
+    public void testProxyToEndsInSlash() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("httpReverseProxy.foobar.path", "/ui");
+        props.setProperty("httpReverseProxy.foobar.proxyTo",
+                          backingServer1.getURI().resolve("/foo/").toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r = client.target(webServer.getServiceUri()).path("/ui/foobar").request().get();
+            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r.readEntity(String.class).trim(), "server1,/foo/foobar");
+        } finally {
+            webServer.stop();
+        }
+
+    }
+
+    @Test
+    public void testLongPath() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("httpReverseProxy.foobar.path", "/foo/bar/blah");
+        props.setProperty("httpReverseProxy.foobar.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r = client.target(webServer.getServiceUri()).path("/foo/bar/blah/foobar").request().get();
+            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r.readEntity(String.class).trim(), "server1,/foobar");
+        } finally {
+            webServer.stop();
+        }
+    }
+
+    @Test
+    public void testPathEndsInSlash() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("httpReverseProxy.foobar.path", "/ui/");
+        props.setProperty("httpReverseProxy.foobar.proxyTo", backingServer1.getURI().toString());
+        props.setProperty("servicePort", "0");
+        props.setProperty("webServicePort", "0");
+
+        ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(props, ProxyConfiguration.class);
+        AuthenticationService authService = new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig));
+
+        WebServer webServer = new WebServer(proxyConfig, authService);
+        ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig,
+                                                 new BrokerDiscoveryProvider(proxyConfig, mockZooKeeperClientFactory));
+        webServer.start();
+        try {
+            Response r = client.target(webServer.getServiceUri()).path("/ui/foobar").request().get();
+            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+            Assert.assertEquals(r.readEntity(String.class).trim(), "server1,/foobar");
+        } finally {
+            webServer.stop();
+        }
+
+    }
+
+}


### PR DESCRIPTION
Users normally want to expose as few endpoints as possible. This patch
enables configuring the pulsar proxy as a review HTTP proxy, so that
it can be used as a single endpoint for all pulsar and even non-pulsar
HTTP services.

The reverse proxy uses jetty's built-in implementation.

It is configured in proxy.conf, in the form

```
httpReverseProxy.NAME.path = '/path-on-pulsar-proxy-endpoint'
httpReverseProxy.NAME.proxyTo = 'http://internal-server/some-app'
```

where NAME is any user-defined string. Multiple paths can be
configured this way.
