### PR TITLE
Python3 strings are not bytes

### DIFF
--- a/pulsar-functions/instance/src/main/python/log.py
+++ b/pulsar-functions/instance/src/main/python/log.py
@@ -50,7 +50,7 @@ class LogTopicHandler(logging.Handler):
 
   def emit(self, record):
     msg = self.format(record)
-    self.producer.send_async(str(msg), None)
+    self.producer.send_async(str(msg).encode('utf-8'), None)
 
 def configure(level=logging.INFO):
   """ Configure logger which dumps log on terminal


### PR DESCRIPTION
### Motivation

While publishing messages to the logtopic, we need to ensure that they are converted to bytes.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
