### PR TITLE
Provide a flag to ignore Json format error in pulsar flink connector

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
@@ -43,13 +43,13 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
         (1).false : Throw A IOException and Terminate application。
         (2).true  : Ignore the error line and add a null line。
      */
-    private Boolean ignoreJsonFormatError = false;
+    private boolean ignoreJsonFormatError = false;
 
-    public Boolean getIgnoreJsonFormatError() {
+    public boolean getIgnoreJsonFormatError() {
         return ignoreJsonFormatError;
     }
 
-    public void setIgnoreJsonFormatError(Boolean ignoreJsonFormatError) {
+    public void setIgnoreJsonFormatError(boolean ignoreJsonFormatError) {
         this.ignoreJsonFormatError = ignoreJsonFormatError;
     }
 

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
@@ -45,10 +45,19 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
      */
     private boolean ignoreJsonFormatError = false;
 
+
+    /**
+     *
+     * @return true or false
+     */
     public boolean getIgnoreJsonFormatError() {
         return ignoreJsonFormatError;
     }
 
+    /**
+     * set ignoreJsonFormatError
+     * @param ignoreJsonFormatError
+     */
     public void setIgnoreJsonFormatError(boolean ignoreJsonFormatError) {
         this.ignoreJsonFormatError = ignoreJsonFormatError;
     }
@@ -117,7 +126,7 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 
             return row;
         } catch (Throwable t) {
-            if(ignoreJsonFormatError){
+            if (ignoreJsonFormatError) {
                 final int arity = typeInfo.getArity();
                 final Object[] nullsArray = new Object[arity];
                 return Row.of(nullsArray);
@@ -148,7 +157,4 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
         this.failOnMissingField = failOnMissingField;
     }
 
-    public void errorPaser(){
-
-    }
 }

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
@@ -38,6 +38,21 @@ import java.io.IOException;
  */
 public class JsonRowDeserializationSchema implements DeserializationSchema<Row> {
 
+    /*
+        What to do when detecting that a json line cannot be deserialized :
+        (1).false : Throw A IOException and Terminate application。
+        (2).true  : Ignore the error line and add a null line。
+     */
+    private Boolean ignoreJsonFormatError = false;
+
+    public Boolean getIgnoreJsonFormatError() {
+        return ignoreJsonFormatError;
+    }
+
+    public void setIgnoreJsonFormatError(Boolean ignoreJsonFormatError) {
+        this.ignoreJsonFormatError = ignoreJsonFormatError;
+    }
+
     /**
      * Type information describing the result type.
      */
@@ -102,7 +117,13 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 
             return row;
         } catch (Throwable t) {
-            throw new IOException("Failed to deserialize JSON object.", t);
+            if(ignoreJsonFormatError){
+                final int arity = typeInfo.getArity();
+                final Object[] nullsArray = new Object[arity];
+                return Row.of(nullsArray);
+            }else
+                throw new IOException("Failed to deserialize JSON object.", t);
+
         }
     }
 
@@ -127,4 +148,7 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
         this.failOnMissingField = failOnMissingField;
     }
 
+    public void errorPaser(){
+
+    }
 }

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/serde/JsonRowDeserializationSchema.java
@@ -121,9 +121,9 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
                 final int arity = typeInfo.getArity();
                 final Object[] nullsArray = new Object[arity];
                 return Row.of(nullsArray);
-            }else
+            } else {
                 throw new IOException("Failed to deserialize JSON object.", t);
-
+            }
         }
     }
 


### PR DESCRIPTION

### Motivation

when using flink and pulsar, a Json format error will cause the flink program to fail

### Modifications

provide a flag in pulsar flink connector to ignore json format errors
