### PR TITLE
Fixed race condition in schema initialization in partitioned topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -41,8 +41,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.validation.constraints.NotNull;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -59,9 +57,12 @@ import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 public class BookkeeperSchemaStorage implements SchemaStorage {
+    private static final Logger log = LoggerFactory.getLogger(BookkeeperSchemaStorage.class);
+
     private static final String SchemaPath = "/schemas";
     private static final List<ACL> Acl = ZooDefs.Ids.OPEN_ACL_UNSAFE;
     private static final byte[] LedgerPassword = "".getBytes();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
@@ -38,10 +38,8 @@ public class PartitionedTopicsSchemaTest extends BrokerBkEnsemblesTests {
 
     /**
      * Test that sequence id from a producer is correct when there are send errors
-     *
-     * the test is disabled {@link https://github.com/apache/pulsar/issues/2651}
      */
-    @Test(enabled = false)
+    @Test
     public void partitionedTopicWithSchema() throws Exception {
         admin.namespaces().createNamespace("prop/my-test", Collections.singleton("usc"));
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -126,15 +126,15 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 if (completed.incrementAndGet() == topicMetadata.numPartitions()) {
                     if (createFail.get() == null) {
                         setState(State.Ready);
-                        producerCreatedFuture().complete(PartitionedProducerImpl.this);
                         log.info("[{}] Created partitioned producer", topic);
+                        producerCreatedFuture().complete(PartitionedProducerImpl.this);
                     } else {
+                        log.error("[{}] Could not create partitioned producer.", topic, createFail.get().getCause());
                         closeAsync().handle((ok, closeException) -> {
                             producerCreatedFuture().completeExceptionally(createFail.get());
                             client.cleanupProducer(this);
                             return null;
                         });
-                        log.error("[{}] Could not create partitioned producer.", topic, createFail.get().getCause());
                     }
                 }
 


### PR DESCRIPTION
### Motivation

There is a race condition when producers and consumers are connecting to a new partitioned topic concurrently and try to initialize the schema. 

That results in consumers getting subscribe error (upon application retry, they will succeed).

The exception is like: 

```
1541537636157/test-pythonpartitiontopictest-output-edot-partition-1][test-subs-edot] Failed to create consumer: No such ledger exists
java.util.concurrent.CompletionException: org.apache.bookkeeper.client.BKException$BKNoSuchLedgerExistsException: No such ledger exists
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:943) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:926) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_181]
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$15(BookkeeperSchemaStorage.java:441) ~[org.apache.pulsar-pulsar-broker-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
```

The main issue is that `getOrCreateSchemaLocator()` is creating the z-node with a dummy marker (ledgerId=-1) and then creates a new ledger and finally updates the z-node with the real ledger id. 
Because of that, consumers might see the z-node pointing to ledger -1 and hence the error.

### Modifications

 * Added more information in the BK exception reporting (eg: which operation we are trying to do and ledger id).
 * Removed `getOrCreateSchemaLocator()`. Instead, we do get(), then create ledger and then try to create z-node with real ledger id. There would not be incomplete state visible.
 * Handle concurrent create conflicts (eg: across multiple brokers) by retrying from the get operation again.