### PR TITLE
Handle unknown runtime exception while reading entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -231,7 +231,7 @@ public class EntryCacheImpl implements EntryCache {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
+    private void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
             final ReadEntriesCallback callback, Object ctx) {
         final long ledgerId = lh.getId();
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -162,6 +162,20 @@ public class EntryCacheImpl implements EntryCache {
     @Override
     public void asyncReadEntry(ReadHandle lh, PositionImpl position, final ReadEntryCallback callback,
             final Object ctx) {
+        try {
+            asyncReadEntry0(lh, position, callback, ctx);
+        } catch (Throwable t) {
+            log.warn("failed to read entries for {}-{}", lh.getId(), position, t);
+            // invalidate all entries related to ledger from the cache (it might happen if entry gets corrupt
+            // (entry.data is already deallocate due to any race-condition) so, invalidate cache and next time read from
+            // the bookie)
+            invalidateAllEntries(lh.getId());
+            callback.readEntryFailed(createManagedLedgerException(t), ctx);
+        }
+    }
+    
+    private void asyncReadEntry0(ReadHandle lh, PositionImpl position, final ReadEntryCallback callback,
+            final Object ctx) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Reading entry ledger {}: {}", ml.getName(), lh.getId(), position.getEntryId());
         }
@@ -202,8 +216,22 @@ public class EntryCacheImpl implements EntryCache {
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void asyncReadEntry(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
+            final ReadEntriesCallback callback, Object ctx) {
+        try {
+            asyncReadEntry0(lh, firstEntry, lastEntry, isSlowestReader, callback, ctx);
+        } catch (Throwable t) {
+            log.warn("failed to read entries for {}--{}-{}", lh.getId(), firstEntry, lastEntry, t);
+            // invalidate all entries related to ledger from the cache (it might happen if entry gets corrupt
+            // (entry.data is already deallocate due to any race-condition) so, invalidate cache and next time read from
+            // the bookie)
+            invalidateAllEntries(lh.getId());
+            callback.readEntriesFailed(createManagedLedgerException(t), ctx);
+        }
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
             final ReadEntriesCallback callback, Object ctx) {
         final long ledgerId = lh.getId();
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;


### PR DESCRIPTION
### Motivation

Recently we have seen below runtime-exception while reading entries at broker and broker is not handling it correctly and not completing read callback so, dispatch get stuck for the subscription.

```
22:16:58.424 [bookkeeper-ml-workers-OrderedExecutor-0-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.EntryImpl.create(EntryImpl.java:89) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.EntryCacheImpl.asyncReadEntry(EntryCacheImpl.java:225) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalReadFromLedger(ManagedLedgerImpl.java:1509) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncReadEntries(ManagedLedgerImpl.java:1359) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.notifyEntriesAvailable(ManagedCursorImpl.java:2221) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.lambda$notifyCursors$27(ManagedLedgerImpl.java:1580) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.7.2.jar:4.7.2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_131]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```

```
3:22:26.425 [bookkeeper-ml-workers-OrderedExecutor-10-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.EntryImpl.create(EntryImpl.java:89) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.EntryCacheImpl.asyncReadEntry(EntryCacheImpl.java:225) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalReadFromLedger(ManagedLedgerImpl.java:1509) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncReadEntries(ManagedLedgerImpl.java:1359) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.OpReadEntry.lambda$checkReadCompletion$76(OpReadEntry.java:136) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]


        06:58:57.334 [bookkeeper-ml-workers-OrderedExecutor-19-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.EntryImpl.create(EntryImpl.java:89) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.EntryCacheImpl.asyncReadEntry(EntryCacheImpl.java:225) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalReadFromLedger(ManagedLedgerImpl.java:1509) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncReadEntries(ManagedLedgerImpl.java:1359) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.notifyEntriesAvailable(ManagedCursorImpl.java:2221) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.lambda$notifyCursors$27(ManagedLedgerImpl.java:1580) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.7.2.jar:4.7.2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_131]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```

### Modifications

Handle NPE and complete the callback with failure.

### Result

Dispatch will not be blocked if there is runtime exception while reading entries.
