### PR TITLE
Exception Handling for Null Pointer Exception in BrokerService

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -433,7 +433,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 } catch (PulsarServerException.NotFoundException ne) {
                     log.warn("Broker load-manager znode doesn't exist ", ne);
                     // still continue and release bundle ownership as broker's registration node doesn't exist.
-                } catch (NullPointerException ne) {
+if (pulsar.getLoadManager() != null && pulsar.getLoadManager().get() != null)
                     log.warn("Broker load-manager reference returns a null value ", ne);
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -429,12 +429,14 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             // make broker-node unavailable from the cluster
             if (pulsar.getLoadManager() != null) {
                 try {
-                    pulsar.getLoadManager().get().disableBroker();
+                    if (pulsar.getLoadManager() == null || pulsar.getLoadManager().get() == null) {
+                        log.warn("Broker load-manager reference returns a null value ");
+                    } else {
+                        pulsar.getLoadManager().get().disableBroker();
+                    }
                 } catch (PulsarServerException.NotFoundException ne) {
                     log.warn("Broker load-manager znode doesn't exist ", ne);
                     // still continue and release bundle ownership as broker's registration node doesn't exist.
-if (pulsar.getLoadManager() != null && pulsar.getLoadManager().get() != null)
-                    log.warn("Broker load-manager reference returns a null value ", ne);
                 }
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -433,6 +433,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 } catch (PulsarServerException.NotFoundException ne) {
                     log.warn("Broker load-manager znode doesn't exist ", ne);
                     // still continue and release bundle ownership as broker's registration node doesn't exist.
+                } catch (NullPointerException ne) {
+                    log.warn("Broker load-manager reference returns a null value ", ne);
                 }
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -427,13 +427,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public void unloadNamespaceBundlesGracefully() {
         try {
             // make broker-node unavailable from the cluster
-            if (pulsar.getLoadManager() != null) {
+            if (pulsar.getLoadManager() != null && pulsar.getLoadManager().get() != null) {
                 try {
-                    if (pulsar.getLoadManager() == null || pulsar.getLoadManager().get() == null) {
-                        log.warn("Broker load-manager reference returns a null value ");
-                    } else {
-                        pulsar.getLoadManager().get().disableBroker();
-                    }
+                    pulsar.getLoadManager().get().disableBroker();
                 } catch (PulsarServerException.NotFoundException ne) {
                     log.warn("Broker load-manager znode doesn't exist ", ne);
                     // still continue and release bundle ownership as broker's registration node doesn't exist.


### PR DESCRIPTION
### Motivation
In a unit test under pulsar-broker, I have found that some NullPointerExceptions were thrown, although the tests had passed. I decided it will be best if we minimized the number of such exceptions as they are usually not intentionally thrown.

### Modifications
I have added a catch clause to capture the NullPointerException found in BrokerService.

### Result
The NullPointerException will no longer occur.
