### PR TITLE
Handle builtin/functionpkgurl properly in externally managed schedulers

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -74,19 +74,12 @@ metricsSamplingPeriodSec: 60
 
 #threadContainerFactory:
 #  threadGroupName: "Thread Function Container Group"
-#processContainerFactory:
-#  logDirectory:
+processContainerFactory:
+  logDirectory:
   # change the jar location only when you put the java instance jar in a different location
-#  javaInstanceJarLocation:
+  javaInstanceJarLocation:
   # change the python instance location only when you put the python instance jar in a different location
-#  pythonInstanceLocation:
-kubernetesContainerFactory:
-  pulsarDockerImageName: "srkukarni/pulsar"
-  submittingInsidePod: true
-  pulsarServiceUrl: pulsar://pulsar:6650/
-  pulsarAdminUrl: http://pulsar:8080/
-  installUserCodeDependencies: true
-  pythonDependencyRepository: https://test.pypi.org/simple/
+  pythonInstanceLocation:
 #kubernetesContainerFactory:
 #  # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
 #  k8Uri:

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -74,12 +74,19 @@ metricsSamplingPeriodSec: 60
 
 #threadContainerFactory:
 #  threadGroupName: "Thread Function Container Group"
-processContainerFactory:
-  logDirectory:
+#processContainerFactory:
+#  logDirectory:
   # change the jar location only when you put the java instance jar in a different location
-  javaInstanceJarLocation:
+#  javaInstanceJarLocation:
   # change the python instance location only when you put the python instance jar in a different location
-  pythonInstanceLocation:
+#  pythonInstanceLocation:
+kubernetesContainerFactory:
+  pulsarDockerImageName: "srkukarni/pulsar"
+  submittingInsidePod: true
+  pulsarServiceUrl: pulsar://pulsar:6650/
+  pulsarAdminUrl: http://pulsar:8080/
+  installUserCodeDependencies: true
+  pythonDependencyRepository: https://test.pypi.org/simple/
 #kubernetesContainerFactory:
 #  # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
 #  k8Uri:

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -238,18 +238,23 @@ public class Utils {
     }
 
     public static ClassLoader extractClassLoader(String destPkgUrl) throws IOException, URISyntaxException {
+        File file = extractFileFromPkg(destPkgUrl);
+        try {
+            return loadJar(file);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(
+                    "Corrupt User PackageFile " + file + " with error " + e.getMessage());
+        }
+    }
+
+    public static File extractFileFromPkg(String destPkgUrl) throws IOException, URISyntaxException {
         if (destPkgUrl.startsWith(FILE)) {
             URL url = new URL(destPkgUrl);
             File file = new File(url.toURI());
             if (!file.exists()) {
                 throw new IOException(destPkgUrl + " does not exists locally");
             }
-            try {
-                return loadJar(file);
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException(
-                        "Corrupt User PackageFile " + file + " with error " + e.getMessage());
-            }
+            return file;
         } else if (destPkgUrl.startsWith("http")) {
             URL website = new URL(destPkgUrl);
             File tempFile = File.createTempFile("function", ".tmp");
@@ -260,7 +265,7 @@ public class Utils {
             if (tempFile.exists()) {
                 tempFile.delete();
             }
-            return loadJar(tempFile);
+            return tempFile;
         } else {
             throw new IllegalArgumentException("Unsupported url protocol "+ destPkgUrl +", supported url protocols: [file/http/https]");
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -143,26 +143,26 @@ public class FunctionActioner implements AutoCloseable {
         String pkgLocation = functionMetaData.getPackageLocation().getPackagePath();
         boolean isPkgUrlProvided = isFunctionPackageUrlSupported(pkgLocation);
 
-        if (isPkgUrlProvided && pkgLocation.startsWith(FILE)) {
-            URL url = new URL(pkgLocation);
-            File pkgFile = new File(url.toURI());
-            packageFile = pkgFile.getAbsolutePath();
-        } else if (isFunctionCodeBuiltin(functionDetails)) {
-            File pkgFile = getBuiltinArchive(functionDetails);
-            packageFile = pkgFile.getAbsolutePath();
-        } else if (runtimeFactory.externallyManaged()) {
+        if (runtimeFactory.externallyManaged()) {
             packageFile = pkgLocation;
         } else {
-            File pkgDir = new File(
-                    workerConfig.getDownloadDirectory(),
-                    getDownloadPackagePath(functionMetaData, instanceId));
-            pkgDir.mkdirs();
-
-            File pkgFile = new File(
-                    pkgDir,
-                    new File(FunctionDetailsUtils.getDownloadFileName(functionMetaData.getFunctionDetails(), functionMetaData.getPackageLocation())).getName());
-            downloadFile(pkgFile, isPkgUrlProvided, functionMetaData, instanceId);
-            packageFile = pkgFile.getAbsolutePath();
+            if (isPkgUrlProvided && pkgLocation.startsWith(FILE)) {
+                URL url = new URL(pkgLocation);
+                File pkgFile = new File(url.toURI());
+                packageFile = pkgFile.getAbsolutePath();
+            } else if (isFunctionCodeBuiltin(functionDetails)) {
+                File pkgFile = getBuiltinArchive(functionDetails);
+                packageFile = pkgFile.getAbsolutePath();
+            } else {
+                File pkgDir = new File(workerConfig.getDownloadDirectory(),
+                        getDownloadPackagePath(functionMetaData, instanceId));
+                pkgDir.mkdirs();
+                File pkgFile = new File(
+                        pkgDir,
+                        new File(FunctionDetailsUtils.getDownloadFileName(functionMetaData.getFunctionDetails(), functionMetaData.getPackageLocation())).getName());
+                downloadFile(pkgFile, isPkgUrlProvided, functionMetaData, instanceId);
+                packageFile = pkgFile.getAbsolutePath();
+            }
         }
 
         InstanceConfig instanceConfig = new InstanceConfig();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
@@ -18,12 +18,7 @@
  */
 package org.apache.pulsar.functions.worker;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
@@ -78,6 +73,11 @@ public final class Utils {
 
     public static String getUniquePackageName(String packageName) {
         return String.format("%s-%s", UUID.randomUUID().toString(), packageName);
+    }
+
+    public static void uploadToBookkeeper(String packagePath, File sourceFile, Namespace dlogNamespace) throws IOException {
+        FileInputStream uploadedInputStream = new FileInputStream(sourceFile);
+        uploadToBookeeper(dlogNamespace, uploadedInputStream, packagePath);
     }
 
     public static void uploadToBookeeper(Namespace dlogNamespace,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
@@ -75,7 +75,7 @@ public final class Utils {
         return String.format("%s-%s", UUID.randomUUID().toString(), packageName);
     }
 
-    public static void uploadToBookkeeper(String packagePath, File sourceFile, Namespace dlogNamespace) throws IOException {
+    public static void uploadFileToBookkeeper(String packagePath, File sourceFile, Namespace dlogNamespace) throws IOException {
         FileInputStream uploadedInputStream = new FileInputStream(sourceFile);
         uploadToBookeeper(dlogNamespace, uploadedInputStream, packagePath);
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -233,20 +233,20 @@ public class FunctionsImpl {
                         sinkOrSource.getName()));
                 packageLocationMetaDataBuilder.setOriginalFileName(sinkOrSource.getName());
                 log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
-                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), sinkOrSource, worker().getDlogNamespace());
+                Utils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), sinkOrSource, worker().getDlogNamespace());
             } else if (isPkgUrlProvided) {
                 File file = extractFileFromPkg(functionPkgUrl);
                 packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
                         file.getName()));
                 packageLocationMetaDataBuilder.setOriginalFileName(file.getName());
                 log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
-                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), file, worker().getDlogNamespace());
+                Utils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), file, worker().getDlogNamespace());
             } else {
                 packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
                         fileDetail.getName()));
                 packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getName());
                 log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
