### PR TITLE
Use raw message when manually parsing messages from topic storage

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.api.raw;
 
 import io.netty.buffer.ByteBuf;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
@@ -1,0 +1,86 @@
+package org.apache.pulsar.common.api.raw;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * View of a message that exposes the internal direct-memory buffer for more efficient processing.
+ *
+ * The message needs to be released when the processing is done.
+ */
+public interface RawMessage {
+
+    /**
+     * Release all the resources associated with this raw message
+     */
+    void release();
+
+    /**
+     * Return the properties attached to the message.
+     *
+     * Properties are application defined key/value pairs that will be attached to the message
+     *
+     * @return an unmodifiable view of the properties map
+     */
+    Map<String, String> getProperties();
+
+    /**
+     * Get the content of the message
+     *
+     * @return the byte array with the message payload
+     */
+    ByteBuf getData();
+
+    /**
+     * Get the unique message ID associated with this message.
+     *
+     * The message id can be used to univocally refer to a message without having the keep the entire payload in memory.
+     *
+     * Only messages received from the consumer will have a message id assigned.
+     *
+     * @return the message id null if this message was not received by this client instance
+     */
+    RawMessageId getMessageId();
+
+    /**
+     * Get the publish time of this message. The publish time is the timestamp that a client publish the message.
+     *
+     * @return publish time of this message.
+     * @see #getEventTime()
+     */
+    long getPublishTime();
+
+    /**
+     * Get the event time associated with this message. It is typically set by the applications via
+     * {@link MessageBuilder#setEventTime(long)}.
+     *
+     * <p>
+     * If there isn't any event time associated with this event, it will return 0.
+     */
+    long getEventTime();
+
+    /**
+     * Get the sequence id associated with this message. It is typically set by the applications via
+     * {@link MessageBuilder#setSequenceId(long)}.
+     *
+     * @return sequence id associated with this message.
+     * @see MessageBuilder#setEventTime(long)
+     */
+    long getSequenceId();
+
+    /**
+     * Get the producer name who produced this message.
+     *
+     * @return producer name who produced this message, null if producer name is not set.
+     */
+    String getProducerName();
+
+    /**
+     * Get the key of the message
+     *
+     * @return the key of the message
+     */
+    Optional<String> getKey();
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageId.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageId.java
@@ -1,0 +1,5 @@
+package org.apache.pulsar.common.api.raw;
+
+public interface RawMessageId {
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageId.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageId.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.api.raw;
 
 public interface RawMessageId {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageIdImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageIdImpl.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.api.raw;
 
 public class RawMessageIdImpl implements RawMessageId {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageIdImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageIdImpl.java
@@ -1,0 +1,21 @@
+package org.apache.pulsar.common.api.raw;
+
+public class RawMessageIdImpl implements RawMessageId {
+
+    long ledgerId;
+    long entryId;
+    long batchIndex;
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append('(')
+                .append(ledgerId)
+                .append(',')
+                .append(entryId)
+                .append(',')
+                .append(batchIndex)
+                .append(')')
+                .toString();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.api.raw;
 
 import io.netty.buffer.ByteBuf;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -1,0 +1,121 @@
+package org.apache.pulsar.common.api.raw;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+
+public class RawMessageImpl implements RawMessage {
+
+    private final RawMessageIdImpl messageId = new RawMessageIdImpl();
+
+    private MessageMetadata msgMetadata;
+    private PulsarApi.SingleMessageMetadata.Builder singleMessageMetadata;
+    private ByteBuf payload;
+
+    private static final Recycler<RawMessageImpl> RECYCLER = new Recycler<RawMessageImpl>() {
+        @Override
+        protected RawMessageImpl newObject(Handle<RawMessageImpl> handle) {
+            return new RawMessageImpl(handle);
+        }
+    };
+
+    private final Handle<RawMessageImpl> handle;
+
+    private RawMessageImpl(Handle<RawMessageImpl> handle) {
+        this.handle = handle;
+    }
+
+    @Override
+    public void release() {
+        if (singleMessageMetadata != null) {
+            singleMessageMetadata.recycle();
+            singleMessageMetadata = null;
+        }
+
+        payload.release();
+        handle.recycle(this);
+    }
+
+    public static RawMessage get(MessageMetadata msgMetadata,
+            PulsarApi.SingleMessageMetadata.Builder singleMessageMetadata,
+            ByteBuf payload,
+            long ledgerId, long entryId, long batchIndex) {
+        RawMessageImpl msg = RECYCLER.get();
+        msg.msgMetadata = msgMetadata;
+        msg.singleMessageMetadata = singleMessageMetadata;
+        msg.messageId.ledgerId = ledgerId;
+        msg.messageId.entryId = entryId;
+        msg.messageId.batchIndex = batchIndex;
+        msg.payload = payload;
+        return msg;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (singleMessageMetadata != null && singleMessageMetadata.getPropertiesCount() > 0) {
+            return singleMessageMetadata.getPropertiesList().stream()
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+        } else if (msgMetadata.getPropertiesCount() > 0) {
+            return msgMetadata.getPropertiesList().stream()
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public ByteBuf getData() {
+        return payload;
+    }
+
+    @Override
+    public RawMessageId getMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public long getPublishTime() {
+        return msgMetadata.getPublishTime();
+    }
+
+    @Override
+    public long getEventTime() {
+        if (singleMessageMetadata != null && singleMessageMetadata.hasEventTime()) {
+            return singleMessageMetadata.getEventTime();
+        } else if (msgMetadata.hasEventTime()) {
+            return msgMetadata.getEventTime();
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public long getSequenceId() {
+        return msgMetadata.getSequenceId() + messageId.batchIndex;
+    }
+
+    @Override
+    public String getProducerName() {
+        return msgMetadata.getProducerName();
+    }
+
+    @Override
+    public Optional<String> getKey() {
+        if (singleMessageMetadata != null && singleMessageMetadata.hasPartitionKey()) {
+            return Optional.of(singleMessageMetadata.getPartitionKey());
+        } else if (msgMetadata.hasPartitionKey()){
+            return Optional.of(msgMetadata.getPartitionKey());
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
@@ -20,12 +20,16 @@ package org.apache.pulsar.sql.presto;
 
 import com.dslplatform.json.DslJson;
 import com.facebook.presto.spi.type.Type;
+
 import io.airlift.log.Logger;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.pulsar.shade.io.netty.buffer.ByteBuf;
+import org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocal;
 
 public class JSONSchemaHandler implements SchemaHandler {
 
@@ -35,24 +39,43 @@ public class JSONSchemaHandler implements SchemaHandler {
 
     private final DslJson<Object> dslJson = new DslJson<>();
 
+    private static final FastThreadLocal<byte[]> tmpBuffer = new FastThreadLocal<byte[]>() {
+        @Override
+        protected byte[] initialValue() {
+            return new byte[1024];
+        }
+    };
+
     public JSONSchemaHandler(List<PulsarColumnHandle> columnHandles) {
         this.columnHandles = columnHandles;
     }
 
     @Override
-    public Object deserialize(byte[] bytes) {
-        try {
-            return dslJson.deserialize(Map.class, bytes, bytes.length);
-        } catch (IOException e) {
-            log.error(e);
+    public Object deserialize(ByteBuf payload) {
+        // Since JSON deserializer only works on a byte[] we need to convert a direct mem buffer into
+        // a byte[].
+        int size = payload.readableBytes();
+        byte[] buffer = tmpBuffer.get();
+        if (buffer.length < size) {
+            // If the thread-local buffer is not big enough, replace it with
+            // a bigger one
+            buffer = new byte[size * 2];
+            tmpBuffer.set(buffer);
         }
-        return null;
+
+        payload.readBytes(buffer);
+
+        try {
+            return dslJson.deserialize(Map.class, buffer, size);
+        } catch (IOException e) {
+            log.error("Failed to deserialize Json object", e);
+            return null;
+        }
     }
 
     @Override
     public Object extractField(int index, Object currentRecord) {
         try {
-
             Map jsonObject = (Map) currentRecord;
             PulsarColumnHandle pulsarColumnHandle = columnHandles.get(index);
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
@@ -63,7 +63,7 @@ public class JSONSchemaHandler implements SchemaHandler {
             tmpBuffer.set(buffer);
         }
 
-        payload.readBytes(buffer);
+        payload.readBytes(buffer, 0, size);
 
         try {
             return dslJson.deserialize(Map.class, buffer, size);

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarInternalColumn.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarInternalColumn.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.common.api.raw.RawMessage;
 
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +46,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             return message.getEventTime() == 0 ? null : message.getEventTime();
         }
     }
@@ -58,7 +58,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             return message.getPublishTime();
         }
     }
@@ -70,7 +70,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             return message.getMessageId().toString();
         }
     }
@@ -82,7 +82,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             return message.getSequenceId();
         }
     }
@@ -94,7 +94,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             return message.getProducerName();
         }
     }
@@ -106,8 +106,8 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
-            return message.hasKey() ? message.getKey() : null;
+        public Object getData(RawMessage message) {
+            return message.getKey().orElse(null);
         }
     }
 
@@ -121,7 +121,7 @@ public abstract class PulsarInternalColumn {
         }
 
         @Override
-        public Object getData(Message message) {
+        public Object getData(RawMessage message) {
             try {
                 return mapper.writeValueAsString(message.getProperties());
             } catch (JsonProcessingException e) {
@@ -201,5 +201,5 @@ public abstract class PulsarInternalColumn {
         return builder.build();
     }
 
-    public abstract Object getData(Message message);
+    public abstract Object getData(RawMessage message);
 }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -18,37 +18,6 @@
  */
 package org.apache.pulsar.sql.presto;
 
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.RecordCursor;
-import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.annotations.VisibleForTesting;
-import io.airlift.log.Logger;
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
-import org.apache.avro.Schema;
-import org.apache.bookkeeper.mledger.AsyncCallbacks;
-import org.apache.bookkeeper.mledger.Entry;
-import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
-import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.ReadOnlyCursor;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.impl.MessageParser;
-import org.apache.pulsar.common.naming.NamespaceName;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.schema.SchemaType;
-import org.jctools.queues.MessagePassingQueue;
-import org.jctools.queues.SpscArrayQueue;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -62,6 +31,39 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.annotations.VisibleForTesting;
+
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.avro.Schema;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.ReadOnlyCursor;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.raw.MessageParser;
+import org.apache.pulsar.common.api.raw.RawMessage;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.jctools.queues.MessagePassingQueue;
+import org.jctools.queues.SpscArrayQueue;
+
 
 public class PulsarRecordCursor implements RecordCursor {
 
@@ -69,10 +71,10 @@ public class PulsarRecordCursor implements RecordCursor {
     private PulsarSplit pulsarSplit;
     private PulsarConnectorConfig pulsarConnectorConfig;
     private ReadOnlyCursor cursor;
-    private SpscArrayQueue<Message> messageQueue;
+    private SpscArrayQueue<RawMessage> messageQueue;
     private SpscArrayQueue<Entry> entryQueue;
     private Object currentRecord;
-    private Message currentMessage;
+    private RawMessage currentMessage;
     private Map<String, PulsarInternalColumn> internalColumnMap = PulsarInternalColumn.getInternalFieldsMap();
     private SchemaHandler schemaHandler;
     private int maxBatchSize;
@@ -126,8 +128,8 @@ public class PulsarRecordCursor implements RecordCursor {
         this.pulsarSplit = pulsarSplit;
         this.pulsarConnectorConfig = pulsarConnectorConfig;
         this.maxBatchSize = pulsarConnectorConfig.getMaxEntryReadBatchSize();
-        this.messageQueue = new SpscArrayQueue(pulsarConnectorConfig.getMaxSplitMessageQueueSize());
-        this.entryQueue = new SpscArrayQueue(pulsarConnectorConfig.getMaxSplitEntryQueueSize());
+        this.messageQueue = new SpscArrayQueue<>(pulsarConnectorConfig.getMaxSplitMessageQueueSize());
+        this.entryQueue = new SpscArrayQueue<>(pulsarConnectorConfig.getMaxSplitEntryQueueSize());
         this.topicName = TopicName.get("persistent",
                 NamespaceName.get(pulsarSplit.getSchemaName()),
                 pulsarSplit.getTableName());
@@ -236,7 +238,7 @@ public class PulsarRecordCursor implements RecordCursor {
 
                             try {
                                 MessageParser.parseMessage(topicName, entry.getLedgerId(), entry.getEntryId(),
-                                        entry.getDataBuffer(), (messageId, message, byteBuf) -> {
+                                        entry.getDataBuffer(), (message) -> {
                                             try {
                                                 // start time for message queue read
                                                 metricsTracker.start_MESSAGE_QUEUE_ENQUEUE_WAIT_TIME();
@@ -355,7 +357,6 @@ public class PulsarRecordCursor implements RecordCursor {
         }
     }
 
-
     @Override
     public boolean advanceNextPosition() {
 
@@ -366,6 +367,11 @@ public class PulsarRecordCursor implements RecordCursor {
 
             readEntries = new ReadEntries();
             readEntries.run();
+        }
+
+        if (currentMessage != null) {
+            currentMessage.release();
+            currentMessage = null;
         }
 
         while(true) {
@@ -495,6 +501,14 @@ public class PulsarRecordCursor implements RecordCursor {
 
     @Override
     public void close() {
+        log.info("Closing cursor record");
+
+        if (currentMessage != null) {
+            currentMessage.release();
+        }
+
+        messageQueue.drain(RawMessage::release);
+        entryQueue.drain(Entry::release);
 
         if (deserializeEntries != null) {
             deserializeEntries.interrupt();

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -341,7 +341,7 @@ public class PulsarRecordCursor implements RecordCursor {
             metricsTracker.incr_NUM_ENTRIES_PER_BATCH_SUCCESS(entries.size());
         }
 
-        public boolean hashFinished() {
+        public boolean hasFinished() {
             return messageQueue.isEmpty() && isDone && outstandingReadsRequests.get() >=1 && splitSize <= entriesProcessed;
         }
 
@@ -375,7 +375,7 @@ public class PulsarRecordCursor implements RecordCursor {
         }
 
         while(true) {
-            if (readEntries.hashFinished()) {
+            if (readEntries.hasFinished()) {
                 return false;
             }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
@@ -47,6 +47,9 @@ public class PulsarSplit implements ConnectorSplit {
     private final long endPositionLedgerId;
     private final TupleDomain<ColumnHandle> tupleDomain;
 
+    private final PositionImpl startPosition;
+    private final PositionImpl endPosition;
+
     @JsonCreator
     public PulsarSplit(
             @JsonProperty("splitId") long splitId,
@@ -73,6 +76,8 @@ public class PulsarSplit implements ConnectorSplit {
         this.startPositionLedgerId = startPositionLedgerId;
         this.endPositionLedgerId = endPositionLedgerId;
         this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+        this.startPosition = PositionImpl.get(startPositionLedgerId, startPositionEntryId);
+        this.endPosition = PositionImpl.get(endPositionLedgerId, endPositionEntryId);
     }
 
     @JsonProperty
@@ -136,11 +141,11 @@ public class PulsarSplit implements ConnectorSplit {
     }
 
     public PositionImpl getStartPosition() {
-        return PositionImpl.get(startPositionLedgerId, startPositionEntryId);
+        return startPosition;
     }
 
     public PositionImpl getEndPosition() {
-        return PositionImpl.get(endPositionLedgerId, endPositionEntryId);
+        return endPosition;
     }
 
     @Override

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/SchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/SchemaHandler.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import org.apache.pulsar.shade.io.netty.buffer.ByteBuf;
+
 public interface SchemaHandler {
 
-    Object deserialize(byte[] bytes);
+    Object deserialize(ByteBuf payload);
 
     Object extractField(int index, Object currentRecord);
 


### PR DESCRIPTION
### Motivation

Use "raw" message interface when reading messages directly from storage.

The regular `Message` interface exposes only a `byte[]` with the payload and it was meant to be simple. Eg. there is no ref-counting for messages. 

When we are reading from storage directly, we need to take advantage that buffers are coming from direct memory and are already pooled. This will allow to avoid all memory copies and many objects allocation by exposing a lower level message interface, on which the users will need to explicitly call release.

Note: this is a step-gap solution until we have more comprehensive and encapsulated API for direct storage access.