### PR TITLE
Fix helm lint error for zookeeper-metadata.yaml

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/zookeeper-metadata.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/zookeeper-metadata.yaml
@@ -46,9 +46,9 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeperMetadata.component }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-      {{- if .Values.zookeeper_metadata.resources }}
+      {{- if .Values.zookeeperMetadata.resources }}
         resources:
-{{ toYaml .Values.zookeeper_metadata.resources | indent 10 }}
+{{ toYaml .Values.zookeeperMetadata.resources | indent 10 }}
       {{- end }}
         command: ["sh", "-c"]
         args:

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -256,6 +256,7 @@ proxy:
   ##
   service:
     annotations: {}
+    type: NodePort
     ports:
     - name: http
       port: 8080


### PR DESCRIPTION
### Motivation

The following errors occurs when running : 

helm lint pulsar/
==> Linting pulsar/
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: render error in "pulsar/templates/zookeeper-metadata.yaml": template: pulsar/templates/zookeeper-metadata.yaml:49:20: executing "pulsar/templates/zookeeper-metadata.yaml" at <.Values.zookeeper_me...>: can't evaluate field resources in type interface {}

### Modifications

Change  zookeeper_metadata in deployment/kubernetes/helm/pulsar/templates/zookeeper-metadata.yaml to zookeeperMetadata

### Result

helm lint pulsar/
==> Linting pulsar/
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures