### PR TITLE
impove the doc 'Deploying and managing Pulsar Functions'

### DIFF
--- a/site/docs/latest/functions/deployment.md
+++ b/site/docs/latest/functions/deployment.md
@@ -22,6 +22,8 @@ In order to deploy and manage Pulsar Functions, you need to have a Pulsar {% pop
 
 If you're running a non-{% popover standalone %} cluster, you'll need to obtain the service URL for the cluster. How you obtain the service URL will depend on how you deployed your Pulsar cluster.
 
+If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
+
 ## Command-line interface {#cli}
 
 Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](../../reference/CliTools#pulsar-admin-functions) interface, which contains commands such as [`create`](../../reference/CliTools#pulsar-admin-functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](../../reference/CliTools#pulsar-admin-functions-trigger) for [triggering](#triggering) functions, [`list`](../../reference/CliTools#pulsar-admin-functions-list) for listing deployed functions, and several others.

--- a/site2/docs/functions-deploying.md
+++ b/site2/docs/functions-deploying.md
@@ -23,6 +23,8 @@ In order to deploy and manage Pulsar Functions, you need to have a Pulsar cluste
 
 If you're running a non-[standalone](reference-terminology.md#standalone) cluster, you'll need to obtain the service URL for the cluster. How you obtain the service URL will depend on how you deployed your Pulsar cluster.
 
+If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
+
 ## Command-line interface
 
 Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#trigger) for [triggering](#triggering-pulsar-functions) functions, [`list`](reference-pulsar-admin.md#list-2) for listing deployed functions, and several others.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/functions-deploying.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/functions-deploying.md
@@ -24,6 +24,8 @@ In order to deploy and manage Pulsar Functions, you need to have a Pulsar cluste
 
 If you're running a non-[standalone](reference-terminology.md#standalone) cluster, you'll need to obtain the service URL for the cluster. How you obtain the service URL will depend on how you deployed your Pulsar cluster.
 
+If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
+
 ## Command-line interface
 
 Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#trigger) for [triggering](#triggering-pulsar-functions) functions, [`list`](reference-pulsar-admin.md#list-2) for listing deployed functions, and several others.

--- a/site2/website/versioned_docs/version-2.1.1-incubating/functions-deploying.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/functions-deploying.md
@@ -24,6 +24,8 @@ In order to deploy and manage Pulsar Functions, you need to have a Pulsar cluste
 
 If you're running a non-[standalone](reference-terminology.md#standalone) cluster, you'll need to obtain the service URL for the cluster. How you obtain the service URL will depend on how you deployed your Pulsar cluster.
 
+If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
+
 ## Command-line interface
 
 Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#trigger) for [triggering](#triggering-pulsar-functions) functions, [`list`](reference-pulsar-admin.md#list-2) for listing deployed functions, and several others.

--- a/site2/website/versioned_docs/version-2.2.0/functions-deploying.md
+++ b/site2/website/versioned_docs/version-2.2.0/functions-deploying.md
@@ -24,6 +24,8 @@ In order to deploy and manage Pulsar Functions, you need to have a Pulsar cluste
 
 If you're running a non-[standalone](reference-terminology.md#standalone) cluster, you'll need to obtain the service URL for the cluster. How you obtain the service URL will depend on how you deployed your Pulsar cluster.
 
+If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
+
 ## Command-line interface
 
 Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#trigger) for [triggering](#triggering-pulsar-functions) functions, [`list`](reference-pulsar-admin.md#list-2) for listing deployed functions, and several others.


### PR DESCRIPTION
Just as discussed with @jiazhai , when follow the doc [Deploying and managing Pulsar Functions](http://pulsar.apache.org/docs/en/functions-deploying/) to do python udf function create and deploy, we will encounter an exception as follow.
```bash
$ bin/pulsar-admin functions create --tenant public --namespace default --name myfunc --py myfunc.py --classname myfunc --input persistent://public/default/in --out persistent://public/default/out
"Created successfully"
$ bin/pulsar-admin functions list
myfunc
$ bin/pulsar-admin functions trigger --tenant public --namespace default --name myfunc --trigger-value "hello world"
HTTP 408 Request Timeout

Reason: HTTP 408 Request Timeout
```

With the help of @jiazhai , we found the root cause is the python environment is not ready. To be specific, we should install pulsar python client before do python udf function creating and deploy.

Maybe we should point it out clearly in the doc as following, and that is what the PR is doing.
```text
If you're going to deploy and trigger python user-defined functions, you should install [the pulsar python client](http://pulsar.apache.org/docs/en/client-libraries-python/) first.
```