### PR TITLE
Removed metrics from getstatus

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -367,10 +367,9 @@ public class PulsarFunctionE2ETest {
         assertEquals(numInstances, 1);
 
         FunctionStatus stats = functionStats.getFunctionStatusListList().get(0);
-        Map<String, DataDigest> metricsData = stats.getMetrics().getMetricsMap();
 
-        double count = metricsData.get(JavaInstanceRunnable.METRICS_TOTAL_PROCESSED).getCount();
-        double success = metricsData.get(JavaInstanceRunnable.METRICS_TOTAL_SUCCESS).getCount();
+        double count = stats.getNumProcessed();
+        double success = stats.getNumSuccessfullyProcessed();
         String ownerWorkerId = stats.getWorkerId();
         assertEquals((int) count, totalMsgs);
         assertEquals((int) success, totalMsgs);

--- a/pulsar-functions/proto/src/main/proto/InstanceCommunication.proto
+++ b/pulsar-functions/proto/src/main/proto/InstanceCommunication.proto
@@ -49,7 +49,7 @@ message FunctionStatus {
     // expressed in ms since epoch
     int64 lastInvocationTime = 13;
     string instanceId = 14;
-    MetricsData metrics = 15;
+    MetricsData metrics = 15 [deprecated=true];
     // owner of function-instance
     string workerId = 16;
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -113,13 +113,7 @@ class ThreadRuntime implements Runtime {
         }
         FunctionStatus.Builder functionStatusBuilder = javaInstanceRunnable.getFunctionStatus();
         functionStatusBuilder.setRunning(true);
-        getMetrics().handle((metrics, e) -> {
-            if (e == null) {
-                functionStatusBuilder.setMetrics(metrics);
-            }
-            statsFuture.complete(functionStatusBuilder.build());
-            return null;
-        });
+        statsFuture.complete(functionStatusBuilder.build());
         return statsFuture;
     }
 


### PR DESCRIPTION
### Motivation

GetStatus is supposed to display short information about a particular function instance as opposed to getting details metrics about the function.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
