### PR TITLE
Issue #2582: Schema javadoc missing from client api docs

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -74,7 +74,7 @@ serve: clean_local
 
 .PHONY: javadoc
 javadoc:
-	rm -rf api/{admin,client}
+	rm -rf api/{admin,client,pulsar-functions}
 	scripts/javadoc-gen.sh
 
 python_doc_gen:

--- a/site/scripts/javadoc-gen.sh
+++ b/site/scripts/javadoc-gen.sh
@@ -36,7 +36,8 @@ JDK_COMMON_PKGS=java.lang:java.util:java.util.concurrent:java.nio:java.net:java.
     -noqualifier $JDK_COMMON_PKGS \
     -notimestamp \
     -Xdoclint:none \
-    `find pulsar-client/src/main/java/org/apache/pulsar/client/api -name *.java`
+    `find pulsar-client/src/main/java/org/apache/pulsar/client/api -name *.java` \
+    `find pulsar-client-schema/src/main/java -name *.java | grep -v /impl/`
 
   # Java admin
   javadoc \


### PR DESCRIPTION
*Motivation*

Fixes #2582

Schema javadoc is missing from client api docs
