### PR TITLE
Fix Websocket Consume Messages in Partitioned Topics

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import java.io.Serializable;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
 
 /**
  * Opaque unique identifier of a single message
@@ -47,6 +48,10 @@ public interface MessageId extends Comparable<MessageId>, Serializable {
      */
     public static MessageId fromByteArray(byte[] data) throws IOException {
         return MessageIdImpl.fromByteArray(data);
+    }
+
+    public static MessageId fromByteArrayWithTopic(byte[] data, TopicName topicName) throws IOException {
+        return MessageIdImpl.fromByteArrayWithTopic(data, topicName);
     }
 
     public static final MessageId earliest = new MessageIdImpl(-1, -1, -1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.apache.pulsar.shaded.com.google.protobuf.v241.UninitializedMessageException;
@@ -105,6 +106,36 @@ public class MessageIdImpl implements MessageId {
                     idData.getBatchIndex());
         } else {
             messageId = new MessageIdImpl(idData.getLedgerId(), idData.getEntryId(), idData.getPartition());
+        }
+
+        inputStream.recycle();
+        builder.recycle();
+        idData.recycle();
+        return messageId;
+    }
+
+    public static MessageId fromByteArrayWithTopic(byte[] data, TopicName topicName) throws IOException {
+        checkNotNull(data);
+        ByteBufCodedInputStream inputStream = ByteBufCodedInputStream.get(Unpooled.wrappedBuffer(data, 0, data.length));
+        PulsarApi.MessageIdData.Builder builder = PulsarApi.MessageIdData.newBuilder();
+
+        PulsarApi.MessageIdData idData;
+        try {
+            idData = builder.mergeFrom(inputStream, null).build();
+        } catch (UninitializedMessageException e) {
+            throw new IOException(e);
+        }
+
+        MessageId messageId;
+        if (idData.hasBatchIndex()) {
+            messageId = new BatchMessageIdImpl(idData.getLedgerId(), idData.getEntryId(), idData.getPartition(),
+                    idData.getBatchIndex());
+        } else {
+            messageId = new MessageIdImpl(idData.getLedgerId(), idData.getEntryId(), idData.getPartition());
+        }
+        if (idData.getPartition() > -1 && topicName != null) {
+            messageId = new TopicMessageIdImpl(
+                    topicName.getPartition(idData.getPartition()).toString(), topicName.toString(), messageId);
         }
 
         inputStream.recycle();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -31,7 +31,7 @@ public class TopicMessageIdImpl implements MessageId {
     private final String topicName;
     private final MessageId messageId;
 
-    TopicMessageIdImpl(String topicPartitionName, String topicName, MessageId messageId) {
+    public TopicMessageIdImpl(String topicPartitionName, String topicName, MessageId messageId) {
         this.messageId = messageId;
         this.topicPartitionName = topicPartitionName;
         this.topicName = topicName;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -31,7 +31,7 @@ public class TopicMessageIdImpl implements MessageId {
     private final String topicName;
     private final MessageId messageId;
 
-    public TopicMessageIdImpl(String topicPartitionName, String topicName, MessageId messageId) {
+    TopicMessageIdImpl(String topicPartitionName, String topicName, MessageId messageId) {
         this.messageId = messageId;
         this.topicPartitionName = topicPartitionName;
         this.topicName = topicName;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -223,7 +223,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             ConsumerAck ack = ObjectMapperFactory.getThreadLocal().readValue(message, ConsumerAck.class);
             msgId = MessageId.fromByteArray(Base64.getDecoder().decode(ack.messageId));
             int partitionIndex = Integer.parseInt(msgId.toString().split(":")[2]);
-            if(partitionIndex > -1)
+            if (partitionIndex > -1)
                 msgId = new TopicMessageIdImpl(topic.getPartition(partitionIndex).toString(), topic.toString(), msgId);
         } catch (IOException e) {
             log.warn("Failed to deserialize message id: {}", message, e);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException
 import org.apache.pulsar.client.api.PulsarClientException.ConsumerBusyException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
+import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ConsumerAck;
@@ -221,6 +222,9 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         try {
             ConsumerAck ack = ObjectMapperFactory.getThreadLocal().readValue(message, ConsumerAck.class);
             msgId = MessageId.fromByteArray(Base64.getDecoder().decode(ack.messageId));
+            int partitionIndex = Integer.parseInt(msgId.toString().split(":")[2]);
+            if(partitionIndex > -1)
+                msgId = new TopicMessageIdImpl(topic.getPartition(partitionIndex).toString(), topic.toString(), msgId);
         } catch (IOException e) {
             log.warn("Failed to deserialize message id: {}", message, e);
             close(WebSocketError.FailedToDeserializeFromJSON);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -221,10 +221,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         MessageId msgId;
         try {
             ConsumerAck ack = ObjectMapperFactory.getThreadLocal().readValue(message, ConsumerAck.class);
-            msgId = MessageId.fromByteArray(Base64.getDecoder().decode(ack.messageId));
-            int partitionIndex = Integer.parseInt(msgId.toString().split(":")[2]);
-            if (partitionIndex > -1)
-                msgId = new TopicMessageIdImpl(topic.getPartition(partitionIndex).toString(), topic.toString(), msgId);
+            msgId = MessageId.fromByteArrayWithTopic(Base64.getDecoder().decode(ack.messageId), topic);
         } catch (IOException e) {
             log.warn("Failed to deserialize message id: {}", message, e);
             close(WebSocketError.FailedToDeserializeFromJSON);


### PR DESCRIPTION
### Motivation

When clients consumed messages in partitioned topics on websocket, it occurred above errors:
```
15:46:31.854 [pulsar-web-28-8] WARN  o.a.pulsar.websocket.ConsumerHandler - Unhandled Error (closing connection)
java.lang.NullPointerException: null
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.doAcknowledge(MultiTopicsConsumerImpl.java:384) ~[pulsar-client-original-2.1.1.2-incubating-yjrelease.jar:2.1.1-incubating]
	at org.apache.pulsar.client.impl.ConsumerBase.acknowledgeAsync(ConsumerBase.java:243) ~[pulsar-client-original-2.1.1.2-incubating-yjrelease.jar:2.1.1-incubating]
	at org.apache.pulsar.websocket.ConsumerHandler.onWebSocketText(ConsumerHandler.java:238) ~[pulsar-websocket-2.1.1.2-incubating-yjrelease.jar:2.1.1-incubating]
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:189) ~[websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69) ~[websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:66) ~[websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:158) ~[websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:162) ~[websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:376) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.extensions.AbstractExtension.nextIncomingFrame(AbstractExtension.java:176) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.nextIncomingFrame(PerMessageDeflateExtension.java:105) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.incomingFrame(PerMessageDeflateExtension.java:70) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:220) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:256) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:679) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:511) [websocket-common-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:273) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:202) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:273) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:93) [jetty-io-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.executeProduceConsume(ExecuteProduceConsume.java:303) [jetty-util-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:148) [jetty-util-9.3.11.v20160721.jar:9.3.11.v20160721]
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:136) [jetty-util-9.3.11.v20160721.jar:9.3.11.v20160721]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1
```

### Modifications

- Add `public` to `TopicMessageIdImpl` class.
- Parse messages and get a partitioned topic name.
- If a message is from a partitioned topic, `msgId` changes `TopicMessageIdImpl` instance.  

### Result

When clients are able to consume messages in partitioned topics on websocket.