### PR TITLE
[Pulsar-Client] Extends ProducerBuilder Validations

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -232,6 +232,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public ProducerBuilder<T> property(String key, String value) {
         checkArgument(StringUtils.isNotBlank(key), "property key cannot be blank");
+        checkArgument(StringUtils.isNotBlank(value), "property value cannot be blank");
         conf.getProperties().put(key, value);
         return this;
     }
@@ -240,6 +241,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
         properties.keySet().forEach(key ->
                 checkArgument(StringUtils.isNotBlank(key), "properties' key cannot be blank"));
+        properties.values().forEach(value ->
+                checkArgument(StringUtils.isNotBlank(value), "properties' value cannot be blank"));
         conf.getProperties().putAll(properties);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -231,8 +231,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     @Override
     public ProducerBuilder<T> property(String key, String value) {
-        checkArgument(StringUtils.isNotBlank(key), "property key cannot be blank");
-        checkArgument(StringUtils.isNotBlank(value), "property value cannot be blank");
+        checkArgument(StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value),
+                "property key/value cannot be blank");
         conf.getProperties().put(key, value);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -239,10 +239,11 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     @Override
     public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
-        properties.keySet().forEach(key ->
-                checkArgument(StringUtils.isNotBlank(key), "properties' key cannot be blank"));
-        properties.values().forEach(value ->
-                checkArgument(StringUtils.isNotBlank(value), "properties' value cannot be blank"));
+        checkArgument(!properties.isEmpty(), "properties cannot be empty");
+        properties.entrySet().forEach(entry -> {
+            checkArgument(StringUtils.isNotBlank(entry.getKey()), "properties' key cannot be blank");
+            checkArgument(StringUtils.isNotBlank(entry.getValue()), "properties' value cannot be blank");
+        });
         conf.getProperties().putAll(properties);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -240,10 +240,9 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
         checkArgument(!properties.isEmpty(), "properties cannot be empty");
-        properties.entrySet().forEach(entry -> {
-            checkArgument(StringUtils.isNotBlank(entry.getKey()), "properties' key cannot be blank");
-            checkArgument(StringUtils.isNotBlank(entry.getValue()), "properties' value cannot be blank");
-        });
+        properties.entrySet().forEach(entry ->
+            checkArgument(StringUtils.isNotBlank(entry.getKey()) && StringUtils.isNotBlank(entry.getValue()),
+                    "properties' key/value cannot be blank"));
         conf.getProperties().putAll(properties);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.HashingScheme;
@@ -44,6 +45,8 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
 
 import lombok.NonNull;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
