### PR TITLE
Set default for expectedMetricsCollectionInterval

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -143,7 +143,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         private String pythonDependencyRepository;
         private String pythonExtraDependencyRepository;
         private Map<String, String> customLabels;
-        private Integer expectedMetricsCollectionInterval;
+        private Integer expectedMetricsCollectionInterval = 30;
         // Kubernetes Runtime will periodically checkback on
         // this configMap if defined and if there are any changes
         // to the kubernetes specific stuff, we apply those changes


### PR DESCRIPTION
There is no reason the default should be null which will cause metrics collection not to happen in prometheus even though a metrics server is launched