### PR TITLE
Use IPv4 ZK address to avoid initial connection to IPv6

### DIFF
--- a/conf/presto/catalog/pulsar.properties
+++ b/conf/presto/catalog/pulsar.properties
@@ -22,7 +22,7 @@ connector.name=pulsar
 # the url of Pulsar broker service
 pulsar.broker-service-url=http://localhost:8080
 # URI of Zookeeper cluster
-pulsar.zookeeper-uri=localhost:2181
+pulsar.zookeeper-uri=127.0.0.1:2181
 # minimum number of entries to read at a single time
 pulsar.max-entry-read-batch-size=100
 # default number of splits to use per query


### PR DESCRIPTION
### Motivation

The ZK clients hangs for a few seconds when connecting to `localhost` since it first tries the IPv6 address and then falls back to IPv4. This happens when starting any query on the pulsar-presto connector.