### PR TITLE
Removed AspectJ build plugin from pulsar-broker

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -252,17 +252,6 @@
       <version>${avro.version}</version>
     </dependency>
 
-    <!-- aspectJ dependencies -->
-    <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjrt</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjweaver</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
@@ -295,30 +284,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.github.m50d</groupId>
-        <artifactId>aspectj-maven-plugin</artifactId>
-        <version>${aspectj-maven-plugin.version}</version>
-        <configuration>
-          <complianceLevel>1.8</complianceLevel>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWeaveInfo>true</showWeaveInfo>
-          <weaveDependencies>
-            <weaveDependency>
-              <groupId>org.apache.zookeeper</groupId>
-              <artifactId>zookeeper</artifactId>
-            </weaveDependency>
-          </weaveDependencies>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
### Motivation

In #3023 I had moved AspectJ to `pulsar-zookeeper-utils` module. Now the build plugin is not needed anymore in `pulsar-broker`.