### PR TITLE
Prevent race condition while calculating unack-msg offset stats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -665,7 +665,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getNumberOfEntriesSinceFirstNotAckedMessage() {
-        return ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, readPosition));
+        // sometimes for already caught up consumer: due to race condition markDeletePosition > readPosition. so,
+        // validate it before preparing range
+        return (markDeletePosition.compareTo(readPosition) < 0)
+                ? ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, readPosition))
+                : 0;
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -667,6 +667,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     public long getNumberOfEntriesSinceFirstNotAckedMessage() {
         // sometimes for already caught up consumer: due to race condition markDeletePosition > readPosition. so,
         // validate it before preparing range
+        PositionImpl markDeletePosition = this.markDeletePosition;
+        PositionImpl readPosition = this.readPosition;
         return (markDeletePosition.compareTo(readPosition) < 0)
                 ? ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, readPosition))
                 : 0;


### PR DESCRIPTION
### Motivation

Sometimes, stats-generation fails with below exception while calculating unack-msg offset because `getNumberOfEntriesSinceFirstNotAckedMessage()` is not thread-safe. It happens with already caught up consumer and due to race condition `markDeletePosition` can be higher than `readPosition`.

```
21:28:13.319 [pulsar-stats-updater-22-1] ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - Got exception when creating consumer stats for subscription triton-userlocationevent-nrt-ib: Invalid range: (451537712:52987..451537712:48666]
java.lang.IllegalArgumentException: Invalid range: (451537712:52987..451537712:48666]
        at com.google.common.collect.Range.<init>(Range.java:352) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at com.google.common.collect.Range.create(Range.java:146) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at com.google.common.collect.Range.openClosed(Range.java:194) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNumberOfEntriesSinceFirstNotAckedMessage(ManagedCursorImpl.java:668) ~[managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.getNumberOfEntriesSinceFirstNotAckedMessage(PersistentSubscription.java:480) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$40(PersistentTopic.java:1287) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.updateRates(PersistentTopic.java:1252) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$5(PulsarStats.java:134) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$3(PulsarStats.java:131) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$0(PulsarStats.java:120) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-functions-metrics-2.2.2-yahoo.jar:?]
        at org.apache.pulsar.broker.service.PulsarStats.updateStats(PulsarStats.java:110) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.BrokerService.updateRates(BrokerService.java:836) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) [managed-ledger-original-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.7.2.jar:4.7.2]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_131]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_131]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [pulsar-functions-metrics-2.2.2-yahoo.jar:?]
```

### Modifications

Handle invalid range for unack-msg offset calculation while generating stats.
