### PR TITLE
 Fix Get Function Cluster in Master Docs

### DIFF
--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -96,7 +96,7 @@ telnet localhost 6650
 2. Check pulsar function cluster
 
 ```bash
-curl -s http://localhost:8080/admin/v2/functions/cluster
+curl -s http://localhost:8080/admin/v2/worker/cluster
 ```
 
 Example output:


### PR DESCRIPTION
### Motivation

About #2948 , fix path in master docs.

### Modifications
Change `curl -s http://localhost:8080/admin/v2/functions/cluster` to `curl -s http://localhost:8080/admin/v2/worker/cluster`