### PR TITLE
Use direct memory instead of Heap to determine a broker is "overloaded" in memory usage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -355,7 +355,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
     public Set<String> getAvailableBrokers() throws Exception {
         return this.availableActiveBrokers.get();
     }
-    
+
     public ZooKeeperDataCache<LoadReport> getLoadReportCache() {
         return this.loadReportCacheZk;
     }
@@ -1062,13 +1062,15 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
     public static boolean isAboveLoadLevel(SystemResourceUsage usage, float thresholdPercentage) {
         return (usage.bandwidthOut.percentUsage() > thresholdPercentage
                 || usage.bandwidthIn.percentUsage() > thresholdPercentage
-                || usage.cpu.percentUsage() > thresholdPercentage || usage.memory.percentUsage() > thresholdPercentage);
+                || usage.cpu.percentUsage() > thresholdPercentage
+                || usage.directMemory.percentUsage() > thresholdPercentage);
     }
 
     public static boolean isBelowLoadLevel(SystemResourceUsage usage, float thresholdPercentage) {
         return (usage.bandwidthOut.percentUsage() < thresholdPercentage
                 && usage.bandwidthIn.percentUsage() < thresholdPercentage
-                && usage.cpu.percentUsage() < thresholdPercentage && usage.memory.percentUsage() < thresholdPercentage);
+                && usage.cpu.percentUsage() < thresholdPercentage
+                && usage.directMemory.percentUsage() < thresholdPercentage);
     }
 
     private static long getRealtimeJvmHeapUsageMBytes() {


### PR DESCRIPTION
### Motivation

When a broker is configured with a relatively low JVM heap size, it might be reporting it's "overloaded" by exceeding the default threshold of max 85% of Heap memory used, when in fact it's not overloaded.

The reason is that the jvm heap will grow and shrink like:

![image](https://user-images.githubusercontent.com/62500/50051148-ef994c00-00c1-11e9-9d79-29b04e2e958a.png)

This is typically not a problem with larger heap sizes (and using the `-XX:G1NewSizePercent=50` flag which forces G1GC to do young gen collection when the 50% threshold is filled up. In this case the heap will be cleaned well before the 85% value is reached.

On the other hand, on smaller heaps like the above example with `-Xmx512MB`, since the load report uses the instant value of the heap size, it might be signaling that the broker is overloaded (mem usage >85%) while in fact is just that JVM is deferring the GC until the 512MB are entirely filled up.

Since there is no way to get a good proxy measure for "real" heap usage from JVM, we should just rather use the direct memory for the overload considerations.

The effect of the broker being marked as overloaded is that the traffic shedding mechanism gets triggered and it will bounce some topics around. In pathological cases, some topics can be bounced between brokers every 30mins.