### PR TITLE
Fixed lookup of boost_python with boost-1.68

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -117,7 +117,7 @@ if (PYTHONLIBS_VERSION_STRING MATCHES "^3.+$")
     set(BOOST_PYTHON_NAME_LIST python3;python3-mt;python-py${BOOST_PYTHON_NAME_POSTFIX};python${BOOST_PYTHON_NAME_POSTFIX}-mt;python${BOOST_PYTHON_NAME_POSTFIX})
 else ()
     # Regular boost_python
-    set(BOOST_PYTHON_NAME_LIST python;python-mt;python-py27;python27-mt)
+    set(BOOST_PYTHON_NAME_LIST python;python-mt;python-py27;python27-mt;python27)
 endif ()
 
 foreach (BOOST_PYTHON_NAME IN LISTS BOOST_PYTHON_NAME_LIST)


### PR DESCRIPTION
### Motivation

The new build image use boost-1.68 that has a different naming for the boost_python library.