-                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
+                Utils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
             }
         } else {
             // For pulsar managed schedulers, the pkgUrl/builtin stuff should be copied to bk
@@ -258,7 +258,7 @@ public class FunctionsImpl {
                 packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName, fileDetail.getFileName()));
                 packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
                 log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
-                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
+                Utils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
             }
         }
         return packageLocationMetaDataBuilder;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -194,22 +194,76 @@ public class FunctionsImpl {
         FunctionMetaData.Builder functionMetaDataBuilder = FunctionMetaData.newBuilder()
                 .setFunctionDetails(functionDetails).setCreateTime(System.currentTimeMillis()).setVersion(0);
 
-        PackageLocationMetaData.Builder packageLocationMetaDataBuilder = PackageLocationMetaData.newBuilder();
-        boolean isBuiltin = isFunctionCodeBuiltin(functionDetails);
-        if (isBuiltin) {
-            packageLocationMetaDataBuilder.setPackagePath("builtin://" + getFunctionCodeBuiltin(functionDetails));
-        } else {
-            packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
-                    : createPackagePath(tenant, namespace, componentName, fileDetail.getFileName()));
-            if (!isPkgUrlProvided) {
-                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
-            }
+
+        PackageLocationMetaData.Builder packageLocationMetaDataBuilder;
+        try {
+            packageLocationMetaDataBuilder = getFunctionPackageLocation(functionDetails, componentType,
+                functionPkgUrl, fileDetail, uploadedInputStreamAsFile);
+        } catch (Exception e) {
+            return Response.serverError().type(MediaType.APPLICATION_JSON).entity(new ErrorData(e.getMessage()))
+                    .build();
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
-        return (isPkgUrlProvided || isBuiltin) ? updateRequest(functionMetaDataBuilder.build())
-                : updateRequest(functionMetaDataBuilder.build(), uploadedInputStreamAsFile);
+        return updateRequest(functionMetaDataBuilder.build());
     }
+
+    private PackageLocationMetaData.Builder getFunctionPackageLocation(FunctionDetails functionDetails,
+                                                                       String componentType, String functionPkgUrl,
+                                                                       final FormDataContentDisposition fileDetail,
+                                                                       File uploadedInputStreamAsFile) throws Exception {
+        String tenant = functionDetails.getTenant();
+        String namespace = functionDetails.getNamespace();
+        String componentName = functionDetails.getName();
+        PackageLocationMetaData.Builder packageLocationMetaDataBuilder = PackageLocationMetaData.newBuilder();
+        boolean isBuiltin = isFunctionCodeBuiltin(functionDetails);
+        boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
+        if (worker().getFunctionRuntimeManager().getRuntimeFactory().externallyManaged()) {
+            // For externally managed schedulers, the pkgUrl/builtin stuff should be copied to bk
+            if (isBuiltin) {
+                File sinkOrSource;
+                if (componentType.equals(SOURCE)) {
+                    String archiveName = functionDetails.getSource().getBuiltin();
+                    sinkOrSource = worker().getConnectorsManager().getSourceArchive(archiveName).toFile();
+                } else {
+                    String archiveName = functionDetails.getSink().getBuiltin();
+                    sinkOrSource = worker().getConnectorsManager().getSinkArchive(archiveName).toFile();
+                }
+                packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
+                        sinkOrSource.getName()));
+                packageLocationMetaDataBuilder.setOriginalFileName(sinkOrSource.getName());
+                log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
+                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), sinkOrSource, worker().getDlogNamespace());
+            } else if (isPkgUrlProvided) {
+                File file = extractFileFromPkg(functionPkgUrl);
+                packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
+                        file.getName()));
+                packageLocationMetaDataBuilder.setOriginalFileName(file.getName());
+                log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
+                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), file, worker().getDlogNamespace());
+            } else {
+                packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
+                        uploadedInputStreamAsFile.getName()));
+                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getName());
+                log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
+                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
+            }
+        } else {
+            // For pulsar managed schedulers, the pkgUrl/builtin stuff should be copied to bk
+            if (isBuiltin) {
+                packageLocationMetaDataBuilder.setPackagePath("builtin://" + getFunctionCodeBuiltin(functionDetails));
+            } else if (isPkgUrlProvided) {
+                packageLocationMetaDataBuilder.setPackagePath(functionPkgUrl);
+            } else {
+                packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName, fileDetail.getFileName()));
+                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
+                log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
+                Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());
+            }
+        }
+        return packageLocationMetaDataBuilder;
+    }
+
 
     public Response updateFunction(final String tenant, final String namespace, final String componentName,
             final InputStream uploadedInputStream, final FormDataContentDisposition fileDetail,
@@ -273,22 +327,17 @@ public class FunctionsImpl {
         FunctionMetaData.Builder functionMetaDataBuilder = FunctionMetaData.newBuilder()
                 .setFunctionDetails(functionDetails).setCreateTime(System.currentTimeMillis()).setVersion(0);
 
-        PackageLocationMetaData.Builder packageLocationMetaDataBuilder = PackageLocationMetaData.newBuilder();
-
-        boolean isBuiltin = isFunctionCodeBuiltin(functionDetails);
-        if (isBuiltin) {
-            packageLocationMetaDataBuilder.setPackagePath("builtin://" + getFunctionCodeBuiltin(functionDetails));
-        } else {
-            packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
-                    : createPackagePath(tenant, namespace, componentName, fileDetail.getFileName()));
-            if (!isPkgUrlProvided) {
-                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
-            }
+        PackageLocationMetaData.Builder packageLocationMetaDataBuilder;
+        try {
+            packageLocationMetaDataBuilder = getFunctionPackageLocation(functionDetails, componentType,
+                    functionPkgUrl, fileDetail, uploadedInputStreamAsFile);
+        } catch (Exception e) {
+            return Response.serverError().type(MediaType.APPLICATION_JSON).entity(new ErrorData(e.getMessage()))
+                    .build();
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
-        return (isPkgUrlProvided || isBuiltin) ? updateRequest(functionMetaDataBuilder.build())
-                : updateRequest(functionMetaDataBuilder.build(), uploadedInputStreamAsFile);
+        return updateRequest(functionMetaDataBuilder.build());
     }
 
     public Response deregisterFunction(final String tenant, final String namespace, final String componentName,
@@ -631,22 +680,6 @@ public class FunctionsImpl {
         }
 
         return Response.status(Status.OK).entity(new Gson().toJson(retval.toArray())).build();
-    }
-
-    private Response updateRequest(FunctionMetaData functionMetaData, File uploadedInputStreamAsFile) {
-        // Upload to bookkeeper
-        try {
-            log.info("Uploading function package to {}", functionMetaData.getPackageLocation());
-            FileInputStream uploadedInputStream = new FileInputStream(uploadedInputStreamAsFile);
-
-            Utils.uploadToBookeeper(worker().getDlogNamespace(), uploadedInputStream,
-                    functionMetaData.getPackageLocation().getPackagePath());
-        } catch (IOException e) {
-            log.error("Error uploading file {}", functionMetaData.getPackageLocation(), e);
-            return Response.serverError().type(MediaType.APPLICATION_JSON).entity(new ErrorData(e.getMessage()))
-                    .build();
-        }
-        return updateRequest(functionMetaData);
     }
 
     private Response updateRequest(FunctionMetaData functionMetaData) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -243,7 +243,7 @@ public class FunctionsImpl {
                 Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), file, worker().getDlogNamespace());
             } else {
                 packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
-                        uploadedInputStreamAsFile.getName()));
+                        fileDetail.getName()));
                 packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getName());
                 log.info("Uploading {} package to {}", componentType, packageLocationMetaDataBuilder.getPackagePath());
                 Utils.uploadToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), uploadedInputStreamAsFile, worker().getDlogNamespace());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -358,10 +358,10 @@ public class FunctionApiV2ResourceTest {
     public void testRegisterFunctionUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+            any(File.class),
+            any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(function))).thenReturn(false);
 
