### PR TITLE
Add "dashboard" to list of modules so that pom version gets auto updated

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.1.0-incubating-SNAPSHOT</version>
+    <version>2.2.0</version>
     <relativePath>../docker</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../docker</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-zookeeper</module>
     <module>pulsar-log4j2-appender</module>
     <module>pulsar-sql</module>
+    <module>dashboard</module>
 
     <!-- jclouds shaded for gson conflict: https://issues.apache.org/jira/browse/JCLOUDS-1166 -->
     <module>jclouds-shaded</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1036,7 +1036,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/*.graffle</exclude>
             <exclude>**/*.hgrm</exclude>
             <exclude>**/CMakeFiles/**</exclude>
-            <exclude>dashboard/django/stats/migrations/*.py</exclude>
+            <exclude>**/django/stats/migrations/*.py</exclude>
             <exclude>site/vendor/**</exclude>
             <exclude>site/scripts/doxygen/**</exclude>
             <exclude>site/api/**</exclude>
@@ -1143,7 +1143,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/META-INF/services/com.facebook.presto.spi.Plugin</exclude>
 
             <!-- Django generated code -->
-            <exclude>dashboard/django/stats/migrations/*.py</exclude>
+            <exclude>**/django/stats/migrations/*.py</exclude>
             <exclude>**/conf/uwsgi_params</exclude>
 
             <!-- Exclude certificates used for tests -->


### PR DESCRIPTION
### Motivation

Since the `dashboard` module is not listed in root pom, it's version won't get automatically updated once we prepare a release. 