### PR TITLE
Fixed ZLib decompression in C++ client

### DIFF
--- a/pulsar-client-cpp/lib/CompressionCodec.h
+++ b/pulsar-client-cpp/lib/CompressionCodec.h
@@ -28,6 +28,9 @@
 
 #include <map>
 
+// Make symbol visible to unit tests
+#pragma GCC visibility push(default)
+
 using namespace pulsar;
 namespace pulsar {
 
@@ -85,5 +88,7 @@ class CompressionCodecNone : public CompressionCodec {
     bool decode(const SharedBuffer& encoded, uint32_t uncompressedSize, SharedBuffer& decoded);
 };
 }  // namespace pulsar
+
+#pragma GCC visibility pop
 
 #endif /* LIB_COMPRESSIONCODEC_H_ */

--- a/pulsar-client-cpp/lib/CompressionCodecZLib.h
+++ b/pulsar-client-cpp/lib/CompressionCodecZLib.h
@@ -23,10 +23,10 @@
 #include <zlib.h>
 #include <boost/thread/mutex.hpp>
 
-namespace pulsar {
-
 // Make symbol visible to unit tests
 #pragma GCC visibility push(default)
+
+namespace pulsar {
 
 class CompressionCodecZLib : public CompressionCodec {
    public:
@@ -35,8 +35,8 @@ class CompressionCodecZLib : public CompressionCodec {
     bool decode(const SharedBuffer& encoded, uint32_t uncompressedSize, SharedBuffer& decoded);
 };
 
-#pragma GCC visibility pop
-
 }  // namespace pulsar
+
+#pragma GCC visibility pop
 
 #endif /* LIB_COMPRESSIONCODECZLIB_H_ */

--- a/pulsar-client-cpp/lib/CompressionCodecZLib.h
+++ b/pulsar-client-cpp/lib/CompressionCodecZLib.h
@@ -25,12 +25,18 @@
 
 namespace pulsar {
 
+// Make symbol visible to unit tests
+#pragma GCC visibility push(default)
+
 class CompressionCodecZLib : public CompressionCodec {
    public:
     SharedBuffer encode(const SharedBuffer& raw);
 
     bool decode(const SharedBuffer& encoded, uint32_t uncompressedSize, SharedBuffer& decoded);
 };
+
+#pragma GCC visibility pop
+
 }  // namespace pulsar
 
 #endif /* LIB_COMPRESSIONCODECZLIB_H_ */

--- a/pulsar-client-cpp/tests/ZLibCompressionTest.cc
+++ b/pulsar-client-cpp/tests/ZLibCompressionTest.cc
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <lib/CompressionCodecZLib.h>
+
+using namespace pulsar;
+
+TEST(ZLibCompressionTest, compressDecompress) {
+    CompressionCodecZLib codec;
+
+    std::string payload = "Payload to compress";
+    SharedBuffer compressed = codec.encode(SharedBuffer::copy(payload.c_str(), payload.size()));
+
+    SharedBuffer uncompressed;
+    bool res = codec.decode(compressed, payload.size(), uncompressed);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(payload, std::string(uncompressed.data(), uncompressed.readableBytes()));
+}
+
+// Java and C++ are using different ZLib settings when compressing, so the resulting
+// compressed blobs are slightly different. Both should lead to the same result when
+// decompressing
+TEST(ZLibCompressionTest, decodeCppCompressed) {
+    CompressionCodecZLib codec;
+
+    const uint8_t compressed[] = {0x78, 0x9c, 0x63, 0x60, 0x80, 0x01, 0x00, 0x00, 0x0a, 0x00, 0x01};
+
+    SharedBuffer uncompressed;
+    uint32_t uncompressedSize = 10;
+
+    bool res = codec.decode(SharedBuffer::copy((const char*)compressed, sizeof(compressed)), uncompressedSize,
+                            uncompressed);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(uncompressedSize, uncompressed.readableBytes());
+}
+
+TEST(ZLibCompressionTest, decodeJavaCompressed) {
+    CompressionCodecZLib codec;
+
+    const uint8_t compressed[] = {0x78, 0x9c, 0x62, 0x60, 0x80, 0x01, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff};
+
+    SharedBuffer uncompressed;
+    uint32_t uncompressedSize = 10;
+
+    bool res = codec.decode(SharedBuffer::copy((const char*)compressed, sizeof(compressed)), uncompressedSize,
+                            uncompressed);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(uncompressedSize, uncompressed.readableBytes());
+}


### PR DESCRIPTION
### Motivation

The ZLib method `uncompress()` is not able to process data that was compressed from Pulsar Java producer with ZLib. 

This is due to the the initialization settings that are used inside the `uncompress()` functions and that are different from how ZLib is used within the JDK. 

This causes C++ (and derivatives) consumers to drop messages that were compressed by Java producer. A Java consumer is able to correctly decompress both.

### Modifications

 * Fixed decompression in C++ to be able to inflate both zstream terminations
 * Added option in C++ perf producer to compress messages
