### PR TITLE
Fix typo in consumer code

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -235,7 +235,7 @@ if err != nil {
 
 defer consumer.Close()
 
-for cm := range channel {
+for cm := range msgChannel {
     msg := cm.Message
 
     fmt.Printf("Message ID: %s", msg.ID())


### PR DESCRIPTION
### Motivation

Fixing a small typo in the example consumer code which stops it from working

### Modifications

Small fix to resolve an incorrectly named variable in the example consumer client code

### Result

The example works
