### PR TITLE
Error open RocksDB database in docker for windows

### DIFF
--- a/site/docs/latest/getting-started/docker.md
+++ b/site/docs/latest/getting-started/docker.md
@@ -46,7 +46,19 @@ $ docker run -it \
   bin/pulsar standalone
 ```
 
+Under Windows, you should use something like the following docker command:
+
+```shell
+$ docker run -it \
+  -p 6650:6650 \
+  -p 8080:8080 \
+  -v "$PWD/data:/pulsar/data".ToLower() \
+  apachepulsar/pulsar:{{site.current_version}} \
+  bin/pulsar standalone
+```
+
 A few things to note about this command:
+ * `$PWD/data` : The docker host directory under the Windows operating system must be lowercase.`$PWD/data` can provide you with the specified directory, for example: `E:/data`.
  * `-v $PWD/data:/pulsar/data`: This will make the process inside the container to store the
    data and metadata in the filesystem outside the container, in order to not start "fresh" every
    time the container is restarted.

--- a/site2/docs/getting-started-docker.md
+++ b/site2/docs/getting-started-docker.md
@@ -17,11 +17,23 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v $PWD/data:/pulsar/data \
-  apachepulsar/pulsar:{{pulsar:version}} \
+  apachepulsar/pulsar:{{site.current_version}} \
+  bin/pulsar standalone
+```
+
+Under Windows, you should use something like the following docker command:
+
+```shell
+$ docker run -it \
+  -p 6650:6650 \
+  -p 8080:8080 \
+  -v "$PWD/data:/pulsar/data".ToLower() \
+  apachepulsar/pulsar:{{site.current_version}} \
   bin/pulsar standalone
 ```
 
 A few things to note about this command:
+ * `$PWD/data` : The docker host directory under the Windows operating system must be lowercase.`$PWD/data` can provide you with the specified directory, for example: `E:/data`.
  * `-v $PWD/data:/pulsar/data`: This will make the process inside the container to store the
    data and metadata in the filesystem outside the container, in order to not start "fresh" every
    time the container is restarted.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-docker.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-docker.md
@@ -18,11 +18,23 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v $PWD/data:/pulsar/data \
-  apachepulsar/pulsar:{{pulsar:version}} \
+  apachepulsar/pulsar:{{site.current_version}} \
+  bin/pulsar standalone
+```
+
+Under Windows, you should use something like the following docker command:
+
+```shell
+$ docker run -it \
+  -p 6650:6650 \
+  -p 8080:8080 \
+  -v "$PWD/data:/pulsar/data".ToLower() \
+  apachepulsar/pulsar:{{site.current_version}} \
   bin/pulsar standalone
 ```
 
 A few things to note about this command:
+ * `$PWD/data` : The docker host directory under the Windows operating system must be lowercase.`$PWD/data` can provide you with the specified directory, for example: `E:/data`.
  * `-v $PWD/data:/pulsar/data`: This will make the process inside the container to store the
    data and metadata in the filesystem outside the container, in order to not start "fresh" every
    time the container is restarted.


### PR DESCRIPTION
### Motivation

To solve the error open RocksDB database in docker for windows

### Modifications

```shell
$ docker run -it \
  -p 6650:6650 \
  -p 8080:8080 \
  -v "E:/data:/pulsar/data".ToLower() \
  apachepulsar/pulsar:{{site.current_version}} \
  bin/pulsar standalone
```

### Result

Have no effect on.
