### PR TITLE
Remove metrics from getstatus in python functions

### DIFF
--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -388,7 +388,6 @@ class PythonInstance(object):
     status.serializationExceptions = self.total_stats.nserialization_exceptions
     status.averageLatency = self.total_stats.compute_latency()
     status.lastInvocationTime = self.total_stats.lastinvocationtime
-    status.metrics.CopyFrom(self.get_metrics())
     return status
 
   def join(self):


### PR DESCRIPTION
### Motivation

GetStatus should not return metrics information. Java already removed this in #2866. This change removes this from python

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
