### PR TITLE
[Pulsar-Netty] Add Netty Connector Support for Tcp Messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-storm</module>
     <module>pulsar-flink</module>
     <module>pulsar-spark</module>
+    <module>pulsar-netty</module>
     <module>pulsar-zookeeper-utils</module>
     <module>pulsar-testclient</module>
     <module>pulsar-broker-auth-athenz</module>

--- a/pulsar-netty/pom.xml
+++ b/pulsar-netty/pom.xml
@@ -1,0 +1,77 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>pulsar-netty</artifactId>
+    <name>Pulsar Netty Connectors</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/common/PulsarUtils.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/common/PulsarUtils.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.common;
+
+import com.google.common.base.Preconditions;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PulsarUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarUtils.class);
+
+    private static volatile Producer<byte[]> producer;
+
+    public static Producer<byte[]> getProducerInstance(String serviceUrl, String topicName) throws PulsarClientException {
+        if(producer == null){
+            synchronized (PulsarUtils.class) {
+                if(producer == null){
+                    producer = Preconditions.checkNotNull(createPulsarProducer(serviceUrl, topicName),
+                            "Pulsar producer cannot be null.");
+                }
+            }
+        }
+        return producer;
+    }
+
+    private static Producer<byte[]> createPulsarProducer(String serviceUrl, String topicName) throws PulsarClientException {
+        try {
+            PulsarClient client = PulsarClient.builder().serviceUrl(serviceUrl).build();
+            return client.newProducer().topic(topicName).create();
+        } catch (PulsarClientException e) {
+            LOG.error("Pulsar producer cannot be created.", e);
+            throw e;
+        }
+    }
+}

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/serde/PulsarSerializer.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/serde/PulsarSerializer.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.serde;
+
+import java.io.Serializable;
+
+/**
+ * Pulsar Generic Serializer to serialize generic typed message to byte-array
+ */
+public interface PulsarSerializer<T> extends Serializable {
+
+    byte[] serialize(T t);
+
+}

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/serde/PulsarStringSerializer.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/serde/PulsarStringSerializer.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.serde;
+
+/**
+ * Pulsar String Serializer to serialize String message to byte-array
+ */
+public class PulsarStringSerializer implements PulsarSerializer<String> {
+
+    @Override
+    public byte[] serialize(String s) {
+        return s.getBytes();
+    }
+
+}

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarChannelInitializer.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarChannelInitializer.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.tcp.server;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.serialization.ClassResolvers;
+import io.netty.handler.codec.serialization.ObjectDecoder;
+
+import java.util.Optional;
+
+/**
+ * Pulsar Channel Initializer to support different types of decoder and handler
+ */
+public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    private Optional<ChannelInboundHandlerAdapter> decoder;
+    private ChannelInboundHandlerAdapter handler;
+
+    public PulsarChannelInitializer(Optional<ChannelInboundHandlerAdapter> decoder,
+                                    ChannelInboundHandlerAdapter handler) {
+        this.decoder = decoder;
+        this.handler = handler;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel socketChannel) throws Exception {
+        if(this.decoder.isPresent()) {
+            socketChannel.pipeline().addLast(this.decoder.get());
+        } else {
+            socketChannel.pipeline().addLast(new ObjectDecoder(Integer.MAX_VALUE,
+                    ClassResolvers.cacheDisabled(null)));
+        }
+
+        socketChannel.pipeline().addLast(this.handler);
+    }
+
+}

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServer.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServer.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.tcp.server;
+
+import com.google.common.base.Preconditions;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.netty.serde.PulsarSerializer;
+
+import java.util.Optional;
+
+/**
+ * Pulsar Tcp Server to accept any incoming data through Tcp.
+ */
+public class PulsarTcpServer<T> {
+
+    private String host;
+    private int port;
+    private String serviceUrl;
+    private String topicName;
+    private PulsarSerializer<T> pulsarSerializer;
+    private Optional<ChannelInboundHandlerAdapter> decoder;
+    private int numberOfThreads;
+
+    private PulsarTcpServer(Builder<T> builder) {
+        this.host = builder.host;
+        this.port = builder.port;
+        this.serviceUrl = builder.serviceUrl;
+        this.topicName = builder.topicName;
+        this.pulsarSerializer = builder.pulsarSerializer;
+        this.decoder = Optional.ofNullable(builder.decoder);
+        this.numberOfThreads = builder.numberOfThreads;
+    }
+
+    public void run() throws Exception {
+        EventLoopGroup bossGroup = new NioEventLoopGroup(this.numberOfThreads);
+        EventLoopGroup workerGroup = new NioEventLoopGroup(this.numberOfThreads);
+        try {
+            ServerBootstrap serverBootstrap = new ServerBootstrap();
+            serverBootstrap.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(new PulsarChannelInitializer(this.decoder,
+                            new PulsarTcpServerHandler(this.serviceUrl, this.topicName, this.pulsarSerializer)))
+                    .option(ChannelOption.SO_BACKLOG, 1024)
+                    .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+            ChannelFuture channelFuture = serverBootstrap.bind(this.host, this.port).sync();
+            channelFuture.channel().closeFuture().sync();
+        } finally {
+            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully();
+        }
+    }
+
+    /**
+     * Pulsar Tcp Server Builder.
+     */
+    public static class Builder<T> {
+
+        private String host;
+        private int port;
+        private String serviceUrl;
+        private String topicName;
+        private PulsarSerializer pulsarSerializer;
+        private ChannelInboundHandlerAdapter decoder;
+        private int numberOfThreads;
+
+        public Builder<T> setHost(String host) {
+            Preconditions.checkArgument(StringUtils.isNotBlank(host), "host cannot be blank");
+            this.host = host;
+            return this;
+        }
+
+        public Builder<T> setPort(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder<T> setServiceUrl(String serviceUrl) {
+            Preconditions.checkArgument(StringUtils.isNotBlank(serviceUrl), "serviceUrl cannot be blank");
+            this.serviceUrl = serviceUrl;
+            return this;
+        }
+
+        public Builder<T> setTopicName(String topicName) {
+            Preconditions.checkArgument(StringUtils.isNotBlank(topicName), "topicName cannot be blank");
+            this.topicName = topicName;
+            return this;
+        }
+
+        public Builder<T> setPulsarSerializer(PulsarSerializer<T> pulsarSerializer) {
+            this.pulsarSerializer = Preconditions.checkNotNull(pulsarSerializer, "pulsarSerializer cannot be null");
+            return this;
+        }
+
+        public Builder<T> setDecoder(ChannelInboundHandlerAdapter decoder) {
+            this.decoder = decoder;
+            return this;
+        }
+
+        public Builder<T> setNumberOfThreads(int numberOfThreads) {
+            Preconditions.checkArgument(numberOfThreads > 0, "numberOfThreads must be positive");
+            this.numberOfThreads = numberOfThreads;
+            return this;
+        }
+
+        public PulsarTcpServer<T> build() {
+            Preconditions.checkNotNull(this.host, "host must be set");
+            Preconditions.checkArgument(this.port >= 1024, "port must be set equal or bigger than 1024");
+            Preconditions.checkNotNull(this.serviceUrl, "serviceUrl must be set");
+            Preconditions.checkNotNull(this.topicName, "topicName must be set");
+            Preconditions.checkNotNull(this.pulsarSerializer, "pulsarSerializer must be set");
+            Preconditions.checkArgument(this.numberOfThreads > 0,
+                    "numberOfThreads must be set as positive");
+
+            return new PulsarTcpServer<>(this);
+        }
+    }
+
+}

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServer.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServer.java
@@ -83,7 +83,7 @@ public class PulsarTcpServer<T> {
         private int port;
         private String serviceUrl;
         private String topicName;
-        private PulsarSerializer pulsarSerializer;
+        private PulsarSerializer<T> pulsarSerializer;
         private ChannelInboundHandlerAdapter decoder;
         private int numberOfThreads;
 

--- a/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServerHandler.java
+++ b/pulsar-netty/src/main/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServerHandler.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.tcp.server;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.netty.serde.PulsarSerializer;
+import org.apache.pulsar.netty.common.PulsarUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
+
+/**
+ * Handles a server-side channel
+ */
+@ChannelHandler.Sharable
+public class PulsarTcpServerHandler<T> extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarTcpServerHandler.class);
+    private String serviceUrl;
+    private String topicName;
+    private PulsarSerializer<T> pulsarSerializer;
+    private Function<Throwable, MessageId> failureCallback;
+
+    public PulsarTcpServerHandler(String serviceUrl, String topicName, PulsarSerializer<T> pulsarSerializer) {
+        this.serviceUrl = serviceUrl;
+        this.topicName = topicName;
+        this.pulsarSerializer = pulsarSerializer;
+
+        this.failureCallback = cause -> {
+            LOG.error("Error while sending record to Pulsar : " + cause.getMessage(), cause);
+            return null;
+        };
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg)
+            throws Exception {
+        T t = (T) msg;
+        byte[] dataBytes = this.pulsarSerializer.serialize(t);
+        PulsarUtils.getProducerInstance(this.serviceUrl, this.topicName)
+            .sendAsync(dataBytes)
+            .exceptionally(failureCallback);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        LOG.error("Error when processing incoming data", cause);
+        ctx.close();
+    }
+
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/PulsarTcpServerWithPojoMessageExample.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/PulsarTcpServerWithPojoMessageExample.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.example;
+
+import org.apache.pulsar.netty.serde.PulsarSerializer;
+import org.apache.pulsar.netty.tcp.server.PulsarTcpServer;
+
+public class PulsarTcpServerWithPojoMessageExample {
+
+    private static String HOST = "localhost";
+    private static int PORT = 8999;
+    private static final String SERVICE_URL = "pulsar://127.0.0.1:6650";
+    private static final String TOPIC_NAME = "my-netty-topic";
+
+    public static void main(String[] args) throws Exception {
+        PulsarTcpServer<User> pulsarTcpServer = new PulsarTcpServer.Builder<User>()
+                .setHost(HOST)
+                .setPort(PORT)
+                .setServiceUrl(SERVICE_URL)
+                .setTopicName(TOPIC_NAME)
+                .setNumberOfThreads(2)
+                .setPulsarSerializer(new MyPulsarSerializer())
+                .build();
+        pulsarTcpServer.run();
+    }
+
+    private static class MyPulsarSerializer implements PulsarSerializer<User> {
+        @Override
+        public byte[] serialize(User user) {
+            return user.toString().getBytes();
+        }
+    }
+
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/PulsarTcpServerWithStringMessageExample.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/PulsarTcpServerWithStringMessageExample.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.example;
+
+import io.netty.handler.codec.string.StringDecoder;
+import org.apache.pulsar.netty.serde.PulsarSerializer;
+import org.apache.pulsar.netty.tcp.server.PulsarTcpServer;
+
+public class PulsarTcpServerWithStringMessageExample {
+
+    private static String HOST = "localhost";
+    private static int PORT = 8999;
+    private static final String SERVICE_URL = "pulsar://127.0.0.1:6650";
+    private static final String TOPIC_NAME = "my-netty-topic";
+
+    public static void main(String[] args) throws Exception {
+
+        PulsarTcpServer<String> pulsarTcpServer = new PulsarTcpServer.Builder<String>()
+                .setHost(HOST)
+                .setPort(PORT)
+                .setServiceUrl(SERVICE_URL)
+                .setTopicName(TOPIC_NAME)
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new MyUpperCaseStringSerializer())
+                .build();
+
+        pulsarTcpServer.run();
+    }
+
+    private static class MyUpperCaseStringSerializer implements PulsarSerializer<String> {
+
+        @Override
+        public byte[] serialize(String s) {
+            return s.toUpperCase().getBytes();
+        }
+
+    }
+
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/README.md
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/README.md
@@ -1,0 +1,99 @@
+The Pulsar Netty Connector enables Tcp Clients [Netty](https://netty.io/) to write Tcp messages to Pulsar.
+
+# Prerequisites
+
+To use this connector, include a dependency for the `pulsar-netty` library in your Java configuration.
+
+# Maven
+
+If you're using Maven, add this to your `pom.xml`:
+
+```xml
+<!-- in your <properties> block -->
+<pulsar.version>{{pulsar:version}}</pulsar.version>
+
+<!-- in your <dependencies> block -->
+<dependency>
+  <groupId>org.apache.pulsar</groupId>
+  <artifactId>pulsar-netty</artifactId>
+  <version>${pulsar.version}</version>
+</dependency>
+```
+
+# Gradle
+
+If you're using Gradle, add this to your `build.gradle` file:
+
+```groovy
+def pulsarVersion = "{{pulsar:version}}"
+
+dependencies {
+    compile group: 'org.apache.pulsar', name: 'pulsar-netty', version: pulsarVersion
+}
+```
+
+# PulsarTcpServer
+### Usage
+
+Please find a sample usage as follows. Custom Serializer is used in this example. Also, `PulsarStringSerializer` can be used:
+
+```java
+        private static String HOST = "localhost";
+        private static int PORT = 8999;
+        private static final String SERVICE_URL = "pulsar://127.0.0.1:6650";
+        private static final String TOPIC_NAME = "my-netty-topic";
+
+        public static void main(String[] args) throws Exception {
+
+            PulsarTcpServer<String> pulsarTcpServer = new PulsarTcpServer.Builder<String>()
+                    .setHost(HOST)
+                    .setPort(PORT)
+                    .setServiceUrl(SERVICE_URL)
+                    .setTopicName(TOPIC_NAME)
+                    .setNumberOfThreads(2)
+                    .setDecoder(new StringDecoder())
+                    .setPulsarSerializer(new MyUpperCaseStringSerializer())
+                    .build();
+
+            pulsarTcpServer.run();
+        }
+
+        private static class MyUpperCaseStringSerializer implements PulsarSerializer<String> {
+
+            @Override
+            public byte[] serialize(String s) {
+                return s.toUpperCase().getBytes();
+            }
+
+        }
+```
+
+###  Tcp Client
+
+Please use telnet as Tcp client to send messages as follows:
+```
+telnet localhost 8999
+```
+
+### Sample Output
+
+Please find sample input and output for above application as follows:
+
+**Input:**
+```
+Houston, we do not have a problem :)
+```
+
+**Output:**
+```
+HOUSTON, WE DO NOT HAVE A PROBLEM :)
+```
+
+### Complete Example
+
+You can find a complete examples [here](https://github.com/apache/incubator-pulsar/tree/master/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/).
+In this example, Incoming Tcp messages are being written to Pulsar.
+
+### References
+https://netty.io/wiki/user-guide-for-4.x.html
+https://netty.io/wiki/

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/User.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/example/User.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.example;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+    private Long id;
+    private String name;
+
+    public User(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "User: " +
+                "id " + id +
+                " - name: " + name;
+    }
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/serde/PulsarStringSerializerTest.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/serde/PulsarStringSerializerTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.serde;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for Pulsar String Serializer
+ */
+public class PulsarStringSerializerTest {
+
+    @Test
+    public void testPulsarStringSerializer() throws IOException {
+        String expectedContent = "This is the test content";
+        PulsarStringSerializer pulsarStringSerializer = new PulsarStringSerializer();
+        byte[] bytes = pulsarStringSerializer.serialize(expectedContent);
+        String actualContent = IOUtils.toString(bytes, StandardCharsets.UTF_8.toString());
+        assertEquals(expectedContent, actualContent);
+    }
+
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/tcp/server/PulsarChannelInitializerTest.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/tcp/server/PulsarChannelInitializerTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.tcp.server;
+
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.string.StringDecoder;
+import org.apache.pulsar.netty.serde.PulsarStringSerializer;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for Pulsar Channel Initializer
+ */
+public class PulsarChannelInitializerTest {
+
+    @Test
+    public void testGenericChannelInitializerWhenDecoderIsSet() throws Exception {
+        NioSocketChannel channel = new NioSocketChannel();
+
+        PulsarChannelInitializer pulsarChannelInitializer = new PulsarChannelInitializer(
+                Optional.ofNullable(new StringDecoder()),
+                new PulsarTcpServerHandler<>("testServiceUrl", "testTopic", new PulsarStringSerializer()));
+        pulsarChannelInitializer.initChannel(channel);
+
+        assertNotNull(channel.pipeline().toMap());
+        assertEquals(2, channel.pipeline().toMap().size());
+    }
+
+    @Test
+    public void testGenericChannelInitializerWhenDecoderIsNotSet() throws Exception {
+        NioSocketChannel channel = new NioSocketChannel();
+
+        PulsarChannelInitializer pulsarChannelInitializer = new PulsarChannelInitializer(
+                Optional.empty(),
+                new PulsarTcpServerHandler<>("testServiceUrl", "testTopic", new PulsarStringSerializer()));
+        pulsarChannelInitializer.initChannel(channel);
+
+        assertNotNull(channel.pipeline().toMap());
+        assertEquals(2, channel.pipeline().toMap().size());
+    }
+
+}

--- a/pulsar-netty/src/test/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServerTest.java
+++ b/pulsar-netty/src/test/java/org/apache/pulsar/netty/tcp/server/PulsarTcpServerTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.netty.tcp.server;
+
+import io.netty.handler.codec.string.StringDecoder;
+import org.apache.pulsar.netty.serde.PulsarStringSerializer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for Pulsar Tcp Server
+ */
+public class PulsarTcpServerTest {
+
+    @Test
+    public void testPulsarTcpServerConstructor() {
+        PulsarTcpServer<String> pulsarTcpServer = new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+
+        assertNotNull(pulsarTcpServer);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarTcpServerConstructorWhenHostIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerConstructorWhenPortIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarTcpServerConstructorWhenServiceUrlIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarTcpServerConstructorWhenTopicNameIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerConstructorWhenNumberOfThreadsIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test
+    public void testPulsarTcpServerConstructorWhenDecoderIsNotSet() {
+        PulsarTcpServer<String> pulsarTcpServer = new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+
+        assertNotNull(pulsarTcpServer);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPulsarTcpServerConstructorWhenPulsarSerializerIsNotSet() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenHostIsSetAsBlank() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost(" ")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenPortIsSetAsZero() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(0)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenPortIsSetLowerThan1024() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(1022)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenServiceUrlIsSetAsBlank() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl(" ")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenTopicNameIsSetAsBlank() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName(" ")
+                .setNumberOfThreads(2)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPulsarTcpServerWhenNumberOfThreadsIsSetAsZero() {
+        new PulsarTcpServer.Builder<String>()
+                .setHost("localhost")
+                .setPort(10999)
+                .setServiceUrl("pulsar://127.0.0.1:6650")
+                .setTopicName("my-netty-topic")
+                .setNumberOfThreads(0)
+                .setDecoder(new StringDecoder())
+                .setPulsarSerializer(new PulsarStringSerializer())
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation
Netty is NIO client server framework by supporting asynchronous event-driven communication and custom protocol implementation.
**Ref:** https://netty.io/ 

This PR proposes `Pulsar-Netty` Connector by helping the Tcp clients. It enables an embedded Tcp Server to listen incoming Tcp messages and writes them to Pulsar by behaving as Pulsar Source.

There are also other potential use-cases for this connector as follows:
- `Tcp Client` (Pulsar Sink): It can listen Pulsar messages and can write to remote Tcp Server.
- `Http Server` and `Client` (Pulsar Source and Sink)
- `Udp Server` and `Client` (Pulsar Source and Sink)
- Also `Pulsar Functions` can be applied to incoming Tcp, Http and Udp messages through related topics.

### Modifications
1- `PulsarTcpServer`: Initializes an embedded Tcp Server to listen incoming Tcp Requests
2- `PulsarTcpServerHandler`: Inbound Channel Handler to handle incoming Tcp Requests
3- `PulsarChannelInitializer`: Pulsar Channel Initializer to support different types of decoders and handlers
4- `PulsarSerializer`: Pulsar Generic Serializer Interface to serialize generic typed objects to byte-array
5- `PulsarStringSerializer`: String Implementation of Generic Serializer Interface as user-ready
6- `PulsarUtils`: Initializes and services singleton Pulsar Producer
7- UT Coverage
8- `Examples`: Covers both String and Pojo based message examples
9- `README.md`