### PR TITLE
Use unique test names in PartitionedProducerConsumerTest to avoid individual tests inter-dependencies

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -68,7 +68,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic1");
+        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic1-" + System.currentTimeMillis());
 
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
@@ -110,7 +110,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         int numPartitions = 4;
         final String specialCharacter = "! * ' ( ) ; : @ & = + $ , \\ ? % # [ ]";
         TopicName topicName = TopicName
-                .get("persistent://my-property/my-ns/my-partitionedtopic1" + specialCharacter);
+                .get("persistent://my-property/my-ns/my-partitionedtopic1-" + System.currentTimeMillis() + specialCharacter);
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
         // Try to create producer which does lookup and create connection with broker
@@ -126,7 +126,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic2");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic2-" + System.currentTimeMillis());
 
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
@@ -167,7 +168,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic3");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic3-" + System.currentTimeMillis());
         String dummyKey1 = "dummykey1";
         String dummyKey2 = "dummykey2";
 
@@ -219,7 +221,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic4");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic4-" + System.currentTimeMillis());
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName.toString())
@@ -269,7 +272,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
     public void testSillyUser() throws Exception {
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic5");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic5-" + System.currentTimeMillis());
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
         Producer<byte[]> producer = null;
@@ -311,7 +315,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
     @Test(timeOut = 30000)
     public void testDeletePartitionedTopic() throws Exception {
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic6");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic6-" + System.currentTimeMillis());
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName.toString()).create();
@@ -338,7 +343,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         final Set<String> consumeMsgs = Sets.newHashSet();
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic1");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic1-" + System.currentTimeMillis());
 
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName.toString())
@@ -386,7 +392,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         final Set<String> consumeMsgs = Sets.newHashSet();
 
         int numPartitions = 4;
-        TopicName topicName = TopicName.get("persistent://my-property/my-ns/my-partitionedtopic1");
+        TopicName topicName = TopicName
+                .get("persistent://my-property/my-ns/my-partitionedtopic1-" + System.currentTimeMillis());
 
         admin.topics().createPartitionedTopic(topicName.toString(), numPartitions);
 
@@ -436,7 +443,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int numPartitions = 2;
-        final String topicName = "persistent://my-property/my-ns/my-topic";
+        final String topicName = "persistent://my-property/my-ns/my-topic-" + System.currentTimeMillis();
         final String producer1Msg = "producer1";
         final String producer2Msg = "producer2";
         final int queueSize = 10;


### PR DESCRIPTION
### Motivation

PartitionedProducerConsumerTest has some occasional flaky tests that are failing with same partitioned topic not being removed by previous test. Using unique names to avoid conflicts.