### PR TITLE
timeout stuck producer/consumer operation request

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -189,7 +189,7 @@ public class ClientErrorsTest {
             fail("Should have failed");
         } catch (Exception e) {
             // we fail even on the retriable error
-            assertTrue(e instanceof PulsarClientException.LookupException);
+            assertTrue(e instanceof PulsarClientException);
         }
 
         mockBrokerService.resetHandleProducer();
@@ -417,7 +417,7 @@ public class ClientErrorsTest {
             fail("Should have failed");
         } catch (Exception e) {
             // we fail even on the retriable error
-            assertEquals(e.getClass(), LookupException.class);
+            assertTrue(e instanceof PulsarClientException);
         }
 
         mockBrokerService.resetHandleSubscribe();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -670,10 +670,9 @@ public class ClientCnx extends PulsarHandler {
         });
         eventLoopGroup.schedule(() -> {
             CompletableFuture<ProducerResponse> requestFuture = pendingRequests.remove(requestId);
-            if (requestFuture != null && !requestFuture.isDone()) {
+            if (requestFuture != null && !requestFuture.isDone() && requestFuture.completeExceptionally(
+                    new TimeoutException(requestId + " lookup request timedout after ms " + operationTimeoutMs))) {
                 log.warn("{} request {} timed out after {} ms", ctx.channel(), requestId, operationTimeoutMs);
-                future.completeExceptionally(
-                        new TimeoutException(requestId + " lookup request timedout after ms " + operationTimeoutMs));
             } else {
                 // request is already completed successfully.
             }


### PR DESCRIPTION
### Motivation

Sometimes due to broker's bug, broker could not complete producer/consumer creation request and in this case, client is not timing out which causes stuck producer/consumer/replicator-producer.

Recently we have seen that due to below exception replication producer gets stuck and remote broker is not notifying to the repl-producer.

```
Caused by: java.lang.NullPointerException
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.hasSchema(PersistentTopic.java:1815) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$25(ServerCnx.java:836) ~[pulsar-broker-2.2.2-yahoo.jar:2.2.2-yahoo]
        at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[?:1.8.0_131]
        ... 24 more
```

### Modifications

Client producer/consumer creation timesout after configured operation-timeout if broker doesn't complete request in a given timeout.

### Result

It helps to unblock stuck producer/consumer request.
