### PR TITLE
Fix hdfs module dependencies in pulsar-io/docs module

### DIFF
--- a/pulsar-io/docs/pom.xml
+++ b/pulsar-io/docs/pom.xml
@@ -69,7 +69,12 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-io-hdfs</artifactId>
+      <artifactId>pulsar-io-hdfs2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-hdfs3</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
*Motivation*

In #2966, pulsar-io-hdfs is changed to two modules `pulsar-io-hdfs2`
and `pulsar-io-hdfs3`. But the module is not updated in `pulsar-io/docs` module.

