### PR TITLE
Upgrade jackson version to 2.9.7

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -314,23 +314,23 @@ The Apache Software License, Version 2.0
  * Jackson
      - org.codehaus.jackson-jackson-core-asl-1.9.13.jar
      - org.codehaus.jackson-jackson-mapper-asl-1.9.13.jar
-     - com.fasterxml.jackson.core-jackson-annotations-2.8.4.jar
-     - com.fasterxml.jackson.core-jackson-core-2.8.4.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.8.4.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.8.4.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.8.4.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.8.4.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.8.4.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.8.4.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.9.7.jar
+     - com.fasterxml.jackson.core-jackson-core-2.9.7.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.9.7.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.7.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.7.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.7.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.7.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.7.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.3.3.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.0.0.jar
  * Gson -- com.google.code.gson-gson-2.8.2.jar
  * Guava -- com.google.guava-guava-21.0.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.0.jar
  * Swagger
-    - io.swagger-swagger-annotations-1.5.20.jar
-    - io.swagger-swagger-core-1.5.20.jar
-    - io.swagger-swagger-models-1.5.20.jar
+    - io.swagger-swagger-annotations-1.5.21.jar
+    - io.swagger-swagger-core-1.5.21.jar
+    - io.swagger-swagger-models-1.5.21.jar
  * DataSketches
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
@@ -412,7 +412,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-common-9.4.12.v20180830.jar
     - org.eclipse.jetty.websocket-websocket-server-9.4.12.v20180830.jar
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.12.v20180830.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.15.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.23.jar
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * HttpClient
     - org.apache.httpcomponents-httpclient-4.5.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,8 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.25</slf4j.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.55</bouncycastle.version>
-    <jackson.version>2.8.4</jackson.version>
+    <jackson.version>2.9.7</jackson.version>
+    <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.3.7</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
@@ -624,13 +625,13 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-core</artifactId>
-        <version>1.5.20</version>
+        <version>${swagger.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-annotations</artifactId>
-        <version>1.5.20</version>
+        <version>${swagger.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <parent>
@@ -31,10 +31,84 @@
     <artifactId>pulsar-sql</artifactId>
     <name>Pulsar SQL :: Parent</name>
 
+    <properties>
+        <jackson.version>2.9.7</jackson.version>
+    </properties>
+
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>
         <module>presto-distribution</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base </artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jsonSchema</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -208,24 +208,21 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.8.1.jar
-    - jackson-databind-2.8.1.jar
-    - jackson-dataformat-smile-2.8.1.jar
-    - jackson-datatype-guava-2.8.1.jar
-    - jackson-datatype-guava-2.8.1.jar
-    - jackson-datatype-jdk8-2.8.1.jar
-    - jackson-datatype-jdk8-2.8.1.jar
-    - jackson-datatype-joda-2.8.1.jar
-    - jackson-datatype-joda-2.8.4.jar
-    - jackson-datatype-jsr310-2.8.1.jar
-    - jackson-datatype-jsr310-2.8.1.jar
+    - jackson-annotations-2.9.7.jar
+    - jackson-databind-2.9.7.jar
+    - jackson-dataformat-smile-2.9.7.jar
+    - jackson-datatype-guava-2.9.7.jar
+    - jackson-datatype-guava-2.9.7.jar
+    - jackson-datatype-jdk8-2.9.7.jar
+    - jackson-datatype-jdk8-2.9.7.jar
+    - jackson-datatype-joda-2.9.7.jar
+    - jackson-datatype-jsr310-2.9.7.jar
     - jackson-annotations-2.8.4.jar
-    - jackson-core-2.8.1.jar
-    - jackson-core-2.8.4.jar
+    - jackson-core-2.9.7.jar
     - jackson-core-asl-1.9.13.jar
-    - jackson-databind-2.8.4.jar
+    - jackson-databind-2.9.7.jar
     - jackson-mapper-asl-1.9.13.jar
-    - jackson-dataformat-yaml-2.8.4.jar
+    - jackson-dataformat-yaml-2.9.7.jar
  * Guava
     - guava-21.0.jar
     - guava-24.1-jre.jar
@@ -403,7 +400,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-5.13.3.jar
   * SnakeYAML
-    - snakeyaml-1.15.jar
+    - snakeyaml-1.23.jar
   * Snappy Java
     - snappy-java-1.1.1.3.jar
   * Bean Validation API

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -217,7 +217,6 @@ The Apache Software License, Version 2.0
     - jackson-datatype-jdk8-2.9.7.jar
     - jackson-datatype-joda-2.9.7.jar
     - jackson-datatype-jsr310-2.9.7.jar
-    - jackson-annotations-2.8.4.jar
     - jackson-core-2.9.7.jar
     - jackson-core-asl-1.9.13.jar
     - jackson-databind-2.9.7.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,6 +42,7 @@
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
+        <jackson.version>2.9.7</jackson.version>
     </properties>
 
     <dependencies>
@@ -51,7 +52,7 @@
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>
             <exclusions>
-                <!-- exclude openjdk because of GPL license-->
+                <!-- exclude openjdk because of GPL license -->
                 <exclusion>
                     <groupId>org.openjdk.jol</groupId>
                     <artifactId>jol-core</artifactId>
@@ -106,6 +107,62 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
             <version>${guice.version}</version>
+        </dependency>
+
+        <!-- jackson dependencies -->
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### Motivation

[CVE-2018-7489](https://www.cvedetails.com/cve/CVE-2018-7489/) FasterXML jackson-databind before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw.
So, upgrade jackson version to 2.9.7

