### PR TITLE
[Pulsar-Flink] Add Batch Csv Sink Support

### DIFF
--- a/pulsar-flink/pom.xml
+++ b/pulsar-flink/pom.xml
@@ -58,6 +58,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.5</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-runtime_${scala.binary.version}</artifactId>
       <version>${flink.version}</version>
@@ -93,12 +100,6 @@
       <artifactId>javassist</artifactId>
       <version>3.20.0-GA</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-csv</artifactId>
-      <version>1.5</version>
     </dependency>
 
   </dependencies>

--- a/pulsar-flink/pom.xml
+++ b/pulsar-flink/pom.xml
@@ -95,6 +95,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.5</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-flink/pom.xml
+++ b/pulsar-flink/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.batch.connectors.pulsar;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BasePulsarOutputFormat.class);
+    private static final long serialVersionUID = 2304601727522060427L;
+
+    protected static String serviceUrl;
+    protected static String topicName;
+
+    protected transient Function<Throwable, MessageId> failureCallback;
+
+    protected static volatile Producer<byte[]> producer;
+
+    protected SerializationSchema<T> serializationSchema;
+
+    protected BasePulsarOutputFormat(String serviceUrl, String topicName) {
+        Preconditions.checkNotNull(serviceUrl, "serviceUrl cannot be null.");
+        Preconditions.checkArgument(StringUtils.isNotBlank(topicName),  "topicName cannot be blank.");
+
+        this.serviceUrl = serviceUrl;
+        this.topicName = topicName;
+
+        this.failureCallback = cause -> {
+            LOG.error("Error while sending record to Pulsar : " + cause.getMessage(), cause);
+            return null;
+        };
+
+        LOG.info("PulsarOutputFormat is being started to write batches to Pulsar topic {}", this.topicName);
+    }
+
+    @Override
+    public void configure(Configuration configuration) {
+
+    }
+
+    @Override
+    public void open(int taskNumber, int numTasks) throws IOException {
+        this.producer = getProducerInstance();
+    }
+
+    @Override
+    public void writeRecord(T t) throws IOException {
+        byte[] data = this.serializationSchema.serialize(t);
+        this.producer.sendAsync(data)
+                .exceptionally(this.failureCallback);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    protected static Producer<byte[]> getProducerInstance() throws PulsarClientException {
+        if(producer == null){
+            synchronized (PulsarOutputFormat.class) {
+                if(producer == null){
+                    producer = Preconditions.checkNotNull(createPulsarProducer(),
+                            "Pulsar producer cannot be null.");
+                }
+            }
+        }
+        return producer;
+    }
+
+    private static Producer<byte[]> createPulsarProducer() throws PulsarClientException {
+        try {
+            PulsarClient client = PulsarClient.builder().serviceUrl(serviceUrl).build();
+            return client.newProducer().topic(topicName).create();
+        } catch (PulsarClientException e) {
+            LOG.error("Pulsar producer cannot be created.", e);
+            throw e;
+        }
+    }
+}

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -54,11 +54,6 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
         this.serviceUrl = serviceUrl;
         this.topicName = topicName;
 
-        this.failureCallback = cause -> {
-            LOG.error("Error while sending record to Pulsar : " + cause.getMessage(), cause);
-            return null;
-        };
-
         LOG.info("PulsarOutputFormat is being started to write batches to Pulsar topic {}", this.topicName);
     }
 
@@ -70,6 +65,11 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
         this.producer = getProducerInstance();
+
+        this.failureCallback = cause -> {
+            LOG.error("Error while sending record to Pulsar : " + cause.getMessage(), cause);
+            return null;
+        };
     }
 
     @Override

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -33,22 +33,23 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.function.Function;
 
+/**
+ * Base Pulsar Output Format to write Flink DataSets into a Pulsar topic.
+ */
 public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     private static final Logger LOG = LoggerFactory.getLogger(BasePulsarOutputFormat.class);
     private static final long serialVersionUID = 2304601727522060427L;
 
+    private transient Function<Throwable, MessageId> failureCallback;
+    private static volatile Producer<byte[]> producer;
+
     protected static String serviceUrl;
     protected static String topicName;
