### PR TITLE
Upgrade commons-collections for Security Vulnerabilities[CVE-2015-7501]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <aspectj.version>1.9.1</aspectj.version>
     <rocksdb.version>5.13.3</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.55</bouncycastle.version>
     <jackson.version>2.8.4</jackson.version>
@@ -812,6 +813,12 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>bookkeeper-server</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${commons.collections.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

Apache Commons Collections Security Vulnerabilities is fixed with commons-collection::3.2.2 

https://commons.apache.org/proper/commons-collections/security-reports.html
