### PR TITLE
Expose metrics via http port in function instance

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.functions.instance;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Gauge;
 import io.prometheus.client.Summary;
 import lombok.Getter;
 import lombok.Setter;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -98,7 +98,6 @@ class ContextImpl implements Context, SinkContext, SourceContext {
         }
     }
 
-    private ConcurrentMap<String, AccumulatedMetricDatum> currentAccumulatedMetrics;
     private ConcurrentMap<String, AccumulatedMetricDatum> accumulatedMetrics;
 
     private Map<String, Producer<?>> publishProducers;
@@ -131,7 +130,6 @@ class ContextImpl implements Context, SinkContext, SourceContext {
                        SecretsProvider secretsProvider, CollectorRegistry collectorRegistry, String[] metricsLabels) {
         this.config = config;
         this.logger = logger;
-        this.currentAccumulatedMetrics = new ConcurrentHashMap<>();
         this.accumulatedMetrics = new ConcurrentHashMap<>();
         this.publishProducers = new HashMap<>();
         this.inputTopics = inputTopics;
@@ -351,8 +349,8 @@ class ContextImpl implements Context, SinkContext, SourceContext {
                 .register(collectorRegistry));
 
         userMetrics.get(metricName).labels(userMetricsLabels).set(value);
-        currentAccumulatedMetrics.putIfAbsent(metricName, new AccumulatedMetricDatum());
-        currentAccumulatedMetrics.get(metricName).update(value);
+        accumulatedMetrics.putIfAbsent(metricName, new AccumulatedMetricDatum());
+        accumulatedMetrics.get(metricName).update(value);
     }
 
     public MetricsData getAndResetMetrics() {
@@ -364,8 +362,6 @@ class ContextImpl implements Context, SinkContext, SourceContext {
     public void resetMetrics() {
         userMetrics.values().forEach(gauge -> gauge.clear());
         this.accumulatedMetrics.clear();
-        this.accumulatedMetrics.putAll(currentAccumulatedMetrics);
-        this.currentAccumulatedMetrics.clear();
     }
 
     public MetricsData getMetrics() {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.instance;
 import com.google.common.collect.EvictingQueue;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Summary;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,7 +36,16 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 @Setter
 public class FunctionStats {
 
-    static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id"};
+    static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id", "cluster"};
+
+    /** Declare metric names **/
+    static final String PULSAR_FUNCTION_PROCESSED_TOTAL = "pulsar_function_processed_total";
+    static final String PULSAR_FUNCTION_PROCESSED_SUCCESSFULLY_TOTAL = "pulsar_function_processed_successfully_total";
+    static final String PULSAR_FUNCTION_SYSTEM_EXCEPTIONS_TOTAL = "pulsar_function_system_exceptions_total";
+    static final String PULSAR_FUNCTION_USER_EXCEPTIONS_TOTAL = "pulsar_function_user_exceptions_total";
+    static final String PULSAR_FUNCTION_PROCESS_LATENCY_MS = "pulsar_function_process_latency_ms";
+    static final String PULSAR_FUNCTION_LAST_INVOCATION = "pulsar_function_last_invocation";
+    static final String PULSAR_FUNCTION_RECEIVED_TOTAL = "pulsar_function_received_total";
 
     /** Declare Prometheus stats **/
 
@@ -49,6 +59,10 @@ public class FunctionStats {
 
     final Summary statProcessLatency;
 
+    final Gauge statlastInvocation;
+
+    final Counter statTotalRecordsRecieved;
+
     CollectorRegistry functionCollectorRegistry;
 
     @Getter
@@ -56,45 +70,54 @@ public class FunctionStats {
     @Getter
     private EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> latestSystemExceptions = EvictingQueue.create(10);
 
-    @Getter
-    @Setter
-    private long lastInvocationTime = 0;
-
     public FunctionStats(CollectorRegistry collectorRegistry) {
         // Declare function local collector registry so that it will not clash with other function instances'
         // metrics collection especially in threaded mode
         functionCollectorRegistry = new CollectorRegistry();
 
         statTotalProcessed = Counter.build()
-                .name("pulsar_function_processed_total")
+                .name(PULSAR_FUNCTION_PROCESSED_TOTAL)
                 .help("Total number of messages processed.")
                 .labelNames(metricsLabelNames)
                 .register(collectorRegistry);
 
         statTotalProcessedSuccessfully = Counter.build()
-                .name("pulsar_function_processed_successfully_total")
+                .name(PULSAR_FUNCTION_PROCESSED_SUCCESSFULLY_TOTAL)
                 .help("Total number of messages processed successfully.")
                 .labelNames(metricsLabelNames)
                 .register(collectorRegistry);
 
         statTotalSysExceptions = Counter.build()
-                .name("pulsar_function_system_exceptions_total")
+                .name(PULSAR_FUNCTION_SYSTEM_EXCEPTIONS_TOTAL)
                 .help("Total number of system exceptions.")
                 .labelNames(metricsLabelNames)
                 .register(collectorRegistry);
 
         statTotalUserExceptions = Counter.build()
-                .name("pulsar_function_user_exceptions_total")
+                .name(PULSAR_FUNCTION_USER_EXCEPTIONS_TOTAL)
                 .help("Total number of user exceptions.")
                 .labelNames(metricsLabelNames)
                 .register(collectorRegistry);
 
         statProcessLatency = Summary.build()
-                .name("pulsar_function_process_latency_ms").help("Process latency in milliseconds.")
+                .name(PULSAR_FUNCTION_PROCESS_LATENCY_MS)
+                .help("Process latency in milliseconds.")
                 .quantile(0.5, 0.01)
                 .quantile(0.9, 0.01)
                 .quantile(0.99, 0.01)
                 .quantile(0.999, 0.01)
+                .labelNames(metricsLabelNames)
+                .register(collectorRegistry);
+
+        statlastInvocation = Gauge.build()
+                .name(PULSAR_FUNCTION_LAST_INVOCATION)
+                .help("The timestamp of the last invocation of the function")
+                .labelNames(metricsLabelNames)
+                .register(collectorRegistry);
+
+        statTotalRecordsRecieved = Counter.build()
+                .name(PULSAR_FUNCTION_RECEIVED_TOTAL)
+                .help("Total number of messages received from source.")
                 .labelNames(metricsLabelNames)
                 .register(collectorRegistry);
     }
@@ -120,8 +143,9 @@ public class FunctionStats {
         statTotalSysExceptions.clear();
         statTotalUserExceptions.clear();
         statProcessLatency.clear();
+        statlastInvocation.clear();
+        statTotalRecordsRecieved.clear();
         latestUserExceptions.clear();
         latestSystemExceptions.clear();
-        lastInvocationTime = 0;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
@@ -36,7 +36,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 @Setter
 public class FunctionStats {
 
-    static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id", "cluster"};
+    static final String[] metricsLabelNames = {"tenant", "namespace", "function", "instance_id", "cluster"};
 
     /** Declare metric names **/
     static final String PULSAR_FUNCTION_PROCESSED_TOTAL = "pulsar_function_processed_total";

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
@@ -35,7 +35,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 @Setter
 public class FunctionStats {
 
-    private static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id"};
+    static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id"};
 
     /** Declare Prometheus stats **/
 
@@ -60,43 +60,43 @@ public class FunctionStats {
     @Setter
     private long lastInvocationTime = 0;
 
-    public FunctionStats() {
+    public FunctionStats(CollectorRegistry collectorRegistry) {
         // Declare function local collector registry so that it will not clash with other function instances'
         // metrics collection especially in threaded mode
         functionCollectorRegistry = new CollectorRegistry();
 
         statTotalProcessed = Counter.build()
-                .name("__function_total_processed__")
+                .name("pulsar_function_processed_total")
                 .help("Total number of messages processed.")
                 .labelNames(metricsLabelNames)
-                .register(functionCollectorRegistry);
+                .register(collectorRegistry);
 
         statTotalProcessedSuccessfully = Counter.build()
-                .name("__function_total_successfully_processed__")
+                .name("pulsar_function_processed_successfully_total")
                 .help("Total number of messages processed successfully.")
                 .labelNames(metricsLabelNames)
-                .register(functionCollectorRegistry);
+                .register(collectorRegistry);
 
         statTotalSysExceptions = Counter.build()
-                .name("__function_total_system_exceptions__")
+                .name("pulsar_function_system_exceptions_total")
                 .help("Total number of system exceptions.")
                 .labelNames(metricsLabelNames)
-                .register(functionCollectorRegistry);
+                .register(collectorRegistry);
 
         statTotalUserExceptions = Counter.build()
-                .name("__function_total_user_exceptions__")
+                .name("pulsar_function_user_exceptions_total")
                 .help("Total number of user exceptions.")
                 .labelNames(metricsLabelNames)
-                .register(functionCollectorRegistry);
+                .register(collectorRegistry);
 
         statProcessLatency = Summary.build()
-                .name("__function_process_latency_ms__").help("Process latency in milliseconds.")
+                .name("pulsar_function_process_latency_ms").help("Process latency in milliseconds.")
                 .quantile(0.5, 0.01)
                 .quantile(0.9, 0.01)
                 .quantile(0.99, 0.01)
                 .quantile(0.999, 0.01)
                 .labelNames(metricsLabelNames)
-                .register(functionCollectorRegistry);
+                .register(collectorRegistry);
     }
 
     public void addUserException(Exception ex) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -41,6 +41,7 @@ public class InstanceConfig {
     private FunctionDetails functionDetails;
     private int maxBufferedTuples;
     private int port;
+    private String clusterName;
 
     /**
      * Get the string representation of {@link #getInstanceId()}.

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -479,7 +479,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 stats.statProcessLatency.labels(metricsLabels).get().count == 0.0
                         ? 0 : stats.statProcessLatency.labels(metricsLabels).get().sum / stats.statProcessLatency
                         .labels(metricsLabels).get().count);
-        functionStatusBuilder.setLastInvocationTime((long) stats.statlastInvocation.get());
+        functionStatusBuilder.setLastInvocationTime((long) stats.statlastInvocation.labels(metricsLabels).get());
         return functionStatusBuilder;
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -459,6 +459,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 stats.statProcessLatency.labels(metricsLabels).get().count <= 0.0
                         ? 0 : stats.statProcessLatency.labels(metricsLabels).get().sum / stats.statProcessLatency.labels(metricsLabels).get().count,
                 bldr);
+        addSystemMetrics(FunctionStats.PULSAR_FUNCTION_LAST_INVOCATION, stats.statlastInvocation.labels(metricsLabels).get(), bldr);
         return bldr;
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -140,7 +140,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 instanceConfig.getFunctionDetails().getTenant(),
                 String.format("%s/%s", instanceConfig.getFunctionDetails().getTenant(),
                         instanceConfig.getFunctionDetails().getNamespace()),
-                instanceConfig.getFunctionDetails().getName(),
+                String.format("%s/%s/%s", instanceConfig.getFunctionDetails().getTenant(),
+                        instanceConfig.getFunctionDetails().getNamespace(),
+                        instanceConfig.getFunctionDetails().getName()),
                 String.valueOf(instanceConfig.getInstanceId()),
                 instanceConfig.getClusterName()
         };

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -77,9 +77,9 @@ class ContextImpl(pulsar.Context):
 
     self.metrics_labels = metrics_labels
     self.user_metrics_labels = dict()
-    self.user_metrics_gauge = Summary("pulsar_function_user_metric",
+    self.user_metrics_summary = Summary("pulsar_function_user_metric",
                                     'Pulsar Function user defined metric',
-                                    ContextImpl.user_metrics_label_names)
+                                        ContextImpl.user_metrics_label_names)
 
   # Called on a per message basis to set the context for the current message
   def set_current_message_context(self, msgid, topic):
@@ -131,7 +131,7 @@ class ContextImpl(pulsar.Context):
   def record_metric(self, metric_name, metric_value):
     if metric_name not in self.user_metrics_labels:
       self.user_metrics_labels[metric_name] = self.metrics_labels + [metric_name]
-    self.user_metrics_gauge.labels(*self.user_metrics_labels[metric_name]).observe(metric_value)
+    self.user_metrics_summary.labels(*self.user_metrics_labels[metric_name]).observe(metric_value)
     if not metric_name in self.accumulated_metrics:
       self.accumulated_metrics[metric_name] = AccumulatedMetricDatum()
     self.accumulated_metrics[metric_name].update(metric_value)
@@ -180,8 +180,8 @@ class ContextImpl(pulsar.Context):
   def reset_metrics(self):
     # TODO: Make it thread safe
     for labels in self.user_metrics_labels.values():
-      self.user_metrics_gauge.labels(*labels)._sum.set(0.0)
-      self.user_metrics_gauge.labels(*labels)._count.set(0.0)
+      self.user_metrics_summary.labels(*labels)._sum.set(0.0)
+      self.user_metrics_summary.labels(*labels)._count.set(0.0)
     self.accumulated_metrics.clear()
 
   def get_metrics(self):

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -132,7 +132,6 @@ class ContextImpl(pulsar.Context):
     if metric_name not in self.user_metrics_labels:
       self.user_metrics_labels[metric_name] = self.metrics_labels + [metric_name]
     self.user_metrics_gauge.labels(*self.user_metrics_labels[metric_name]).set(metric_value)
-
     if not metric_name in self.accumulated_metrics:
       self.accumulated_metrics[metric_name] = AccumulatedMetricDatum()
     self.accumulated_metrics[metric_name].update(metric_value)
@@ -180,8 +179,8 @@ class ContextImpl(pulsar.Context):
 
   def reset_metrics(self):
     # TODO: Make it thread safe
-    for gauge in self.user_metrics.values():
-      gauge.labels(*self.user_metrics_labels).set(0.0)
+    for labels in self.user_metrics_labels.values():
+      self.user_metrics_gauge.labels(*labels).set(0.0)
     self.accumulated_metrics.clear()
 
   def get_metrics(self):

--- a/pulsar-functions/instance/src/main/python/function_stats.py
+++ b/pulsar-functions/instance/src/main/python/function_stats.py
@@ -24,7 +24,7 @@ from prometheus_client import Counter, Summary, Gauge
 
 # We keep track of the following metrics
 class Stats(object):
-  metrics_label_names = ['tenant', 'namespace', 'name', 'instance_id', 'cluster']
+  metrics_label_names = ['tenant', 'namespace', 'function', 'instance_id', 'cluster']
 
   TOTAL_PROCESSED = 'pulsar_function_processed_total'
   TOTAL_SUCCESSFULLY_PROCESSED = 'pulsar_function_processed_successfully_total'

--- a/pulsar-functions/instance/src/main/python/function_stats.py
+++ b/pulsar-functions/instance/src/main/python/function_stats.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import traceback
+import time
+
+from prometheus_client import Counter, Summary
+
+# We keep track of the following metrics
+class Stats(object):
+  metrics_label_names = ['tenant', 'namespace', 'name', 'instance_id']
+
+  TOTAL_PROCESSED = 'pulsar_function_processed_total'
+  TOTAL_SUCCESSFULLY_PROCESSED = 'pulsar_function_processed_successfully_total'
+  TOTAL_SYSTEM_EXCEPTIONS = 'pulsar_function_system_exceptions_total'
+  TOTAL_USER_EXCEPTIONS = 'pulsar_function_user_exceptions_total'
+  PROCESS_LATENCY_MS = 'pulsar_function_process_latency_ms'
+
+  # Declare Prometheus
+  stat_total_processed = Counter(TOTAL_PROCESSED, 'Total number of messages processed.', metrics_label_names)
+  stat_total_processed_successfully = Counter(TOTAL_SUCCESSFULLY_PROCESSED,
+                                              'Total number of messages processed successfully.', metrics_label_names)
+  stat_total_sys_exceptions = Counter(TOTAL_SYSTEM_EXCEPTIONS, 'Total number of system exceptions.',
+                                      metrics_label_names)
+  stat_total_user_exceptions = Counter(TOTAL_USER_EXCEPTIONS, 'Total number of user exceptions.',
+                                       metrics_label_names)
+
+  stats_process_latency_ms = Summary(PROCESS_LATENCY_MS, 'Process latency in milliseconds.', metrics_label_names)
+
+  latest_user_exception = []
+  latest_sys_exception = []
+
+  last_invocation_time = 0.0
+
+  def add_user_exception(self):
+    self.latest_sys_exception.append((traceback.format_exc(), int(time.time() * 1000)))
+    if len(self.latest_sys_exception) > 10:
+      self.latest_sys_exception.pop(0)
+
+  def add_sys_exception(self):
+    self.latest_sys_exception.append((traceback.format_exc(), int(time.time() * 1000)))
+    if len(self.latest_sys_exception) > 10:
+      self.latest_sys_exception.pop(0)
+
+  def reset(self, metrics_labels):
+    self.latest_user_exception = []
+    self.latest_sys_exception = []
+    self.stat_total_processed.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_processed_successfully.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_user_exceptions.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_sys_exceptions.labels(*metrics_labels)._value.set(0.0)
+    self.stats_process_latency_ms.labels(*metrics_labels)._sum.set(0)
+    self.stats_process_latency_ms.labels(*metrics_labels)._count.set(0);

--- a/pulsar-functions/instance/src/main/python/function_stats.py
+++ b/pulsar-functions/instance/src/main/python/function_stats.py
@@ -20,17 +20,19 @@
 import traceback
 import time
 
-from prometheus_client import Counter, Summary
+from prometheus_client import Counter, Summary, Gauge
 
 # We keep track of the following metrics
 class Stats(object):
-  metrics_label_names = ['tenant', 'namespace', 'name', 'instance_id']
+  metrics_label_names = ['tenant', 'namespace', 'name', 'instance_id', 'cluster']
 
   TOTAL_PROCESSED = 'pulsar_function_processed_total'
   TOTAL_SUCCESSFULLY_PROCESSED = 'pulsar_function_processed_successfully_total'
   TOTAL_SYSTEM_EXCEPTIONS = 'pulsar_function_system_exceptions_total'
   TOTAL_USER_EXCEPTIONS = 'pulsar_function_user_exceptions_total'
   PROCESS_LATENCY_MS = 'pulsar_function_process_latency_ms'
+  LAST_INVOCATION = 'pulsar_function_last_invocation'
+  TOTAL_RECEIVED = 'pulsar_function_received_total'
 
   # Declare Prometheus
   stat_total_processed = Counter(TOTAL_PROCESSED, 'Total number of messages processed.', metrics_label_names)
@@ -41,12 +43,14 @@ class Stats(object):
   stat_total_user_exceptions = Counter(TOTAL_USER_EXCEPTIONS, 'Total number of user exceptions.',
                                        metrics_label_names)
 
-  stats_process_latency_ms = Summary(PROCESS_LATENCY_MS, 'Process latency in milliseconds.', metrics_label_names)
+  stat_process_latency_ms = Summary(PROCESS_LATENCY_MS, 'Process latency in milliseconds.', metrics_label_names)
+
+  stat_last_invocation = Gauge(LAST_INVOCATION, 'The timestamp of the last invocation of the function.', metrics_label_names)
+
+  stat_total_received = Counter(TOTAL_RECEIVED, 'Total number of messages received from source.', metrics_label_names)
 
   latest_user_exception = []
   latest_sys_exception = []
-
-  last_invocation_time = 0.0
 
   def add_user_exception(self):
     self.latest_sys_exception.append((traceback.format_exc(), int(time.time() * 1000)))
@@ -65,5 +69,7 @@ class Stats(object):
     self.stat_total_processed_successfully.labels(*metrics_labels)._value.set(0.0)
     self.stat_total_user_exceptions.labels(*metrics_labels)._value.set(0.0)
     self.stat_total_sys_exceptions.labels(*metrics_labels)._value.set(0.0)
-    self.stats_process_latency_ms.labels(*metrics_labels)._sum.set(0)
-    self.stats_process_latency_ms.labels(*metrics_labels)._count.set(0);
+    self.stat_process_latency_ms.labels(*metrics_labels)._sum.set(0.0)
+    self.stat_process_latency_ms.labels(*metrics_labels)._count.set(0.0)
+    self.stat_last_invocation.labels(*metrics_labels).set(0.0)
+    self.stat_total_received.labels(*metrics_labels)._value.set(0.0)

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -104,15 +104,15 @@ class Stats(object):
     if len(self.latest_sys_exception) > 10:
       self.latest_sys_exception.pop(0)
 
-  def reset(self):
-    self.latest_user_exception.clear()
-    self.latest_sys_exception.clear()
-    self.stat_total_processed._value.set(0.0)
-    self.stat_total_processed_successfully._value.set(0.0)
-    self.stat_total_user_exceptions._value.set(0.0)
-    self.stat_total_sys_exceptions._value.set(0.0)
-    self.stats_process_latency_ms._sum.set(0)
-    self.stats_process_latency_ms._count.set(0);
+  def reset(self, metrics_labels):
+    self.latest_user_exception = []
+    self.latest_sys_exception = []
+    self.stat_total_processed.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_processed_successfully.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_user_exceptions.labels(*metrics_labels)._value.set(0.0)
+    self.stat_total_sys_exceptions.labels(*metrics_labels)._value.set(0.0)
+    self.stats_process_latency_ms.labels(*metrics_labels)._sum.set(0)
+    self.stats_process_latency_ms.labels(*metrics_labels)._count.set(0);
     self.last_invocation_time = 0.0
 
 class PythonInstance(object):
@@ -321,7 +321,7 @@ class PythonInstance(object):
     return metrics
 
   def reset_metrics(self):
-    self.stats.reset()
+    self.stats.reset(self.metrics_labels)
     self.contextimpl.reset_metrics()
 
   def get_metrics(self):

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -308,23 +308,32 @@ class PythonInstance(object):
   def get_function_status(self):
     status = InstanceCommunication_pb2.FunctionStatus()
     status.running = True
-    status.numProcessed = long(Stats.stat_total_processed.labels(*self.metrics_labels)._value.get())
-    status.numSuccessfullyProcessed = long(Stats.stat_total_processed_successfully.labels(*self.metrics_labels)._value.get())
-    status.numUserExceptions = long(Stats.stat_total_user_exceptions.labels(*self.metrics_labels)._value.get())
+
+    total_processed = Stats.stat_total_processed.labels(*self.metrics_labels)._value.get()
+    stat_total_processed_successfully = Stats.stat_total_processed_successfully.labels(*self.metrics_labels)._value.get()
+    stat_total_user_exceptions = Stats.stat_total_user_exceptions.labels(*self.metrics_labels)._value.get()
+    stat_total_sys_exceptions = Stats.stat_total_sys_exceptions.labels(*self.metrics_labels)._value.get()
+    stat_process_latency_ms_count = Stats.stat_process_latency_ms.labels(*self.metrics_labels)._count.get()
+    stat_process_latency_ms_sum = Stats.stat_process_latency_ms.labels(*self.metrics_labels)._sum.get()
+    stat_last_invocation = Stats.stat_last_invocation.labels(*self.metrics_labels)._value.get()
+
+    status.numProcessed =  total_processed if sys.version_info.major >= 3 else long(total_processed)
+    status.numSuccessfullyProcessed = stat_total_processed_successfully if sys.version_info.major >= 3 else long(stat_total_processed_successfully)
+    status.numUserExceptions = stat_total_user_exceptions if sys.version_info.major >= 3 else long(stat_total_user_exceptions)
     status.instanceId = self.instance_config.instance_id
     for ex, tm in self.stats.latest_user_exception:
       to_add = status.latestUserExceptions.add()
       to_add.exceptionString = ex
       to_add.msSinceEpoch = tm
-    status.numSystemExceptions = long(Stats.stat_total_sys_exceptions.labels(*self.metrics_labels)._value.get())
+    status.numSystemExceptions = stat_total_sys_exceptions if sys.version_info.major >= 3 else long(stat_total_sys_exceptions)
     for ex, tm in self.stats.latest_sys_exception:
       to_add = status.latestSystemExceptions.add()
       to_add.exceptionString = ex
       to_add.msSinceEpoch = tm
     status.averageLatency = 0.0 \
-      if Stats.stat_process_latency_ms.labels(*self.metrics_labels)._count.get() <= 0.0 \
-      else Stats.stat_process_latency_ms.labels(*self.metrics_labels)._sum.get() / Stats.stat_process_latency_ms.labels(*self.metrics_labels)._count.get()
-    status.lastInvocationTime = long(Stats.stat_last_invocation.labels(*self.metrics_labels)._value.get())
+      if stat_process_latency_ms_count <= 0.0 \
+      else stat_process_latency_ms_sum / stat_process_latency_ms_count
+    status.lastInvocationTime = stat_last_invocation if sys.version_info.major >= 3 else long(stat_last_invocation)
     return status
 
   def join(self):

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -67,53 +67,6 @@ def base64ify(bytes_or_str):
     else:
         return output_bytes
 
-# We keep track of the following metrics
-class Stats(object):
-  metrics_label_names = ['tenant', 'namespace', 'name', 'instance_id']
-
-  TOTAL_PROCESSED = '__function_total_processed__'
-  TOTAL_SUCCESSFULLY_PROCESSED = '__function_total_successfully_processed__'
-  TOTAL_SYSTEM_EXCEPTIONS = '__function_total_system_exceptions__'
-  TOTAL_USER_EXCEPTIONS = '__function_total_user_exceptions__'
-  PROCESS_LATENCY_MS = '__function_process_latency_ms__'
-
-  # Declare Prometheus
-  stat_total_processed = Counter(TOTAL_PROCESSED, 'Total number of messages processed.', metrics_label_names)
-  stat_total_processed_successfully = Counter(TOTAL_SUCCESSFULLY_PROCESSED,
-                                              'Total number of messages processed successfully.', metrics_label_names)
-  stat_total_sys_exceptions = Counter(TOTAL_SYSTEM_EXCEPTIONS, 'Total number of system exceptions.',
-                                      metrics_label_names)
-  stat_total_user_exceptions = Counter(TOTAL_USER_EXCEPTIONS, 'Total number of user exceptions.',
-                                       metrics_label_names)
-
-  stats_process_latency_ms = Summary(PROCESS_LATENCY_MS, 'Process latency in milliseconds.', metrics_label_names)
-
-  latest_user_exception = []
-  latest_sys_exception = []
-
-  last_invocation_time = 0.0
-
-  def add_user_exception(self):
-    self.latest_sys_exception.append((traceback.format_exc(), int(time.time() * 1000)))
-    if len(self.latest_sys_exception) > 10:
-      self.latest_sys_exception.pop(0)
-
-  def add_sys_exception(self):
-    self.latest_sys_exception.append((traceback.format_exc(), int(time.time() * 1000)))
-    if len(self.latest_sys_exception) > 10:
-      self.latest_sys_exception.pop(0)
-
-  def reset(self, metrics_labels):
-    self.latest_user_exception = []
-    self.latest_sys_exception = []
-    self.stat_total_processed.labels(*metrics_labels)._value.set(0.0)
-    self.stat_total_processed_successfully.labels(*metrics_labels)._value.set(0.0)
-    self.stat_total_user_exceptions.labels(*metrics_labels)._value.set(0.0)
-    self.stat_total_sys_exceptions.labels(*metrics_labels)._value.set(0.0)
-    self.stats_process_latency_ms.labels(*metrics_labels)._sum.set(0)
-    self.stats_process_latency_ms.labels(*metrics_labels)._count.set(0);
-    self.last_invocation_time = 0.0
-
 class PythonInstance(object):
   def __init__(self, instance_id, function_id, function_version, function_details, max_buffered_tuples, expected_healthcheck_interval, user_code, pulsar_client, secrets_provider):
     self.instance_config = InstanceConfig(instance_id, function_id, function_version, function_details, max_buffered_tuples)

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -95,7 +95,8 @@ class PythonInstance(object):
     self.secrets_provider = secrets_provider
     self.metrics_labels = [function_details.tenant,
                            "%s/%s" % (function_details.tenant, function_details.namespace),
-                           function_details.name, instance_id, cluster_name]
+                           "%s/%s/%s" % (function_details.tenant, function_details.namespace, function_details.name),
+                           instance_id, cluster_name]
 
   def health_check(self):
     self.last_health_check_ts = time.time()

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -93,7 +93,7 @@ class PythonInstance(object):
     self.timeout_ms = function_details.source.timeoutMs if function_details.source.timeoutMs > 0 else None
     self.expected_healthcheck_interval = expected_healthcheck_interval
     self.secrets_provider = secrets_provider
-    self.metrics_labels = [function_details.tenant, 
+    self.metrics_labels = [function_details.tenant,
                            "%s/%s" % (function_details.tenant, function_details.namespace),
                            function_details.name, instance_id, cluster_name]
 
@@ -287,14 +287,16 @@ class PythonInstance(object):
     # First get any user metrics
     metrics = self.contextimpl.get_metrics()
     # Now add system metrics as well
-    self.add_system_metrics("__total_processed__", Stats.stat_total_processed.labels(*self.metrics_labels)._value.get(), metrics)
-    self.add_system_metrics("__total_successfully_processed__", Stats.stat_total_processed_successfully.labels(*self.metrics_labels)._value.get(), metrics)
-    self.add_system_metrics("__total_system_exceptions__", Stats.stat_total_sys_exceptions.labels(*self.metrics_labels)._value.get(), metrics)
-    self.add_system_metrics("__total_user_exceptions__", Stats.stat_total_user_exceptions.labels(*self.metrics_labels)._value.get(), metrics)
-    self.add_system_metrics("__avg_latency_ms__",
+    self.add_system_metrics(Stats.TOTAL_PROCESSED, Stats.stat_total_processed.labels(*self.metrics_labels)._value.get(), metrics)
+    self.add_system_metrics(Stats.TOTAL_SUCCESSFULLY_PROCESSED, Stats.stat_total_processed_successfully.labels(*self.metrics_labels)._value.get(), metrics)
+    self.add_system_metrics(Stats.TOTAL_SYSTEM_EXCEPTIONS, Stats.stat_total_sys_exceptions.labels(*self.metrics_labels)._value.get(), metrics)
+    self.add_system_metrics(Stats.TOTAL_USER_EXCEPTIONS, Stats.stat_total_user_exceptions.labels(*self.metrics_labels)._value.get(), metrics)
+    self.add_system_metrics(Stats.PROCESS_LATENCY_MS,
                             0.0 if Stats.stat_process_latency_ms.labels(*self.metrics_labels)._count.get() <= 0.0
                             else Stats.stat_process_latency_ms.labels(*self.metrics_labels)._sum.get() / Stats.stat_process_latency_ms.labels(*self.metrics_labels)._count.get(),
                             metrics)
+    self.add_system_metrics(Stats.TOTAL_RECEIVED, Stats.stat_total_received.labels(*self.metrics_labels)._value.get(), metrics)
+    self.add_system_metrics(Stats.LAST_INVOCATION, Stats.stat_last_invocation.labels(*self.metrics_labels)._value.get(), metrics)
     return metrics
 
   def add_system_metrics(self, metric_name, value, metrics):

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -317,15 +317,15 @@ class PythonInstance(object):
     stat_process_latency_ms_sum = Stats.stat_process_latency_ms.labels(*self.metrics_labels)._sum.get()
     stat_last_invocation = Stats.stat_last_invocation.labels(*self.metrics_labels)._value.get()
 
-    status.numProcessed =  total_processed if sys.version_info.major >= 3 else long(total_processed)
-    status.numSuccessfullyProcessed = stat_total_processed_successfully if sys.version_info.major >= 3 else long(stat_total_processed_successfully)
-    status.numUserExceptions = stat_total_user_exceptions if sys.version_info.major >= 3 else long(stat_total_user_exceptions)
+    status.numProcessed =  int(total_processed) if sys.version_info.major >= 3 else long(total_processed)
+    status.numSuccessfullyProcessed = int(stat_total_processed_successfully) if sys.version_info.major >= 3 else long(stat_total_processed_successfully)
+    status.numUserExceptions = int(stat_total_user_exceptions) if sys.version_info.major >= 3 else long(stat_total_user_exceptions)
     status.instanceId = self.instance_config.instance_id
     for ex, tm in self.stats.latest_user_exception:
       to_add = status.latestUserExceptions.add()
       to_add.exceptionString = ex
       to_add.msSinceEpoch = tm
-    status.numSystemExceptions = stat_total_sys_exceptions if sys.version_info.major >= 3 else long(stat_total_sys_exceptions)
+    status.numSystemExceptions = int(stat_total_sys_exceptions) if sys.version_info.major >= 3 else long(stat_total_sys_exceptions)
     for ex, tm in self.stats.latest_sys_exception:
       to_add = status.latestSystemExceptions.add()
       to_add.exceptionString = ex
@@ -333,7 +333,7 @@ class PythonInstance(object):
     status.averageLatency = 0.0 \
       if stat_process_latency_ms_count <= 0.0 \
       else stat_process_latency_ms_sum / stat_process_latency_ms_count
-    status.lastInvocationTime = stat_last_invocation if sys.version_info.major >= 3 else long(stat_last_invocation)
+    status.lastInvocationTime = int(stat_last_invocation) if sys.version_info.major >= 3 else long(stat_last_invocation)
     return status
 
   def join(self):

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -82,6 +82,7 @@ def main():
   parser.add_argument('--install_usercode_dependencies', required=False, help='For packaged python like wheel files, do we need to install all dependencies', type=bool)
   parser.add_argument('--dependency_repository', required=False, help='For packaged python like wheel files, which repository to pull the dependencies from')
   parser.add_argument('--extra_dependency_repository', required=False, help='For packaged python like wheel files, any extra repository to pull the dependencies from')
+  parser.add_argument('--cluster_name', required=True, help='The name of the cluster this instance is running on')
 
   args = parser.parse_args()
   function_details = Function_pb2.FunctionDetails()
@@ -169,7 +170,7 @@ def main():
                                               str(args.function_version), function_details,
                                               int(args.max_buffered_tuples),
                                               int(args.expected_healthcheck_interval),
-                                              str(args.py), pulsar_client, secrets_provider)
+                                              str(args.py), pulsar_client, secrets_provider, args.cluster_name)
   pyinstance.run()
   server_instance = server.serve(args.port, pyinstance)
 

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -39,6 +39,8 @@ import log
 import server
 import python_instance
 import util
+import prometheus_client
+
 from google.protobuf import json_format
 
 to_run = True
@@ -69,6 +71,7 @@ def main():
   parser.add_argument('--hostname_verification_enabled', required=False, help='Enable hostname verification')
   parser.add_argument('--tls_trust_cert_path', required=False, help='Tls trust cert file path')
   parser.add_argument('--port', required=True, help='Instance Port', type=int)
+  parser.add_argument('--metrics_port', required=True, help="Port metrics will be exposed on", type=int)
   parser.add_argument('--max_buffered_tuples', required=True, help='Maximum number of Buffered tuples')
   parser.add_argument('--logging_directory', required=True, help='Logging Directory')
   parser.add_argument('--logging_file', required=True, help='Log file name')
@@ -169,6 +172,8 @@ def main():
                                               str(args.py), pulsar_client, secrets_provider)
   pyinstance.run()
   server_instance = server.serve(args.port, pyinstance)
+
+  prometheus_client.start_http_server(args.metrics_port)
 
   global to_run
   while to_run:

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import io.prometheus.client.CollectorRegistry;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -75,7 +76,7 @@ public class ContextImplTest {
             logger,
             client,
             new ArrayList<>(),
-            new EnvironmentBasedSecretsProvider()
+            new EnvironmentBasedSecretsProvider(), new CollectorRegistry(), new String[0]
         );
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -56,7 +56,7 @@ public class JavaInstanceRunnableTest {
     private JavaInstanceRunnable createRunnable(boolean addCustom, String outputSerde) throws Exception {
         InstanceConfig config = createInstanceConfig(addCustom, outputSerde);
         JavaInstanceRunnable javaInstanceRunnable = new JavaInstanceRunnable(
-                config, null, null, null, null, null);
+                config, null, null, null, null, null, null);
         return javaInstanceRunnable;
     }
 

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -48,7 +48,7 @@ class TestContextImpl(unittest.TestCase):
     pulsar_client.create_producer = Mock(return_value=producer)
     user_code=__file__
     consumers = None
-    context_impl = ContextImpl(instance_config, logger, pulsar_client, user_code, consumers, None)
+    context_impl = ContextImpl(instance_config, logger, pulsar_client, user_code, consumers, None, None)
 
     context_impl.publish("test_topic_name", "test_message")
 

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ExclamationFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ExclamationFunction.java
@@ -21,20 +21,13 @@ package org.apache.pulsar.functions.api.examples;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 
-import java.util.Random;
-
 /**
  * The classic Exclamation Function that appends an exclamation at the end
  * of the input
  */
 public class ExclamationFunction implements Function<String, String> {
-
-    double count = 0;
     @Override
     public String process(String input, Context context) {
-
-        context.recordMetric("test_metrics", count);
-        count++;
         return String.format("%s!", input);
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ExclamationFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ExclamationFunction.java
@@ -21,13 +21,20 @@ package org.apache.pulsar.functions.api.examples;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 
+import java.util.Random;
+
 /**
  * The classic Exclamation Function that appends an exclamation at the end
  * of the input
  */
 public class ExclamationFunction implements Function<String, String> {
+
+    double count = 0;
     @Override
     public String process(String input, Context context) {
+
+        context.recordMetric("test_metrics", count);
+        count++;
         return String.format("%s!", input);
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -125,6 +125,9 @@ public class JavaInstanceMain implements AutoCloseable {
     @Parameter(names = "--secrets_provider_config", description = "The config that needs to be passed to secrets provider", required = false)
     protected String secretsProviderConfig;
 
+    @Parameter(names = "--cluster_name", description = "The name of the cluster this instance is running on", required = true)
+    protected String clusterName;
+
     private Server server;
     private RuntimeSpawner runtimeSpawner;
     private ThreadRuntimeFactory containerFactory;
@@ -141,6 +144,7 @@ public class JavaInstanceMain implements AutoCloseable {
         instanceConfig.setFunctionVersion(functionVersion);
         instanceConfig.setInstanceId(instanceId);
         instanceConfig.setMaxBufferedTuples(maxBufferedTuples);
+        instanceConfig.setClusterName(clusterName);
         FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
         if (functionDetailsJsonString.charAt(0) == '\'') {
             functionDetailsJsonString = functionDetailsJsonString.substring(1);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -29,8 +29,17 @@ import com.google.protobuf.util.JsonFormat;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.BufferPoolsExports;
+import io.prometheus.client.hotspot.ClassLoadingExports;
 import io.prometheus.client.hotspot.DefaultExports;
+import io.prometheus.client.hotspot.GarbageCollectorExports;
+import io.prometheus.client.hotspot.MemoryPoolsExports;
+import io.prometheus.client.hotspot.StandardExports;
+import io.prometheus.client.hotspot.ThreadExports;
+import io.prometheus.client.hotspot.VersionInfoExports;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
@@ -43,12 +52,14 @@ import org.apache.pulsar.functions.secretsprovider.SecretsProvider;
 import org.apache.pulsar.functions.utils.Reflections;
 
 import java.lang.reflect.Type;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * A function container implemented using java thread.
@@ -99,6 +110,9 @@ public class JavaInstanceMain implements AutoCloseable {
     @Parameter(names = "--port", description = "Port to listen on\n", required = true)
     protected int port;
 
+    @Parameter(names = "--metrics_port", description = "Port metrics will be exposed on\n", required = true)
+    protected int metrics_port;
+
     @Parameter(names = "--max_buffered_tuples", description = "Maximum number of tuples to buffer\n", required = true)
     protected int maxBufferedTuples;
 
@@ -116,6 +130,7 @@ public class JavaInstanceMain implements AutoCloseable {
     private ThreadRuntimeFactory containerFactory;
     private Long lastHealthCheckTs = null;
     private ScheduledExecutorService timer;
+    private HTTPServer metricsServer;
 
     public JavaInstanceMain() { }
 
@@ -162,6 +177,9 @@ public class JavaInstanceMain implements AutoCloseable {
         }
         secretsProvider.init(secretsProviderConfigMap);
 
+        // Collector Registry for prometheus metrics
+        CollectorRegistry collectorRegistry = new CollectorRegistry();
+
         containerFactory = new ThreadRuntimeFactory("LocalRunnerThreadGroup", pulsarServiceUrl,
                 stateStorageServiceUrl,
                 AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthenticationPlugin)
@@ -169,7 +187,7 @@ public class JavaInstanceMain implements AutoCloseable {
                         .tlsAllowInsecureConnection(isTrue(tlsAllowInsecureConnection))
                         .tlsHostnameVerificationEnable(isTrue(tlsHostNameVerificationEnabled))
                         .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
-                secretsProvider);
+                secretsProvider, collectorRegistry);
         runtimeSpawner = new RuntimeSpawner(
                 instanceConfig,
                 jarFile,
@@ -195,11 +213,21 @@ public class JavaInstanceMain implements AutoCloseable {
             }
         });
 
-        // registering jvm metrics to prometheus
-        DefaultExports.initialize();
-
         log.info("Starting runtimeSpawner");
         runtimeSpawner.start();
+
+        // registering jvm metrics to prometheus
+//        (new StandardExports()).register(collectorRegistry);
+//        (new MemoryPoolsExports()).register(collectorRegistry);
+//        (new BufferPoolsExports()).register(collectorRegistry);
+//        (new GarbageCollectorExports()).register(collectorRegistry);
+//        (new ThreadExports()).register(collectorRegistry);
+//        (new ClassLoadingExports()).register(collectorRegistry);
+//        (new VersionInfoExports()).register(collectorRegistry);
+
+        // starting metrics server
+        log.info("Starting metrics server on port {}", metrics_port);
+        metricsServer = new HTTPServer(new InetSocketAddress(metrics_port), collectorRegistry, true);
 
         if (expectedHealthCheckInterval > 0) {
             timer = Executors.newSingleThreadScheduledExecutor();
@@ -252,6 +280,9 @@ public class JavaInstanceMain implements AutoCloseable {
             }
             if (containerFactory != null) {
                 containerFactory.close();
+            }
+            if (metricsServer != null) {
+                metricsServer.stop();
             }
         } catch (Exception ex) {
             System.err.println(ex);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -216,15 +216,6 @@ public class JavaInstanceMain implements AutoCloseable {
         log.info("Starting runtimeSpawner");
         runtimeSpawner.start();
 
-        // registering jvm metrics to prometheus
-//        (new StandardExports()).register(collectorRegistry);
-//        (new MemoryPoolsExports()).register(collectorRegistry);
-//        (new BufferPoolsExports()).register(collectorRegistry);
-//        (new GarbageCollectorExports()).register(collectorRegistry);
-//        (new ThreadExports()).register(collectorRegistry);
-//        (new ClassLoadingExports()).register(collectorRegistry);
-//        (new VersionInfoExports()).register(collectorRegistry);
-
         // starting metrics server
         log.info("Starting metrics server on port {}", metrics_port);
         metricsServer = new HTTPServer(new InetSocketAddress(metrics_port), collectorRegistry, true);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -520,9 +520,10 @@ class KubernetesRuntime implements Runtime {
 
     private Map<String, String> getLabels(Function.FunctionDetails functionDetails) {
         final Map<String, String> labels = new HashMap<>();
-        labels.put("app", createJobName(functionDetails));
-        labels.put("namespace", functionDetails.getNamespace());
+        labels.put("namespace", String.format("%s/%s",functionDetails.getTenant(), functionDetails.getNamespace()));
         labels.put("tenant", functionDetails.getTenant());
+        labels.put("function", String.format("%s/%s/%s", functionDetails.getTenant(),
+                functionDetails.getNamespace(), functionDetails.getName()));
         if (customLabels != null && !customLabels.isEmpty()) {
             labels.putAll(customLabels);
         }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -89,8 +89,6 @@ class KubernetesRuntime implements Runtime {
     private static final int maxJobNameSize = 55;
     private static final Integer GRPC_PORT = 9093;
     private static final Integer METRICS_PORT = 9094;
-//    private static final Double prometheusMetricsServerCpu = 0.1;
-//    private static final Long prometheusMetricsServerRam = 125000000l;
     public static final Pattern VALID_POD_NAME_REGEX =
             Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
                     Pattern.CASE_INSENSITIVE);
@@ -110,7 +108,6 @@ class KubernetesRuntime implements Runtime {
     // The thread that invokes the function
     @Getter
     private List<String> processArgs;
-//    private List<String> prometheusMetricsServerArgs;
     @Getter
     private ManagedChannel[] channel;
     private InstanceControlGrpc.InstanceControlFutureStub[] stub;
@@ -192,7 +189,6 @@ class KubernetesRuntime implements Runtime {
             pythonDependencyRepository,
             pythonExtraDependencyRepository,
                 METRICS_PORT);
-//        this.prometheusMetricsServerArgs = composePrometheusMetricsServerArgs(prometheusMetricsServerJarFile, expectedMetricsInterval);
         running = false;
         doChecks(instanceConfig.getFunctionDetails());
     }
@@ -454,14 +450,6 @@ class KubernetesRuntime implements Runtime {
         );
     }
 
-//    protected List<String> getPrometheusMetricsServerCommand() {
-//        return Arrays.asList(
-//                "sh",
-//                "-c",
-//                String.join(" ", prometheusMetricsServerArgs)
-//        );
-//    }
-
     private List<String> getDownloadCommand(String bkPath, String userCodeFilePath) {
         return Arrays.asList(
                 pulsarRootDir + "/bin/pulsar-admin",
@@ -553,7 +541,6 @@ class KubernetesRuntime implements Runtime {
 
         List<V1Container> containers = new LinkedList<>();
         containers.add(getFunctionContainer(instanceCommand, resource));
-//        containers.add(getPrometheusContainer());
         podSpec.containers(containers);
 
         // Configure secrets
@@ -608,38 +595,6 @@ class KubernetesRuntime implements Runtime {
         return container;
     }
 
-//    private V1Container getPrometheusContainer() {
-//        final V1Container container = new V1Container().name("prometheusmetricsserver");
-//
-//        // set up the container images
-//        container.setImage(pulsarDockerImageName);
-//
-//        // set up the container command
-//        container.setCommand(getPrometheusMetricsServerCommand());
-//
-//        // setup the environment variables for the container
-//        final V1EnvVar envVarPodName = new V1EnvVar();
-//        envVarPodName.name("POD_NAME")
-//                .valueFrom(new V1EnvVarSource()
-//                        .fieldRef(new V1ObjectFieldSelector()
-//                                .fieldPath("metadata.name")));
-//        container.setEnv(Arrays.asList(envVarPodName));
-//
-//
-//        // set container resources
-//        final V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
-//        final Map<String, Quantity> requests = new HashMap<>();
-//        requests.put("memory", Quantity.fromString(Long.toString(prometheusMetricsServerRam)));
-//        requests.put("cpu", Quantity.fromString(Double.toString(prometheusMetricsServerCpu)));
-//        resourceRequirements.setRequests(requests);
-//        container.setResources(resourceRequirements);
-//
-//        // set container ports
-//        container.setPorts(getPrometheusContainerPorts());
-//
-//        return container;
-//    }
-
     private List<V1ContainerPort> getFunctionContainerPorts() {
         List<V1ContainerPort> ports = new ArrayList<>();
         final V1ContainerPort port = new V1ContainerPort();
@@ -681,24 +636,4 @@ class KubernetesRuntime implements Runtime {
             throw new RuntimeException("Kubernetes job name size should be less than " + maxJobNameSize);
         }
     }
-
-//    private List<String> composePrometheusMetricsServerArgs(String prometheusMetricsServerFile,
-//                                                            Integer expectedMetricsInterval) throws Exception {
-//        List<String> args = new LinkedList<>();
-//        args.add("java");
-//        args.add("-cp");
-//        args.add(prometheusMetricsServerFile);
-//        args.add("-Dlog4j.configurationFile=prometheus_metricsserver_log4j2.yml");
-//        args.add("-Xmx" + String.valueOf(prometheusMetricsServerRam));
-//        args.add(PrometheusMetricsServer.class.getName());
-//        args.add("--function_details");
-//        args.add("'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'");
-//        args.add("--prometheus_port");
-//        args.add(String.valueOf(METRICS_PORT));
-//        args.add("--grpc_port");
-//        args.add(String.valueOf(GRPC_PORT));
-//        args.add("--collection_interval");
-//        args.add(String.valueOf(expectedMetricsInterval));
-//        return args;
-//    }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -88,9 +88,9 @@ class KubernetesRuntime implements Runtime {
     private static final String ENV_SHARD_ID = "SHARD_ID";
     private static final int maxJobNameSize = 55;
     private static final Integer GRPC_PORT = 9093;
-    private static final Integer PROMETHEUS_PORT = 9094;
-    private static final Double prometheusMetricsServerCpu = 0.1;
-    private static final Long prometheusMetricsServerRam = 125000000l;
+    private static final Integer METRICS_PORT = 9094;
+//    private static final Double prometheusMetricsServerCpu = 0.1;
+//    private static final Long prometheusMetricsServerRam = 125000000l;
     public static final Pattern VALID_POD_NAME_REGEX =
             Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
                     Pattern.CASE_INSENSITIVE);
@@ -110,7 +110,7 @@ class KubernetesRuntime implements Runtime {
     // The thread that invokes the function
     @Getter
     private List<String> processArgs;
-    private List<String> prometheusMetricsServerArgs;
+//    private List<String> prometheusMetricsServerArgs;
     @Getter
     private ManagedChannel[] channel;
     private InstanceControlGrpc.InstanceControlFutureStub[] stub;
@@ -190,8 +190,9 @@ class KubernetesRuntime implements Runtime {
             secretsProviderConfig,
             installUserCodeDependencies,
             pythonDependencyRepository,
-            pythonExtraDependencyRepository);
-        this.prometheusMetricsServerArgs = composePrometheusMetricsServerArgs(prometheusMetricsServerJarFile, expectedMetricsInterval);
+            pythonExtraDependencyRepository,
+                METRICS_PORT);
+//        this.prometheusMetricsServerArgs = composePrometheusMetricsServerArgs(prometheusMetricsServerJarFile, expectedMetricsInterval);
         running = false;
         doChecks(instanceConfig.getFunctionDetails());
     }
@@ -453,13 +454,13 @@ class KubernetesRuntime implements Runtime {
         );
     }
 
-    protected List<String> getPrometheusMetricsServerCommand() {
-        return Arrays.asList(
-                "sh",
-                "-c",
-                String.join(" ", prometheusMetricsServerArgs)
-        );
-    }
+//    protected List<String> getPrometheusMetricsServerCommand() {
+//        return Arrays.asList(
+//                "sh",
+//                "-c",
+//                String.join(" ", prometheusMetricsServerArgs)
+//        );
+//    }
 
     private List<String> getDownloadCommand(String bkPath, String userCodeFilePath) {
         return Arrays.asList(
@@ -525,7 +526,7 @@ class KubernetesRuntime implements Runtime {
     private Map<String, String> getPrometheusAnnotations() {
         final Map<String, String> annotations = new HashMap<>();
         annotations.put("prometheus.io/scrape", "true");
-        annotations.put("prometheus.io/port", String.valueOf(PROMETHEUS_PORT));
+        annotations.put("prometheus.io/port", String.valueOf(METRICS_PORT));
         return annotations;
     }
 
@@ -552,7 +553,7 @@ class KubernetesRuntime implements Runtime {
 
         List<V1Container> containers = new LinkedList<>();
         containers.add(getFunctionContainer(instanceCommand, resource));
-        containers.add(getPrometheusContainer());
+//        containers.add(getPrometheusContainer());
         podSpec.containers(containers);
 
         // Configure secrets
@@ -607,37 +608,37 @@ class KubernetesRuntime implements Runtime {
         return container;
     }
 
-    private V1Container getPrometheusContainer() {
-        final V1Container container = new V1Container().name("prometheusmetricsserver");
-
-        // set up the container images
-        container.setImage(pulsarDockerImageName);
-
-        // set up the container command
-        container.setCommand(getPrometheusMetricsServerCommand());
-
-        // setup the environment variables for the container
-        final V1EnvVar envVarPodName = new V1EnvVar();
-        envVarPodName.name("POD_NAME")
-                .valueFrom(new V1EnvVarSource()
-                        .fieldRef(new V1ObjectFieldSelector()
-                                .fieldPath("metadata.name")));
-        container.setEnv(Arrays.asList(envVarPodName));
-
-
-        // set container resources
-        final V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
-        final Map<String, Quantity> requests = new HashMap<>();
-        requests.put("memory", Quantity.fromString(Long.toString(prometheusMetricsServerRam)));
-        requests.put("cpu", Quantity.fromString(Double.toString(prometheusMetricsServerCpu)));
-        resourceRequirements.setRequests(requests);
-        container.setResources(resourceRequirements);
-
-        // set container ports
-        container.setPorts(getPrometheusContainerPorts());
-
-        return container;
-    }
+//    private V1Container getPrometheusContainer() {
+//        final V1Container container = new V1Container().name("prometheusmetricsserver");
+//
+//        // set up the container images
+//        container.setImage(pulsarDockerImageName);
+//
+//        // set up the container command
+//        container.setCommand(getPrometheusMetricsServerCommand());
+//
+//        // setup the environment variables for the container
+//        final V1EnvVar envVarPodName = new V1EnvVar();
+//        envVarPodName.name("POD_NAME")
+//                .valueFrom(new V1EnvVarSource()
+//                        .fieldRef(new V1ObjectFieldSelector()
+//                                .fieldPath("metadata.name")));
+//        container.setEnv(Arrays.asList(envVarPodName));
+//
+//
+//        // set container resources
+//        final V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
+//        final Map<String, Quantity> requests = new HashMap<>();
+//        requests.put("memory", Quantity.fromString(Long.toString(prometheusMetricsServerRam)));
+//        requests.put("cpu", Quantity.fromString(Double.toString(prometheusMetricsServerCpu)));
+//        resourceRequirements.setRequests(requests);
+//        container.setResources(resourceRequirements);
+//
+//        // set container ports
+//        container.setPorts(getPrometheusContainerPorts());
+//
+//        return container;
+//    }
 
     private List<V1ContainerPort> getFunctionContainerPorts() {
         List<V1ContainerPort> ports = new ArrayList<>();
@@ -652,7 +653,7 @@ class KubernetesRuntime implements Runtime {
         List<V1ContainerPort> ports = new ArrayList<>();
         final V1ContainerPort port = new V1ContainerPort();
         port.setName("prometheus");
-        port.setContainerPort(PROMETHEUS_PORT);
+        port.setContainerPort(METRICS_PORT);
         ports.add(port);
         return ports;
     }
@@ -681,23 +682,23 @@ class KubernetesRuntime implements Runtime {
         }
     }
 
-    private List<String> composePrometheusMetricsServerArgs(String prometheusMetricsServerFile,
-                                                            Integer expectedMetricsInterval) throws Exception {
-        List<String> args = new LinkedList<>();
-        args.add("java");
-        args.add("-cp");
-        args.add(prometheusMetricsServerFile);
-        args.add("-Dlog4j.configurationFile=prometheus_metricsserver_log4j2.yml");
-        args.add("-Xmx" + String.valueOf(prometheusMetricsServerRam));
-        args.add(PrometheusMetricsServer.class.getName());
-        args.add("--function_details");
-        args.add("'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'");
-        args.add("--prometheus_port");
-        args.add(String.valueOf(PROMETHEUS_PORT));
-        args.add("--grpc_port");
-        args.add(String.valueOf(GRPC_PORT));
-        args.add("--collection_interval");
-        args.add(String.valueOf(expectedMetricsInterval));
-        return args;
-    }
+//    private List<String> composePrometheusMetricsServerArgs(String prometheusMetricsServerFile,
+//                                                            Integer expectedMetricsInterval) throws Exception {
+//        List<String> args = new LinkedList<>();
+//        args.add("java");
+//        args.add("-cp");
+//        args.add(prometheusMetricsServerFile);
+//        args.add("-Dlog4j.configurationFile=prometheus_metricsserver_log4j2.yml");
+//        args.add("-Xmx" + String.valueOf(prometheusMetricsServerRam));
+//        args.add(PrometheusMetricsServer.class.getName());
+//        args.add("--function_details");
+//        args.add("'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'");
+//        args.add("--prometheus_port");
+//        args.add(String.valueOf(METRICS_PORT));
+//        args.add("--grpc_port");
+//        args.add(String.valueOf(GRPC_PORT));
+//        args.add("--collection_interval");
+//        args.add(String.valueOf(expectedMetricsInterval));
+//        return args;
+//    }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/LocalRunner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/LocalRunner.java
@@ -189,6 +189,7 @@ public class LocalRunner {
                 instanceConfig.setInstanceId(i + instanceIdOffset);
                 instanceConfig.setMaxBufferedTuples(1024);
                 instanceConfig.setPort(Utils.findAvailablePort());
+                instanceConfig.setClusterName("local");
                 RuntimeSpawner runtimeSpawner = new RuntimeSpawner(
                         instanceConfig,
                         userCodeFile,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
 import org.apache.pulsar.functions.proto.InstanceControlGrpc;
 import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
 import org.apache.pulsar.functions.secretsproviderconfigurator.SecretsProviderConfigurator;
+import org.apache.pulsar.functions.utils.Utils;
 
 import java.io.InputStream;
 import java.util.List;
@@ -112,7 +113,8 @@ class ProcessRuntime implements Runtime {
             secretsProviderConfig,
             false,
             null,
-            null);
+            null,
+                Utils.findAvailablePort());
     }
 
     /**

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -179,6 +179,9 @@ class RuntimeUtils {
             args.add("--secrets_provider_config");
             args.add("'" + secretsProviderConfig + "'");
         }
+
+        args.add("--cluster_name");
+        args.add(instanceConfig.getClusterName());
         return args;
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -57,7 +57,8 @@ class RuntimeUtils {
                                            String secretsProviderConfig,
                                            Boolean installUserCodeDepdendencies,
                                            String pythonDependencyRepository,
-                                           String pythonExtraDependencyRepository) throws Exception {
+                                           String pythonExtraDependencyRepository,
+                                           int metricsPort) throws Exception {
         List<String> args = new LinkedList<>();
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {
             args.add("java");
@@ -159,6 +160,9 @@ class RuntimeUtils {
 
         args.add("--port");
         args.add(String.valueOf(grpcPort));
+
+        args.add("--metrics_port");
+        args.add(String.valueOf(metricsPort));
 
         // state storage configs
         if (null != stateStorageServiceUrl

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -99,7 +99,7 @@ class RuntimeUtils {
             if (StringUtils.isNotEmpty(extraDependenciesDir)) {
                 args.add("PYTHONPATH=${PYTHONPATH}:" + extraDependenciesDir);
             }
-            args.add("python3");
+            args.add("python");
             args.add(instanceFile);
             args.add("--py");
             args.add(originalCodeFileName);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -99,7 +99,7 @@ class RuntimeUtils {
             if (StringUtils.isNotEmpty(extraDependenciesDir)) {
                 args.add("PYTHONPATH=${PYTHONPATH}:" + extraDependenciesDir);
             }
-            args.add("python");
+            args.add("python3");
             args.add(instanceFile);
             args.add("--py");
             args.add(originalCodeFileName);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.runtime;
 
 import java.util.concurrent.CompletableFuture;
 
+import io.prometheus.client.CollectorRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -53,7 +54,8 @@ class ThreadRuntime implements Runtime {
                   String jarFile,
                   PulsarClient pulsarClient,
                   String stateStorageServiceUrl,
-                  SecretsProvider secretsProvider) {
+                  SecretsProvider secretsProvider,
+                  CollectorRegistry collectorRegistry) {
         this.instanceConfig = instanceConfig;
         if (instanceConfig.getFunctionDetails().getRuntime() != Function.FunctionDetails.Runtime.JAVA) {
             throw new RuntimeException("Thread Container only supports Java Runtime");
@@ -64,7 +66,8 @@ class ThreadRuntime implements Runtime {
             jarFile,
             pulsarClient,
             stateStorageServiceUrl,
-            secretsProvider);
+            secretsProvider,
+            collectorRegistry);
         this.threadGroup = threadGroup;
     }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -60,6 +60,14 @@ class ThreadRuntime implements Runtime {
         if (instanceConfig.getFunctionDetails().getRuntime() != Function.FunctionDetails.Runtime.JAVA) {
             throw new RuntimeException("Thread Container only supports Java Runtime");
         }
+
+        // if collector registry is not set, create one for this thread.
+        // since each thread / instance will needs its own collector registry for metrics collection
+        CollectorRegistry instanceCollectorRegistry = collectorRegistry;
+        if (instanceCollectorRegistry == null) {
+            instanceCollectorRegistry = new CollectorRegistry();
+        }
+
         this.javaInstanceRunnable = new JavaInstanceRunnable(
             instanceConfig,
             fnCache,
@@ -67,7 +75,7 @@ class ThreadRuntime implements Runtime {
             pulsarClient,
             stateStorageServiceUrl,
             secretsProvider,
-            collectorRegistry);
+            instanceCollectorRegistry);
         this.threadGroup = threadGroup;
     }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntimeFactory.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.runtime;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import io.prometheus.client.CollectorRegistry;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -45,21 +46,23 @@ public class ThreadRuntimeFactory implements RuntimeFactory {
     private final PulsarClient pulsarClient;
     private final String storageServiceUrl;
     private final SecretsProvider secretsProvider;
+    private final CollectorRegistry collectorRegistry;
     private volatile boolean closed;
 
     public ThreadRuntimeFactory(String threadGroupName, String pulsarServiceUrl, String storageServiceUrl,
-                                AuthenticationConfig authConfig, SecretsProvider secretsProvider) throws Exception {
-        this(threadGroupName, createPulsarClient(pulsarServiceUrl, authConfig), storageServiceUrl, secretsProvider);
+                                AuthenticationConfig authConfig, SecretsProvider secretsProvider, CollectorRegistry collectorRegistry) throws Exception {
+        this(threadGroupName, createPulsarClient(pulsarServiceUrl, authConfig), storageServiceUrl, secretsProvider, collectorRegistry);
     }
 
     @VisibleForTesting
     public ThreadRuntimeFactory(String threadGroupName, PulsarClient pulsarClient, String storageServiceUrl,
-                                SecretsProvider secretsProvider) {
+                                SecretsProvider secretsProvider, CollectorRegistry collectorRegistry) {
         this.secretsProvider = secretsProvider;
         this.fnCache = new FunctionCacheManagerImpl();
         this.threadGroup = new ThreadGroup(threadGroupName);
         this.pulsarClient = pulsarClient;
         this.storageServiceUrl = storageServiceUrl;
+        this.collectorRegistry = collectorRegistry;
     }
 
     private static PulsarClient createPulsarClient(String pulsarServiceUrl, AuthenticationConfig authConfig)
@@ -94,7 +97,8 @@ public class ThreadRuntimeFactory implements RuntimeFactory {
             jarFile,
             pulsarClient,
             storageServiceUrl,
-            secretsProvider);
+            secretsProvider,
+            collectorRegistry);
     }
 
     @Override

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -217,16 +217,19 @@ public class KubernetesRuntimeTest {
         String classpath = javaInstanceJarFile;
         String extraDepsEnv;
         int portArg;
+        int metricsPortArg;
         int totalArgs;
         if (null != depsDir) {
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir;
             classpath = classpath + ":" + depsDir + "/*";
-            totalArgs = 33;
+            totalArgs = 35;
             portArg = 24;
+            metricsPortArg = 26;
         } else {
             extraDepsEnv = "";
             portArg = 23;
-            totalArgs = 32;
+            totalArgs = 34;
+            metricsPortArg = 25;
         }
 
         assertEquals(args.size(), totalArgs,
@@ -244,7 +247,7 @@ public class KubernetesRuntimeTest {
                 + " --function_version " + config.getFunctionVersion()
                 + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(portArg)
+                + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval -1"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"
@@ -280,15 +283,18 @@ public class KubernetesRuntimeTest {
         int portArg;
         String pythonPath;
         int configArg;
+        int metricsPortArg;
         if (null == extraDepsDir) {
-            totalArgs = 36;
+            totalArgs = 38;
             portArg = 29;
             configArg = 9;
             pythonPath = "";
+            metricsPortArg = 31;
         } else {
-            totalArgs = 37;
+            totalArgs = 39;
             portArg = 30;
             configArg = 10;
+            metricsPortArg = 32;
             pythonPath = "PYTHONPATH=${PYTHONPATH}:" + extraDepsDir + " ";
         }
 
@@ -307,7 +313,7 @@ public class KubernetesRuntimeTest {
                 + " --function_version " + config.getFunctionVersion()
                 + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(portArg)
+                + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --expected_healthcheck_interval -1"
                 + " --secrets_provider secretsprovider.ClearTextSecretsProvider"
                 + " --secrets_provider_config '{\"Somevalue\":\"myvalue\"}'";

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -185,6 +185,7 @@ public class KubernetesRuntimeTest {
         config.setFunctionVersion("1.0");
         config.setInstanceId(0);
         config.setMaxBufferedTuples(1024);
+        config.setClusterName("standalone");
 
         return config;
     }
@@ -222,13 +223,13 @@ public class KubernetesRuntimeTest {
         if (null != depsDir) {
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir;
             classpath = classpath + ":" + depsDir + "/*";
-            totalArgs = 35;
+            totalArgs = 37;
             portArg = 24;
             metricsPortArg = 26;
         } else {
             extraDepsEnv = "";
             portArg = 23;
-            totalArgs = 34;
+            totalArgs = 36;
             metricsPortArg = 25;
         }
 
@@ -251,7 +252,8 @@ public class KubernetesRuntimeTest {
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval -1"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config '{\"Somevalue\":\"myvalue\"}'";
+                + " --secrets_provider_config '{\"Somevalue\":\"myvalue\"}'"
+                + " --cluster_name standalone";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 
@@ -285,13 +287,13 @@ public class KubernetesRuntimeTest {
         int configArg;
         int metricsPortArg;
         if (null == extraDepsDir) {
-            totalArgs = 38;
+            totalArgs = 40;
             portArg = 29;
             configArg = 9;
             pythonPath = "";
             metricsPortArg = 31;
         } else {
-            totalArgs = 39;
+            totalArgs = 41;
             portArg = 30;
             configArg = 10;
             metricsPortArg = 32;
@@ -316,7 +318,8 @@ public class KubernetesRuntimeTest {
                 + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --expected_healthcheck_interval -1"
                 + " --secrets_provider secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config '{\"Somevalue\":\"myvalue\"}'";
+                + " --secrets_provider_config '{\"Somevalue\":\"myvalue\"}'"
+                + " --cluster_name standalone";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -248,15 +248,18 @@ public class ProcessRuntimeTest {
         String classpath = javaInstanceJarFile;
         String extraDepsEnv;
         int portArg;
+        int metricsPortArg;
         if (null != depsDir) {
-            assertEquals(args.size(), 33);
+            assertEquals(args.size(), 35);
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir.toString();
             classpath = classpath + ":" + depsDir + "/*";
             portArg = 24;
+            metricsPortArg = 26;
         } else {
-            assertEquals(args.size(), 32);
+            assertEquals(args.size(), 34);
             extraDepsEnv = "";
             portArg = 23;
+            metricsPortArg = 25;
         }
 
         String expectedArgs = "java -cp " + classpath
@@ -271,7 +274,7 @@ public class ProcessRuntimeTest {
                 + " --function_version " + config.getFunctionVersion()
                 + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(portArg)
+                + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"
@@ -305,16 +308,19 @@ public class ProcessRuntimeTest {
 
         int totalArgs;
         int portArg;
+        int metricsPortArg;
         String pythonPath;
         int configArg;
         if (null == extraDepsDir) {
-            totalArgs = 30;
+            totalArgs = 32;
             portArg = 23;
+            metricsPortArg = 25;
             configArg = 9;
             pythonPath = "";
         } else {
-            totalArgs = 31;
+            totalArgs = 33;
             portArg = 24;
+            metricsPortArg = 26;
             configArg = 10;
             pythonPath = "PYTHONPATH=${PYTHONPATH}:" + extraDepsDir + " ";
         }
@@ -328,7 +334,7 @@ public class ProcessRuntimeTest {
                 + " --function_version " + config.getFunctionVersion()
                 + " --function_details '" + JsonFormat.printer().omittingInsignificantWhitespace().print(config.getFunctionDetails())
                 + "' --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(portArg)
+                + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider secretsprovider.ClearTextSecretsProvider"
                 + " --secrets_provider_config '{\"Config\":\"Value\"}'";

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -170,6 +170,7 @@ public class ProcessRuntimeTest {
         config.setFunctionVersion("1.0");
         config.setInstanceId(0);
         config.setMaxBufferedTuples(1024);
+        config.setClusterName("standalone");
 
         return config;
     }
@@ -250,13 +251,13 @@ public class ProcessRuntimeTest {
         int portArg;
         int metricsPortArg;
         if (null != depsDir) {
-            assertEquals(args.size(), 35);
+            assertEquals(args.size(), 37);
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir.toString();
             classpath = classpath + ":" + depsDir + "/*";
             portArg = 24;
             metricsPortArg = 26;
         } else {
-            assertEquals(args.size(), 34);
+            assertEquals(args.size(), 36);
             extraDepsEnv = "";
             portArg = 23;
             metricsPortArg = 25;
@@ -278,7 +279,8 @@ public class ProcessRuntimeTest {
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config '{\"Config\":\"Value\"}'";
+                + " --secrets_provider_config '{\"Config\":\"Value\"}'"
+                + " --cluster_name standalone";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 
@@ -306,7 +308,7 @@ public class ProcessRuntimeTest {
         ProcessRuntime container = factory.createContainer(config, userJarFile, null, 30l);
         List<String> args = container.getProcessArgs();
 
-        int totalArgs = 32;
+        int totalArgs = 34;
         int portArg = 23;
         int metricsPortArg = 25;
         String pythonPath = "";
@@ -324,7 +326,8 @@ public class ProcessRuntimeTest {
                 + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider secretsprovider.ClearTextSecretsProvider"
-                + " --secrets_provider_config '{\"Config\":\"Value\"}'";
+                + " --secrets_provider_config '{\"Config\":\"Value\"}'"
+                + " --cluster_name standalone";
         assertEquals(String.join(" ", args), expectedArgs);
     }
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -306,24 +306,11 @@ public class ProcessRuntimeTest {
         ProcessRuntime container = factory.createContainer(config, userJarFile, null, 30l);
         List<String> args = container.getProcessArgs();
 
-        int totalArgs;
-        int portArg;
-        int metricsPortArg;
-        String pythonPath;
-        int configArg;
-        if (null == extraDepsDir) {
-            totalArgs = 32;
-            portArg = 23;
-            metricsPortArg = 25;
-            configArg = 9;
-            pythonPath = "";
-        } else {
-            totalArgs = 33;
-            portArg = 24;
-            metricsPortArg = 26;
-            configArg = 10;
-            pythonPath = "PYTHONPATH=${PYTHONPATH}:" + extraDepsDir + " ";
-        }
+        int totalArgs = 32;
+        int portArg = 23;
+        int metricsPortArg = 25;
+        String pythonPath = "";
+        int configArg = 9;
 
         assertEquals(args.size(), totalArgs);
         String expectedArgs = pythonPath + "python " + pythonInstanceFile

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -172,6 +172,7 @@ public class FunctionActioner implements AutoCloseable {
         instanceConfig.setInstanceId(instanceId);
         instanceConfig.setMaxBufferedTuples(1024);
         instanceConfig.setPort(org.apache.pulsar.functions.utils.Utils.findAvailablePort());
+        instanceConfig.setClusterName(workerConfig.getPulsarFunctionsCluster());
 
         log.info("{}/{}/{}-{} start process with instance config {}", functionDetails.getTenant(), functionDetails.getNamespace(),
                 functionDetails.getName(), instanceId, instanceConfig);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -132,7 +132,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     workerConfig.getStateStorageServiceUrl(),
                     authConfig,
                     new ClearTextSecretsProvider(),
-                    new CollectorRegistry());
+                     null);
         } else if (workerConfig.getProcessContainerFactory() != null) {
             this.runtimeFactory = new ProcessRuntimeFactory(
                     workerConfig.getPulsarServiceUrl(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -36,6 +36,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 
+import io.prometheus.client.CollectorRegistry;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.distributedlog.api.namespace.Namespace;
@@ -130,7 +131,8 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     workerConfig.getPulsarServiceUrl(),
                     workerConfig.getStateStorageServiceUrl(),
                     authConfig,
-                    new ClearTextSecretsProvider());
+                    new ClearTextSecretsProvider(),
+                    new CollectorRegistry());
         } else if (workerConfig.getProcessContainerFactory() != null) {
             this.runtimeFactory = new ProcessRuntimeFactory(
                     workerConfig.getPulsarServiceUrl(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionsStatsGenerator.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionsStatsGenerator.java
@@ -73,13 +73,13 @@ public class FunctionsStatsGenerator {
                                 int instanceId = functionRuntimeInfo.getFunctionInstance().getInstanceId();
                                 String qualifiedNamespace = String.format("%s/%s", tenant, namespace);
 
-                                metric(out, cluster, qualifiedNamespace, name, String.format("%scount", metricName),
+                                metric(out, cluster, qualifiedNamespace, name, String.format("%s_count", metricName),
                                         instanceId, dataDigest.getCount());
-                                metric(out, cluster, qualifiedNamespace, name, String.format("%smax", metricName),
+                                metric(out, cluster, qualifiedNamespace, name, String.format("%s_max", metricName),
                                         instanceId, dataDigest.getMax());
-                                metric(out, cluster, qualifiedNamespace,name, String.format("%smin", metricName),
+                                metric(out, cluster, qualifiedNamespace,name, String.format("%s_min", metricName),
                                         instanceId, dataDigest.getMin());
-                                metric(out, cluster, qualifiedNamespace, name, String.format("%ssum", metricName),
+                                metric(out, cluster, qualifiedNamespace, name, String.format("%s_sum", metricName),
                                         instanceId, dataDigest.getSum());
 
                             }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
@@ -87,10 +87,10 @@ public class FunctionStatsGeneratorTest {
         CompletableFuture<InstanceCommunication.MetricsData> metricsDataCompletableFuture = new CompletableFuture<>();
         InstanceCommunication.MetricsData metricsData = InstanceCommunication.MetricsData.newBuilder()
                 .putMetrics(
-                        "__function_total_processed__",
+                        "pulsar_function_processed_total",
                         InstanceCommunication.MetricsData.DataDigest.newBuilder()
                                 .setCount(100.0).setMax(200.0).setSum(300.0).setMin(0.0).build())
-                .putMetrics("__function_process_latency_ms__",
+                .putMetrics("pulsar_function_process_latency_ms",
                         InstanceCommunication.MetricsData.DataDigest.newBuilder()
                                 .setCount(10.0).setMax(20.0).setSum(30.0).setMin(0.0).build())
                 .build();
@@ -127,56 +127,56 @@ public class FunctionStatsGeneratorTest {
         Assert.assertEquals(metrics.size(), 8);
 
         System.out.println("metrics: " + metrics);
-        Metric m = metrics.get("__function_total_processed__count");
+        Metric m = metrics.get("pulsar_function_processed_total_count");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 100.0);
 
-        m = metrics.get("__function_total_processed__max");
+        m = metrics.get("pulsar_function_processed_total_max");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 200.0);
 
-        m = metrics.get("__function_total_processed__sum");
+        m = metrics.get("pulsar_function_processed_total_sum");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 300.0);
 
-        m = metrics.get("__function_total_processed__min");
+        m = metrics.get("pulsar_function_processed_total_min");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 0.0);
 
-        m = metrics.get("__function_process_latency_ms__count");
+        m = metrics.get("pulsar_function_process_latency_ms_count");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 10.0);
 
-        m = metrics.get("__function_process_latency_ms__max");
+        m = metrics.get("pulsar_function_process_latency_ms_max");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 20.0);
 
-        m = metrics.get("__function_process_latency_ms__sum");
+        m = metrics.get("pulsar_function_process_latency_ms_sum");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");
         assertEquals(m.tags.get("namespace"), "test-tenant/test-namespace");
         assertEquals(m.value, 30.0);
 
-        m = metrics.get("__function_process_latency_ms__min");
+        m = metrics.get("pulsar_function_process_latency_ms_min");
         assertEquals(m.tags.get("cluster"), "default");
         assertEquals(m.tags.get("instanceId"), "0");
         assertEquals(m.tags.get("name"), "func-1");

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.worker;
 import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.prometheus.client.CollectorRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.MessageId;
@@ -128,7 +129,7 @@ public class SchedulerManagerTest {
     public void stop() {
         this.executor.shutdown();
     }
-    
+
     @Test
     public void testSchedule() throws Exception {
 
@@ -141,7 +142,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function1);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -187,7 +188,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function1);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -234,7 +235,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -294,7 +295,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function1);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -359,7 +360,8 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider
+                (), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -470,7 +472,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -597,7 +599,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         Map<String, Map<String, Function.Assignment>> currentAssignments = new HashMap<>();
@@ -651,7 +653,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments
@@ -784,7 +786,7 @@ public class SchedulerManagerTest {
         functionMetaDataList.add(function2);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
 
-        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider());
+        ThreadRuntimeFactory factory = new ThreadRuntimeFactory("dummy", null, "dummy", new ClearTextSecretsProvider(), new CollectorRegistry());
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 
         // set assignments


### PR DESCRIPTION
Expose prometheus metrics via port on function instance.

python prometheus metrics
```
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="2",minor="7",patchlevel="10",version="2.7.10"} 1.0
# HELP pulsar_function_user_exceptions_total Total number of user exceptions.
# TYPE pulsar_function_user_exceptions_total counter
# HELP pulsar_function_processed_total Total number of messages processed.
# TYPE pulsar_function_processed_total counter
pulsar_function_processed_total{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 97.0
# TYPE pulsar_function_processed_created gauge
pulsar_function_processed_created{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 1541494449.234989
# HELP pulsar_function_process_latency_ms Process latency in milliseconds.
# TYPE pulsar_function_process_latency_ms summary
pulsar_function_process_latency_ms_count{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 97.0
pulsar_function_process_latency_ms_sum{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 6.733417510986328
# TYPE pulsar_function_process_latency_ms_created gauge
pulsar_function_process_latency_ms_created{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 1541494449.23497
# HELP pulsar_function_last_invocation The timestamp of the last invocation of the function.
# TYPE pulsar_function_last_invocation gauge
pulsar_function_last_invocation{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 1541494458814.92
# HELP pulsar_function_received_total Total number of messages received from source.
# TYPE pulsar_function_received_total counter
pulsar_function_received_total{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 97.0
# TYPE pulsar_function_received_created gauge
pulsar_function_received_created{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 1541494449.234695
# HELP pulsar_function_system_exceptions_total Total number of system exceptions.
# TYPE pulsar_function_system_exceptions_total counter
# HELP pulsar_function_user_metric Pulsar Function user defined metric
# TYPE pulsar_function_user_metric gauge
pulsar_function_user_metric{cluster="standalone",instance_id="0",metric="test_metric-3",name="test",namespace="public/default",tenant="public"} 288.0
pulsar_function_user_metric{cluster="standalone",instance_id="0",metric="test_metric-2",name="test",namespace="public/default",tenant="public"} 192.0
pulsar_function_user_metric{cluster="standalone",instance_id="0",metric="test_metric-1",name="test",namespace="public/default",tenant="public"} 96.0
# HELP pulsar_function_processed_successfully_total Total number of messages processed successfully.
# TYPE pulsar_function_processed_successfully_total counter
pulsar_function_processed_successfully_total{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 97.0
# TYPE pulsar_function_processed_successfully_created gauge
pulsar_function_processed_successfully_created{cluster="standalone",instance_id="0",name="test",namespace="public/default",tenant="public"} 1541494449.254965
```

java metrics:

```
# HELP pulsar_function_user_metric Pulsar Function user defined metric.
# TYPE pulsar_function_user_metric gauge
pulsar_function_user_metric{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",metric="test_metrics-1",} 365.5
pulsar_function_user_metric{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",metric="test_metrics-2",} 1462.0
pulsar_function_user_metric{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",metric="test_metrics-3",} 2193.0
# HELP pulsar_function_processed_total Total number of messages processed.
# TYPE pulsar_function_processed_total counter
pulsar_function_processed_total{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 619.0
# HELP pulsar_function_last_invocation The timestamp of the last invocation of the function
# TYPE pulsar_function_last_invocation gauge
pulsar_function_last_invocation{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 1.541494416857E12
# HELP pulsar_function_processed_successfully_total Total number of messages processed successfully.
# TYPE pulsar_function_processed_successfully_total counter
pulsar_function_processed_successfully_total{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 619.0
# HELP pulsar_function_system_exceptions_total Total number of system exceptions.
# TYPE pulsar_function_system_exceptions_total counter
pulsar_function_system_exceptions_total{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 0.0
# HELP pulsar_function_user_exceptions_total Total number of user exceptions.
# TYPE pulsar_function_user_exceptions_total counter
pulsar_function_user_exceptions_total{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 0.0
# HELP pulsar_function_process_latency_ms Process latency in milliseconds.
# TYPE pulsar_function_process_latency_ms summary
pulsar_function_process_latency_ms{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",quantile="0.5",} 4.1899E-5
pulsar_function_process_latency_ms{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",quantile="0.9",} 5.9537E-5
pulsar_function_process_latency_ms{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",quantile="0.99",} 1.02174E-4
pulsar_function_process_latency_ms{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",quantile="0.999",} 1.07808E-4
pulsar_function_process_latency_ms_count{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 619.0
pulsar_function_process_latency_ms_sum{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 0.027786551
# HELP pulsar_function_received_total Total number of messages received from source.
# TYPE pulsar_function_received_total counter
pulsar_function_received_total{tenant="public",namespace="public/default",name="exclamation",instance_id="0",cluster="standalone",} 619.0
```