### PR TITLE
add replication_delay to namespace metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1224,8 +1224,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
             nsStats.msgReplBacklog += rStat.replicationBacklog;
             // replication delay for a namespace is the max repl-delay among all the topics under this namespace
-            if (rStat.replicationDelayInSeconds > nsStats.msgReplDelayInSeconds) {
-                nsStats.msgReplDelayInSeconds = rStat.replicationDelayInSeconds;
+            if (rStat.replicationDelayInSeconds > nsStats.maxMsgReplDelayInSeconds) {
+                nsStats.maxMsgReplDelayInSeconds = rStat.replicationDelayInSeconds;
             }
 
             if (replStats.isMetricsEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1223,6 +1223,10 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             topicStatsStream.endObject();
 
             nsStats.msgReplBacklog += rStat.replicationBacklog;
+            // replication delay for a namespace is the max repl-delay among all the topics under this namespace
+            if (rStat.replicationDelayInSeconds > nsStats.msgReplDelayInSeconds) {
+                nsStats.msgReplDelayInSeconds = rStat.replicationDelayInSeconds;
+            }
 
             if (replStats.isMetricsEnabled()) {
                 String namespaceClusterKey = replStats.getKeyName(namespace, cluster);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/NamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/NamespaceStats.java
@@ -33,6 +33,7 @@ public class NamespaceStats {
     public double storageSize;
     public double msgBacklog;
     public double msgReplBacklog;
+    public double msgReplDelayInSeconds;
     public int consumerCount;
     public int producerCount;
     public int replicatorCount;
@@ -50,6 +51,7 @@ public class NamespaceStats {
         this.storageSize = 0;
         this.msgBacklog = 0;
         this.msgReplBacklog = 0;
+        this.msgReplDelayInSeconds = 0;
         this.consumerCount = 0;
         this.producerCount = 0;
         this.replicatorCount = 0;
@@ -72,6 +74,7 @@ public class NamespaceStats {
         dMetrics.put("brk_no_of_consumers", consumerCount);
         dMetrics.put("brk_msg_backlog", msgBacklog);
         dMetrics.put("brk_replication_backlog", msgReplBacklog);
+        dMetrics.put("brk_replication_delay_second", msgReplDelayInSeconds);
 
         return dMetrics;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/NamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/NamespaceStats.java
@@ -33,7 +33,7 @@ public class NamespaceStats {
     public double storageSize;
     public double msgBacklog;
     public double msgReplBacklog;
-    public double msgReplDelayInSeconds;
+    public double maxMsgReplDelayInSeconds;
     public int consumerCount;
     public int producerCount;
     public int replicatorCount;
@@ -51,7 +51,7 @@ public class NamespaceStats {
         this.storageSize = 0;
         this.msgBacklog = 0;
         this.msgReplBacklog = 0;
-        this.msgReplDelayInSeconds = 0;
+        this.maxMsgReplDelayInSeconds = 0;
         this.consumerCount = 0;
         this.producerCount = 0;
         this.replicatorCount = 0;
@@ -74,7 +74,7 @@ public class NamespaceStats {
         dMetrics.put("brk_no_of_consumers", consumerCount);
         dMetrics.put("brk_msg_backlog", msgBacklog);
         dMetrics.put("brk_replication_backlog", msgReplBacklog);
-        dMetrics.put("brk_replication_delay_second", msgReplDelayInSeconds);
+        dMetrics.put("brk_max_replication_delay_second", maxMsgReplDelayInSeconds);
 
         return dMetrics;
 


### PR DESCRIPTION
### Motivation

Right now, broker metrics provide `replicationDelay` per topic level but we have setup monitoring on namespace metrics `./pulsar-admin  broker-stats monitoring-metrics` and we also need `replicationDelay` at namespace level to get estimate delay from namespace graphs.

### Modifications

Find out max replication-delay among all the topics of a namespace and use it to namespace-metrics to provide estimate repl-dealy for a namespace.


