### PR TITLE
default enable cpp client producer batch

### DIFF
--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -53,7 +53,7 @@ struct ProducerConfigurationImpl {
           routingMode(ProducerConfiguration::UseSinglePartition),
           hashingScheme(ProducerConfiguration::BoostHash),
           blockIfQueueFull(false),
-          batchingEnabled(false),
+          batchingEnabled(true),
           batchingMaxMessages(1000),
           batchingMaxAllowedSizeInBytes(128 * 1024),  // 128 KB
           batchingMaxPublishDelayMs(10),              // 10 milli seconds

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1080,6 +1080,7 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     Promise<Result, Producer> producerPromise2;
     ProducerConfiguration conf;
     conf.setCompressionType(CompressionLZ4);
+    conf.setBatchingEnabled(false);
     client.createProducerAsync(topicName, conf, WaitForCallbackValue<Producer>(producerPromise2));
     producerFuture = producerPromise2.getFuture();
     result = producerFuture.get(producer2);
@@ -1267,6 +1268,7 @@ TEST(BasicEndToEndTest, testEncryptionFailure) {
     {
         ProducerConfiguration prodConf;
         prodConf.setCryptoKeyReader(keyReader);
+        prodConf.setBatchingEnabled(false);
         prodConf.addEncryptionKey("client-non-existing-rsa.pem");
 
         Promise<Result, Producer> producerPromise;
@@ -1282,6 +1284,7 @@ TEST(BasicEndToEndTest, testEncryptionFailure) {
     {
         ProducerConfiguration prodConf;
         prodConf.setCryptoKeyReader(keyReader);
+        prodConf.setBatchingEnabled(false);
         prodConf.addEncryptionKey("client-rsa.pem");
 
         Promise<Result, Producer> producerPromise;

--- a/pulsar-client-cpp/tests/ReaderTest.cc
+++ b/pulsar-client-cpp/tests/ReaderTest.cc
@@ -363,7 +363,7 @@ TEST(ReaderTest, testReaderReachEndOfTopic) {
     client.close();
 }
 
-TEST(ReaderTest, testReaderReachEndOfTopicMessageWithBatches) {
+TEST(ReaderTest, testReaderReachEndOfTopicMessageWithoutBatches) {
     Client client(serviceUrl);
 
     std::string topicName =
@@ -371,7 +371,9 @@ TEST(ReaderTest, testReaderReachEndOfTopicMessageWithBatches) {
 
     // 1. create producer
     Producer producer;
-    ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
+    ProducerConfiguration producerConf;
+    producerConf.setBatchingEnabled(false);
+    ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConf, producer));
 
     // 2. create reader, and expect hasMessageAvailable return false since no message produced.
     ReaderConfiguration readerConf;


### PR DESCRIPTION
### Motivation

In Cpp client  producer batching is disabled by default, This is not align with java client, and use default value will cause  benchmark has a low result. 

### Modifications

default enable cpp producer batch

### Result

ut pass