### PR TITLE
Remove conflicting log4j2 policies

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -68,10 +68,6 @@ Configuration:
           modulate: true
         SizeBasedTriggeringPolicy:
           size: 1 GB
-        # Trigger every day at midnight that also scan
-        # roll-over strategy that deletes older file
-        CronTriggeringPolicy:
-          schedule: "0 0 0 * * ?"
       # Delete file older than 30days
       DefaultRolloverStrategy:
           Delete:


### PR DESCRIPTION
### Motivation

After moving to log4j2, issue was that sometimes our log files were not rolling over properly and rolled-over archived file was not complete and it was because of conflicting roll-over policies `TimeBasedTriggeringPolicy` and `CronTriggeringPolicy`. `TimeBasedTriggeringPolicy` already rolls-over file after a day so, log4j2 doesn't need `CronTriggeringPolicy` which was causing issue while rolling the file. Removal of `CronTriggeringPolicy` fixed the issue.
