### PR TITLE
Fixed a broken link

### DIFF
--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -7,7 +7,7 @@ This is the first release of Pulsar as an Apache Top Level Project
 
 This is a feature release, including several new features, improvements and fixes for  issues reported for 2.1.1-incubating.
  
-* [Pulsar Java Client Interceptors](https://github.com/apache/pulsar/pull/2627) 
+* [Pulsar Java Client Interceptors](https://github.com/apache/pulsar/pull/2471)
 
 * [Integration of functions and io with schema registry](https://github.com/apache/pulsar/pull/2266) 
 


### PR DESCRIPTION
### Motivation

The release notes for 2.2.0 https://pulsar.apache.org/release-notes/#2.2.0 have the wrong URL for the first feature (Pulsar Java Client Interceptors)

### Modifications

Updated the link to point to the correct issue, https://github.com/apache/pulsar/pull/2471

### Result

Link is correct
