### PR TITLE
Fix Get Function Cluster in Doc

### DIFF
--- a/site2/website/versioned_docs/version-2.2.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.2.0/io-quickstart.md
@@ -97,7 +97,7 @@ telnet localhost 6650
 2. Check pulsar function cluster
 
 ```bash
-curl -s http://localhost:8080/admin/v2/functions/cluster
+curl -s http://localhost:8080/admin/v2/worker/cluster
 ```
 
 Example output:


### PR DESCRIPTION
### Motivation

http://pulsar.apache.org/docs/en/io-quickstart/
> curl -s http://localhost:8080/admin/v2/functions/cluster

This command returns the result like example in v2.1.1.
> [{"workerId":"c-standalone-fw-localhost-6750","workerHostname":"localhost","port":6750}] 

But it returns 404 in v2.2.0.

### Modifications

Change `curl -s http://localhost:8080/admin/v2/functions/cluster` to `curl -s http://localhost:8080/admin/v2/worker/cluster`
