### PR TITLE
fix rpm links issue in https://pulsar.apache.org/docs/en/client-libraries-cpp/

### DIFF
--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -50,7 +50,7 @@ function rpmReleaseUrl(version, type) {
   if (version.includes('incubating')) {
       return `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}.x86_64.rpm`
   } else {
-      return `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}.x86_64.rpm`
+      return `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}-1.x86_64.rpm`
   }
 }
 


### PR DESCRIPTION
Fix the rpm links in the url https://pulsar.apache.org/docs/en/client-libraries-cpp/