### PR TITLE
Fix pulsar function-metrics artifacts deploy

### DIFF
--- a/pulsar-functions/metrics/pom.xml
+++ b/pulsar-functions/metrics/pom.xml
@@ -56,28 +56,29 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <finalName>
-                PrometheusMetricsServer
-              </finalName>
-              <archive>
-                <manifest>
-                  <mainClass>
-                    org.apache.pulsar.functions.sink.PrometheusMetricsServer
-                  </mainClass>
-                </manifest>
-              </archive>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-              <appendAssemblyId>false</appendAssemblyId>
+              <finalName>PrometheusMetricsServer</finalName>
+              <minimizeJar>false</minimizeJar>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <filters>
+                <filter>
+                  <!-- Shading signed JARs will fail without
+                      this. http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### Motivation

Right now, maven deploys shaded jar of `pulsar-function-metrics` and broker distribution uses shaded `pulsar-function-metrics` because of that `pulsar-function-metrics` classes are having conflict with other jars in the classpath. Ideally, broker should never depend on any shaded pulsar artifacts unless it requires to avoid any unexpected shading change into dependent artifacts.

eg: below stacktrace shows how broker loads all classes from `pulsar-function-metrics`
```
      at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) ~[?:1.8.0_131]
        at org.apache.pulsar.broker.service.BrokerService.getOrCreateTopic(BrokerService.java:457) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$18(ServerCnx.java:591) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) ~[?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) ~[?:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$6(ServerCnx.java:550) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602) [?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) [?:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) [?:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.handleSubscribe(ServerCnx.java:539) [pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:202) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:945) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:806) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:404) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
```

### Modifications

with this change maven can deploy all original and shaded artifacts to the maven repo and broker will only fetch original artifact of pulsar-function-metrics.
