### PR TITLE
Increase tests timeout from 2 to 5min

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.tests;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
@@ -27,7 +28,7 @@ import org.testng.annotations.ITestAnnotation;
 @SuppressWarnings("rawtypes")
 public class AnnotationListener implements IAnnotationTransformer {
 
-    private static final int DEFAULT_TEST_TIMEOUT_MILLIS = 120000;
+    private static final long DEFAULT_TEST_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
     public AnnotationListener() {
         System.out.println("Created annotation listener");


### PR DESCRIPTION
### Motivation

Some integration tests have running time of close to 2minutes and sometimes spill over and fail with timeout.

Since this is an upper bound (to avoid the CI job to get stuck for hours), there's no downside in increasing the default timeout.