### PR TITLE
Added pause and resume to Java client Consumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -294,4 +294,14 @@ public interface Consumer<T> extends Closeable {
      * @return consumer name.
      */
     String getConsumerName();
+
+    /**
+     * Stop requesting new messages from the broker until {@link #resume()} is called.
+     */
+    void pause();
+
+    /**
+     * Resume requesting messages from the broker.
+     */
+    void resume();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -296,7 +296,8 @@ public interface Consumer<T> extends Closeable {
     String getConsumerName();
 
     /**
-     * Stop requesting new messages from the broker until {@link #resume()} is called.
+     * Stop requesting new messages from the broker until {@link #resume()} is called. Note that this might cause
+     * {@link #receive()} to block until {@link #resume()} is called and new messages are pushed by the broker.
      */
     void pause();
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -855,7 +855,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public void pause() {
-        for (Map.Entry<String, ConsumerImpl<T>> e : consumers.entrySet()) e.getValue().pause();
+        consumers.forEach((name, consumer) -> consumer.pause());
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -860,7 +860,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public void resume() {
-        for (Map.Entry<String, ConsumerImpl<T>> e : consumers.entrySet()) e.getValue().resume();
+        consumers.forEach((name, consumer) -> consumer.resume());
     }
 
     private static final Logger log = LoggerFactory.getLogger(MultiTopicsConsumerImpl.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -853,5 +853,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         return consumers.values().stream().collect(Collectors.toList());
     }
 
+    @Override
+    public void pause() {
+        for (Map.Entry<String, ConsumerImpl<T>> e : consumers.entrySet()) e.getValue().pause();
+    }
+
+    @Override
+    public void resume() {
+        for (Map.Entry<String, ConsumerImpl<T>> e : consumers.entrySet()) e.getValue().resume();
+    }
+
     private static final Logger log = LoggerFactory.getLogger(MultiTopicsConsumerImpl.class);
 }

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
@@ -504,6 +504,16 @@ public class PulsarConsumerSourceTests {
         public String getConsumerName() {
             return "test-consumer-0";
         }
+
+        @Override
+        public void pause() {
+
+        }
+
+        @Override
+        public void resume() {
+
+        }
     }
 
     private static List<Message> createMessages(int startIndex, int numMessages) {

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
@@ -507,12 +507,10 @@ public class PulsarConsumerSourceTests {
 
         @Override
         public void pause() {
-
         }
 
         @Override
         public void resume() {
-
         }
     }
 


### PR DESCRIPTION
### Motivation

It is useful to be able to control message flow from the client but still use MessageListener to be notified when new messages arrive. Currently you have to use Consumer.receive() and receiverQueueSize which requires polling, which is inefficient for thousands of consumers. The C++ client has Consumer.pauseMessageListener() and resumeMessageListener().

### Modifications

Added Consumer.pause() and Consumer.resume(). When paused the consumer does not send requests for more messages to the broker. This works when using MessageListener and Consumer.receive() which is why I didn't use the same names as the C++ client.

### Result

Applications using the Java API can now do client side message flow control very easily based on their own internal state.