### PR TITLE
Fixed protobuf-shaded/pom.xml with correct version

### DIFF
--- a/protobuf-shaded/pom.xml
+++ b/protobuf-shaded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
### Motivation

Parent link was still stuck on 2.2 version.