### PR TITLE
reverting jackson version bump for sql

### DIFF
--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -32,7 +32,10 @@
     <name>Pulsar SQL :: Parent</name>
 
     <properties>
-        <jackson.version>2.8.1</jackson.version>
+        <jackson.version>2.8.11</jackson.version>
+        <!--fix Security Vulnerabilities-->
+        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
+        <jackson.databind.version>2.8.11.1</jackson.databind.version>
     </properties>
 
     <modules>
@@ -58,7 +61,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
 
             <dependency>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -32,7 +32,7 @@
     <name>Pulsar SQL :: Parent</name>
 
     <properties>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.8.1</jackson.version>
     </properties>
 
     <modules>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -208,20 +208,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.9.7.jar
-    - jackson-databind-2.9.7.jar
-    - jackson-dataformat-smile-2.9.7.jar
-    - jackson-datatype-guava-2.9.7.jar
-    - jackson-datatype-guava-2.9.7.jar
-    - jackson-datatype-jdk8-2.9.7.jar
-    - jackson-datatype-jdk8-2.9.7.jar
-    - jackson-datatype-joda-2.9.7.jar
-    - jackson-datatype-jsr310-2.9.7.jar
-    - jackson-core-2.9.7.jar
+    - jackson-annotations-2.8.11.jar
+    - jackson-databind-2.8.11.1.jar
+    - jackson-dataformat-smile-2.8.11.jar
+    - jackson-datatype-guava-2.8.11.jar
+    - jackson-datatype-guava-2.8.11.jar
+    - jackson-datatype-jdk8-2.8.11.jar
+    - jackson-datatype-jdk8-2.8.11.jar
+    - jackson-datatype-joda-2.8.11.jar
+    - jackson-datatype-jsr310-2.8.11.jar
+    - jackson-core-2.8.11.jar
     - jackson-core-asl-1.9.13.jar
-    - jackson-databind-2.9.7.jar
     - jackson-mapper-asl-1.9.13.jar
-    - jackson-dataformat-yaml-2.9.7.jar
+    - jackson-dataformat-yaml-2.8.11.jar
  * Guava
     - guava-21.0.jar
     - guava-24.1-jre.jar
@@ -372,7 +371,8 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-5.13.3.jar
   * SnakeYAML
-    - snakeyaml-1.23.jar
+    - snakeyaml-1.17.jar
+    - snakeyaml-1.23.jar 
   * Snappy Java
     - snappy-java-1.1.1.3.jar
   * Bean Validation API

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -109,62 +109,6 @@
             <version>${guice.version}</version>
         </dependency>
 
-        <!-- jackson dependencies -->
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-smile</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -42,7 +42,10 @@
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.8.11</jackson.version>
+        <!--fix Security Vulnerabilities-->
+        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
+        <jackson.databind.version>2.8.11.1</jackson.databind.version>
     </properties>
 
     <dependencies>
@@ -107,6 +110,62 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
             <version>${guice.version}</version>
+        </dependency>
+
+        <!-- jackson dependencies -->
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
     </dependencies>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -87,6 +87,14 @@ public class TestBasicPresto extends PulsarTestSuite {
             producer.send(stock);
         }
 
+        ContainerExecResult result = execQuery("show schemas in pulsar;");
+        assertThat(result.getExitCode()).isEqualTo(0);
+        assertThat(result.getStdout()).contains("public/default");
+
+        result = execQuery("show tables in pulsar.\"public/default\";");
+        assertThat(result.getExitCode()).isEqualTo(0);
+        assertThat(result.getStdout()).contains("stocks");
+
         ContainerExecResult containerExecResult = execQuery("select * from pulsar.\"public/default\".stocks order by entryid;");
         assertThat(containerExecResult.getExitCode()).isEqualTo(0);
         log.info("select sql query output \n{}", containerExecResult.getStdout());


### PR DESCRIPTION
### Motivation

Bumping Jackson version to 2.9.7 breaks the Presto pulsar connector since the presto version we are using packages Jackson 2.8.1 via Airlift. 

In the latest version of Airlift (version 88), Jackson 2.8.1 is packaged but presto is yet to release a version with the latest Airlift version. We will have to wait for a presto version that includes that version or later of Airlift.

I also added additional checks to presto pulsar integration test that covers that functionality that was broken because of this issue
