### PR TITLE
[bookkeeper] bump bookkeeper version to 4.7.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -368,28 +368,28 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-web-2.10.0.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.7.2.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.7.2.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.7.2.jar
-    - org.apache.bookkeeper-circe-checksum-4.7.2.jar
-    - org.apache.bookkeeper-statelib-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-api-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-common-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-server-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.7.2.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.7.2.jar
-    - org.apache.bookkeeper.http-http-server-4.7.2.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.7.2.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.7.2.jar
-    - org.apache.bookkeeper.tests-stream-storage-tests-common-4.7.2.jar
-    - org.apache.distributedlog-distributedlog-common-4.7.2.jar
-    - org.apache.distributedlog-distributedlog-core-4.7.2-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.7.2.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.7.2.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.7.2.jar
+    - org.apache.bookkeeper-bookkeeper-common-4.7.3.jar
+    - org.apache.bookkeeper-bookkeeper-proto-4.7.3.jar
+    - org.apache.bookkeeper-bookkeeper-server-4.7.3.jar
+    - org.apache.bookkeeper-circe-checksum-4.7.3.jar
+    - org.apache.bookkeeper-statelib-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-api-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-common-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-base-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-proto-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-server-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-service-api-4.7.3.jar
+    - org.apache.bookkeeper-stream-storage-service-impl-4.7.3.jar
+    - org.apache.bookkeeper.http-http-server-4.7.3.jar
+    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.7.3.jar
+    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.7.3.jar
+    - org.apache.bookkeeper.tests-stream-storage-tests-common-4.7.3.jar
+    - org.apache.distributedlog-distributedlog-common-4.7.3.jar
+    - org.apache.distributedlog-distributedlog-core-4.7.3-tests.jar
+    - org.apache.distributedlog-distributedlog-core-4.7.3.jar
+    - org.apache.distributedlog-distributedlog-protocol-4.7.3.jar
+    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.7.3.jar
  * LZ4 -- org.lz4-lz4-java-1.5.0.jar
  * AsyncHttpClient
     - org.asynchttpclient-async-http-client-2.1.0-alpha26.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.15</commons-compress.version>
 
-    <bookkeeper.version>4.7.2</bookkeeper.version>
+    <bookkeeper.version>4.7.3</bookkeeper.version>
     <zookeeper.version>3.4.13</zookeeper.version>
     <netty.version>4.1.22.Final</netty.version>
     <storm.version>1.0.5</storm.version>

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -60,7 +60,6 @@ import org.apache.bookkeeper.stream.proto.NamespaceProperties;
 import org.apache.bookkeeper.stream.server.StreamStorageLifecycleComponent;
 import org.apache.bookkeeper.stream.storage.api.cluster.ClusterInitializer;
 import org.apache.bookkeeper.stream.storage.impl.cluster.ZkClusterInitializer;
-import org.apache.bookkeeper.util.MathUtils;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -429,7 +428,7 @@ public class LocalBookkeeperEnsemble {
     }
 
     public static boolean waitForServerUp(String hp, long timeout) {
-        long start = MathUtils.now();
+        long start = System.currentTimeMillis();
         String split[] = hp.split(":");
         String host = split[0];
         int port = Integer.parseInt(split[1]);
@@ -459,7 +458,7 @@ public class LocalBookkeeperEnsemble {
                 LOG.info("server " + hp + " not up " + e);
             }
 
-            if (MathUtils.now() > start + timeout) {
+            if (System.currentTimeMillis() > start + timeout) {
                 break;
             }
             try {


### PR DESCRIPTION
*Motivation*

There are bunch of fixes in 4.7.3 regarding dns cache, ledger storage flushes.
4.7.3 is a minor release of 4.7.2, so it is safe to upgrade and included in 2.2.1 release

