### PR TITLE
add eks broker proxy

### DIFF
--- a/deployment/kubernetes/aws/proxy.yaml
+++ b/deployment/kubernetes/aws/proxy.yaml
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-proxy-config
+data:
+  PULSAR_MEM: "\" -Xms4g -Xmx4g -XX:MaxDirectMemorySize=4g\""
+  brokerServiceURL: pulsar://broker:6650
+  brokerWebServiceURL: http://broker:8080
+  clusterName: pulsar-eks
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: broker-proxy
+  labels:
+    app: pulsar
+    component: proxy
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        component: proxy
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+        - name: pulsar-proxy
+          image: apachepulsar/pulsar:latest
+          command: ["sh", "-c"]
+          args:
+            - >
+              bin/apply-config-from-env.py conf/proxy.conf &&
+              bin/apply-config-from-env.py conf/pulsar_env.sh &&
+              bin/pulsar proxy
+          ports:
+            - containerPort: 6650
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: pulsar-proxy-config
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: broker-proxy
+  labels:
+    app: pulsar
+    component: proxy
+spec:
+  type: LoadBalancer
+  ports:
+    - name: pulsar
+      port: 6650
+      protocol: TCP
+    - name: http
+      port: 8080
+      protocol: TCP
+  selector:
+    app: pulsar
+    component: broker
+


### PR DESCRIPTION
### Motivation

The EKS configuration is missing the yaml to create broker-proxy service required for accessing pulsar externally.

### Modifications

Add proxy.yaml that contains configuration for broker-proxy

### Result

Creates a broker-proxy service that exposes a load balancer externally.