### PR TITLE
Fix: schema init for topic-name with special char

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -130,5 +130,10 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
         // Ignore test
     }
 
+    @Test(enabled = false)
+    public void testTopicWithWildCardChar() throws Exception {
+        // Ignore test
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(RackAwareTest.class);
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -337,7 +337,7 @@ public class TopicName implements ServiceUnitId {
     public String getSchemaName() {
         return getTenant()
             + "/" + getNamespacePortion()
-            + "/" + getLocalName();
+            + "/" + getEncodedLocalName();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Right now, Pulsar-schema creates z-node for topic without encoding topic-name which can cause issue for topics which has special char which creates invalid znode-path.
```
21:15:34.909 [pulsar-io-21-1] WARN  org.apache.pulsar.zookeeper.ZooKeeperCache - Failed to access zkSession for /schemas/cms-single-parallel/SNS-6d1849fe-f3de-4c4d-b570-394071738d8c/`~!@#$%^&*()-_+=[]://{}|\;:'"<>,./?-30e04524-fcff-4fee-babf-74c9aab06dfc Invalid path string "/schemas/cms-single-parallel/SNS-6d1849fe-f3de-4c4d-b570-394071738d8c/`~!@#$%^&*()-_+=[]://{}|\;:'"<>,./?-30e04524-fcff-4fee-babf-74c9aab06dfc" caused by empty node name specified @90
java.lang.IllegalArgumentException: Invalid path string "/schemas/cms-single-parallel/SNS-6d1849fe-f3de-4c4d-b570-394071738d8c/`~!@#$%^&*()-_+=[]://{}|\;:'"<>,./?-30e04524-fcff-4fee-babf-74c9aab06dfc" caused by empty node name specified @90
        at org.apache.zookeeper.common.PathUtils.validatePath(PathUtils.java:99) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.ZooKeeper.getData(ZooKeeper.java:1196) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient.access$2901(ZooKeeperClient.java:70) ~[bookkeeper-server-4.7.2-Auth0.jar:4.7.2-Auth0]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$19.zkRun(ZooKeeperClient.java:1004) ~[bookkeeper-server-4.7.2-Auth0.jar:4.7.2-Auth0]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$ZkRetryRunnable.run(ZooKeeperClient.java:389) ~[bookkeeper-server-4.7.2-Auth0.jar:4.7.2-Auth0]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient.getData(ZooKeeperClient.java:1016) ~[bookkeeper-server-4.7.2-Auth0.jar:4.7.2-Auth0]
        at org.apache.pulsar.zookeeper.ZooKeeperCache.lambda$6(ZooKeeperCache.java:322) ~[pulsar-zookeeper-utils-2.2.0.jar:2.2.0]
        at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache.lambda$get$2(LocalAsyncLoadingCache.java:126) ~[caffeine-2.3.3.jar:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$16(BoundedLocalCache.java:1973) ~[caffeine-2.3.3.jar:?]
        at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1853) ~[?:1.8.0_131]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:1971) ~[caffeine-2.3.3.jar:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:1954) ~[caffeine-2.3.3.jar:?]
        at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache.get(LocalAsyncLoadingCache.java:125) ~[caffeine-2.3.3.jar:?]
        at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache.get(LocalAsyncLoadingCache.java:117) ~[caffeine-2.3.3.jar:?]
        at org.apache.pulsar.zookeeper.ZooKeeperCache.getDataAsync(ZooKeeperCache.java:316) ~[pulsar-zookeeper-utils-2.2.0.jar:2.2.0]
        at org.apache.pulsar.zookeeper.ZooKeeperCache.getEntryAsync(ZooKeeperCache.java:242) ~[pulsar-zookeeper-utils-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.getSchemaLocator(BookkeeperSchemaStorage.java:347) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$0(BookkeeperSchemaStorage.java:129) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660) ~[?:1.8.0_131]
        at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.getSchema(BookkeeperSchemaStorage.java:126) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.get(BookkeeperSchemaStorage.java:111) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.schema.SchemaRegistryServiceImpl.getSchema(SchemaRegistryServiceImpl.java:72) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.schema.SchemaRegistryServiceImpl.getSchema(SchemaRegistryServiceImpl.java:66) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.hasSchema(PersistentTopic.java:1815) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$25(ServerCnx.java:836) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:669) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:1997) ~[?:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$20(ServerCnx.java:801) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) ~[?:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$8(ServerCnx.java:764) ~[pulsar-broker-2.2.0.jar:2.2.0]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602) [?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) [?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) [?:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.handleProducer(ServerCnx.java:754) [pulsar-broker-2.2.0.jar:2.2.0]
        at org.apache.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:175) [pulsar-common-2.2.0.jar:2.2.0]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-codec-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [netty-codec-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:945) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:806) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:404) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```


### Modifications

Encode topic-name before using it for schema.

### Result

topic loading will not fail for topic with special char in the name.
