### PR TITLE
jackson.version should be 2.8.11 according to other pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.55</bouncycastle.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.8.11</jackson.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.3.7</dockerfile-maven.version>


### PR DESCRIPTION



### Motivation

according to this pr 
## reverting jackson version bump for sql #2978
we need to revert the jackson version from pom.xml also , or build will fail 

[INFO] Apache Pulsar :: Tests :: Pulsar Kafka Compat Client Tests SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.192 s
[INFO] Finished at: 2018-11-15T17:20:55+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project pulsar-common: Compilation failure: Compilation failure:
[ERROR] error reading /Users/haoli/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.7/jackson-core-2.9.7.jar; zip file is empty
[ERROR] error reading /Users/haoli/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.7/jackson-core-2.9.7.jar; zip file is empty

### Modifications

pulsar/pom.xml


### Result

build successfully after change.

[INFO] Apache Pulsar :: Tests :: Docker Images :: Latest Version Testing SUCCESS [  0.033 s]
[INFO] Apache Pulsar :: Tests :: Integration .............. SUCCESS [  9.061 s]
[INFO] Apache Pulsar :: Tests :: Pulsar Kafka Compat Client Tests SUCCESS [  6.070 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] -------------------------------------------------------------------