### PR TITLE
Publish pulsar-standalone image along with other images

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -66,20 +66,24 @@ docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:latest
 docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:latest
+docker tag pulsar-standalone:latest ${docker_registry_org}/pulsar-standalone:latest
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
+docker tag pulsar-standalone:latest ${docker_registry_org}/pulsar-standalone:$MVN_VERSION
 
 # Push all images and tags
 docker push ${docker_registry_org}/pulsar:latest
 docker push ${docker_registry_org}/pulsar-all:latest
 docker push ${docker_registry_org}/pulsar-grafana:latest
 docker push ${docker_registry_org}/pulsar-dashboard:latest
+docker push ${docker_registry_org}/pulsar-standalone:latest
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
+docker push ${docker_registry_org}/pulsar-standalone:$MVN_VERSION
 
 echo "Finished pushing images to ${docker_registry_org}"


### PR DESCRIPTION
*Motivation*

Fixes #3013 

`pulsar-standalone` was introduced in 2.2.0 release. However the release script was not
updated to publish this image.

*Change*

add `pulsar-standalone` image to the release script
