### PR TITLE
Make sure that the returned object is string for conversion purposes

### DIFF
--- a/pulsar-functions/python-examples/config_based_append_function.py
+++ b/pulsar-functions/python-examples/config_based_append_function.py
@@ -31,4 +31,4 @@ class ConfigBasedAppendFunction(Function):
     append_value = "!"
     if key in context.get_user_config_map():
       append_value = context.get_user_config_value(key)
-    return input + append_value
+    return input + str(append_value)


### PR DESCRIPTION
### Motivation

IdentitySerde does not handle unicode type which is python2 specific. Thus ensure that we convert anything from config into string so that IdentitySerde can handle it

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
