### PR TITLE
Issue #2751: Add check to fix NPE 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -76,12 +76,15 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     @Override
     public TypedMessageBuilder<T> value(T value) {
+        checkArgument(value != null, "Need Non-Null content value");
         this.content = ByteBuffer.wrap(schema.encode(value));
         return this;
     }
 
     @Override
     public TypedMessageBuilder<T> property(String name, String value) {
+        checkArgument(name != null, "Need Non-Null name");
+        checkArgument(value != null, "Need Non-Null value for name: " + name);
         msgMetadataBuilder.addProperties(KeyValue.newBuilder().setKey(name).setValue(value).build());
         return this;
     }
@@ -89,6 +92,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     @Override
     public TypedMessageBuilder<T> properties(Map<String, String> properties) {
         for (Map.Entry<String, String> entry : properties.entrySet()) {
+            checkArgument(entry.getKey() != null, "Need Non-Null key");
+            checkArgument(entry.getValue() != null, "Need Non-Null value for key: " + entry.getKey());
             msgMetadataBuilder
                     .addProperties(KeyValue.newBuilder().setKey(entry.getKey()).setValue(entry.getValue()).build());
         }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -163,6 +163,10 @@ public class ProducerHandler extends AbstractWebSocketHandler {
             String msg = format("Invalid Base64 message-payload error=%s", e.getMessage());
             sendAckResponse(new ProducerAck(PayloadEncodingError, msg, null, requestContext));
             return;
+        } catch (NullPointerException e) {
+            // Null payload
+            sendAckResponse(new ProducerAck(PayloadEncodingError, e.getMessage(), null, requestContext));
+            return;
         }
 
         final long msgSize = rawPayload.length;


### PR DESCRIPTION
### Motivation

We may meet NPE like this: 
```
java.lang.NullPointerException: null
at org.apache.pulsar.common.api.proto.PulsarApi$KeyValue$Builder.setValue(PulsarApi.java:1923) ~[org.apache.pulsar-pulsar-common-2.1.1-incubating.jar:2.1.1-incubating]
```
This is related to protobuf, it does not support null-able field directly.
protocolbuffers/protobuf#1606

In this fix we try to avoid this by add checking before this method is called.

