### PR TITLE
[zookeeper] remove hardcoded zookeeper session timeout

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperCache.java
@@ -65,7 +65,7 @@ public class GlobalZooKeeperCache extends ZooKeeperCache implements Closeable {
 
         // Initial session creation with global ZK must work
         try {
-            ZooKeeper newSession = zkFuture.get(10, TimeUnit.SECONDS);
+            ZooKeeper newSession = zkFuture.get(zkSessionTimeoutMillis, TimeUnit.MILLISECONDS);
             // Register self as a watcher to receive notification when session expires and trigger a new session to be
             // created
             newSession.register(this);


### PR DESCRIPTION
*Motivation*

If zookeeper hostname resolution takes longer time (e.g. more than 10s).
both initing cluster and starting broker will fail due to session timeout.

*Changes*

remove hardcoded zookeeper session timeout and make them take settings from configuration or arguments.

