### PR TITLE
Fix NPE caused by the race condition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2609,16 +2609,18 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     public void deactivateCursor(ManagedCursor cursor) {
-        if (activeCursors.get(cursor.getName()) != null) {
-            activeCursors.removeCursor(cursor.getName());
-            if (activeCursors.isEmpty()) {
-                // cleanup cache if there is no active subscription
-                entryCache.clear();
-            } else {
-                // if removed subscription was the slowest subscription : update cursor and let it clear cache: till
-                // new slowest-cursor's read-position
-                discardEntriesFromCache((ManagedCursorImpl) activeCursors.getSlowestReader(),
-                        getPreviousPosition((PositionImpl) activeCursors.getSlowestReader().getReadPosition()));
+        synchronized (activeCursors) {
+            if (activeCursors.get(cursor.getName()) != null) {
+                activeCursors.removeCursor(cursor.getName());
+                if (activeCursors.isEmpty()) {
+                    // cleanup cache if there is no active subscription
+                    entryCache.clear();
+                } else {
+                    // if removed subscription was the slowest subscription : update cursor and let it clear cache:
+                    // till new slowest-cursor's read-position
+                    discardEntriesFromCache((ManagedCursorImpl) activeCursors.getSlowestReader(),
+                            getPreviousPosition((PositionImpl) activeCursors.getSlowestReader().getReadPosition()));
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation

There is a possibility that NPE occurs in `ManagedLedgerImpl#deactivateCursor()`.

A thread checks whether `activeCursors` is empty on L2614. If `activeCursors` is not empty, `activeCursors.getSlowestReader().getReadPosition()` will be called on line L2621. However, another thread may remove a cursor from `activeCursors` in the meantime. If `activeCursors` becomes empty, `activeCursors.getSlowestReader()` returns null and NPE is thrown.
https://github.com/apache/pulsar/blob/d5e88c1ec16df557655e42c9f648a2fd3343d759/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2611-L2624

As a result, closing of the `PersistentTopic` does not complete normally, and the fenced topic is left.

### Modifications

Make `ManagedLedgerImpl#deactivateCursor()` synchronized.

### Result

Fixes https://github.com/apache/pulsar/issues/2967