### PR TITLE
Always cover gson generated json with quotes

### DIFF
--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -154,6 +154,11 @@ def main():
   secrets_provider = secrets_provider()
   secrets_provider_config = None
   if args.secrets_provider_config is not None:
+    args.secrets_provider_config = str(args.secrets_provider_config)
+    if args.secrets_provider_config[0] == '\'':
+      args.secrets_provider_config = args.secrets_provider_config[1:]
+    if args.secrets_provider_config[-1] == '\'':
+      args.secrets_provider_config = args.secrets_provider_config[:-1]
     secrets_provider_config = json.loads(str(args.secrets_provider_config))
   secrets_provider.init(secrets_provider_config)
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -138,6 +138,12 @@ public class JavaInstanceMain implements AutoCloseable {
 
         Map<String, String> secretsProviderConfigMap = null;
         if (!StringUtils.isEmpty(secretsProviderConfig)) {
+            if (secretsProviderConfig.charAt(0) == '\'') {
+                secretsProviderConfig = secretsProviderConfig.substring(1);
+            }
+            if (secretsProviderConfig.charAt(secretsProviderConfig.length() - 1) == '\'') {
+                secretsProviderConfig = secretsProviderConfig.substring(0, secretsProviderConfig.length() - 1);
+            }
             Type type = new TypeToken<Map<String, String>>() {}.getType();
             secretsProviderConfigMap = new Gson().fromJson(secretsProviderConfig, type);
         }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -158,7 +158,7 @@ class RuntimeUtils {
         args.add(secretsProviderClassName);
         if (!StringUtils.isEmpty(secretsProviderConfig)) {
             args.add("--secrets_provider_config");
-            args.add(secretsProviderConfig);
+            args.add("'" + secretsProviderConfig + "'");
         }
         return args;
     }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -181,7 +181,7 @@ public class ProcessRuntimeTest {
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config {\"Config\":\"Value\"}";
+                + " --secrets_provider_config '{\"Config\":\"Value\"}'";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 
@@ -203,7 +203,7 @@ public class ProcessRuntimeTest {
                 + " --max_buffered_tuples 1024 --port " + args.get(23)
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config {\"Config\":\"Value\"}";
+                + " --secrets_provider_config '{\"Config\":\"Value\"}'";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 


### PR DESCRIPTION
### Motivation

Kubernetes has troubles viewing arguments with string embedded in them. So cover the secrets_config with quotes

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
