### PR TITLE
Python Client: fix `Consumer.unsubscribe`

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -811,7 +811,7 @@ class Consumer:
 
         This consumer object cannot be reused.
         """
-        return self._consumer.unsubcribe()
+        return self._consumer.unsubscribe()
 
     def receive(self, timeout_millis=None):
         """

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -135,6 +135,7 @@ class PulsarTest(TestCase):
         except:
             pass  # Exception is expected
 
+        consumer.unsubscribe()
         client.close()
 
     def test_tls_auth(self):


### PR DESCRIPTION
Fix a typo in `self._consumer.unsubscribe`