@@ -644,10 +644,10 @@ public class FunctionApiV2ResourceTest {
     public void testUpdateFunctionUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+            any(File.class),
+            any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(function))).thenReturn(true);
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/SinkApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/SinkApiV2ResourceTest.java
@@ -52,6 +52,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -307,10 +308,10 @@ public class SinkApiV2ResourceTest {
     public void testRegisterSinkUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+            any(File.class),
+            any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(false);
 
@@ -323,10 +324,10 @@ public class SinkApiV2ResourceTest {
     public void testRegisterSinkSuccess() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(false);
 
@@ -344,10 +345,10 @@ public class SinkApiV2ResourceTest {
     public void testRegisterSinkFailure() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(false);
 
@@ -366,10 +367,10 @@ public class SinkApiV2ResourceTest {
     public void testRegisterSinkInterrupted() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(false);
 
@@ -539,10 +540,10 @@ public class SinkApiV2ResourceTest {
     public void testUpdateSinkUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 
@@ -555,10 +556,10 @@ public class SinkApiV2ResourceTest {
     public void testUpdateSinkSuccess() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 
@@ -613,10 +614,10 @@ public class SinkApiV2ResourceTest {
     public void testUpdateSinkFailure() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 
@@ -635,10 +636,10 @@ public class SinkApiV2ResourceTest {
     public void testUpdateSinkInterrupted() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/SourceApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/SourceApiV2ResourceTest.java
@@ -307,10 +307,10 @@ public class SourceApiV2ResourceTest {
     public void testRegisterSourceUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(false);
 
@@ -323,10 +323,10 @@ public class SourceApiV2ResourceTest {
     public void testRegisterSourceSuccess() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(false);
 
@@ -344,10 +344,10 @@ public class SourceApiV2ResourceTest {
     public void testRegisterSourceFailure() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(false);
 
@@ -366,10 +366,10 @@ public class SourceApiV2ResourceTest {
     public void testRegisterSourceInterrupted() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(false);
 
@@ -549,10 +549,10 @@ public class SourceApiV2ResourceTest {
     public void testUpdateSourceUploadFailure() throws Exception {
         mockStatic(Utils.class);
         doThrow(new IOException("upload failure")).when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 
@@ -565,10 +565,10 @@ public class SourceApiV2ResourceTest {
     public void testUpdateSourceSuccess() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 
@@ -624,10 +624,10 @@ public class SourceApiV2ResourceTest {
     public void testUpdateSourceFailure() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 
@@ -646,10 +646,10 @@ public class SourceApiV2ResourceTest {
     public void testUpdateSourceInterrupted() throws Exception {
         mockStatic(Utils.class);
         doNothing().when(Utils.class);
-        Utils.uploadToBookeeper(
-            any(Namespace.class),
-            any(InputStream.class),
-            anyString());
+        Utils.uploadFileToBookkeeper(
+                anyString(),
+                any(File.class),
+                any(Namespace.class));
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 


### PR DESCRIPTION
### Motivation

When trying to submit builtin functions/connectors to pulsar cluster, if the pulsar worker is using an externally managed scheduler for functions(like kubernetes), the containers may not have access to the builtin or package urls. In those cases, its best if the worker who has access to them, uploads the contents to bk.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
