### PR TITLE
In dashboard, class ActiveBroker don't have attribute url

### DIFF
--- a/dashboard/django/stats/models.py
+++ b/dashboard/django/stats/models.py
@@ -50,7 +50,7 @@ class ActiveBroker(Model):
     timestamp = BigIntegerField(db_index=True)
 
     def __str__(self):
-        return self.url
+        return self.broker.url
 
 @python_2_unicode_compatible
 class Property(Model):


### PR DESCRIPTION
### Motivation

Use dashboard, click http://localhost/admin/stats/topic/add/  http://localhost/admin/stats/topic/395/change/, report error 'ActiveBroker' object has no attribute 'url'.

### Modifications

In class ActiveBroker, modify self.url to self.broker.url.

### Result

Normal response.
