### PR TITLE
Fixed C++ CMake dependency and enabled parallel build

### DIFF
--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -41,4 +41,4 @@ DOCKER_CMD="docker run -i -v $ROOT_DIR:/pulsar $IMAGE"
 find . -name CMakeCache.txt | xargs rm -f
 find . -name CMakeFiles | xargs rm -rf
 
-$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make"
+$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"

--- a/pulsar-client-cpp/examples/CMakeLists.txt
+++ b/pulsar-client-cpp/examples/CMakeLists.txt
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -60,11 +60,11 @@ add_executable(SampleConsumerCApi         ${SAMPLE_CONSUMER_C_SOURCES})
 add_executable(SampleConsumerListenerCApi         ${SAMPLE_CONSUMER_LISTENER_C_SOURCES})
 add_executable(SampleReaderCApi         ${SAMPLE_READER_C_SOURCES})
 
-target_link_libraries(SampleAsyncProducer    ${CLIENT_LIBS})
-target_link_libraries(SampleConsumer         ${CLIENT_LIBS})
-target_link_libraries(SampleConsumerListener ${CLIENT_LIBS})
-target_link_libraries(SampleProducer         ${CLIENT_LIBS})
-target_link_libraries(SampleProducerCApi     ${CLIENT_LIBS})
-target_link_libraries(SampleConsumerCApi     ${CLIENT_LIBS})
-target_link_libraries(SampleConsumerListenerCApi     ${CLIENT_LIBS})
-target_link_libraries(SampleReaderCApi     ${CLIENT_LIBS})
+target_link_libraries(SampleAsyncProducer    ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumer         ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerListener ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleProducer         ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleProducerCApi     ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerCApi     ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerListenerCApi     ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleReaderCApi     ${CLIENT_LIBS} pulsarShared)

--- a/pulsar-client-cpp/tests/CMakeLists.txt
+++ b/pulsar-client-cpp/tests/CMakeLists.txt
@@ -25,4 +25,4 @@ add_executable(main ${TEST_SOURCES})
 
 target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
-target_link_libraries(main ${CLIENT_LIBS} ${GMOCK_LIBRARY_PATH})
+target_link_libraries(main ${CLIENT_LIBS} pulsarShared ${GMOCK_LIBRARY_PATH})


### PR DESCRIPTION
### Motivation

The tests binary was not setting the dependency correctly and would fail to compile in parallel (trying to link before the library was ready).