### PR TITLE
Update dockerfile-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@ flexible messaging model and an intuitive client API.</description>
     <jackson.version>2.9.7</jackson.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
-    <dockerfile-maven.version>1.3.7</dockerfile-maven.version>
+    <dockerfile-maven.version>1.4.9</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.5.1</protobuf3.version>


### PR DESCRIPTION
### Motivation

dockerfile-maven 1.3.7 has issues connecting to newer Docker daemons. Latest version works fine.