### PR TITLE
Enforce timeout on all integration tests

### DIFF
--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -181,7 +181,7 @@
               <properties>
                 <property>
                   <name>listener</name>
-                  <value>org.apache.pulsar.tests.PulsarTestListener</value>
+                  <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener</value>
                 </property>
               </properties>
               <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
@@ -45,7 +45,7 @@ import org.testng.collections.Maps;
 @Slf4j
 public class TestCompaction extends PulsarTestSuite {
 
-    @Test(dataProvider = "ServiceUrls")
+    @Test(dataProvider = "ServiceUrls", timeOut=300_000)
     public void testPublishCompactAndConsumeCLI(String serviceUrl) throws Exception {
 
         final String tenant = "compaction-test-cli-" + randomName(4);
@@ -99,7 +99,7 @@ public class TestCompaction extends PulsarTestSuite {
         }
     }
 
-    @Test(dataProvider = "ServiceUrls")
+    @Test(dataProvider = "ServiceUrls", timeOut=300_000)
     public void testPublishCompactAndConsumeRest(String serviceUrl) throws Exception {
 
         final String tenant = "compaction-test-rest-" + randomName(4);
@@ -152,7 +152,7 @@ public class TestCompaction extends PulsarTestSuite {
         }
     }
 
-    @Test(dataProvider = "ServiceUrls")
+    @Test(dataProvider = "ServiceUrls", timeOut=300_000)
     public void testPublishCompactAndConsumePartitionedTopics(String serviceUrl) throws Exception {
 
         final String tenant = "compaction-test-partitioned-topic-" + randomName(4);
@@ -301,7 +301,7 @@ public class TestCompaction extends PulsarTestSuite {
         }
     }
 
-    @Test(dataProvider = "ServiceUrls")
+    @Test(dataProvider = "ServiceUrls", timeOut=300_000)
     public void testPublishWithAutoCompaction(String serviceUrl) throws Exception {
 
         final String tenant = "compaction-test-auto-" + randomName(4);


### PR DESCRIPTION
### Motivation

There are integration tests that are in occasions never finishing. Eg.: https://builds.apache.org/job/pulsar_precommit_integrationtests/4929/

We need to enforce a timeout on all the tests so we know which one is failing (and get a stack trace for where it was stuck at).