### PR TITLE
WIP: option to not to use rbac in helm deployment

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/prometheus-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/prometheus-deployment.yaml
@@ -55,7 +55,9 @@ spec:
       tolerations:
 {{ toYaml .Values.prometheus.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.prometheus_rbac }}
       serviceAccount: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.prometheus.gracePeriod }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"

--- a/deployment/kubernetes/helm/pulsar/templates/prometheus-rbac.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/prometheus-rbac.yaml
@@ -18,6 +18,7 @@
 #
 
 {{- if .Values.extra.monitoring }}
+{{- if .Values.prometheus_rbac }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -54,4 +55,5 @@ subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
   namespace: {{ .Values.namespace }}
+{{- end }}
 {{- end }}

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -31,6 +31,8 @@ persistence: no
 ## will be deployed with emptyDir
 prometheus_persistence: no
 
+prometheus_rbac: yes
+
 ## which extra components to deploy
 extra:
   # Pulsar proxy

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -31,6 +31,8 @@ persistence: no
 ## will be deployed with emptyDir
 prometheus_persistence: yes
 
+prometheus_rbac: yes
+
 ## which extra components to deploy
 extra:
   # Pulsar proxy


### PR DESCRIPTION
### Motivation

Enable deployment with helm on kubernetes clusters without rbac enabled. 

### Modifications

Added prometheus_rbac value with default value yes
Added conditons around rbac block for prometheus

### Result


