### PR TITLE
Added some basic checks for function/source/sink in cli as well

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -478,6 +478,18 @@ public class CmdFunctions extends CmdBase {
         }
 
         protected void validateFunctionConfigs(FunctionConfig functionConfig) {
+            if (StringUtils.isEmpty(functionConfig.getClassName())) {
+                throw new IllegalArgumentException("No Function Classname specified");
+            }
+            if (StringUtils.isEmpty(functionConfig.getName())) {
+                org.apache.pulsar.common.functions.Utils.inferMissingFunctionName(functionConfig);
+            }
+            if (StringUtils.isEmpty(functionConfig.getTenant())) {
+                org.apache.pulsar.common.functions.Utils.inferMissingTenant(functionConfig);
+            }
+            if (StringUtils.isEmpty(functionConfig.getNamespace())) {
+                org.apache.pulsar.common.functions.Utils.inferMissingNamespace(functionConfig);
+            }
 
             if (isNotBlank(functionConfig.getJar()) && isNotBlank(functionConfig.getPy())) {
                 throw new ParameterException("Either a Java jar or a Python file needs to"

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -414,6 +414,8 @@ public class CmdSinks extends CmdBase {
                 throw new ParameterException("Sink archive not specfied");
             }
 
+            org.apache.pulsar.common.functions.Utils.inferMissingArguments(sinkConfig);
+
             if (!Utils.isFunctionPackageUrlSupported(sinkConfig.getArchive()) &&
                     !sinkConfig.getArchive().startsWith(Utils.BUILTIN)) {
                 if (!new File(sinkConfig.getArchive()).exists()) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -370,6 +370,7 @@ public class CmdSources extends CmdBase {
             if (isBlank(sourceConfig.getArchive())) {
                 throw new ParameterException("Source archive not specfied");
             }
+            org.apache.pulsar.common.functions.Utils.inferMissingArguments(sourceConfig);
             if (!Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive()) &&
                 !sourceConfig.getArchive().startsWith(Utils.BUILTIN)) {
                 if (!new File(sourceConfig.getArchive()).exists()) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pulsar.common.functions;
 
+import org.apache.pulsar.common.io.SinkConfig;
+import org.apache.pulsar.common.io.SourceConfig;
+
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
+import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 
 public class Utils {
     public static String HTTP = "http";
@@ -28,5 +33,40 @@ public class Utils {
     public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
         return isNotBlank(functionPkgUrl) && (functionPkgUrl.startsWith(HTTP)
                 || functionPkgUrl.startsWith(FILE));
+    }
+
+    public static void inferMissingFunctionName(FunctionConfig functionConfig) {
+        String[] domains = functionConfig.getClassName().split("\\.");
+        if (domains.length == 0) {
+            functionConfig.setName(functionConfig.getClassName());
+        } else {
+            functionConfig.setName(domains[domains.length - 1]);
+        }
+    }
+
+    public static void inferMissingTenant(FunctionConfig functionConfig) {
+        functionConfig.setTenant(PUBLIC_TENANT);
+    }
+
+    public static void inferMissingNamespace(FunctionConfig functionConfig) {
+        functionConfig.setNamespace(DEFAULT_NAMESPACE);
+    }
+
+    public static void inferMissingArguments(SourceConfig sourceConfig) {
+        if (sourceConfig.getTenant() == null) {
+            sourceConfig.setTenant(PUBLIC_TENANT);
+        }
+        if (sourceConfig.getNamespace() == null) {
+            sourceConfig.setNamespace(DEFAULT_NAMESPACE);
+        }
+    }
+
+    public static void inferMissingArguments(SinkConfig sinkConfig) {
+        if (sinkConfig.getTenant() == null) {
+            sinkConfig.setTenant(PUBLIC_TENANT);
+        }
+        if (sinkConfig.getNamespace() == null) {
+            sinkConfig.setNamespace(DEFAULT_NAMESPACE);
+        }
     }
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -38,8 +38,6 @@ import java.util.*;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
-import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.apache.pulsar.common.functions.Utils.BUILTIN;
 import static org.apache.pulsar.functions.utils.Utils.loadJar;
 
@@ -299,13 +297,13 @@ public class FunctionConfigUtils {
 
     public static void inferMissingArguments(FunctionConfig functionConfig) {
         if (StringUtils.isEmpty(functionConfig.getName())) {
-            inferMissingFunctionName(functionConfig);
+            org.apache.pulsar.common.functions.Utils.inferMissingFunctionName(functionConfig);
         }
         if (StringUtils.isEmpty(functionConfig.getTenant())) {
-            inferMissingTenant(functionConfig);
+            org.apache.pulsar.common.functions.Utils.inferMissingTenant(functionConfig);
         }
         if (StringUtils.isEmpty(functionConfig.getNamespace())) {
-            inferMissingNamespace(functionConfig);
+            org.apache.pulsar.common.functions.Utils.inferMissingNamespace(functionConfig);
         }
 
         if (functionConfig.getParallelism() == 0) {
@@ -323,23 +321,6 @@ public class FunctionConfigUtils {
             WindowConfigUtils.inferMissingArguments(windowConfig);
             functionConfig.setAutoAck(false);
         }
-    }
-
-    private static void inferMissingFunctionName(FunctionConfig functionConfig) {
-        String[] domains = functionConfig.getClassName().split("\\.");
-        if (domains.length == 0) {
-            functionConfig.setName(functionConfig.getClassName());
-        } else {
-            functionConfig.setName(domains[domains.length - 1]);
-        }
-    }
-
-    private static void inferMissingTenant(FunctionConfig functionConfig) {
-        functionConfig.setTenant(PUBLIC_TENANT);
-    }
-
-    private static void inferMissingNamespace(FunctionConfig functionConfig) {
-        functionConfig.setNamespace(DEFAULT_NAMESPACE);
     }
 
     private static void doJavaChecks(FunctionConfig functionConfig, ClassLoader clsLoader) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -328,15 +328,6 @@ public class SinkConfigUtils {
         return classLoader;
     }
 
-    public static void inferMissingArguments(SinkConfig sinkConfig) {
-        if (sinkConfig.getTenant() == null) {
-            sinkConfig.setTenant(PUBLIC_TENANT);
-        }
-        if (sinkConfig.getNamespace() == null) {
-            sinkConfig.setNamespace(DEFAULT_NAMESPACE);
-        }
-    }
-
     private static Collection<String> collectAllInputTopics(SinkConfig sinkConfig) {
         List<String> retval = new LinkedList<>();
         if (sinkConfig.getInputs() != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -236,12 +236,4 @@ public class SourceConfigUtils {
         return classLoader;
     }
 
-    public static void inferMissingArguments(SourceConfig sourceConfig) {
-        if (sourceConfig.getTenant() == null) {
-            sourceConfig.setTenant(PUBLIC_TENANT);
-        }
-        if (sourceConfig.getNamespace() == null) {
-            sourceConfig.setNamespace(DEFAULT_NAMESPACE);
-        }
-    }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -1118,7 +1118,7 @@ public class FunctionsImpl {
             sourceConfig.setTenant(tenant);
             sourceConfig.setNamespace(namespace);
             sourceConfig.setName(componentName);
-            SourceConfigUtils.inferMissingArguments(sourceConfig);
+            org.apache.pulsar.common.functions.Utils.inferMissingArguments(sourceConfig);
             if (!StringUtils.isEmpty(sourceConfig.getArchive())) {
                 String builtinArchive = sourceConfig.getArchive();
                 if (builtinArchive.startsWith(org.apache.pulsar.common.functions.Utils.BUILTIN)) {
@@ -1140,7 +1140,7 @@ public class FunctionsImpl {
             sinkConfig.setTenant(tenant);
             sinkConfig.setNamespace(namespace);
             sinkConfig.setName(componentName);
-            SinkConfigUtils.inferMissingArguments(sinkConfig);
+            org.apache.pulsar.common.functions.Utils.inferMissingArguments(sinkConfig);
             if (!StringUtils.isEmpty(sinkConfig.getArchive())) {
                 String builtinArchive = sinkConfig.getArchive();
                 if (builtinArchive.startsWith(org.apache.pulsar.common.functions.Utils.BUILTIN)) {


### PR DESCRIPTION
### Motivation

We recently moved all config validation from client side to server side.
However in order for the cli to submit its function to the server, users should supply some basic information(like tenant/namespace/name) because the submission path involves them.
This pr adds back some basic checks back in the client so that we do basic checks for these fields.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
