### PR TITLE
add topicName to fix NPE for example config debezium-mysql-source-config.yaml

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/resources/debezium-mysql-source-config.yaml
+++ b/pulsar-io/kafka-connect-adaptor/src/main/resources/debezium-mysql-source-config.yaml
@@ -20,6 +20,8 @@
 tenant: "test"
 namespace: "test-namespace"
 name: "debezium-kafka-source"
+topicName: "kafka-connect-topic"
+archive: "connectors/pulsar-io-kafka-connect-adaptor-2.3.0-SNAPSHOT.nar"
 
 ##autoAck: true
 parallelism: 1


### PR DESCRIPTION
### Motivation

With the latest master code, `pulsar-admin source localrun` would fail if no topicName was provided in the config file example.
```
$ bin/pulsar-admin source localrun  --sourceConfigFile debezium-mysql-source-config.yaml --archive connectors/pulsar-io-kafka-connect-adaptor-2.3.0-SNAPSHOT.nar
...
Exception in thread "main" java.lang.NullPointerException
	at org.apache.pulsar.functions.proto.Function$SinkSpec$Builder.setTopic(Function.java:8197)
	at org.apache.pulsar.functions.utils.SourceConfigUtils.convert(SourceConfigUtils.java:126)
	at org.apache.pulsar.functions.runtime.LocalRunner.start(LocalRunner.java:135)
	at org.apache.pulsar.functions.runtime.LocalRunner.main(LocalRunner.java:89)
```

### Modifications

Add topicName in example configuration
