### PR TITLE
Add configs for broker stats update frequency

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -510,6 +510,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     /**** --- Broker Web Stats --- ****/
     // If true, export publisher stats when returning topics stats from the admin rest api
     private boolean exposePublisherStats = true;
+    private int statsUpdateFrequencyInSecs = 60;
+    private int statsUpdateInitailDelayInSecs = 60;
 
     /**** --- Ledger Offloading --- ****/
     /****
@@ -1759,6 +1761,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public boolean isRunningStandalone() {
         return isRunningStandalone;
+    }
+
+    public int getStatsUpdateFrequencyInSecs() {
+        return statsUpdateFrequencyInSecs;
+    }
+
+    public void setStatsUpdateFrequencyInSecs(int statsUpdateFrequencyInSecs) {
+        this.statsUpdateFrequencyInSecs = statsUpdateFrequencyInSecs;
+    }
+
+    public int getStatsUpdateInitialDelayInSecs() {
+        return statsUpdateInitailDelayInSecs;
+    }
+
+    public void setStatsUpdateInitailDelayInSecs(int statsUpdateInitailDelayInSecs) {
+        this.statsUpdateInitailDelayInSecs = statsUpdateInitailDelayInSecs;
     }
 
     public void setRunningStandalone(boolean isRunningStandalone) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -311,7 +311,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         }
 
         // start other housekeeping functions
-        this.startStatsUpdater();
+        this.startStatsUpdater(
+                serviceConfig.getStatsUpdateInitialDelayInSecs(),
+                serviceConfig.getStatsUpdateFrequencyInSecs());
         this.startInactivityMonitor();
         this.startMessageExpiryMonitor();
         this.startCompactionMonitor();
@@ -321,8 +323,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         ClientCnxnAspect.registerExecutor(pulsar.getExecutor());
     }
 
-    void startStatsUpdater() {
-        statsUpdater.scheduleAtFixedRate(safeRun(this::updateRates), 60, 60, TimeUnit.SECONDS);
+    void startStatsUpdater(int statsUpdateInitailDelayInSecs, int statsUpdateFrequencyInSecs) {
+        statsUpdater.scheduleAtFixedRate(safeRun(this::updateRates),
+                statsUpdateInitailDelayInSecs, statsUpdateFrequencyInSecs, TimeUnit.SECONDS);
 
         // Ensure the broker starts up with initial stats
         updateRates();


### PR DESCRIPTION
This allows to configure the initial delay and update frequency for broker stats. This is useful for dev and test clusters.

Fixes #687 