### PR TITLE
Fix C++ tests after merge

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.tests;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
@@ -27,7 +28,7 @@ import org.testng.annotations.ITestAnnotation;
 @SuppressWarnings("rawtypes")
 public class AnnotationListener implements IAnnotationTransformer {
 
-    private static final int DEFAULT_TEST_TIMEOUT_MILLIS = 120000;
+    private static final long DEFAULT_TEST_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
     public AnnotationListener() {
         System.out.println("Created annotation listener");

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2200,7 +2200,7 @@ TEST(BasicEndToEndTest, testGetTopicPartitions) {
 TEST(BasicEndToEndTest, testFlushInProducer) {
     ClientConfiguration config;
     Client client(lookupUrl);
-    std::string topicName = "persistent://property/cluster/namespace/test-flush-in-producer";
+    std::string topicName = "test-flush-in-producer";
     std::string subName = "subscription-name";
     Producer producer;
     int numOfMessages = 10;
@@ -2287,10 +2287,10 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
 
 TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     Client client(lookupUrl);
-    std::string topicName = "persistent://prop/unit/ns/partition-testFlushInPartitionedProducer";
+    std::string topicName = "partition-testFlushInPartitionedProducer";
     // call admin api to make it partitioned
     std::string url =
-        adminUrl + "admin/persistent/prop/unit/ns/partition-testFlushInPartitionedProducer/partitions";
+        adminUrl + "admin/v2/persistent/public/default/partition-testFlushInPartitionedProducer/partitions";
     int res = makePutRequest(url, "5");
     int numberOfPartitions = 5;
 

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2287,7 +2287,7 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
 
 TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     Client client(lookupUrl);
-    std::string topicName = "partition-testFlushInPartitionedProducer";
+    std::string topicName = "persistent://public/default/partition-testFlushInPartitionedProducer";
     // call admin api to make it partitioned
     std::string url =
         adminUrl + "admin/v2/persistent/public/default/partition-testFlushInPartitionedProducer/partitions";


### PR DESCRIPTION
### Motivation

There was a conflict between #3003 and #3020 that made C++ tests to fail after merging because of the namespaces changes.