### PR TITLE
[proxy] Use ProxyServlet instead of AsyncProxyServlet

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -42,14 +42,14 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.ProtocolHandlers;
 import org.eclipse.jetty.client.RedirectProtocolHandler;
 import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.proxy.AsyncProxyServlet;
+import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.util.HttpCookieStore;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class AdminProxyHandler extends AsyncProxyServlet {
+class AdminProxyHandler extends ProxyServlet {
     private static final Logger LOG = LoggerFactory.getLogger(AdminProxyHandler.class);
 
     private final ProxyConfiguration config;


### PR DESCRIPTION
*Motivation*

java.lang.IllegalStateException is thrown sometime when pulsar-admin connects through a pulsar proxy.

```
06:10:42.202 [pulsar-external-web-60] WARN  org.eclipse.jetty.io.SelectorManager - Exception while notifying connection HttpConnectionOverHTTP@3781919f::SocketChannelEndPoint@3946791f{prod-broker-2.prod-broker.default.svc.cluster.local/192.168.228.141:8080<->/192.168.122.159:41496,OPEN,fill=FI,flush=-,to=1/30000}{io=1/1,kio=1,kro=8}->HttpConnectionOverHTTP@3781919f(l:/192.168.122.159:41496 <-> r:prod-broker-2.prod-broker.default.svc.cluster.local/192.168.228.141:8080,closed=false)=>HttpChannelOverHTTP@3d79faef(exchange=HttpExchange@787b7324 req=PENDING/null@null res=PENDING/null@null)[send=HttpSenderOverHTTP@43cd18dd(req=BEGIN,snd=SENDING,failure=null)[HttpGenerator@49490f3a{s=START}],recv=HttpReceiverOverHTTP@3b153a7e(rsp=IDLE,failure=null)[HttpParser{s=START,0 of -1}]]
java.lang.IllegalStateException: The same org.eclipse.jetty.client.AsyncContentProvider instance cannot be used in multiple requests
    at org.eclipse.jetty.client.util.DeferredContentProvider.setListener(DeferredContentProvider.java:117) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpSender.send(HttpSender.java:207) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.http.HttpChannelOverHTTP.send(HttpChannelOverHTTP.java:85) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpChannel.send(HttpChannel.java:128) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpConnection.send(HttpConnection.java:201) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.http.HttpConnectionOverHTTP$Delegate.send(HttpConnectionOverHTTP.java:253) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.send(HttpConnectionOverHTTP.java:122) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.http.HttpDestinationOverHTTP.send(HttpDestinationOverHTTP.java:38) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:347) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:305) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:295) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.HttpDestination.succeeded(HttpDestination.java:229) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.AbstractConnectionPool.proceed(AbstractConnectionPool.java:154) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.AbstractConnectionPool$1.succeeded(AbstractConnectionPool.java:132) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.AbstractConnectionPool$1.succeeded(AbstractConnectionPool.java:124) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.util.Promise$Wrapper.succeeded(Promise.java:130) ~[org.eclipse.jetty-jetty-util-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.onOpen(HttpConnectionOverHTTP.java:130) ~[org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.io.SelectorManager.connectionOpened(SelectorManager.java:324) [org.eclipse.jetty-jetty-io-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.io.ManagedSelector.createEndPoint(ManagedSelector.java:254) [org.eclipse.jetty-jetty-io-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.io.ManagedSelector.access$1800(ManagedSelector.java:61) [org.eclipse.jetty-jetty-io-9.4.12.v20180830.jar:9.4.12.v20180830]
    at org.eclipse.jetty.io.ManagedSelector$CreateEndPoint.run(ManagedSelector.java:886) [org.eclipse.jetty-jetty-io-9.4.12.v20180830.jar:9.4.12.v20180830]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_181]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_181]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
```

The race condition happens somewhere in setting listener. However I have no idea how the race condition
happens. so change to use ProxyServlet to avoid this race condition.

*Changes*

Change AsyncProxyServlet to ProxyServlet