@@ -121,30 +124,28 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     @Override
     public ProducerBuilder<T> topic(String topicName) {
+        checkArgument(StringUtils.isNotBlank(topicName), "topicName cannot be blank");
         conf.setTopicName(topicName);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> producerName(@NonNull String producerName) {
+    public ProducerBuilder<T> producerName(String producerName) {
+        checkArgument(StringUtils.isNotBlank(producerName), "producerName cannot be blank");
         conf.setProducerName(producerName);
         return this;
     }
 
     @Override
     public ProducerBuilder<T> sendTimeout(int sendTimeout, @NonNull TimeUnit unit) {
-        if (sendTimeout < 0) {
-            throw new IllegalArgumentException("sendTimeout needs to be >= 0");
-        }
+        checkArgument(sendTimeout >= 0, "sendTimeout needs to be >= 0");
         conf.setSendTimeoutMs(unit.toMillis(sendTimeout));
         return this;
     }
 
     @Override
     public ProducerBuilder<T> maxPendingMessages(int maxPendingMessages) {
-        if (maxPendingMessages <= 0) {
-            throw new IllegalArgumentException("maxPendingMessages needs to be > 0");
-        }
+        checkArgument(maxPendingMessages > 0, "maxPendingMessages needs to be > 0");
         conf.setMaxPendingMessages(maxPendingMessages);
         return this;
     }
@@ -198,7 +199,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> addEncryptionKey(@NonNull String key) {
+    public ProducerBuilder<T> addEncryptionKey(String key) {
+        checkArgument(StringUtils.isNotBlank(key), "Encryption key cannot be blank");
         conf.getEncryptionKeys().add(key);
         return this;
     }
@@ -228,13 +230,16 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> property(@NonNull String key, @NonNull String value) {
+    public ProducerBuilder<T> property(String key, String value) {
+        checkArgument(StringUtils.isNotBlank(key), "property key cannot be blank");
         conf.getProperties().put(key, value);
         return this;
     }
 
     @Override
     public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
+        properties.keySet().forEach(key ->
+                checkArgument(StringUtils.isNotBlank(key), "properties' key cannot be blank"));
         conf.getProperties().putAll(properties);
         return this;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -24,7 +24,10 @@ import org.mockito.Matchers;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -50,6 +53,23 @@ public class ProducerBuilderImplTest {
         when(client.createProducerAsync(
                 Matchers.any(ProducerConfigurationData.class), Matchers.any(Schema.class), eq(null)))
                 .thenReturn(CompletableFuture.completedFuture(producer));
+    }
+
+    @Test
+    public void testProducerBuilderImpl() throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key2", "Test-Value2");
+
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        Producer producer = producerBuilderImpl.topic(TOPIC_NAME)
+                .producerName("Test-Producer")
+                .maxPendingMessages(2)
+                .addEncryptionKey("Test-EncryptionKey")
+                .property("Test-Key", "Test-Value")
+                .properties(properties)
+                .create();
+
+        assertNotNull(producer);
     }
 
     @Test
@@ -123,6 +143,108 @@ public class ProducerBuilderImplTest {
         ProducerBuilderImpl producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .messageRoutingMode(MessageRoutingMode.CustomPartition)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenTopicNameIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(null)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenTopicNameIsBlank()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic("   ")
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenProducerNameIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .producerName(null)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenProducerNameIsBlank()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .producerName("   ")
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenSendTimeoutIsNegative()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .producerName("Test-Producer")
+                .sendTimeout(-1, TimeUnit.MILLISECONDS)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenMaxPendingMessagesIsNegative()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .producerName("Test-Producer")
+                .maxPendingMessages(-1)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenEncryptionKeyIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .addEncryptionKey(null)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenEncryptionKeyIsBlank()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .addEncryptionKey("   ")
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertyKeyIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .property(null, "Test-Value")
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertyKeyIsBlank()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .property("   ", "Test-Value")
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesKeyIsBlank()
+            throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(null, "Test-Value");
+
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties)
                 .create();
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -147,24 +147,21 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenTopicNameIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenTopicNameIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(null)
                 .create();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenTopicNameIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenTopicNameIsBlank() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic("   ")
                 .create();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenProducerNameIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenProducerNameIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .producerName(null)
@@ -172,8 +169,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenProducerNameIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenProducerNameIsBlank() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .producerName("   ")
@@ -181,8 +177,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenSendTimeoutIsNegative()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenSendTimeoutIsNegative() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .producerName("Test-Producer")
@@ -191,8 +186,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenMaxPendingMessagesIsNegative()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenMaxPendingMessagesIsNegative() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .producerName("Test-Producer")
@@ -201,8 +195,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenEncryptionKeyIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenEncryptionKeyIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .addEncryptionKey(null)
@@ -210,8 +203,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenEncryptionKeyIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenEncryptionKeyIsBlank() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .addEncryptionKey("   ")
@@ -219,8 +211,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertyKeyIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertyKeyIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .property(null, "Test-Value")
@@ -228,8 +219,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertyKeyIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertyKeyIsBlank() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .property("   ", "Test-Value")
@@ -237,8 +227,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertyValueIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertyValueIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .property("Test-Key", null)
@@ -246,8 +235,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertyValueIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertyValueIsBlank() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .property("Test-Key", "   ")
@@ -255,8 +243,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void testProducerBuilderImplWhenPropertiesIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertiesIsNull() throws PulsarClientException {
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
                 .properties(null)
@@ -264,8 +251,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertiesKeyIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertiesKeyIsNull() throws PulsarClientException {
         Map<String, String> properties = new HashMap<>();
         properties.put(null, "Test-Value");
 
@@ -276,8 +262,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertiesKeyIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertiesKeyIsBlank() throws PulsarClientException {
         Map<String, String> properties = new HashMap<>();
         properties.put("   ", "Test-Value");
 
@@ -288,8 +273,7 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertiesValueIsNull()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertiesValueIsNull() throws PulsarClientException {
         Map<String, String> properties = new HashMap<>();
         properties.put("Test-Key", null);
 
@@ -300,10 +284,19 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertiesValueIsBlank()
-            throws PulsarClientException {
+    public void testProducerBuilderImplWhenPropertiesValueIsBlank() throws PulsarClientException {
         Map<String, String> properties = new HashMap<>();
         properties.put("Test-Key", "   ");
+
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesIsEmpty() throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
 
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -248,6 +248,15 @@ public class ProducerBuilderImplTest {
                 .create();
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testProducerBuilderImplWhenPropertiesIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(null)
+                .create();
+    }
+
     private class CustomMessageRouter implements MessageRouter {
         @Override
         public int choosePartition(Message<?> msg, TopicMetadata metadata) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -237,7 +237,34 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testProducerBuilderImplWhenPropertiesKeyIsBlank()
+    public void testProducerBuilderImplWhenPropertyValueIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .property("Test-Key", null)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertyValueIsBlank()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .property("Test-Key", "   ")
+                .create();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testProducerBuilderImplWhenPropertiesIsNull()
+            throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(null)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesKeyIsNull()
             throws PulsarClientException {
         Map<String, String> properties = new HashMap<>();
         properties.put(null, "Test-Value");
@@ -248,12 +275,39 @@ public class ProducerBuilderImplTest {
                 .create();
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testProducerBuilderImplWhenPropertiesIsNull()
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesKeyIsBlank()
             throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("   ", "Test-Value");
+
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
         producerBuilderImpl.topic(TOPIC_NAME)
-                .properties(null)
+                .properties(properties)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesValueIsNull()
+            throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key", null);
+
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties)
+                .create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testProducerBuilderImplWhenPropertiesValueIsBlank()
+            throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key", "   ");
+
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties)
                 .create();
     }
 


### PR DESCRIPTION
### Motivation
This PR aims to extend validations on `ProducerBuilder`.

### Modifications
1- `ProducerBuilder` needs to be robust for null and blank values as Public API.
      (e.g: When `topicName` is passed as blank, it comes as `persistent://public/default/    `)
2- UT coverage is added.