### PR TITLE
Ensure that the input topic exists before doing trigger

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1041,6 +1041,12 @@ public abstract class ComponentImpl {
 
             return Response.status(Status.BAD_REQUEST).build();
         }
+        try {
+            worker().getBrokerAdmin().topics().getSubscriptions(inputTopicToWrite);
+        } catch (PulsarAdminException e) {
+            log.error("Function in trigger function is not ready @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.BAD_REQUEST).build();
+        }
         String outputTopic = functionMetaData.getFunctionDetails().getSink().getTopic();
         Reader<byte[]> reader = null;
         Producer<byte[]> producer = null;


### PR DESCRIPTION
### Motivation

If a function is created but not yet running(still initializing), and you do a triggerFunction, we need to check if the input topic exists before we  can write to it. Otherwise the trigger producer could go in first and establish a byte schema and later the function wont be able to start because of invalid schema.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
