### PR TITLE
FIX: EKS load balancer selector should be proxy

### DIFF
--- a/deployment/kubernetes/aws/proxy.yaml
+++ b/deployment/kubernetes/aws/proxy.yaml
@@ -81,5 +81,5 @@ spec:
       protocol: TCP
   selector:
     app: pulsar
-    component: broker
+    component: proxy
 


### PR DESCRIPTION
### Motivation

If the selector is broker, the client will try to connect to the internal broker IP, which won't work.  The selector should be proxy so that the client can connect to the proxy instead.

### Modifications

Change LB service selector to proxy.

### Result

The LB will get attached to the proxy, not the broker.
