### PR TITLE
enable java enums to be queried in sql

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -399,6 +399,12 @@ public class PulsarMetadata implements ConnectorMetadata {
         } else if (fieldSchema.getType() == Schema.Type.MAP) {
 
         } else if (fieldSchema.getType() == Schema.Type.ENUM) {
+            PulsarColumnMetadata columnMetadata = new PulsarColumnMetadata(fieldName,
+                    convertType(fieldSchema.getType(), fieldSchema.getLogicalType()),
+                    null, null, false, false,
+                    fieldNames.toArray(new String[fieldNames.size()]),
+                    positionIndices.toArray(new Integer[positionIndices.size()]));
+            columnMetadataList.add(columnMetadata);
 
         } else if (fieldSchema.getType() == Schema.Type.FIXED) {
 
@@ -433,6 +439,8 @@ public class PulsarMetadata implements ConnectorMetadata {
                 return VarbinaryType.VARBINARY;
             case STRING:
                 return VarcharType.VARCHAR;
+            case ENUM:
+                return VarcharType.VARCHAR;
             default:
                 log.error("Cannot convert type: %s", avroType);
                 return null;
@@ -449,5 +457,6 @@ public class PulsarMetadata implements ConnectorMetadata {
                 || Schema.Type.DOUBLE == type
                 || Schema.Type.BYTES == type
                 || Schema.Type.STRING == type;
+
     }
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
@@ -109,6 +109,9 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
                         } else if (fooColumnHandles.get(i).getName().equals("bar.test2.foobar.field1")) {
                             Assert.assertEquals(pulsarRecordCursor.getLong(i), ((Integer) fooFunctions.get("bar.test2.foobar.field1").apply(count)).longValue());
                             columnsSeen.add(fooColumnHandles.get(i).getName());
+                        } else if (fooColumnHandles.get(i).getName().equals("field7")) {
+                            Assert.assertEquals(pulsarRecordCursor.getSlice(i).getBytes(), fooFunctions.get("field7").apply(count).toString().getBytes());
+                            columnsSeen.add(fooColumnHandles.get(i).getName());
                         } else {
                             if (PulsarInternalColumn.getInternalFieldsMap().containsKey(fooColumnHandles.get(i).getName())) {
                                 columnsSeen.add(fooColumnHandles.get(i).getName());


### PR DESCRIPTION
### Motivation

Allow enums in POJOs to be visible in sql for querying

Enums in POJOs will be presented as VARCHAR in Presto