### PR TITLE
Changed secretsproviderconfigurator interface to pass v1podspec

### DIFF
--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1PodSpec;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.ConsumerSpec;
@@ -70,7 +71,7 @@ public class ProcessRuntimeTest {
         }
 
         @Override
-        public void configureKubernetesRuntimeSecretsProvider(V1Container container, FunctionDetails functionDetails) {
+        public void configureKubernetesRuntimeSecretsProvider(V1PodSpec podSpec, String functionsContainerName, FunctionDetails functionDetails) {
         }
 
         @Override

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.functions.secretsproviderconfigurator;
 
 import com.google.gson.reflect.TypeToken;
-import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1PodSpec;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
 
@@ -51,7 +51,7 @@ public class DefaultSecretsProviderConfigurator implements SecretsProviderConfig
     }
 
     @Override
-    public void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails) {
+    public void configureKubernetesRuntimeSecretsProvider(V1PodSpec podSpec, String functionsContainerName, Function.FunctionDetails functionDetails) {
         // noop
     }
 

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -20,10 +20,7 @@ package org.apache.pulsar.functions.secretsproviderconfigurator;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import io.kubernetes.client.models.V1Container;
-import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1EnvVarSource;
-import io.kubernetes.client.models.V1SecretKeySelector;
+import io.kubernetes.client.models.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.secretsprovider.EnvironmentBasedSecretsProvider;
@@ -62,7 +59,17 @@ public class KubernetesSecretsProviderConfigurator implements SecretsProviderCon
     // environment variables way. Essentially the secretName/secretPath is attached as secretRef to the environment variables
     // of a pod and kubernetes magically makes the secret pointed to by this combination available as a env variable.
     @Override
-    public void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails) {
+    public void configureKubernetesRuntimeSecretsProvider(V1PodSpec podSpec, String functionsContainerName, Function.FunctionDetails functionDetails) {
+        V1Container container = null;
+        for (V1Container v1Container : podSpec.getContainers()) {
+            if (v1Container.getName().equals(functionsContainerName)) {
+                container = v1Container;
+                break;
+            }
+        }
+        if (container == null) {
+            throw new RuntimeException("No FunctionContainer found");
+        }
         if (!StringUtils.isEmpty(functionDetails.getSecretsMap())) {
             Type type = new TypeToken<Map<String, Object>>() {
             }.getType();

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.secretsproviderconfigurator;
 
-import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1PodSpec;
 import org.apache.pulsar.functions.proto.Function;
 
 import java.lang.reflect.Type;
@@ -51,7 +51,7 @@ public interface SecretsProviderConfigurator {
     /**
      * Attaches any secrets specific stuff to the k8 container for kubernetes runtime
      */
-    void configureKubernetesRuntimeSecretsProvider(V1Container container, Function.FunctionDetails functionDetails);
+    void configureKubernetesRuntimeSecretsProvider(V1PodSpec podSpec, String functionsContainerName, Function.FunctionDetails functionDetails);
 
     /**
      * Attaches any secrets specific stuff to the ProcessBuilder for process runtime


### PR DESCRIPTION
### Motivation

Several Secrets Configurator might require access to the entire pod as opposed to just the functions container. This pr changes the interface of the configurator to take in the whole podspec

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
