### PR TITLE
Force to load LZ4 JNI wrapper

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecLZ4.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecLZ4.java
@@ -32,6 +32,11 @@ import net.jpountz.lz4.LZ4FastDecompressor;
  */
 public class CompressionCodecLZ4 implements CompressionCodec {
 
+    static {
+        // Force the attempt to load LZ4 JNI
+        net.jpountz.util.Native.load();
+    }
+
     private static final LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
     private static final LZ4Compressor compressor = lz4Factory.fastCompressor();
     private static final LZ4FastDecompressor decompressor = lz4Factory.fastDecompressor();


### PR DESCRIPTION
### Motivation

In newer `lz4-java` JNI wrapper, the JNI library is not automatically loaded (or attempted to be loaded): calling explicitly so that we use the more performant C library instead of the Java based fallback code.