### PR TITLE
Secretprovider interfaces and some default implementations

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -82,7 +82,8 @@ public class FunctionConfig {
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that
     // encapsulates how the secret is fetched by the underlying
-    // secrets provider
+    // secrets provider. The type of an value here can be found by the
+    // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
     private Runtime runtime;
     private boolean autoAck;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -58,7 +58,8 @@ public class SinkConfig {
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that
     // encapsulates how the secret is fetched by the underlying
-    // secrets provider
+    // secrets provider. The type of an value here can be found by the
+    // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
     private int parallelism = 1;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -49,7 +49,8 @@ public class SourceConfig {
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that
     // encapsulates how the secret is fetched by the underlying
-    // secrets provider
+    // secrets provider. The type of an value here can be found by the
+    // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
     private int parallelism = 1;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;

--- a/pulsar-functions/secrets/pom.xml
+++ b/pulsar-functions/secrets/pom.xml
@@ -19,50 +19,35 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
   <parent>
     <groupId>org.apache.pulsar</groupId>
-    <artifactId>pulsar</artifactId>
+    <artifactId>pulsar-functions</artifactId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>pulsar-functions</artifactId>
-  <name>Pulsar Functions :: Parent</name>
-
-  <modules>
-    <module>proto</module>
-    <module>proto-shaded</module>
-    <module>api-java</module>
-    <module>java-examples</module>
-    <module>utils</module>
-    <module>metrics</module>
-    <module>instance</module>
-    <module>runtime</module>
-    <module>runtime-shaded</module>
-    <module>runtime-all</module>
-    <module>worker</module>
-    <module>secrets</module>
-  </modules>
-
-  <dependencyManagement>
-    <dependencies>
-
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <version>1.16.12</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
+  <artifactId>pulsar-functions-secrets</artifactId>
+  <name>Pulsar Functions :: Secrets</name>
 
   <dependencies>
+  <dependency>
+    <groupId>io.kubernetes</groupId>
+    <artifactId>client-java</artifactId>
+    <version>2.0.0</version>
+    <scope>compile</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-functions-proto</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsprovider;
+
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public class ClearTextSecretsProvider implements SecretsProvider {
+        /**
+     * Fetches a secret
+     * @return The actual secret
+     */
+    @Override
+    public String provideSecret(String secretName, Object pathToSecret) {
+        return pathToSecret.toString();
+    }
+}

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProvider.java
@@ -18,13 +18,9 @@
  */
 package org.apache.pulsar.functions.secretsprovider;
 
-import java.util.Map;
-
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This file defines a very basic clear text secrets provider which treats
+ * the secrets as being passed in cleartext.
  */
 public class ClearTextSecretsProvider implements SecretsProvider {
         /**

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsprovider;
+
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public class EnvironmentBasedSecretsProvider implements SecretsProvider {
+
+    /**
+     * Fetches a secret
+     * @return The actual secret
+     */
+    @Override
+    public String provideSecret(String secretName, Object pathToSecret) {
+        return System.getenv(secretName);
+    }
+}

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProvider.java
@@ -18,13 +18,9 @@
  */
 package org.apache.pulsar.functions.secretsprovider;
 
-import java.util.Map;
-
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This defines a very simple Secrets Provider that looks up environment variable
+ * thats named the same as secretName and fetches it.
  */
 public class EnvironmentBasedSecretsProvider implements SecretsProvider {
 

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/SecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/SecretsProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsprovider;
+
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public interface SecretsProvider {
+    /**
+     * Initialize the SecretsProvider
+     * @return
+     */
+    default void init(Map<String, String> config) {}
+
+    /**
+     * Fetches a secret
+     * @return The actual secret
+     */
+    String provideSecret(String secretName, Object pathToSecret);
+}

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/SecretsProvider.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsprovider/SecretsProvider.java
@@ -21,10 +21,9 @@ package org.apache.pulsar.functions.secretsprovider;
 import java.util.Map;
 
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This file defines the SecretsProvider interface. This interface is used by the function
+ * instances/containers to actually fetch the secrets. What SecretsProvider to use is
+ * decided by the SecretsProviderConfigurator
  */
 public interface SecretsProvider {
     /**

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsproviderconfigurator;
+
+import com.google.gson.reflect.TypeToken;
+import io.kubernetes.client.models.V1Container;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public class DefaultSecretsProviderConfigurator implements SecretsProviderConfigurator {
+    @Override
+    public String getSecretsProviderClassName(Function.FunctionDetails functionDetails) {
+        switch (functionDetails.getRuntime()) {
+            case JAVA:
+                return ClearTextSecretsProvider.class.getName();
+            case PYTHON:
+                return "secretsprovider.ClearTextSecretsProvider";
+            default:
+                throw new RuntimeException("Unknwon runtime " + functionDetails.getRuntime());
+        }
+    }
+
+    @Override
+    public Map<String, String> getSecretsProviderConfig(Function.FunctionDetails functionDetails) {
+        return null;
+    }
+
+    @Override
+    public void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails) {
+        // noop
+    }
+
+    @Override
+    public void configureProcessRuntimeSecretsProvider(ProcessBuilder processBuilder, Function.FunctionDetails functionDetails) {
+        // noop
+    }
+
+    @Override
+    public Type getSecretObjectType() {
+        return new TypeToken<String>() {}.getType();
+    }
+}

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
@@ -27,10 +27,10 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This is a barebones version of a secrets provider which wires in ClearTextSecretsProvider
+ * to the function instances/containers.
+ * While this is the default configurator, it is highly recommended that for real-security
+ * you use some alternate provider.
  */
 public class DefaultSecretsProviderConfigurator implements SecretsProviderConfigurator {
     @Override

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -26,17 +26,17 @@ import io.kubernetes.client.models.V1EnvVarSource;
 import io.kubernetes.client.models.V1SecretKeySelector;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.proto.Function;
-import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
 import org.apache.pulsar.functions.secretsprovider.EnvironmentBasedSecretsProvider;
 
 import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This file defines the SecretsProviderConfigurator that will be used by default for running in Kubernetes.
+ * As such this implementation is strictly when workers are configured to use kubernetes runtime.
+ * We use kubernetes in built secrets and bind them as environment variables within the function container
+ * to ensure that the secrets are availble to the function at runtime. Then we plug in the
+ * EnvironmentBasedSecretsConfig as the secrets provider who knows how to read these environment variables
  */
 public class KubernetesSecretsProviderConfigurator implements SecretsProviderConfigurator {
     @Override
@@ -77,7 +77,7 @@ public class KubernetesSecretsProviderConfigurator implements SecretsProviderCon
 
     @Override
     public void configureProcessRuntimeSecretsProvider(ProcessBuilder processBuilder, Function.FunctionDetails functionDetails) {
-        // noop
+        throw new RuntimeException("KubernetesSecretsProviderConfigurator should only be setup for Kubernetes Runtime");
     }
 
     @Override

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -56,6 +56,9 @@ public class KubernetesSecretsProviderConfigurator implements SecretsProviderCon
         return null;
     }
 
+    // Kubernetes secrets can be exposed as volume mounts or as environment variables in the pods. We are currently using the
+    // environment variables way. Essentially the secretName/secretPath is attached as secretRef to the environment variables
+    // of a pod and kubernetes magically makes the secret pointed to by this combination available as a env variable.
     @Override
     public void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails) {
         if (!StringUtils.isEmpty(functionDetails.getSecretsMap())) {

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsproviderconfigurator;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1EnvVarSource;
+import io.kubernetes.client.models.V1SecretKeySelector;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
+import org.apache.pulsar.functions.secretsprovider.EnvironmentBasedSecretsProvider;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public class KubernetesSecretsProviderConfigurator implements SecretsProviderConfigurator {
+    @Override
+    public String getSecretsProviderClassName(Function.FunctionDetails functionDetails) {
+        switch (functionDetails.getRuntime()) {
+            case JAVA:
+                return EnvironmentBasedSecretsProvider.class.getName();
+            case PYTHON:
+                return "secretsprovider.EnvironmentBasedSecretsProvider";
+            default:
+                throw new RuntimeException("Unknown function runtime " + functionDetails.getRuntime());
+        }
+    }
+
+    @Override
+    public Map<String, String> getSecretsProviderConfig(Function.FunctionDetails functionDetails) {
+        return null;
+    }
+
+    @Override
+    public void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails) {
+        if (!StringUtils.isEmpty(functionDetails.getSecretsMap())) {
+            Type type = new TypeToken<Map<String, Object>>() {
+            }.getType();
+            Map<String, Object> secretsMap = new Gson().fromJson(functionDetails.getSecretsMap(), type);
+            for (Map.Entry<String, Object> entry : secretsMap.entrySet()) {
+                final V1EnvVar secretEnv = new V1EnvVar();
+                Map<String, String> kv = (Map<String, String>) entry.getValue();
+                secretEnv.name(entry.getKey())
+                        .valueFrom(new V1EnvVarSource()
+                                .secretKeyRef(new V1SecretKeySelector()
+                                        .name(kv.entrySet().iterator().next().getKey())
+                                        .key(kv.entrySet().iterator().next().getValue())));
+                container.addEnvItem(secretEnv);
+            }
+        }
+    }
+
+    @Override
+    public void configureProcessRuntimeSecretsProvider(ProcessBuilder processBuilder, Function.FunctionDetails functionDetails) {
+        // noop
+    }
+
+    @Override
+    public Type getSecretObjectType() {
+        return new TypeToken<Map<String, String>>() {}.getType();
+    }
+}

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -84,4 +84,14 @@ public class KubernetesSecretsProviderConfigurator implements SecretsProviderCon
     public Type getSecretObjectType() {
         return new TypeToken<Map<String, String>>() {}.getType();
     }
+
+    @Override
+    public void validateSecretMap(Map<String, Object> secretMap) {
+        for (Object object : secretMap.values()) {
+            Map<String, String> kubernetesSecret = (Map<String, String>)object;
+            if (kubernetesSecret.size() != 1) {
+                throw new IllegalArgumentException("Kubernetes Secret map only takes one value");
+            }
+        }
+    }
 }

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
@@ -25,10 +25,9 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- * Context provides contextual information to the executing function.
- * Features like which message id we are handling, whats the topic name of the
- * message, what are our operating constraints, etc can be accessed by the
- * executing function
+ * This file defines the SecretsProviderConfigurator interface. This interface is used by the function_workers
+ * to choose the SecretProvider class name(if any) and its associated config at the time of starting
+ * the function instances.
  */
 public interface SecretsProviderConfigurator {
     /**
@@ -38,7 +37,9 @@ public interface SecretsProviderConfigurator {
     default void init(Map<String, String> config) {}
 
     /**
-     * Return the Secrets Provider Classname
+     * Return the Secrets Provider Classname. This will be passed to the cmdline
+     * of the instance and should contain the logic of connecting with the secrets
+     * provider and obtaining secrets
      */
     String getSecretsProviderClassName(Function.FunctionDetails functionDetails);
 
@@ -53,7 +54,7 @@ public interface SecretsProviderConfigurator {
     void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails);
 
     /**
-     * Attaches any secrets specific stuff to the k8 container for kubernetes runtime
+     * Attaches any secrets specific stuff to the ProcessBuilder for process runtime
      */
     void configureProcessRuntimeSecretsProvider(ProcessBuilder processBuilder, Function.FunctionDetails functionDetails);
 

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
@@ -64,4 +64,9 @@ public interface SecretsProviderConfigurator {
      */
     Type getSecretObjectType();
 
+    /**
+     * Do config checks to see whether the secrets provided are conforming
+     */
+    default void validateSecretMap(Map<String, Object> secretMap) {}
+
 }

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.secretsproviderconfigurator;
+
+import io.kubernetes.client.models.V1Container;
+import org.apache.pulsar.functions.proto.Function;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Context provides contextual information to the executing function.
+ * Features like which message id we are handling, whats the topic name of the
+ * message, what are our operating constraints, etc can be accessed by the
+ * executing function
+ */
+public interface SecretsProviderConfigurator {
+    /**
+     * Initialize the SecretsProviderConfigurator
+     * @return
+     */
+    default void init(Map<String, String> config) {}
+
+    /**
+     * Return the Secrets Provider Classname
+     */
+    String getSecretsProviderClassName(Function.FunctionDetails functionDetails);
+
+    /**
+     * Return the secrets provider config
+     */
+    Map<String, String> getSecretsProviderConfig(Function.FunctionDetails functionDetails);
+
+    /**
+     * Attaches any secrets specific stuff to the k8 container for kubernetes runtime
+     */
+    void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails);
+
+    /**
+     * Attaches any secrets specific stuff to the k8 container for kubernetes runtime
+     */
+    void configureProcessRuntimeSecretsProvider(ProcessBuilder processBuilder, Function.FunctionDetails functionDetails);
+
+    /**
+     * What is the type of the object that should be in the user secret config
+     * @return
+     */
+    Type getSecretObjectType();
+
+}

--- a/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProviderTest.java
+++ b/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsprovider/ClearTextSecretsProviderTest.java
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.functions.secretsprovider;
 
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 /**
- * This file defines a very basic clear text secrets provider which treats
- * the secrets as being passed in cleartext.
+ * Unit test of {@link Exceptions}.
  */
-public class ClearTextSecretsProvider implements SecretsProvider {
-        /**
-     * Fetches a secret
-     * @return The actual secret
-     */
-    @Override
-    public String provideSecret(String secretName, Object pathToSecret) {
-        if (pathToSecret != null) {
-            return pathToSecret.toString();
-        } else {
-            return null;
-        }
+public class ClearTextSecretsProviderTest {
+
+    @Test
+    public void testConfigValidation() throws Exception {
+        ClearTextSecretsProvider provider = new ClearTextSecretsProvider();
+        Assert.assertEquals(provider.provideSecret("SecretName", "SecretValue"), "SecretValue");
+        Assert.assertEquals(provider.provideSecret("SecretName", ""), "");
+        Assert.assertEquals(provider.provideSecret("SecretName", null), null);
     }
 }

--- a/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProviderTest.java
+++ b/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsprovider/EnvironmentBasedSecretsProviderTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.secretsprovider;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyString;
+
+/**
+ * Unit test of {@link Exceptions}.
+ */
+public class EnvironmentBasedSecretsProviderTest {
+    @Test
+    public void testConfigValidation() throws Exception {
+        EnvironmentBasedSecretsProvider provider = new EnvironmentBasedSecretsProvider();
+        Assert.assertEquals(provider.provideSecret("mySecretName", "Ignored"), null);
+        injectEnvironmentVariable("mySecretName", "SecretValue");
+        Assert.assertEquals(provider.provideSecret("mySecretName", "Ignored"), "SecretValue");
+    }
+
+    private static void injectEnvironmentVariable(String key, String value)
+            throws Exception {
+
+        Class<?> processEnvironment = Class.forName("java.lang.ProcessEnvironment");
+
+        Field unmodifiableMapField = getAccessibleField(processEnvironment, "theUnmodifiableEnvironment");
+        Object unmodifiableMap = unmodifiableMapField.get(null);
+        injectIntoUnmodifiableMap(key, value, unmodifiableMap);
+
+        Field mapField = getAccessibleField(processEnvironment, "theEnvironment");
+        Map<String, String> map = (Map<String, String>) mapField.get(null);
+        map.put(key, value);
+    }
+
+    private static Field getAccessibleField(Class<?> clazz, String fieldName)
+            throws NoSuchFieldException {
+
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static void injectIntoUnmodifiableMap(String key, String value, Object map)
+            throws ReflectiveOperationException {
+
+        Class unmodifiableMap = Class.forName("java.util.Collections$UnmodifiableMap");
+        Field field = getAccessibleField(unmodifiableMap, "m");
+        Object obj = field.get(map);
+        ((Map<String, String>) obj).put(key, value);
+    }
+}

--- a/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
+++ b/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
@@ -36,7 +36,7 @@ public class KubernetesSecretsProviderConfiguratorTest {
             HashMap<String, Object> map = new HashMap<String, Object>();
             map.put("secretname", "randomsecret");
             provider.validateSecretMap(map);
-            Assert.fail("Non comforming secret object should not validate");
+            Assert.fail("Non conforming secret object should not validate");
         } catch (Exception e) {
         }
         try {
@@ -45,8 +45,18 @@ public class KubernetesSecretsProviderConfiguratorTest {
             map1.put("secretname", "secretvalue");
             map.put("secretname", map1);
             provider.validateSecretMap(map);
+            Assert.fail("Non conforming secret object should not validate");
         } catch (Exception e) {
-            Assert.fail("Comforming secret object should validate");
+        }
+        try {
+            HashMap<String, Object> map = new HashMap<String, Object>();
+            HashMap<String, String> map1 = new HashMap<String, String>();
+            map1.put("id", "secretvalue");
+            map1.put("key", "secretvalue");
+            map.put("secretname", map1);
+            provider.validateSecretMap(map);
+        } catch (Exception e) {
+            Assert.fail("Conforming secret object should validate");
         }
     }
 }

--- a/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
+++ b/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.secretsproviderconfigurator;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+
+/**
+ * Unit test of {@link Exceptions}.
+ */
+public class KubernetesSecretsProviderConfiguratorTest {
+
+    @Test
+    public void testConfigValidation() throws Exception {
+        KubernetesSecretsProviderConfigurator provider = new KubernetesSecretsProviderConfigurator();
+        try {
+            HashMap<String, Object> map = new HashMap<String, Object>();
+            map.put("secretname", "randomsecret");
+            provider.validateSecretMap(map);
+            Assert.fail("Non comforming secret object should not validate");
+        } catch (Exception e) {
+        }
+        try {
+            HashMap<String, Object> map = new HashMap<String, Object>();
+            HashMap<String, String> map1 = new HashMap<String, String>();
+            map1.put("secretname", "secretvalue");
+            map.put("secretname", map1);
+            provider.validateSecretMap(map);
+        } catch (Exception e) {
+            Assert.fail("Comforming secret object should validate");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

This pr defines the SecretsProviderConfigurator that configures the function instances/containers and plugs in the right SecretsProvider for the instances to use.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
