### PR TITLE
[Pulsar-Client] Extends ConsumerBuilder Validations

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -489,16 +489,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             pulsarClient.newConsumer().topic("persistent://my-property/my-ns/my-topic7").subscriptionName(null)
                     .subscribe();
             Assert.fail("Should fail");
-        } catch (PulsarClientException e) {
-            assertEquals(e.getClass(), InvalidConfigurationException.class);
+        } catch (PulsarClientException | IllegalArgumentException e) {
+            assertEquals(e.getClass(), IllegalArgumentException.class);
         }
 
         try {
             pulsarClient.newConsumer().topic("persistent://my-property/my-ns/my-topic7").subscriptionName("")
                     .subscribe();
             Assert.fail("Should fail");
-        } catch (PulsarClientException e) {
-            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+        } catch (PulsarClientException | IllegalArgumentException e) {
+            Assert.assertTrue(e instanceof IllegalArgumentException);
         }
 
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -205,7 +205,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> acknowledgmentGroupTime(long delay, TimeUnit unit) {
-        checkArgument(delay >= 0, "delay needs to be >= 0");
+        checkArgument(delay >= 0, "acknowledgmentGroupTime needs to be >= 0");
         conf.setAcknowledgementsGroupTimeMicros(unit.toMicros(delay));
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -119,14 +119,20 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> topic(String... topicNames) {
-        checkArgument(topicNames.length > 0, "Passed in topicNames should not be empty.");
+        checkArgument(topicNames != null && topicNames.length > 0,
+                "Passed in topicNames should not be null or empty.");
+        Arrays.stream(topicNames).forEach(topicName ->
+                checkArgument(StringUtils.isNotBlank(topicName), "topicNames cannot have blank topic"));
         conf.getTopicNames().addAll(Lists.newArrayList(topicNames));
         return this;
     }
 
     @Override
     public ConsumerBuilder<T> topics(List<String> topicNames) {
-        checkArgument(topicNames != null && !topicNames.isEmpty(), "Passed in topicNames list should not be empty.");
+        checkArgument(topicNames != null && !topicNames.isEmpty(),
+                "Passed in topicNames list should not be null or empty.");
+        topicNames.stream().forEach(topicName ->
+                checkArgument(StringUtils.isNotBlank(topicName), "topicNames cannot have blank topic"));
         conf.getTopicNames().addAll(topicNames);
         return this;
     }
@@ -147,6 +153,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> subscriptionName(String subscriptionName) {
+        checkArgument(StringUtils.isNotBlank(subscriptionName), "subscriptionName cannot be blank");
         conf.setSubscriptionName(subscriptionName);
         return this;
     }
@@ -172,39 +179,40 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> consumerEventListener(ConsumerEventListener consumerEventListener) {
+    public ConsumerBuilder<T> consumerEventListener(@NonNull ConsumerEventListener consumerEventListener) {
         conf.setConsumerEventListener(consumerEventListener);
         return this;
     }
 
     @Override
-    public ConsumerBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
+    public ConsumerBuilder<T> cryptoKeyReader(@NonNull CryptoKeyReader cryptoKeyReader) {
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }
 
     @Override
-    public ConsumerBuilder<T> cryptoFailureAction(ConsumerCryptoFailureAction action) {
+    public ConsumerBuilder<T> cryptoFailureAction(@NonNull ConsumerCryptoFailureAction action) {
         conf.setCryptoFailureAction(action);
         return this;
     }
 
     @Override
     public ConsumerBuilder<T> receiverQueueSize(int receiverQueueSize) {
-        checkArgument(receiverQueueSize >= 0);
+        checkArgument(receiverQueueSize >= 0, "receiverQueueSize needs to be >= 0");
         conf.setReceiverQueueSize(receiverQueueSize);
         return this;
     }
 
     @Override
     public ConsumerBuilder<T> acknowledgmentGroupTime(long delay, TimeUnit unit) {
-        checkArgument(delay >= 0);
+        checkArgument(delay >= 0, "delay needs to be >= 0");
         conf.setAcknowledgementsGroupTimeMicros(unit.toMicros(delay));
         return this;
     }
 
     @Override
     public ConsumerBuilder<T> consumerName(String consumerName) {
+        checkArgument(StringUtils.isNotBlank(consumerName), "consumerName cannot be blank");
         conf.setConsumerName(consumerName);
         return this;
     }
@@ -217,12 +225,19 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> property(String key, String value) {
+        checkArgument(StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value),
+                "property key/value cannot be blank");
         conf.getProperties().put(key, value);
         return this;
     }
 
     @Override
-    public ConsumerBuilder<T> properties(Map<String, String> properties) {
+    public ConsumerBuilder<T> properties(@NonNull Map<String, String> properties) {
+        checkArgument(!properties.isEmpty(), "properties cannot be empty");
+        properties.entrySet().forEach(entry ->
+                checkArgument(
+                        StringUtils.isNotBlank(entry.getKey()) && StringUtils.isNotBlank(entry.getValue()),
+                        "properties' key/value cannot be blank"));
         conf.getProperties().putAll(properties);
         return this;
     }
@@ -246,13 +261,14 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
 	@Override
-	public ConsumerBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition) {
+	public ConsumerBuilder<T> subscriptionInitialPosition(@NonNull SubscriptionInitialPosition
+                                                                      subscriptionInitialPosition) {
         conf.setSubscriptionInitialPosition(subscriptionInitialPosition);
 		return this;
 	}
 
     @Override
-    public ConsumerBuilder<T> subscriptionTopicsMode(Mode mode) {
+    public ConsumerBuilder<T> subscriptionTopicsMode(@NonNull Mode mode) {
         conf.setSubscriptionTopicsMode(mode);
         return this;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Unit tests of {@link ConsumerBuilderImpl}.
+ */
+public class ConsumerBuilderImplTest {
+
+    private static final String TOPIC_NAME = "testTopicName";
+    private PulsarClientImpl client;
+    private ConsumerBuilderImpl consumerBuilderImpl;
+    ConsumerConfigurationData consumerConfigurationData;
+
+    @BeforeTest
+    public void setup() {
+        client = mock(PulsarClientImpl.class);
+    }
+
+    @Test
+    public void testConsumerBuilderImpl() throws PulsarClientException {
+        Consumer consumer = mock(Consumer.class);
+        consumerConfigurationData = mock(ConsumerConfigurationData.class);
+        when(consumerConfigurationData.getTopicsPattern()).thenReturn(Pattern.compile("\\w+"));
+        when(consumerConfigurationData.getSubscriptionName()).thenReturn("testSubscriptionName");
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, consumerConfigurationData, Schema.BYTES);
+        when(consumerBuilderImpl.subscribeAsync())
+                .thenReturn(CompletableFuture.completedFuture(consumer));
+
+        assertNotNull(consumerBuilderImpl.topic(TOPIC_NAME).subscribe());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesVarargsIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesVarargsHasNullTopic() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic("my-topic", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesVarargsHasBlankTopic() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic("my-topic", "  ");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topics(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesIsEmpty() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topics(Arrays.asList());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesHasBlankTopic() {
+        List<String> topicNames = Arrays.asList("my-topic", " ");
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topics(topicNames);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenTopicNamesHasNullTopic() {
+        List<String> topicNames = Arrays.asList("my-topic", null);
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topics(topicNames);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenSubscriptionNameIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME).subscriptionName(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenSubscriptionNameIsBlank() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME).subscriptionName(" ");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenConsumerEventListenerIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .subscriptionName("subscriptionName")
+                .consumerEventListener(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenCryptoKeyReaderIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .subscriptionName("subscriptionName")
+                .cryptoKeyReader(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenCryptoFailureActionIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .subscriptionName("subscriptionName")
+                .cryptoFailureAction(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenConsumerNameIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME).consumerName(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenConsumerNameIsBlank() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME).consumerName(" ");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertyKeyIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .property(null, "Test-Value");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertyKeyIsBlank() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .property("   ", "Test-Value");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertyValueIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .property("Test-Key", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertyValueIsBlank() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .property("Test-Key", "   ");
+    }
+
+    @Test
+    public void testConsumerBuilderImplWhenPropertiesAreCorrect() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key", "Test-Value");
+        properties.put("Test-Key2", "Test-Value2");
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertiesKeyIsNull() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(null, "Test-Value");
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertiesKeyIsBlank() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("  ", "Test-Value");
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertiesValueIsNull() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key", null);
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertiesValueIsBlank() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Test-Key", "   ");
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenPropertiesIsEmpty() {
+        Map<String, String> properties = new HashMap<>();
+
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(properties);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenPropertiesIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .properties(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenSubscriptionInitialPositionIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .subscriptionInitialPosition(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConsumerBuilderImplWhenSubscriptionTopicsModeIsNull() {
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
+        consumerBuilderImpl.topic(TOPIC_NAME)
+                .subscriptionTopicsMode(null);
+    }
+
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -40,87 +40,74 @@ import static org.testng.Assert.assertNotNull;
 public class ConsumerBuilderImplTest {
 
     private static final String TOPIC_NAME = "testTopicName";
-    private PulsarClientImpl client;
     private ConsumerBuilderImpl consumerBuilderImpl;
-    ConsumerConfigurationData consumerConfigurationData;
 
     @BeforeTest
     public void setup() {
-        client = mock(PulsarClientImpl.class);
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ConsumerConfigurationData consumerConfigurationData = mock(ConsumerConfigurationData.class);
+        when(consumerConfigurationData.getTopicsPattern()).thenReturn(Pattern.compile("\\w+"));
+        when(consumerConfigurationData.getSubscriptionName()).thenReturn("testSubscriptionName");
+        consumerBuilderImpl = new ConsumerBuilderImpl(client, consumerConfigurationData, Schema.BYTES);
     }
 
     @Test
     public void testConsumerBuilderImpl() throws PulsarClientException {
         Consumer consumer = mock(Consumer.class);
-        consumerConfigurationData = mock(ConsumerConfigurationData.class);
-        when(consumerConfigurationData.getTopicsPattern()).thenReturn(Pattern.compile("\\w+"));
-        when(consumerConfigurationData.getSubscriptionName()).thenReturn("testSubscriptionName");
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, consumerConfigurationData, Schema.BYTES);
         when(consumerBuilderImpl.subscribeAsync())
                 .thenReturn(CompletableFuture.completedFuture(consumer));
-
         assertNotNull(consumerBuilderImpl.topic(TOPIC_NAME).subscribe());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesVarargsIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesVarargsHasNullTopic() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic("my-topic", null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesVarargsHasBlankTopic() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic("my-topic", "  ");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topics(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesIsEmpty() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topics(Arrays.asList());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesHasBlankTopic() {
         List<String> topicNames = Arrays.asList("my-topic", " ");
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topics(topicNames);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesHasNullTopic() {
         List<String> topicNames = Arrays.asList("my-topic", null);
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topics(topicNames);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenSubscriptionNameIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME).subscriptionName(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenSubscriptionNameIsBlank() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME).subscriptionName(" ");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenConsumerEventListenerIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME)
                 .subscriptionName("subscriptionName")
                 .consumerEventListener(null);
@@ -128,7 +115,6 @@ public class ConsumerBuilderImplTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenCryptoKeyReaderIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME)
                 .subscriptionName("subscriptionName")
                 .cryptoKeyReader(null);
@@ -136,7 +122,6 @@ public class ConsumerBuilderImplTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenCryptoFailureActionIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME)
                 .subscriptionName("subscriptionName")
                 .cryptoFailureAction(null);
@@ -144,42 +129,32 @@ public class ConsumerBuilderImplTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenConsumerNameIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME).consumerName(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenConsumerNameIsBlank() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
         consumerBuilderImpl.topic(TOPIC_NAME).consumerName(" ");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenPropertyKeyIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .property(null, "Test-Value");
+        consumerBuilderImpl.topic(TOPIC_NAME).property(null, "Test-Value");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenPropertyKeyIsBlank() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .property("   ", "Test-Value");
+        consumerBuilderImpl.topic(TOPIC_NAME).property("   ", "Test-Value");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenPropertyValueIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .property("Test-Key", null);
+        consumerBuilderImpl.topic(TOPIC_NAME).property("Test-Key", null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenPropertyValueIsBlank() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .property("Test-Key", "   ");
+        consumerBuilderImpl.topic(TOPIC_NAME).property("Test-Key", "   ");
     }
 
     @Test
@@ -188,9 +163,7 @@ public class ConsumerBuilderImplTest {
         properties.put("Test-Key", "Test-Value");
         properties.put("Test-Key2", "Test-Value2");
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -198,9 +171,7 @@ public class ConsumerBuilderImplTest {
         Map<String, String> properties = new HashMap<>();
         properties.put(null, "Test-Value");
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -208,9 +179,7 @@ public class ConsumerBuilderImplTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("  ", "Test-Value");
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -218,9 +187,7 @@ public class ConsumerBuilderImplTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("Test-Key", null);
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -228,39 +195,29 @@ public class ConsumerBuilderImplTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("Test-Key", "   ");
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenPropertiesIsEmpty() {
         Map<String, String> properties = new HashMap<>();
 
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(properties);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(properties);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenPropertiesIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .properties(null);
+        consumerBuilderImpl.topic(TOPIC_NAME).properties(null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenSubscriptionInitialPositionIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .subscriptionInitialPosition(null);
+        consumerBuilderImpl.topic(TOPIC_NAME).subscriptionInitialPosition(null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testConsumerBuilderImplWhenSubscriptionTopicsModeIsNull() {
-        consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic(TOPIC_NAME)
-                .subscriptionTopicsMode(null);
+        consumerBuilderImpl.topic(TOPIC_NAME).subscriptionTopicsMode(null);
     }
 
 }


### PR DESCRIPTION
### Motivation
This PR aims to extend validations on `ConsumerBuilder` as Public API.

### Modifications
1- `ConsumerBuilder` needs to be robust for **null** and **blank** values as Public API.
2- New UT coverage is added.