### PR TITLE
 Fix bug for not setting resources

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.functions.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -42,7 +41,6 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.pulsar.common.functions.Utils.BUILTIN;
 import static org.apache.pulsar.functions.utils.Utils.loadJar;
 
-@Slf4j
 public class FunctionConfigUtils {
     public static FunctionDetails convert(FunctionConfig functionConfig, ClassLoader classLoader)
             throws IllegalArgumentException {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -41,6 +42,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.pulsar.common.functions.Utils.BUILTIN;
 import static org.apache.pulsar.functions.utils.Utils.loadJar;
 
+@Slf4j
 public class FunctionConfigUtils {
     public static FunctionDetails convert(FunctionConfig functionConfig, ClassLoader classLoader)
             throws IllegalArgumentException {
@@ -300,6 +302,7 @@ public class FunctionConfigUtils {
             resources.setCpu(functionDetails.getResources().getCpu());
             resources.setRam(functionDetails.getResources().getRam());
             resources.setDisk(functionDetails.getResources().getDisk());
+            functionConfig.setResources(resources);
         }
 
         return functionConfig;

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.utils;
 
 import com.google.gson.Gson;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.WindowConfig;
@@ -89,5 +90,65 @@ public class FunctionConfigUtilsTest {
                 new Gson().toJson(functionConfig),
                 new Gson().toJson(convertedConfig)
         );
+    }
+
+    @Test
+    public void testFunctionConfigConvertFromDetails() {
+        String name = "test1";
+        String namespace = "ns1";
+        String tenant = "tenant1";
+        String classname = getClass().getName();
+        int parallelism = 3;
+        Map<String, String> userConfig = new HashMap<>();
+        userConfig.put("key1", "val1");
+        Function.ProcessingGuarantees processingGuarantees = Function.ProcessingGuarantees.EFFECTIVELY_ONCE;
+        Function.FunctionDetails.Runtime runtime = Function.FunctionDetails.Runtime.JAVA;
+        Function.SinkSpec sinkSpec = Function.SinkSpec.newBuilder().setTopic("sinkTopic1").build();
+        Map<String, Function.ConsumerSpec> consumerSpecMap = new HashMap<>();
+        consumerSpecMap.put("sourceTopic1", Function.ConsumerSpec.newBuilder()
+                .setSchemaType(JSONSchema.class.getName()).build());
+        Function.SourceSpec sourceSpec = Function.SourceSpec.newBuilder()
+                .putAllInputSpecs(consumerSpecMap)
+                .setSubscriptionType(Function.SubscriptionType.FAILOVER).build();
+        boolean autoAck = true;
+        String logTopic = "log-topic1";
+        Function.Resources resources = Function.Resources.newBuilder().setCpu(1.5).setDisk(1024 * 20).setRam(1024 * 10).build();
+        String packageUrl = "http://package.url";
+        Map<String, String> secretsMap = new HashMap<>();
+        secretsMap.put("secretConfigKey1", "secretConfigVal1");
+        Function.RetryDetails retryDetails = Function.RetryDetails.newBuilder().setDeadLetterTopic("dead-letter-1").build();
+
+        Function.FunctionDetails functionDetails = Function.FunctionDetails
+                .newBuilder()
+                .setNamespace(namespace)
+                .setTenant(tenant)
+                .setName(name)
+                .setClassName(classname)
+                .setParallelism(parallelism)
+                .setUserConfig(new Gson().toJson(userConfig))
+                .setProcessingGuarantees(processingGuarantees)
+                .setRuntime(runtime)
+                .setSink(sinkSpec)
+                .setSource(sourceSpec)
+                .setAutoAck(autoAck)
+                .setLogTopic(logTopic)
+                .setResources(resources)
+                .setPackageUrl(packageUrl)
+                .setSecretsMap(new Gson().toJson(secretsMap))
+                .setRetryDetails(retryDetails)
+                .build();
+
+        FunctionConfig functionConfig = FunctionConfigUtils.convertFromDetails(functionDetails);
+
+        assertEquals(functionConfig.getTenant(), tenant);
+        assertEquals(functionConfig.getNamespace(), namespace);
+        assertEquals(functionConfig.getName(), name);
+        assertEquals(functionConfig.getClassName(), classname);
+        assertEquals(functionConfig.getLogTopic(), logTopic);
+        assertEquals(functionConfig.getResources().getCpu(), resources.getCpu());
+        assertEquals(functionConfig.getResources().getDisk().longValue(), resources.getDisk());
+        assertEquals(functionConfig.getResources().getRam().longValue(), resources.getRam());
+        assertEquals(functionConfig.getOutput(), sinkSpec.getTopic());
+        assertEquals(functionConfig.getInputSpecs().keySet(), sourceSpec.getInputSpecsMap().keySet());
     }
 }


### PR DESCRIPTION
I also added unit test.

However, I am not sure we are doing the right thing here.  The method convertFromDetails is used to convert FunctionDetails to FunctionConfig and deliver the result back to the user.   However, the functionConfig for a function that gets sent back to the user might now be the same as the one the user submitted which may cause confusion. We should come up with a story that is more consistent here.