### PR TITLE
Don't use default values within the config.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -308,7 +308,7 @@ public class PulsarWorkerAssignmentTest {
         // validate updated function prop = auto-ack=false and instnaceid
         for (int i = 0; i < (totalFunctions - totalDeletedFunction); i++) {
             String functionName = baseFunctionName + i;
-            assertFalse(admin.functions().getFunction(tenant, namespacePortion, functionName).isAutoAck());
+            assertFalse(admin.functions().getFunction(tenant, namespacePortion, functionName).getAutoAck());
         }
     }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
@@ -258,7 +258,7 @@ public class TestCmdSinks {
     @Test
     public void testMissingParallelism() throws Exception {
         SinkConfig sinkConfig = getSinkConfig();
-        sinkConfig.setParallelism(1);
+        sinkConfig.setParallelism(null);
         testCmdSinkCliMissingArgs(
                 TENANT,
                 NAMESPACE,

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
@@ -181,7 +181,7 @@ public class TestCmdSources {
     @Test
     public void testMissingParallelism() throws Exception {
         SourceConfig sourceConfig = getSourceConfig();
-        sourceConfig.setParallelism(1);
+        sourceConfig.setParallelism(null);
         testCmdSourceCliMissingArgs(
                 TENANT,
                 NAMESPACE,

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -77,7 +77,7 @@ public class FunctionConfig {
     private String outputSerdeClassName;
     private String logTopic;
     private ProcessingGuarantees processingGuarantees;
-    private boolean retainOrdering;
+    private Boolean retainOrdering;
     private Map<String, Object> userConfig;
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that
@@ -86,11 +86,11 @@ public class FunctionConfig {
     // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
     private Runtime runtime;
-    private boolean autoAck;
-    private int maxMessageRetries = -1;
+    private Boolean autoAck;
+    private Integer maxMessageRetries;
     private String deadLetterTopic;
     private String subName;
-    private int parallelism = 1;
+    private Integer parallelism;
     private Resources resources;
     private String fqfn;
     private WindowConfig windowConfig;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -61,7 +61,7 @@ public class SinkConfig {
     // secrets provider. The type of an value here can be found by the
     // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
-    private int parallelism = 1;
+    private Integer parallelism;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
     private boolean retainOrdering;
     private Resources resources;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -52,7 +52,7 @@ public class SourceConfig {
     // secrets provider. The type of an value here can be found by the
     // SecretProviderConfigurator.getSecretObjectType() method.
     private Map<String, Object> secrets;
-    private int parallelism = 1;
+    private Integer parallelism;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
     private Resources resources;
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -80,7 +80,11 @@ public class SinkConfigUtils {
             functionDetailsBuilder.setName(sinkConfig.getName());
         }
         functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
-        functionDetailsBuilder.setParallelism(sinkConfig.getParallelism());
+        if (sinkConfig.getParallelism() != null) {
+            functionDetailsBuilder.setParallelism(sinkConfig.getParallelism());
+        } else {
+            functionDetailsBuilder.setParallelism(1);
+        }
         functionDetailsBuilder.setClassName(IdentityFunction.class.getName());
         if (sinkConfig.getProcessingGuarantees() != null) {
             functionDetailsBuilder.setProcessingGuarantees(
@@ -272,7 +276,7 @@ public class SinkConfigUtils {
             }
         }
 
-        if (sinkConfig.getParallelism() <= 0) {
+        if (sinkConfig.getParallelism() != null && sinkConfig.getParallelism() <= 0) {
             throw new IllegalArgumentException("Sink parallelism should positive number");
         }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -77,7 +77,11 @@ public class SourceConfigUtils {
             functionDetailsBuilder.setName(sourceConfig.getName());
         }
         functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
-        functionDetailsBuilder.setParallelism(sourceConfig.getParallelism());
+        if (sourceConfig.getParallelism() != null) {
+            functionDetailsBuilder.setParallelism(sourceConfig.getParallelism());
+        } else {
+            functionDetailsBuilder.setParallelism(1);
+        }
         functionDetailsBuilder.setClassName(IdentityFunction.class.getName());
         functionDetailsBuilder.setAutoAck(true);
         if (sourceConfig.getProcessingGuarantees() != null) {
@@ -201,7 +205,7 @@ public class SourceConfigUtils {
         if (!TopicName.isValid(sourceConfig.getTopicName())) {
             throw new IllegalArgumentException("Topic name is invalid");
         }
-        if (sourceConfig.getParallelism() <= 0) {
+        if (sourceConfig.getParallelism() != null && sourceConfig.getParallelism() <= 0) {
             throw new IllegalArgumentException("Source parallelism should positive number");
         }
         if (sourceConfig.getResources() != null) {

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -42,6 +42,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setTenant("test-tenant");
         functionConfig.setNamespace("test-namespace");
         functionConfig.setName("test-function");
+        functionConfig.setParallelism(1);
         functionConfig.setClassName(IdentityFunction.class.getName());
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
         inputSpecs.put("test-input", ConsumerConfig.builder().isRegexPattern(true).serdeClassName("test-serde").build());
@@ -68,6 +69,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setTenant("test-tenant");
         functionConfig.setNamespace("test-namespace");
         functionConfig.setName("test-function");
+        functionConfig.setParallelism(1);
         functionConfig.setClassName(IdentityFunction.class.getName());
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
         inputSpecs.put("test-input", ConsumerConfig.builder().isRegexPattern(true).serdeClassName("test-serde").build());

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -42,6 +42,7 @@ public class SinkConfigUtilsTest {
         sinkConfig.setTenant("test-tenant");
         sinkConfig.setNamespace("test-namespace");
         sinkConfig.setName("test-source");
+        sinkConfig.setParallelism(1);
         sinkConfig.setArchive("builtin://jdbc");
         sinkConfig.setSourceSubscriptionName("test-subscription");
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -43,6 +43,7 @@ public class SourceConfigUtilsTest {
         sourceConfig.setArchive("builtin://jdbc");
         sourceConfig.setTopicName("test-output");
         sourceConfig.setSerdeClassName("test-serde");
+        sourceConfig.setParallelism(1);
         sourceConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
         sourceConfig.setConfigs(new HashMap<>());
         Function.FunctionDetails functionDetails = SourceConfigUtils.convert(sourceConfig, null);


### PR DESCRIPTION
### Motivation
Make all variables based on Java Objects instead of native types. The reason is that now we will have a better idea which variables were really set by the user.
### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
