### PR TITLE
fix typo in architecture docs

### DIFF
--- a/site/docs/latest/getting-started/ConceptsAndArchitecture.md
+++ b/site/docs/latest/getting-started/ConceptsAndArchitecture.md
@@ -249,7 +249,7 @@ At the highest level, a Pulsar {% popover instance %} is composed of one or more
 In a Pulsar cluster:
 
 * One or more {% popover brokers %} handles and load balances incoming messages from {% popover producers %}, dispatches messages to {% popover consumers %}, communicates with the Pulsar {% popover configuration store %} to handle various coordination tasks, stores messages in {% popover BookKeeper %} instances (aka {% popover bookies %}), relies on a cluster-specific {% popover ZooKeeper %} cluster for certain tasks, and more.
-* A {% popover BookKeeper %} cluster consisting of one more or more {% popover bookies %} handles [persistent storage](#persistent-storage) of messages.
+* A {% popover BookKeeper %} cluster consisting of one or more {% popover bookies %} handles [persistent storage](#persistent-storage) of messages.
 * A {% popover ZooKeeper %} cluster specific to that cluster handles
 
 The diagram below provides an illustration of a Pulsar cluster:

--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -9,7 +9,7 @@ At the highest level, a Pulsar instance is composed of one or more Pulsar cluste
 In a Pulsar cluster:
 
 * One or more brokers handles and load balances incoming messages from producers, dispatches messages to consumers, communicates with the Pulsar configuration store to handle various coordination tasks, stores messages in BookKeeper instances (aka bookies), relies on a cluster-specific ZooKeeper cluster for certain tasks, and more.
-* A BookKeeper cluster consisting of one more or more bookies handles [persistent storage](#persistent-storage) of messages.
+* A BookKeeper cluster consisting of one or more bookies handles [persistent storage](#persistent-storage) of messages.
 * A ZooKeeper cluster specific to that cluster handles
 
 The diagram below provides an illustration of a Pulsar cluster:

--- a/site2/website/versioned_docs/version-2.1.0-incubating/concepts-architecture-overview.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/concepts-architecture-overview.md
@@ -10,7 +10,7 @@ At the highest level, a Pulsar instance is composed of one or more Pulsar cluste
 In a Pulsar cluster:
 
 * One or more brokers handles and load balances incoming messages from producers, dispatches messages to consumers, communicates with the Pulsar configuration store to handle various coordination tasks, stores messages in BookKeeper instances (aka bookies), relies on a cluster-specific ZooKeeper cluster for certain tasks, and more.
-* A BookKeeper cluster consisting of one more or more bookies handles [persistent storage](#persistent-storage) of messages.
+* A BookKeeper cluster consisting of one or more bookies handles [persistent storage](#persistent-storage) of messages.
 * A ZooKeeper cluster specific to that cluster handles
 
 The diagram below provides an illustration of a Pulsar cluster:


### PR DESCRIPTION
### Motivation

fix typo

### Modifications

"one more or more" -> "one or more"

### Result

typo fixed.
