### PR TITLE
Add pull-mode on Websockets

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -465,6 +465,66 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
         }
     }
 
+    @Test(timeOut = 10000)
+    public void socketPullModeTest() throws Exception {
+        final String topic = "my-property/my-ns/my-topic8";
+        final String subscription = "my-sub";
+        final String consumerUri = String.format(
+                "ws://localhost:%d/ws/v2/consumer/persistent/%s/%s?pullMode=true&subscriptionType=Shared",
+                port, topic, subscription
+        );
+        final String producerUri = String.format("ws://localhost:%d/ws/v2/producer/persistent/%s", port, topic);
+
+        URI consumeUri = URI.create(consumerUri);
+        URI produceUri = URI.create(producerUri);
+
+        WebSocketClient consumeClient1 = new WebSocketClient();
+        SimpleConsumerSocket consumeSocket1 = new SimpleConsumerSocket();
+        WebSocketClient consumeClient2 = new WebSocketClient();
+        SimpleConsumerSocket consumeSocket2 = new SimpleConsumerSocket();
+        WebSocketClient produceClient = new WebSocketClient();
+        SimpleProducerSocket produceSocket = new SimpleProducerSocket();
+
+        try {
+            consumeClient1.start();
+            consumeClient2.start();
+            ClientUpgradeRequest consumeRequest1 = new ClientUpgradeRequest();
+            ClientUpgradeRequest consumeRequest2 = new ClientUpgradeRequest();
+            Future<Session> consumerFuture1 = consumeClient1.connect(consumeSocket1, consumeUri, consumeRequest1);
+            Future<Session> consumerFuture2 = consumeClient2.connect(consumeSocket2, consumeUri, consumeRequest2);
+            log.info("Connecting to : {}", consumeUri);
+
+            // let it connect
+            Assert.assertTrue(consumerFuture1.get().isOpen());
+            Assert.assertTrue(consumerFuture2.get().isOpen());
+
+            ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
+            produceClient.start();
+            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
+            Assert.assertTrue(producerFuture.get().isOpen());
+            produceSocket.sendMessage(100);
+
+            Thread.sleep(500);
+
+            // Verify no messages received despite production
+            Assert.assertEquals(consumeSocket1.getReceivedMessagesCount(), 0);
+            Assert.assertEquals(consumeSocket2.getReceivedMessagesCount(), 0);
+
+            consumeSocket1.sendPermits(3);
+            consumeSocket2.sendPermits(2);
+            consumeSocket2.sendPermits(2);
+            consumeSocket2.sendPermits(2);
+
+            Thread.sleep(500);
+
+            Assert.assertEquals(consumeSocket1.getReceivedMessagesCount(), 3);
+            Assert.assertEquals(consumeSocket2.getReceivedMessagesCount(), 6);
+
+        } finally {
+            stopWebSocketClient(consumeClient1, consumeClient2, produceClient);
+        }
+    }
+
     private void verifyTopicStat(Client client, String baseUrl, String topic) {
         String statUrl = baseUrl + topic + "/stats";
         WebTarget webTarget = client.target(statUrl);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleConsumerSocket.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleConsumerSocket.java
@@ -81,6 +81,13 @@ public class SimpleConsumerSocket {
         this.getRemote().sendString(ack.toString());
     }
 
+    public void sendPermits(int nbPermits) throws IOException {
+        JsonObject permitMessage = new JsonObject();
+        permitMessage.add("type", new JsonPrimitive("permit"));
+        permitMessage.add("permitMessages", new JsonPrimitive(nbPermits));
+        this.getRemote().sendString(permitMessage.toString());
+    }
+
     public RemoteEndpoint getRemote() {
         return this.session.getRemote();
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -230,8 +230,8 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
                     throw new IOException("Missing required permitMessages field for 'permit' command");
                 }
                 if (this.pullMode) {
-                    int pending = pendingMessages.addAndGet(-command.permitMessages);
-                    if (pending  < 0) {
+                    int pending = pendingMessages.getAndAdd(-command.permitMessages);
+                    if (pending >= 0) {
                         // Resume delivery
                         receiveMessage();
                     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ConsumerCommand.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ConsumerCommand.java
@@ -18,13 +18,8 @@
  */
 package org.apache.pulsar.websocket.data;
 
-public class ConsumerAck {
+public class ConsumerCommand {
+    public String type;
     public String messageId;
-
-    public ConsumerAck() {
-    }
-
-    public ConsumerAck(String messageId) {
-        this.messageId = messageId;
-    }
+    public Integer permitMessages;
 }


### PR DESCRIPTION
Fix #3052

### Motivation

Pull-mode gives more control on WebSocket for back-pressure than basing on consumer acks.

### Modifications

Added a query param `pullMode` that if set to true will listen to `permit` type consumer commands that indicate a `permitMessages` number of messages to be sent by the proxy.
The change is backward compatible with the current API:
* `pullMode` is false by default
* if no `type` is sent in the `ConsumerCommand`, it assumes the message is a consumer ack.

### Result
```
wscat -c "http://localhost:8080/ws/v2/consumer/persistent/public/default/my-topic/my-subscription?receiverQueueSize=0&pullMode=true"
connected (press CTRL+C to quit)
> {"type": "permit", "permitMessages": 1}
< {"messageId":"CMgTEAA=","payload":"SGVsbG8tMA==","properties":{},"publishTime":"2018-11-26T14:22:59.817+01:00"}
> {"type": "permit", "permitMessages": 2}
< {"messageId":"CMgTEAE=","payload":"SGVsbG8tMQ==","properties":{},"publishTime":"2018-11-26T14:22:59.84+01:00"}
< {"messageId":"CMgTEAI=","payload":"SGVsbG8tMg==","properties":{},"publishTime":"2018-11-26T14:22:59.844+01:00"}
```
