### PR TITLE
Fixed python websocket client sample code

### DIFF
--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -273,7 +273,7 @@ Here's an example Python producer that sends a simple message to a Pulsar [topic
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/producer/persistent/public/default/my-topic'
+TOPIC = 'ws://localhost:8080/ws/v2/producer/persistent/public/default/my-topic'
 
 ws = websocket.create_connection(TOPIC)
 


### PR DESCRIPTION
### Motivation

Python websocket client sample code is invalid for execute producer.
http://pulsar.apache.org/docs/en/client-libraries-websocket/#python-producer

### Modifications

Add `v2` on endpoint URL.

### Result

Sample python producer can send message to my local brokers.
