### PR TITLE
Fix logic to validate admin calls from proxy (validateOriginalPrincipal)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -146,20 +146,16 @@ public abstract class PulsarWebResource {
 
     private static void validateOriginalPrincipal(Set<String> proxyRoles, String authenticatedPrincipal,
                                                   String originalPrincipal) {
-        if (originalPrincipal != null) {
+        if (proxyRoles.contains(authenticatedPrincipal)) {
+            // Request has come from a proxy
             if (StringUtils.isBlank(originalPrincipal)) {
                 log.warn("Original principal empty in request authenticated as {}", authenticatedPrincipal);
-                throw new RestException(Status.UNAUTHORIZED, "Original principal cannot be empty if it is set");
+                throw new RestException(Status.UNAUTHORIZED, "Original principal cannot be empty if the request is via proxy.");               
             }
             if (proxyRoles.contains(originalPrincipal)) {
                 log.warn("Original principal {} cannot be a proxy role ({})", originalPrincipal, proxyRoles);
-                throw new RestException(Status.UNAUTHORIZED, "Original principal cannot be a proxy role");
-            }
-            if (!proxyRoles.contains(authenticatedPrincipal)) {
-                log.warn("Original principal can only be accepted from a client authenticated as a proxy. "
-                        + "{} is not part of proxyRoles", authenticatedPrincipal, proxyRoles);
-                throw new RestException(Status.UNAUTHORIZED, "Original principal only accepted from proxy");
-            }
+                throw new RestException(Status.UNAUTHORIZED, "Original principal cannot be a proxy role");           
+            } 
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -301,20 +301,20 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testNonProxyCannotSetOriginalPrincipal() throws Exception {
+    public void testProxyCannotSetOriginalPrincipalAsEmpty() throws Exception {
         try (PulsarAdmin admin = buildAdminClient("admin")) {
             admin.tenants().createTenant("tenant1",
                                          new TenantInfo(ImmutableSet.of("user1"),
                                                         ImmutableSet.of("test")));
             admin.namespaces().createNamespace("tenant1/ns1");
         }
-        WebTarget root = buildWebClient("admin");
+        WebTarget root = buildWebClient("proxy");
         try {
             root.path("/admin/v2/namespaces").path("tenant1")
                 .request(MediaType.APPLICATION_JSON)
-                .header("X-Original-Principal", "user1")
+                .header("X-Original-Principal", "")
                 .get(new GenericType<List<String>>() {});
-            Assert.fail("admin shouldn't be able to act as proxy even if it is superuser");
+            Assert.fail("Proxy shouldn't be able to set original principal.");
         } catch (NotAuthorizedException e) {
             // expected
         }


### PR DESCRIPTION
As explained in https://github.com/apache/pulsar/issues/2749 :
ProxyRoles is used to identify if a request is made from a proxy machine. If it is then the original principal is mandatory and can't be empty and the original principal should not be a part of proxyRoles.


Fixed: validateOriginalPrincipal to reflect the same.