### PR TITLE
Add Connect and Read timeout to pulsar admin

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -18,17 +18,6 @@
  */
 package org.apache.pulsar.client.admin;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.URL;
-import java.security.cert.X509Certificate;
-import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -64,12 +53,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Pulsar client admin API client.
  */
 @SuppressWarnings("deprecation")
 public class PulsarAdmin implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarAdmin.class);
+
+    public static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 60;
+    public static final int DEFAULT_READ_TIMEOUT_SECONDS = 60;
 
     private final Clusters clusters;
     private final Brokers brokers;
@@ -92,6 +95,10 @@ public class PulsarAdmin implements Closeable {
     private final Schemas schemas;
     protected final WebTarget root;
     protected final Authentication auth;
+    private final int connectTimeout;
+    private final TimeUnit connectTimeoutUnit;
+    private final int readTimeout;
+    private final TimeUnit readTimeoutUnit;
 
     static {
         /**
@@ -118,7 +125,23 @@ public class PulsarAdmin implements Closeable {
         return new PulsarAdminBuilderImpl();
     }
 
+
     public PulsarAdmin(String serviceUrl, ClientConfigurationData clientConfigData) throws PulsarClientException {
+        this(serviceUrl, clientConfigData, DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+    }
+
+    public PulsarAdmin(String serviceUrl,
+                       ClientConfigurationData clientConfigData,
+                       int connectTimeout,
+                       TimeUnit connectTimeoutUnit,
+                       int readTimeout,
+                       TimeUnit readTimeoutUnit) throws PulsarClientException {
+        this.connectTimeout = connectTimeout;
+        this.connectTimeoutUnit = connectTimeoutUnit;
+        this.readTimeout = readTimeout;
+        this.readTimeoutUnit = readTimeoutUnit;
         this.clientConfigData = clientConfigData;
         this.auth = clientConfigData != null ? clientConfigData.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
@@ -134,9 +157,10 @@ public class PulsarAdmin implements Closeable {
         httpConfig.register(MultiPartFeature.class);
 
         ClientBuilder clientBuilder = ClientBuilder.newBuilder()
-            .withConfig(httpConfig)
-            .register(JacksonConfigurator.class)
-            .register(JacksonFeature.class);
+                .withConfig(httpConfig)
+                .connectTimeout(this.connectTimeout, this.connectTimeoutUnit)
+                .readTimeout(this.readTimeout, this.readTimeoutUnit)
+                .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
         boolean useTls = false;
 
@@ -181,7 +205,7 @@ public class PulsarAdmin implements Closeable {
         this.client = clientBuilder.build();
 
         this.serviceUrl = serviceUrl;
-        root = client.target(serviceUrl.toString());
+        root = client.target(serviceUrl);
 
         this.clusters = new ClustersImpl(root, auth);
         this.brokers = new BrokersImpl(root, auth);
@@ -415,4 +439,5 @@ public class PulsarAdmin implements Closeable {
         }
         client.close();
     }
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.admin;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -169,4 +170,21 @@ public interface PulsarAdminBuilder {
      * @param enableTlsHostnameVerification
      */
     PulsarAdminBuilder enableTlsHostnameVerification(boolean enableTlsHostnameVerification);
+
+    /**
+     * This sets the connection time out for the pulsar admin client
+     *
+     * @param connectionTimeout
+     * @param connectionTimeoutUnit
+     */
+    PulsarAdminBuilder connectionTimeout(int connectionTimeout, TimeUnit connectionTimeoutUnit);
+
+    /**
+     * This sets the server response read time out for the pulsar admin client for any request.
+     *
+     * @param readTimeout
+     * @param readTimeoutUnit
+     */
+    PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
-import java.util.Map;
-
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.Authentication;
@@ -28,13 +26,21 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     protected final ClientConfigurationData conf;
+    private int connectTimeout = PulsarAdmin.DEFAULT_CONNECT_TIMEOUT_SECONDS;
+    private int readTimeout = PulsarAdmin.DEFAULT_READ_TIMEOUT_SECONDS;
+    private TimeUnit connectTimeoutUnit = TimeUnit.SECONDS;
+    private TimeUnit readTimeoutUnit = TimeUnit.SECONDS;
 
     @Override
     public PulsarAdmin build() throws PulsarClientException {
-        return new PulsarAdmin(conf.getServiceUrl(), conf);
+        return new PulsarAdmin(conf.getServiceUrl(),
+                conf, connectTimeout, connectTimeoutUnit, readTimeout, readTimeoutUnit);
     }
 
     public PulsarAdminBuilderImpl() {
@@ -91,6 +97,20 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
     @Override
     public PulsarAdminBuilder enableTlsHostnameVerification(boolean enableTlsHostnameVerification) {
         conf.setTlsHostnameVerificationEnable(enableTlsHostnameVerification);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder connectionTimeout(int connectionTimeout, TimeUnit connectionTimeoutUnit) {
+        this.connectTimeout = connectionTimeout;
+        this.connectTimeoutUnit = connectionTimeoutUnit;
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit) {
+        this.readTimeout = readTimeout;
+        this.readTimeoutUnit = readTimeoutUnit;
         return this;
     }
 }


### PR DESCRIPTION
We add a timeout to the admin client of default 60 seconds for both connection and server response.