### PR TITLE
Websocket dead letter topic (PIP22)

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -38,13 +38,13 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
 import org.apache.pulsar.client.api.PulsarClientException.ConsumerBusyException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
-import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ConsumerAck;
@@ -92,13 +92,13 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         this.numMsgsAcked = new LongAdder();
 
         try {
+            // checkAuth() and getConsumerConfiguration() should be called after assigning a value to this.subscription
+            this.subscription = extractSubscription(request);
             builder = (ConsumerBuilderImpl<byte[]>) getConsumerConfiguration(service.getPulsarClient());
             this.maxPendingMessages = (builder.getConf().getReceiverQueueSize() == 0) ? 1
                     : builder.getConf().getReceiverQueueSize();
             this.subscriptionType = builder.getConf().getSubscriptionType();
 
-            // checkAuth() should be called after assigning a value to this.subscription
-            this.subscription = extractSubscription(request);
             if (!checkAuth(response)) {
                 return;
             }
@@ -191,7 +191,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             int pending = pendingMessages.incrementAndGet();
             if (pending < maxPendingMessages) {
                 // Start next read in a separate thread to avoid recursion
-                service.getExecutor().execute(() -> receiveMessage());
+                service.getExecutor().execute(this::receiveMessage);
             }
         }).exceptionally(exception -> {
             if (exception.getCause() instanceof AlreadyClosedException) {
@@ -311,6 +311,19 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
 
         if (queryParams.containsKey("priorityLevel")) {
             builder.priorityLevel(Integer.parseInt(queryParams.get("priorityLevel")));
+        }
+
+        if (queryParams.containsKey("maxRedeliverCount") || queryParams.containsKey("deadLetterTopic")) {
+            DeadLetterPolicy.DeadLetterPolicyBuilder dlpBuilder = DeadLetterPolicy.builder();
+            if (queryParams.containsKey("maxRedeliverCount")) {
+                dlpBuilder.maxRedeliverCount(Integer.parseInt(queryParams.get("maxRedeliverCount")))
+                        .deadLetterTopic(String.format("%s-%s-DLQ", topic, subscription));
+            }
+
+            if (queryParams.containsKey("deadLetterTopic")) {
+                dlpBuilder.deadLetterTopic(queryParams.get("deadLetterTopic"));
+            }
+            builder.deadLetterPolicy(dlpBuilder.build());
         }
 
         return builder;

--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -142,6 +142,8 @@ Key | Type | Required? | Explanation
 `receiverQueueSize` | int | no | Size of the consumer receive queue (default: 1000)
 `consumerName` | string | no | Consumer name
 `priorityLevel` | int | no | Define a [priority](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ConsumerConfiguration.html#setPriorityLevel-int-) for the consumer
+`maxRedeliverCount` | int | no | Define a [maxRedeliverCount](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ConsumerBuilder.html#deadLetterPolicy-org.apache.pulsar.client.api.DeadLetterPolicy-) for the consumer (default: 0). Activates [Dead Letter Topic](https://github.com/apache/pulsar/wiki/PIP-22%3A-Pulsar-Dead-Letter-Topic) feature.
+`deadLetterTopic` | string | no | Define a [deadLetterTopic](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ConsumerBuilder.html#deadLetterPolicy-org.apache.pulsar.client.api.DeadLetterPolicy-) for the consumer (default: {topic}-{subscription}-DLQ). Activates [Dead Letter Topic](https://github.com/apache/pulsar/wiki/PIP-22%3A-Pulsar-Dead-Letter-Topic) feature.
 
 ##### Receiving messages
 


### PR DESCRIPTION
### Motivation

[PIP22 Dead Letter Topic](https://github.com/apache/pulsar/wiki/PIP-22%3A-Pulsar-Dead-Letter-Topic) is available in Java client but not in WebSocket proxy.

### Modifications

Added two query params `maxRedeliverCount` and `deadLetterTopic` to the WebSocket handler to be able to set the `ConsumerBuilder`'s `DeadLetterPolicy`.

### Result

Dead Letter Topic can be used with WebSockets.
Example request:
```
curl --include \
     --no-buffer \
     --header "Connection: Upgrade" \
     --header "Upgrade: websocket" \
     --header "Host: example.com:80" \
     --header "Origin: http://example.com:80" \
     --header "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" \
     --header "Sec-WebSocket-Version: 13" \
"http://localhost:8080/ws/v2/consumer/persistent/public/default/my-topic/my-subscription?subscriptionType=Shared&ackTimeoutMillis=1000&maxRedeliverCount=5&deadLetterTopic=my-DLQ"
```
