### PR TITLE
Update libcurl version included in docker images

### DIFF
--- a/pulsar-client-cpp/docker/Dockerfile
+++ b/pulsar-client-cpp/docker/Dockerfile
@@ -134,12 +134,12 @@ RUN curl -O -L  https://github.com/open-source-parsers/jsoncpp/archive/1.8.0.tar
     rm -rf /1.8.0.tar.gz /jsoncpp-1.8.0
 
 # LibCurl
-RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_58_0/curl-7.58.0.tar.gz && \
-    tar xvfz curl-7.58.0.tar.gz && \
-    cd curl-7.58.0 && \
+RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
+    tar xvfz curl-7.61.0.tar.gz && \
+    cd curl-7.61.0 && \
     CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
     make && make install && \
-    rm -rf /curl-7.58.0.tar.gz /curl-7.58.0
+    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
 
 RUN pip install twine
 

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -29,7 +29,6 @@ cd $ROOT_DIR
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'
    '2.7 cp27-cp27m'
-   '3.3 cp33-cp33m'
    '3.4 cp34-cp34m'
    '3.5 cp35-cp35m'
    '3.6 cp36-cp36m'

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -26,7 +26,6 @@ set -e
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'
    '2.7 cp27-cp27m'
-   '3.3 cp33-cp33m'
    '3.4 cp34-cp34m'
    '3.5 cp35-cp35m'
    '3.6 cp36-cp36m'

--- a/pulsar-client-cpp/docker/push-images.sh
+++ b/pulsar-client-cpp/docker/push-images.sh
@@ -28,7 +28,6 @@ DOCKER_ORG=apachepulsar
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'
    '2.7 cp27-cp27m'
-   '3.3 cp33-cp33m'
    '3.4 cp34-cp34m'
    '3.5 cp35-cp35m'
    '3.6 cp36-cp36m'

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -72,12 +72,12 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz 
     rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # LibCurl
-RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_58_0/curl-7.58.0.tar.gz && \
-    tar xvfz curl-7.58.0.tar.gz && \
-    cd curl-7.58.0 && \
+RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
+    tar xvfz curl-7.61.0.tar.gz && \
+    cd curl-7.61.0 && \
     CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
     make && make install && \
-    rm -rf /curl-7.58.0.tar.gz /curl-7.58.0
+    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
 
 RUN apt-get install -y dpkg-dev
 

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -72,11 +72,11 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz 
     rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # LibCurl
-RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_58_0/curl-7.58.0.tar.gz && \
-    tar xvfz curl-7.58.0.tar.gz && \
-    cd curl-7.58.0 && \
+RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
+    tar xvfz curl-7.61.0.tar.gz && \
+    cd curl-7.61.0 && \
     CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
     make && make install && \
-    rm -rf /curl-7.58.0.tar.gz /curl-7.58.0
+    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
 
 ENV OPENSSL_ROOT_DIR /usr/local/ssl/


### PR DESCRIPTION
This is a continuation of https://github.com/apache/pulsar/pull/3024.

1. For the debian image, we can not enable SSL unless the version of libcurl is 7.61.0 or later.
https://github.com/curl/curl/pull/2659
2. Image `apachepulsar/pulsar-build:manylinux-cp33-cp33m` can not be built due to the following error.
```
ln: creating symbolic link `/opt/python/cp33-cp33m/include/python3.3' to `/opt/python/cp33-cp33m/include/python3.3m': No such file or directory
The command '/bin/sh -c ln -s /opt/python/${PYTHON_SPEC}/include/python${PYTHON_VERSION}m /opt/python/${PYTHON_SPEC}/include/python${PYTHON_VERSION}' returned a non-zero code: 1
```
This file is not included in the latest image `quay.io/pypa/manylinux1_x86_64`.
```
[root@c22e0a446aa0 /]# ls /opt/python/

cp27-cp27m  cp27-cp27mu  cp34-cp34m  cp35-cp35m  cp36-cp36m  cp37-cp37m
```
Since Python-3.3 has already reached EOL, I think `apachepulsar/pulsar-build:manylinux-cp33-cp33m` is no longer necessary.