### PR TITLE
Export Jetty stats to Prometheus

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -353,11 +353,12 @@ The Apache Software License, Version 2.0
     - io.netty-netty-all-4.1.22.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.7.Final.jar
  * Prometheus client
-    - io.prometheus-simpleclient-0.0.23.jar
-    - io.prometheus-simpleclient_common-0.0.23.jar
-    - io.prometheus-simpleclient_hotspot-0.0.23.jar
-    - io.prometheus-simpleclient_servlet-0.0.23.jar
-    - io.prometheus-simpleclient_log4j2-0.0.23.jar
+    - io.prometheus-simpleclient-0.5.0.jar
+    - io.prometheus-simpleclient_common-0.5.0.jar
+    - io.prometheus-simpleclient_hotspot-0.5.0.jar
+    - io.prometheus-simpleclient_servlet-0.5.0.jar
+    - io.prometheus-simpleclient_log4j2-0.5.0.jar
+    - io.prometheus-simpleclient_jetty-0.5.0.jar
  * Bean Validation API -- javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
     - log4j-log4j-1.2.17.jar

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@ flexible messaging model and an intuitive client API.</description>
     <jetty.version>9.3.11.v20160721</jetty.version>
     <jersey.version>2.25</jersey.version>
     <athenz.version>1.7.17</athenz.version>
-    <prometheus.version>0.0.23</prometheus.version>
+    <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.1</aspectj.version>
     <rocksdb.version>5.13.3</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -683,6 +683,12 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_servlet</artifactId>
+        <version>${prometheus.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_jetty</artifactId>
         <version>${prometheus.version}</version>
       </dependency>
 

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -212,6 +212,12 @@
 
     <dependency>
       <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_jetty</artifactId>
+    </dependency>
+
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
     </dependency>
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -172,7 +172,11 @@ public class WebService implements AutoCloseable {
             // Metrics handler
             StatisticsHandler stats = new StatisticsHandler();
             stats.setHandler(server.getHandler());
-            new JettyStatisticsCollector(stats).register();
+            try {
+                new JettyStatisticsCollector(stats).register();
+            } catch (IllegalArgumentException e) {
+                // Already registered. Eg: in unit tests
+            }
             handlers.add(stats);
 
             ContextHandlerCollection contexts = new ContextHandlerCollection();

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -110,6 +110,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_jetty</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${project.version}</version>

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.google.common.collect.Lists;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.prometheus.client.jetty.JettyStatisticsCollector;
 
 import java.io.IOException;
 import java.net.URI;
@@ -52,6 +53,7 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -174,8 +176,13 @@ public class WebServer {
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         contexts.setHandlers(handlers.toArray(new Handler[handlers.size()]));
 
+        // Metrics handler
+        StatisticsHandler stats = new StatisticsHandler();
+        stats.setHandler(server.getHandler());
+        new JettyStatisticsCollector(stats).register();
+
         HandlerCollection handlerCollection = new HandlerCollection();
-        handlerCollection.setHandlers(new Handler[] { contexts, new DefaultHandler(), requestLogHandler });
+        handlerCollection.setHandlers(new Handler[] { contexts, new DefaultHandler(), requestLogHandler, stats });
         server.setHandler(handlerCollection);
 
         try {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -179,7 +179,11 @@ public class WebServer {
         // Metrics handler
         StatisticsHandler stats = new StatisticsHandler();
         stats.setHandler(server.getHandler());
-        new JettyStatisticsCollector(stats).register();
+        try {
+            new JettyStatisticsCollector(stats).register();
+        } catch (IllegalArgumentException e) {
+            // Already registered. Eg: in unit tests
+        }
 
         HandlerCollection handlerCollection = new HandlerCollection();
         handlerCollection.setHandlers(new Handler[] { contexts, new DefaultHandler(), requestLogHandler, stats });

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -415,10 +415,10 @@ The Apache Software License, Version 2.0
     - metrics-graphite-3.1.0.jar
     - metrics-jvm-3.1.0.jar
   * Prometheus
-    - simpleclient-0.0.23.jar
-    - simpleclient_common-0.0.23.jar
-    - simpleclient_hotspot-0.0.23.jar
-    - simpleclient_servlet-0.0.23.jar
+    - simpleclient-0.5.0.jar
+    - simpleclient_common-0.5.0.jar
+    - simpleclient_hotspot-0.5.0.jar
+    - simpleclient_servlet-0.5.0.jar
   * LZ4
     - lz4-java-1.5.0.jar
   * Bookkeeper
@@ -530,4 +530,3 @@ Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
     - bcpkix-jdk15on-1.55.jar
     - bcprov-jdk15on-1.55.jar
-


### PR DESCRIPTION
### Motivation

Expose Jetty stats for broker and proxy directly into Prometheus. The new metrics are : 

```
jetty_requests_total 15.0
jetty_requests_active 0.0
jetty_requests_active_max 1.0
jetty_request_time_max_seconds 0.073
jetty_request_time_seconds_total 0.147
jetty_dispatched_total 15.0
jetty_dispatched_active 0.0
jetty_dispatched_active_max 1.0
jetty_dispatched_time_max 73.0
jetty_dispatched_time_seconds_total 0.147
jetty_async_requests_total 0.0
jetty_async_requests_waiting 0.0
jetty_async_requests_waiting_max 0.0
jetty_async_dispatches_total 0.0
jetty_expires_total 0.0
jetty_responses_total{code="1xx",} 0.0
jetty_responses_total{code="2xx",} 14.0
jetty_responses_total{code="3xx",} 0.0
jetty_responses_total{code="4xx",} 1.0
jetty_responses_total{code="5xx",} 0.0
jetty_stats_seconds 179.302
jetty_responses_bytes_total 137995.0
```
