### PR TITLE
Make Log a logger instead of Logger Adapter

### DIFF
--- a/pulsar-functions/instance/src/main/python/log.py
+++ b/pulsar-functions/instance/src/main/python/log.py
@@ -25,11 +25,13 @@ import logging
 import logging.config
 import logging.handlers
 import os
+import errno
 import pulsar
 
 # Create the logger
 # pylint: disable=invalid-name
-Log = None
+logging.basicConfig()
+Log = logging.getLogger()
 
 # time formatter - date - time - UTC offset
 # e.g. "08/16/1988 21:30:00 +1030"
@@ -51,6 +53,24 @@ class LogTopicHandler(logging.Handler):
     msg = self.format(record)
     self.producer.send_async(str(msg).encode('utf-8'), None)
 
+def mkdir_p(path):
+  try:
+    os.makedirs(path, exist_ok=True)  # Python>3.2
+  except TypeError:
+    try:
+      os.makedirs(path)
+    except OSError as exc: # Python >2.5
+      if exc.errno == errno.EEXIST and os.path.isdir(path):
+        pass
+      else: raise
+
+# logging handler that is RotatingFileHandler but creates path to log file for you
+# if it doesn't exist
+class CreatePathRotatingFileHandler(logging.handlers.RotatingFileHandler):
+  def __init__(self, filename, mode='a', maxBytes=10 * 1024 * 1024, backupCount=5, encoding=None, delay=0):
+    mkdir_p(os.path.dirname(filename))
+    logging.handlers.RotatingFileHandler.__init__(self, filename, mode=mode, maxBytes=maxBytes, backupCount=backupCount, encoding=encoding, delay=delay)
+
 def remove_all_handlers():
   retval = None
   for handler in Log.handlers:
@@ -67,7 +87,8 @@ def add_handler(stream_handler):
 def init_logger(level, logfile, logging_config_file):
   global Log
   # get log file location for function instance
-  os.environ['LOG_FILE'] = logfile
+  os.environ['LOG_FILE'] = logfile;
   logging.config.fileConfig(logging_config_file)
   Log = logging.getLogger()
   Log.setLevel(level)
+


### PR DESCRIPTION
### Motivation
A lot of places in the code assumes Log to be a Logger. Thus change it to be a Logger instance.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
