### PR TITLE
Correct instances of 'availble' found

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -824,7 +824,7 @@ class Consumer:
 
         * `timeout_millis`:
           If specified, the receive will raise an exception if a message is not
-          availble within the timeout.
+          available within the timeout.
         """
         if timeout_millis is None:
             return self._consumer.receive()

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * This file defines the SecretsProviderConfigurator that will be used by default for running in Kubernetes.
  * As such this implementation is strictly when workers are configured to use kubernetes runtime.
  * We use kubernetes in built secrets and bind them as environment variables within the function container
- * to ensure that the secrets are availble to the function at runtime. Then we plug in the
+ * to ensure that the secrets are available to the function at runtime. Then we plug in the
  * EnvironmentBasedSecretsConfig as the secrets provider who knows how to read these environment variables
  */
 public class KubernetesSecretsProviderConfigurator implements SecretsProviderConfigurator {


### PR DESCRIPTION
Fix another typo

The Java one was discovered during `git grep availble`.