### PR TITLE
Ignore the current class while going over variables

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -584,8 +584,7 @@ public class CmdFunctions extends CmdBase {
             localRunArgs.add(new Gson().toJson(functionConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().startsWith("this$0")) continue;
-                if(field.getName().startsWith("$")) continue;
+                if(field.getName().contains("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -585,6 +585,7 @@ public class CmdFunctions extends CmdBase {
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
                 if(field.getName().startsWith("this$0")) continue;
+                if(field.getName().startsWith("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -168,8 +168,7 @@ public class CmdSinks extends CmdBase {
             localRunArgs.add(new Gson().toJson(sinkConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().startsWith("this$0")) continue;
-                if(field.getName().startsWith("$")) continue;
+                if(field.getName().contains("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -169,6 +169,7 @@ public class CmdSinks extends CmdBase {
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
                 if(field.getName().startsWith("this$0")) continue;
+                if(field.getName().startsWith("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -168,6 +168,7 @@ public class CmdSinks extends CmdBase {
             localRunArgs.add(new Gson().toJson(sinkConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
+                if(field.getName().startsWith("this$0")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -172,8 +172,7 @@ public class CmdSources extends CmdBase {
             localRunArgs.add(new Gson().toJson(sourceConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().startsWith("this$0")) continue;
-                if(field.getName().startsWith("$")) continue;
+                if(field.getName().contains("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -172,6 +172,7 @@ public class CmdSources extends CmdBase {
             localRunArgs.add(new Gson().toJson(sourceConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
+                if(field.getName().startsWith("this$0")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -173,6 +173,7 @@ public class CmdSources extends CmdBase {
             for (Field field : this.getClass().getDeclaredFields()) {
                 if (field.getName().startsWith("DEPRECATED")) continue;
                 if(field.getName().startsWith("this$0")) continue;
+                if(field.getName().startsWith("$")) continue;
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());


### PR DESCRIPTION
### Motivation

We go over all the declared fields in LocalRunner class to generate the command for localrunner. However one of the items that getDeclartedFields returns is the this$0 which should be ignored.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