-
-    protected transient Function<Throwable, MessageId> failureCallback;
-
-    protected static volatile Producer<byte[]> producer;
-
     protected SerializationSchema<T> serializationSchema;
 
     protected BasePulsarOutputFormat(String serviceUrl, String topicName) {
-        Preconditions.checkNotNull(serviceUrl, "serviceUrl cannot be null.");
+        Preconditions.checkArgument(StringUtils.isNotBlank(serviceUrl), "serviceUrl cannot be blank.");
         Preconditions.checkArgument(StringUtils.isNotBlank(topicName),  "topicName cannot be blank.");
 
         this.serviceUrl = serviceUrl;
@@ -84,7 +85,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     }
 
-    protected static Producer<byte[]> getProducerInstance() throws PulsarClientException {
+    private static Producer<byte[]> getProducerInstance() throws PulsarClientException {
         if(producer == null){
             synchronized (PulsarOutputFormat.class) {
                 if(producer == null){

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
@@ -18,21 +18,26 @@
  */
 package org.apache.flink.batch.connectors.pulsar;
 
-import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.batch.connectors.pulsar.serialization.CsvSerializationSchema;
 import org.apache.flink.util.Preconditions;
 
+import java.util.List;
+
 /**
- * Flink Batch Sink to write DataSets into a Pulsar topic.
+ * Flink Batch Sink to write DataSets into a Pulsar topic as Csv.
  */
-public class PulsarOutputFormat<T> extends BasePulsarOutputFormat<T> {
+public class PulsarCsvOutputFormat<T> extends BasePulsarOutputFormat<T> {
 
-    private static final long serialVersionUID = 2997027580167793000L;
+    private static final long serialVersionUID = -4461671510903404196L;
 
-    public PulsarOutputFormat(String serviceUrl, String topicName, SerializationSchema<T> serializationSchema) {
+    public PulsarCsvOutputFormat(String serviceUrl, String topicName, List<String> fieldNames) {
         super(serviceUrl, topicName);
-        Preconditions.checkNotNull(serializationSchema,  "serializationSchema cannot be null.");
+        Preconditions.checkNotNull(fieldNames,  "fieldNames cannot be null.");
+        Preconditions.checkArgument(!fieldNames.isEmpty(),  "fieldNames cannot be empty.");
+        Preconditions.checkArgument(fieldNames.stream().allMatch(fieldName -> StringUtils.isNotBlank(fieldName)),  "fieldNames cannot be null/blank.");
 
-        this.serializationSchema = serializationSchema;
+        this.serializationSchema = new CsvSerializationSchema(fieldNames);
     }
 
 }

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
@@ -18,26 +18,20 @@
  */
 package org.apache.flink.batch.connectors.pulsar;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.batch.connectors.pulsar.serialization.CsvSerializationSchema;
-import org.apache.flink.util.Preconditions;
-
-import java.util.List;
 
 /**
  * Flink Batch Sink to write DataSets into a Pulsar topic as Csv.
  */
-public class PulsarCsvOutputFormat<T> extends BasePulsarOutputFormat<T> {
+public class PulsarCsvOutputFormat<T extends Tuple> extends BasePulsarOutputFormat<T> {
 
     private static final long serialVersionUID = -4461671510903404196L;
 
-    public PulsarCsvOutputFormat(String serviceUrl, String topicName, List<String> fieldNames) {
+    public PulsarCsvOutputFormat(String serviceUrl, String topicName) {
         super(serviceUrl, topicName);
-        Preconditions.checkNotNull(fieldNames,  "fieldNames cannot be null.");
-        Preconditions.checkArgument(!fieldNames.isEmpty(),  "fieldNames cannot be empty.");
-        Preconditions.checkArgument(fieldNames.stream().allMatch(fieldName -> StringUtils.isNotBlank(fieldName)),  "fieldNames cannot be null/blank.");
 
-        this.serializationSchema = new CsvSerializationSchema(fieldNames);
+        this.serializationSchema = new CsvSerializationSchema<>();
     }
 
 }

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.batch.connectors.pulsar.serialization.CsvSerializationSchema;
 
 /**
- * Flink Batch Sink to write DataSets into a Pulsar topic as Csv.
+ * Pulsar Csv Output Format to write Flink DataSets into a Pulsar topic in Csv format.
  */
 public class PulsarCsvOutputFormat<T extends Tuple> extends BasePulsarOutputFormat<T> {
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.util.Preconditions;
 
 /**
- * Flink Batch Sink to write DataSets into a Pulsar topic.
+ * Pulsar Output Format to write Flink DataSets into a Pulsar topic in user-defined format.
  */
 public class PulsarOutputFormat<T> extends BasePulsarOutputFormat<T> {
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
@@ -27,15 +27,15 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.StringWriter;
 
+/**
+ * Csv Serialization Schema to serialize Tuples to Csv.
+ */
 public class CsvSerializationSchema<T extends Tuple> implements SerializationSchema<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CsvSerializationSchema.class);
     private static final long serialVersionUID = -3379119592495232636L;
 
     private static final int STRING_WRITER_INITIAL_BUFFER_SIZE = 256;
-
-    public CsvSerializationSchema() {
-    }
 
     @Override
     public byte[] serialize(T t) {

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
@@ -42,14 +42,14 @@ public class CsvSerializationSchema<T extends Tuple> implements SerializationSch
         StringWriter stringWriter = null;
         try {
             Object[] fieldsValues = new Object[t.getArity()];
-            for(int index = 0; index < t.getArity();  index++) {
+            for(int index = 0; index < t.getArity(); index++) {
                 fieldsValues[index] = (t.getField(index));
             }
 
             stringWriter = new StringWriter(STRING_WRITER_INITIAL_BUFFER_SIZE);
             CSVFormat.DEFAULT.withRecordSeparator("").printRecord(stringWriter, fieldsValues);
         } catch (IOException e) {
-            LOG.error("Error while serializing the record to Csv : ", e);
+            LOG.error("Error while serializing the record to Csv", e);
         }
 
         return stringWriter.toString().getBytes();

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchema.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.batch.connectors.pulsar.serialization;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CsvSerializationSchema<T> implements SerializationSchema<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CsvSerializationSchema.class);
+    private static final long serialVersionUID = -3379119592495232636L;
+
+    private static final int STRING_WRITER_INITIAL_BUFFER_SIZE = 256;
+    private List<String> fieldNames;
+    private PropertyUtils propertyUtils;
+
+    public CsvSerializationSchema(List<String> fieldNames) {
+        this.fieldNames = fieldNames;
+        propertyUtils = new PropertyUtils();
+    }
+
+    @Override
+    public byte[] serialize(T t) {
+        StringWriter stringWriter = null;
+        try {
+            Map map = propertyUtils.describe(t);
+            if(fieldNames.size() > map.size()) {
+                throw new RuntimeException("fieldNames size can not be bigger than model property size");
+            }
+
+            List<String> fieldsValues = new ArrayList<>(fieldNames.size());
+            for (String fieldName : fieldNames) {
+                Object obj = map.getOrDefault(fieldName.toLowerCase(), "");
+                fieldsValues.add(obj.toString());
+            }
+
+            stringWriter = new StringWriter(STRING_WRITER_INITIAL_BUFFER_SIZE);
+            CSVFormat.DEFAULT.printRecord(stringWriter, fieldsValues);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | IOException e) {
+            LOG.error("Error while serializing the record to Csv : ", e);
+        }
+
+        return stringWriter.toString().getBytes();
+    }
+
+}

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
@@ -20,9 +20,6 @@ package org.apache.flink.batch.connectors.pulsar;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -30,42 +27,25 @@ import static org.junit.Assert.assertNotNull;
  */
 public class PulsarCsvOutputFormatTest {
 
-    private List<String> fieldNames = Arrays.asList("test-field");
-
     @Test(expected = NullPointerException.class)
     public void testPulsarCsvOutputFormatConstructorWhenServiceUrlIsNull() {
-        new PulsarCsvOutputFormat(null, "testTopic", fieldNames);
+        new PulsarCsvOutputFormat(null, "testTopic");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPulsarCsvOutputFormatConstructorWhenTopicNameIsNull() {
-        new PulsarCsvOutputFormat("testServiceUrl", null, fieldNames);
+        new PulsarCsvOutputFormat("testServiceUrl", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPulsarCsvOutputFormatConstructorWhenTopicNameIsBlank() {
-        new PulsarCsvOutputFormat("testServiceUrl", " ", fieldNames);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyIsNull() {
-        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyIsEmpty() {
-        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", Arrays.asList());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyHasBlankFieldName() {
-        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", Arrays.asList("test-field", " "));
+        new PulsarCsvOutputFormat("testServiceUrl", " ");
     }
 
     @Test
     public void testPulsarCsvOutputFormatConstructor() {
         PulsarCsvOutputFormat pulsarCsvOutputFormat =
-                new PulsarCsvOutputFormat("testServiceUrl", "testTopic", fieldNames);
+                new PulsarCsvOutputFormat("testServiceUrl", "testTopic");
         assertNotNull(pulsarCsvOutputFormat);
     }
 }

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
@@ -23,11 +23,11 @@ import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Tests for PulsarCsvOutputFormat
+ * Tests for Pulsar Csv Output Format
  */
 public class PulsarCsvOutputFormatTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testPulsarCsvOutputFormatConstructorWhenServiceUrlIsNull() {
         new PulsarCsvOutputFormat(null, "testTopic");
     }
@@ -40,6 +40,11 @@ public class PulsarCsvOutputFormatTest {
     @Test(expected = IllegalArgumentException.class)
     public void testPulsarCsvOutputFormatConstructorWhenTopicNameIsBlank() {
         new PulsarCsvOutputFormat("testServiceUrl", " ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenServiceUrlIsBlank() {
+        new PulsarCsvOutputFormat(" ", "testTopic");
     }
 
     @Test

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormatTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.batch.connectors.pulsar;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for PulsarCsvOutputFormat
+ */
+public class PulsarCsvOutputFormatTest {
+
+    private List<String> fieldNames = Arrays.asList("test-field");
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenServiceUrlIsNull() {
+        new PulsarCsvOutputFormat(null, "testTopic", fieldNames);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenTopicNameIsNull() {
+        new PulsarCsvOutputFormat("testServiceUrl", null, fieldNames);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenTopicNameIsBlank() {
+        new PulsarCsvOutputFormat("testServiceUrl", " ", fieldNames);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyIsNull() {
+        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyIsEmpty() {
+        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", Arrays.asList());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarCsvOutputFormatConstructorWhenFieldNamesPropertyHasBlankFieldName() {
+        new PulsarCsvOutputFormat("testServiceUrl", "testTopic", Arrays.asList("test-field", " "));
+    }
+
+    @Test
+    public void testPulsarCsvOutputFormatConstructor() {
+        PulsarCsvOutputFormat pulsarCsvOutputFormat =
+                new PulsarCsvOutputFormat("testServiceUrl", "testTopic", fieldNames);
+        assertNotNull(pulsarCsvOutputFormat);
+    }
+}

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
@@ -81,8 +81,6 @@ public class PulsarOutputFormatTest {
         byte[] bytes = pulsarOutputFormat.serializationSchema.serialize(employee);
         String resultString = IOUtils.toString(bytes, StandardCharsets.UTF_8.toString());
         assertEquals(employee.toString(), resultString);
-
-
     }
 
     /**

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
@@ -18,8 +18,14 @@
  */
 package org.apache.flink.batch.connectors.pulsar;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -48,10 +54,69 @@ public class PulsarOutputFormatTest {
     }
 
     @Test
-    public void testPulsarOutputFormatConstructor() {
+    public void testPulsarOutputFormatWithStringSerializationSchema() throws IOException {
+        String input = "Wolfgang Amadeus Mozart";
         PulsarOutputFormat pulsarOutputFormat =
-                new PulsarOutputFormat("testServiceUrl", "testTopic", text -> text.toString().getBytes());
+                new PulsarOutputFormat("testServiceUrl", "testTopic",
+                        text -> text.toString().getBytes());
         assertNotNull(pulsarOutputFormat);
+        byte[] bytes = pulsarOutputFormat.serializationSchema.serialize(input);
+        String resultString = IOUtils.toString(bytes, StandardCharsets.UTF_8.toString());
+        assertEquals(input, resultString);
+    }
+
+    @Test
+    public void testPulsarOutputFormatWithCustomSerializationSchema() throws IOException {
+        Employee employee = new Employee(1, "Test Employee", "Test Department");
+        PulsarOutputFormat pulsarOutputFormat =
+                new PulsarOutputFormat("testServiceUrl", "testTopic",
+                        new EmployeeSerializationSchema());
+        assertNotNull(pulsarOutputFormat);
+
+        byte[] bytes = pulsarOutputFormat.serializationSchema.serialize(employee);
+        String resultString = IOUtils.toString(bytes, StandardCharsets.UTF_8.toString());
+        assertEquals(employee.toString(), resultString);
+
+
+    }
+
+    /**
+     * Employee Serialization Schema.
+     */
+    private class EmployeeSerializationSchema implements SerializationSchema<Employee> {
+
+        @Override
+        public byte[] serialize(Employee employee) {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append(employee.id);
+            stringBuilder.append(" - ");
+            stringBuilder.append(employee.name);
+            stringBuilder.append(" - ");
+            stringBuilder.append(employee.department);
+
+            return stringBuilder.toString().getBytes();
+        }
+    }
+
+    /**
+     * Data type for Employee Model.
+     */
+    private class Employee {
+
+        public long id;
+        public String name;
+        public String department;
+
+        public Employee(long id, String name, String department) {
+            this.id = id;
+            this.name = name;
+            this.department = department;
+        }
+
+        @Override
+        public String toString() {
+            return id + " - " + name + " - " + department;
+        }
     }
 
 }

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
@@ -29,11 +29,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Tests for PulsarOutputFormat
+ * Tests for Pulsar Output Format
  */
 public class PulsarOutputFormatTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testPulsarOutputFormatConstructorWhenServiceUrlIsNull() {
         new PulsarOutputFormat(null, "testTopic", text -> text.toString().getBytes());
     }
@@ -46,6 +46,11 @@ public class PulsarOutputFormatTest {
     @Test(expected = IllegalArgumentException.class)
     public void testPulsarOutputFormatConstructorWhenTopicNameIsBlank() {
         new PulsarOutputFormat("testServiceUrl", " ", text -> text.toString().getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarOutputFormatConstructorWhenServiceUrlIsBlank() {
+        new PulsarOutputFormat(" ", "testTopic", text -> text.toString().getBytes());
     }
 
     @Test(expected = NullPointerException.class)

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchCsvSinkExample.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchCsvSinkExample.java
@@ -47,7 +47,7 @@ public class FlinkPulsarBatchCsvSinkExample {
         // set up the execution environment
         final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-        // create PulsarOutputFormat instance
+        // create PulsarCsvOutputFormat instance
         final OutputFormat<Tuple4<Integer, String, String, String>> pulsarCsvOutputFormat =
                 new PulsarCsvOutputFormat<>(SERVICE_URL, TOPIC_NAME);
 

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchCsvSinkExample.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchCsvSinkExample.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.batch.connectors.pulsar.example;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.batch.connectors.pulsar.PulsarCsvOutputFormat;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Implements a batch program on Pulsar topic by writing Flink DataSet as Csv.
+ */
+public class FlinkPulsarBatchCsvSinkExample {
+
+    private static final List<Employee> employees = Arrays.asList(
+            new Employee(1, "John", "Tyson", "Engineering", "Test"),
+            new Employee(2, "Pamela", "Tyson", "HR", "Test"),
+            new Employee(3, "Jim", "Sun", "Finance", "Test"),
+            new Employee(4, "Michael", "Star", "Engineering", "Test"));
+
+    private static final List<String> fieldNames = Arrays.asList("id", "name", "surname", "department");
+
+    private static final String SERVICE_URL = "pulsar://127.0.0.1:6650";
+    private static final String TOPIC_NAME = "my-flink-topic";
+
+    public static void main(String[] args) throws Exception {
+
+        // set up the execution environment
+        final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+        // create PulsarOutputFormat instance
+        final OutputFormat<Employee> pulsarCsvOutputFormat =
+                new PulsarCsvOutputFormat<>(SERVICE_URL, TOPIC_NAME, fieldNames);
+
+        // create DataSet
+        DataSet<Employee> textDS = env.fromCollection(employees);
+
+        textDS.map(new MapFunction<Employee, Employee>() {
+            @Override
+            public Employee map(Employee employee) throws Exception {
+                return new Employee(employee.id,
+                        employee.name.toUpperCase(),
+                        employee.surname.toUpperCase(),
+                        employee.department.toUpperCase(),
+                        employee.company.toUpperCase());
+            }
+        })
+        // filter employees which is member of Engineering
+        .filter(wordWithCount -> wordWithCount.department.equals("Engineering"))
+        // write batch data to Pulsar
+        .output(pulsarCsvOutputFormat);
+
+        // execute program
+        env.execute("Flink - Pulsar Batch Csv");
+
+    }
+
+    /**
+     * Data type for Employee Model.
+     */
+    private static class Employee {
+
+        public long id;
+        public String name;
+        public String surname;
+        public String department;
+        public String company;
+
+        public Employee(long id, String name, String surname, String department, String company) {
+            this.id = id;
+            this.name = name;
+            this.surname = surname;
+            this.department = department;
+            this.company = company;
+        }
+
+    }
+}

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/README.md
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/README.md
@@ -1,10 +1,10 @@
 The Flink Batch Sink for Pulsar is a custom sink that enables Apache [Flink](https://flink.apache.org/) to write [DataSet](https://ci.apache.org/projects/flink/flink-docs-stable/dev/batch/index.html) to Pulsar.
 
-## Prerequisites
+# Prerequisites
 
 To use this sink, include a dependency for the `pulsar-flink` library in your Java configuration.
 
-### Maven
+# Maven
 
 If you're using Maven, add this to your `pom.xml`:
 
@@ -20,7 +20,7 @@ If you're using Maven, add this to your `pom.xml`:
 </dependency>
 ```
 
-### Gradle
+# Gradle
 
 If you're using Gradle, add this to your `build.gradle` file:
 
@@ -32,7 +32,8 @@ dependencies {
 }
 ```
 
-## Usage
+# PulsarOutputFormat
+### Usage
 
 Please find a sample usage as follows:
 
@@ -75,7 +76,7 @@ Please find a sample usage as follows:
         }
 ```
 
-## Sample Output
+### Sample Output
 
 Please find sample output for above application as follows:
 ```
@@ -89,12 +90,12 @@ encircles
 world
 ```
 
-## Complete Example
+### Complete Example
 
 You can find a complete example [here](https://github.com/apache/incubator-pulsar/tree/master/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchSinkExample.java).
 In this example, Flink DataSet is processed as word-count and being written to Pulsar.
 
-## Complete Example Output
+### Complete Example Output
 Please find sample output for above linked application as follows:
 ```
 WordWithCount { word = important, count = 1 }
@@ -104,3 +105,56 @@ WordWithCount { word = knowledge, count = 2 }
 WordWithCount { word = limited, count = 1 }
 WordWithCount { word = world, count = 1 }
 ```
+
+# PulsarCsvOutputFormat
+### Usage
+
+Please find a sample usage as follows:
+
+```java
+        public static void main(String[] args) throws Exception {
+
+            // set up the execution environment
+            final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+            // create PulsarOutputFormat instance
+            final OutputFormat<Tuple4<Integer, String, String, String>> pulsarCsvOutputFormat =
+                    new PulsarCsvOutputFormat<>(SERVICE_URL, TOPIC_NAME);
+
+            // create DataSet
+            DataSet<Tuple4<Integer, String, String, String>> employeeDS = env.fromCollection(employeeTuples);
+            // map employees' name, surname and department as upper-case
+            employeeDS.map(
+                    new MapFunction<Tuple4<Integer, String, String, String>, Tuple4<Integer, String, String, String>>() {
+                @Override
+                public Tuple4<Integer, String, String, String> map(
+                        Tuple4<Integer, String, String, String> employeeTuple) throws Exception {
+                    return new Tuple4(employeeTuple.f0,
+                            employeeTuple.f1.toUpperCase(),
+                            employeeTuple.f2.toUpperCase(),
+                            employeeTuple.f3.toUpperCase());
+                }
+            })
+            // filter employees which is member of Engineering
+            .filter(tuple -> tuple.f3.equals("ENGINEERING"))
+            // write batch data to Pulsar
+            .output(pulsarCsvOutputFormat);
+
+            // execute program
+            env.execute("Flink - Pulsar Batch Csv");
+
+        }
+```
+
+### Sample Output
+
+Please find sample output for above application as follows:
+```
+1,JOHN,TYSON,ENGINEERING
+4,MICHAEL,STAR,ENGINEERING
+```
+
+### Complete Example
+
+You can find a complete example [here](https://github.com/apache/incubator-pulsar/tree/master/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/FlinkPulsarBatchCsvSinkExample.java).
+In this example, Flink DataSet is processed as word-count and being written to Pulsar.

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/README.md
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/example/README.md
@@ -112,12 +112,21 @@ WordWithCount { word = world, count = 1 }
 Please find a sample usage as follows:
 
 ```java
+        private static final List<Tuple4<Integer, String, String, String>> employeeTuples = Arrays.asList(
+            new Tuple4(1, "John", "Tyson", "Engineering"),
+            new Tuple4(2, "Pamela", "Moon", "HR"),
+            new Tuple4(3, "Jim", "Sun", "Finance"),
+            new Tuple4(4, "Michael", "Star", "Engineering"));
+
+        private static final String SERVICE_URL = "pulsar://127.0.0.1:6650";
+        private static final String TOPIC_NAME = "my-flink-topic";
+
         public static void main(String[] args) throws Exception {
 
             // set up the execution environment
             final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-            // create PulsarOutputFormat instance
+            // create PulsarCsvOutputFormat instance
             final OutputFormat<Tuple4<Integer, String, String, String>> pulsarCsvOutputFormat =
                     new PulsarCsvOutputFormat<>(SERVICE_URL, TOPIC_NAME);
 
@@ -135,7 +144,7 @@ Please find a sample usage as follows:
                             employeeTuple.f3.toUpperCase());
                 }
             })
-            // filter employees which is member of Engineering
+            // filter employees who are member of Engineering
             .filter(tuple -> tuple.f3.equals("ENGINEERING"))
             // write batch data to Pulsar
             .output(pulsarCsvOutputFormat);

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.batch.connectors.pulsar.serialization;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for CsvSerializationSchema
+ */
+public class CsvSerializationSchemaTest {
+
+    @Test
+    public void testPulsarCsvOutputFormatWithSuccessfulCase() throws IOException {
+        List<String> fieldNames = Arrays.asList("id", "name");
+        Employee employee = new Employee(1, "Mike");
+        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
+        byte[] employeeBytes = schema.serialize(employee);
+        String str = IOUtils.toString(employeeBytes, StandardCharsets.UTF_8.toString());
+        assertEquals(str, "1,Mike");
+    }
+
+    @Test
+    public void testPulsarCsvOutputFormatWithFieldNamesPropertyHasInvalidProperty() throws IOException {
+        List<String> fieldNames = Arrays.asList("id", "invalidPropertyName2");
+        Employee employee = new Employee(1, "Mike");
+        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
+        byte[] employeeBytes = schema.serialize(employee);
+        String str = IOUtils.toString(employeeBytes, StandardCharsets.UTF_8.toString());
+        assertEquals(str, "1,");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPulsarCsvOutputFormatWhenFieldNamesPropertySizeIsBiggerThanPropertySize() throws IOException {
+        List<String> fieldNames = Arrays.asList("test-field1", "test-field2", "test-field3");
+        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
+        schema.serialize(new Employee(1, "Mike"));
+    }
+
+    /**
+     * Data type for Employee Model.
+     */
+    private class Employee {
+
+        public long id;
+        public String name;
+
+        public Employee(long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+    }
+}

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
@@ -28,12 +28,12 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for CsvSerializationSchema
+ * Tests for Csv Serialization Schema
  */
 public class CsvSerializationSchemaTest {
 
     @Test
-    public void testPulsarCsvOutputFormatWithSuccessfulCase() throws IOException {
+    public void testCsvSerializationSchemaWithSuccessfulCase() throws IOException {
         Tuple3<Integer, String, String> employee = new Tuple3(1, "Wolfgang Amadeus", "Mozart");
         CsvSerializationSchema schema = new CsvSerializationSchema();
         byte[] rowBytes = schema.serialize(employee);
@@ -42,7 +42,7 @@ public class CsvSerializationSchemaTest {
     }
 
     @Test
-    public void testPulsarCsvOutputFormatWithEmptyDataset() throws IOException {
+    public void testCsvSerializationSchemaWithEmptyRecord() throws IOException {
         Tuple3<Integer, String, String> employee = new Tuple3();
         CsvSerializationSchema schema = new CsvSerializationSchema();
         byte[] employeeBytes = schema.serialize(employee);

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/serialization/CsvSerializationSchemaTest.java
@@ -19,12 +19,11 @@
 package org.apache.flink.batch.connectors.pulsar.serialization;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,43 +34,20 @@ public class CsvSerializationSchemaTest {
 
     @Test
     public void testPulsarCsvOutputFormatWithSuccessfulCase() throws IOException {
-        List<String> fieldNames = Arrays.asList("id", "name");
-        Employee employee = new Employee(1, "Mike");
-        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
-        byte[] employeeBytes = schema.serialize(employee);
-        String str = IOUtils.toString(employeeBytes, StandardCharsets.UTF_8.toString());
-        assertEquals(str, "1,Mike");
+        Tuple3<Integer, String, String> employee = new Tuple3(1, "Wolfgang Amadeus", "Mozart");
+        CsvSerializationSchema schema = new CsvSerializationSchema();
+        byte[] rowBytes = schema.serialize(employee);
+        String csvContent = IOUtils.toString(rowBytes, StandardCharsets.UTF_8.toString());
+        assertEquals(csvContent, "1,Wolfgang Amadeus,Mozart");
     }
 
     @Test
-    public void testPulsarCsvOutputFormatWithFieldNamesPropertyHasInvalidProperty() throws IOException {
-        List<String> fieldNames = Arrays.asList("id", "invalidPropertyName2");
-        Employee employee = new Employee(1, "Mike");
-        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
+    public void testPulsarCsvOutputFormatWithEmptyDataset() throws IOException {
+        Tuple3<Integer, String, String> employee = new Tuple3();
+        CsvSerializationSchema schema = new CsvSerializationSchema();
         byte[] employeeBytes = schema.serialize(employee);
         String str = IOUtils.toString(employeeBytes, StandardCharsets.UTF_8.toString());
-        assertEquals(str, "1,");
+        assertEquals(str, ",,");
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testPulsarCsvOutputFormatWhenFieldNamesPropertySizeIsBiggerThanPropertySize() throws IOException {
-        List<String> fieldNames = Arrays.asList("test-field1", "test-field2", "test-field3");
-        CsvSerializationSchema<Employee> schema = new CsvSerializationSchema<>(fieldNames);
-        schema.serialize(new Employee(1, "Mike"));
-    }
-
-    /**
-     * Data type for Employee Model.
-     */
-    private class Employee {
-
-        public long id;
-        public String name;
-
-        public Employee(long id, String name) {
-            this.id = id;
-            this.name = name;
-        }
-
-    }
 }


### PR DESCRIPTION
### Motivation
This PR aims to add Flink - Pulsar Batch Csv Sink Support. If user works with Flink DataSet API and would like to write the DataSets to Pulsar in Csv format, this sink can help.

This is also similar approach what Flink currently offers:
```
DataSet<Tuple3<String, Integer, Double>> values = // [...]
values.writeAsCsv(filepath) // writing Datasets to FileSystem
```
Ref: [Flink Batch Sink API](https://ci.apache.org/projects/flink/flink-docs-stable/dev/batch/#data-sinks)

### Modifications
Please find the change-set as follows:

**1-** Defines `PulsarCsvOutputFormat` to write Flink Batch `DataSets` into Pulsar by providing ready `CsvSerializationSchema`.
**2-** Abstracts current implementation to support both `PulsarOutputFormat` (which supports for user-defined serialization schema) and `PulsarCsvOutputFormat`
**3-** UT Coverages
**4-** `FlinkPulsarBatchCsvSinkExample` to show how to be used by users.
**5-** `README.md `documentation
