### PR TITLE
Set version for exec-maven-plugin in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -809,7 +809,7 @@ flexible messaging model and an intuitive client API.</description>
           </exclusion>
         </exclusions>
       </dependency>
-      
+
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
@@ -1241,6 +1241,11 @@ flexible messaging model and an intuitive client API.</description>
           <configuration>
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
### Motivation

Some warnings are being printed by Maven because we're not setting the version for the exec-maven-plugin

```
WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:managed-ledger:jar:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ org.apache.pulsar:managed-ledger:[unknown-version], /Users/mmerli/prg/pulsar/managed-ledger-shaded/pom.xml, line 274, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-broker-shaded:jar:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ org.apache.pulsar:pulsar-broker-shaded:[unknown-version], /Users/mmerli/prg/pulsar/pulsar-broker-shaded/pom.xml, line 331, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-client:jar:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ org.apache.pulsar:pulsar-client:[unknown-version], /Users/mmerli/prg/pulsar/pulsar-client-shaded/pom.xml, line 192, column 15
```