### PR TITLE
Fix memory issue in cpp ZTSClient

### DIFF
--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -150,7 +150,10 @@ char *ZTSClient::base64Decode(const char *input) {
     bio = BIO_push(b64, bio);
 
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
-    BIO_read(bio, result, length);
+    int decodeStrLen = BIO_read(bio, result, length);
+    if(decodeStrLen > 0) {
+        result[decodeStrLen] = '\0';
+    }
     BIO_free_all(bio);
 
     return result;

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -143,7 +143,7 @@ std::string ZTSClient::ybase64Encode(const unsigned char *input, int length) {
 char *ZTSClient::base64Decode(const char *input) {
     BIO *bio, *b64;
     size_t length = strlen(input);
-    char *result = (char *)calloc(length, sizeof(char));
+    char *result = (char *)malloc(length);
 
     bio = BIO_new_mem_buf((void *)input, -1);
     b64 = BIO_new(BIO_f_base64());
@@ -151,8 +151,10 @@ char *ZTSClient::base64Decode(const char *input) {
 
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
     int decodeStrLen = BIO_read(bio, result, length);
-    if(decodeStrLen > 0) {
+    if (decodeStrLen > 0) {
         result[decodeStrLen] = '\0';
+    } else {
+        result[0] = '\0';
     }
     BIO_free_all(bio);
 
@@ -191,6 +193,12 @@ const std::string ZTSClient::getPrincipalToken() const {
             return "";
         }
         char *decodeStr = base64Decode(privateKeyUri_.data.c_str());
+
+        if (strlen(decodeStr) == 0) {
+            LOG_ERROR("Failed to decode privateKey");
+            free(decodeStr);
+            return "";
+        }
 
         BIO *bio = BIO_new_mem_buf((void *)decodeStr, -1);
         BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -141,6 +141,9 @@ std::string ZTSClient::ybase64Encode(const unsigned char *input, int length) {
 }
 
 char *ZTSClient::base64Decode(const char *input) {
+    if (input == NULL || strlen(input) == 0) {
+        return NULL;
+    }
     BIO *bio, *b64;
     size_t length = strlen(input);
     char *result = (char *)malloc(length);
@@ -154,7 +157,7 @@ char *ZTSClient::base64Decode(const char *input) {
     if (decodeStrLen > 0) {
         result[decodeStrLen] = '\0';
     } else {
-        result[0] = '\0';
+        return NULL;
     }
     BIO_free_all(bio);
 
@@ -194,9 +197,8 @@ const std::string ZTSClient::getPrincipalToken() const {
         }
         char *decodeStr = base64Decode(privateKeyUri_.data.c_str());
 
-        if (strlen(decodeStr) == 0) {
+        if (decodeStr == NULL) {
             LOG_ERROR("Failed to decode privateKey");
-            free(decodeStr);
             return "";
         }
 

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -141,11 +141,16 @@ std::string ZTSClient::ybase64Encode(const unsigned char *input, int length) {
 }
 
 char *ZTSClient::base64Decode(const char *input) {
-    if (input == NULL || strlen(input) == 0) {
+    if (input == NULL) {
         return NULL;
     }
-    BIO *bio, *b64;
+
     size_t length = strlen(input);
+    if (length == 0) {
+        return NULL;
+    }
+
+    BIO *bio, *b64;
     char *result = (char *)malloc(length);
 
     bio = BIO_new_mem_buf((void *)input, -1);
@@ -154,14 +159,14 @@ char *ZTSClient::base64Decode(const char *input) {
 
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
     int decodeStrLen = BIO_read(bio, result, length);
+    BIO_free_all(bio);
     if (decodeStrLen > 0) {
         result[decodeStrLen] = '\0';
-    } else {
-        return NULL;
-    }
-    BIO_free_all(bio);
+        return result;
+    } 
+    free(result);
 
-    return result;
+    return NULL;
 }
 
 const std::string ZTSClient::getPrincipalToken() const {

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -146,7 +146,7 @@ char *ZTSClient::base64Decode(const char *input) {
     }
 
     size_t length = strlen(input);
-    if (length == 0) {
+    if (length == 0) {
         return NULL;
     }
 
@@ -163,7 +163,7 @@ char *ZTSClient::base64Decode(const char *input) {
     if (decodeStrLen > 0) {
         result[decodeStrLen] = '\0';
         return result;
-    } 
+    }
     free(result);
 
     return NULL;


### PR DESCRIPTION

### Modifications

* Use `calloc` instead of `malloc` in order to add Termination character(`\0`).
* Free memory allocated with `calloc` and `PEM_read_bio_RSAPrivateKey`.
