### PR TITLE
Disable ZK & BK fsync calls in integration tests

### DIFF
--- a/conf/zookeeper.conf
+++ b/conf/zookeeper.conf
@@ -52,4 +52,5 @@ autopurge.purgeInterval=1
 # Requires updates to be synced to media of the transaction log before finishing
 # processing the update. If this option is set to 'no', ZooKeeper will not require
 # updates to be synced to the media.
+# WARNING: it's not recommended to run a production ZK cluster with forceSync disabled.
 forceSync=yes

--- a/conf/zookeeper.conf
+++ b/conf/zookeeper.conf
@@ -48,3 +48,8 @@ autopurge.snapRetainCount=3
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
 autopurge.purgeInterval=1
+
+# Requires updates to be synced to media of the transaction log before finishing
+# processing the update. If this option is set to 'no', ZooKeeper will not require
+# updates to be synced to the media.
+forceSync=yes

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -111,6 +111,7 @@ public class PulsarCluster {
             .withEnv("clusterName", clusterName)
             .withEnv("zkServers", ZKContainer.NAME)
             .withEnv("configurationStore", CSContainer.NAME + ":" + CS_PORT)
+            .withEnv("forceSync", "no")
             .withEnv("pulsarNode", "pulsar-broker-0");
 
         this.csContainer = new CSContainer(clusterName)
@@ -136,6 +137,9 @@ public class PulsarCluster {
                         .withNetworkAliases(name)
                         .withEnv("zkServers", ZKContainer.NAME)
                         .withEnv("useHostNameAsBookieID", "true")
+                        // Disable fsyncs for tests since they're slow within the containers
+                        .withEnv("journalSyncData", "false")
+                        .withEnv("journalMaxGroupWaitMSec", "0")
                         .withEnv("clusterName", clusterName)
                 )
         );


### PR DESCRIPTION
### Motivation

Fysncs are very slow when writing within Docker containers. We should disable these in ZooKeeper and Bookies when running integration tests, since we're not really testing data durability on disk there.