### PR TITLE
Use std::call_once instead of pthread_once

### DIFF
--- a/pulsar-client-cpp/lib/c/c_MessageId.cc
+++ b/pulsar-client-cpp/lib/c/c_MessageId.cc
@@ -20,10 +20,10 @@
 #include <pulsar/c/message_id.h>
 #include "c_structs.h"
 
-#include <boost/thread/once.hpp>
+#include <mutex>
 #include <sstream>
 
-boost::once_flag initialized = BOOST_ONCE_INIT;
+std::once_flag initialized;
 
 static pulsar_message_id_t earliest;
 static pulsar_message_id_t latest;
@@ -34,12 +34,12 @@ static void initialize() {
 }
 
 const pulsar_message_id_t *pulsar_message_id_earliest() {
-    boost::call_once(&initialize, initialized);
+    std::call_once(initialized, &initialize);
     return &earliest;
 }
 
 const pulsar_message_id_t *pulsar_message_id_latest() {
-    boost::call_once(&initialize, initialized);
+    std::call_once(initialized, &initialize);
     return &latest;
 }
 

--- a/pulsar-client-cpp/lib/checksum/crc32c_sw.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sw.cc
@@ -38,13 +38,13 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <boost/thread/once.hpp>
+#include <mutex>
 
 /* CRC-32C (iSCSI) polynomial in reversed bit order. */
 #define POLY 0x82f63b78
 
 /* Table for a quadword-at-a-time software crc. */
-boost::once_flag crc32c_once_sw = BOOST_ONCE_INIT;
+std::once_flag crc32c_once_sw;
 static uint32_t crc32c_table[8][256];
 
 /* Construct table for software CRC-32C calculation. */
@@ -79,7 +79,7 @@ uint32_t crc32c_sw(uint32_t crci, const void *buf, int len) {
     const char *next = (const char *)buf;
     uint64_t crc;
 
-    boost::call_once(&crc32c_init_sw, crc32c_once_sw);
+    std::call_once(crc32c_once_sw, &crc32c_init_sw);
     crc = crci ^ 0xffffffff;
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = crc32c_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);

--- a/pulsar-client-cpp/lib/checksum/crc32c_sw.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sw.cc
@@ -38,17 +38,17 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <pthread.h>
+#include <boost/thread/once.hpp>
 
 /* CRC-32C (iSCSI) polynomial in reversed bit order. */
 #define POLY 0x82f63b78
 
 /* Table for a quadword-at-a-time software crc. */
-static pthread_once_t crc32c_once_sw = PTHREAD_ONCE_INIT;
+boost::once_flag crc32c_once_sw = BOOST_ONCE_INIT;
 static uint32_t crc32c_table[8][256];
 
 /* Construct table for software CRC-32C calculation. */
-static void crc32c_init_sw(void) {
+static void crc32c_init_sw() {
     uint32_t n, crc, k;
 
     for (n = 0; n < 256; n++) {
@@ -79,7 +79,7 @@ uint32_t crc32c_sw(uint32_t crci, const void *buf, int len) {
     const char *next = (const char *)buf;
     uint64_t crc;
 
-    pthread_once(&crc32c_once_sw, crc32c_init_sw);
+    boost::call_once(&crc32c_init_sw, crc32c_once_sw);
     crc = crci ^ 0xffffffff;
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = crc32c_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);


### PR DESCRIPTION
### Motivation

Use `std::call_once` instead of `pthread_once` because it's portable across platforms.