### PR TITLE
Support topic name with / in name

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
@@ -52,7 +52,7 @@ public class ServiceUrlProviderTest extends ProducerConsumerBase {
     }
 
     @DataProvider(name = "cluster")
-    public Object[][] codecProvider() {
+    public Object[][] clusterProvider() {
         return new Object[][] { {Boolean.TRUE}, {Boolean.FALSE} };
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -139,6 +139,15 @@ public class TopicName implements ServiceUnitId {
 
 
             parts = Splitter.on("/").limit(4).splitToList(rest);
+            if (parts.size() == 4) {
+                try {
+                    NamedEntity.checkName(parts.get(2));
+                } catch (IllegalArgumentException ie) {
+                    // It happens when topic-local-name has "/" in the name and cluster doesn't present into the
+                    // topic-name
+                    parts = Splitter.on("/").limit(3).splitToList(rest);
+                }
+            }
             if (parts.size() == 3) {
                 // New topic name without cluster name
                 this.tenant = parts.get(0);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
@@ -23,11 +23,34 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
 import org.apache.pulsar.common.util.Codec;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test
 public class TopicNameTest {
 
+    @DataProvider(name = "cluster")
+    public Object[][] clusterProvider() {
+        return new Object[][] { {Boolean.TRUE}, {Boolean.FALSE} };
+    }
+
+    @Test(dataProvider = "cluster")
+    public void testClientWithSpecialCharTopicName(boolean isCluster) throws Exception {
+
+        final String cluster = "test";
+        final String topicLocalName = "`~!@#$%^&*()-_+=[]://{}|\\;:'\"<>,./?-my-topic";
+        final String topic = "persistent://my-property/" + (isCluster ? cluster + "/" : "") + "my-ns/" + topicLocalName;
+
+        TopicName topicName = TopicName.get(topic);
+        Assert.assertEquals(topicName.getTenant(), "my-property");
+        Assert.assertEquals(topicName.getNamespacePortion(), "my-ns");
+        Assert.assertEquals(topicName.getLocalName(), topicLocalName);
+        if(isCluster) {
+            Assert.assertEquals(topicName.getCluster(), "test");    
+        }
+    }
+    
     @Test
     void topic() {
         try {


### PR DESCRIPTION
### Motivation

we have application which has topic-name with "/" in it. with Pulsar-2.0 client-lib change, it's broken.

### Modifications

Support "/" in the topic name.

