### PR TITLE
[Pulsar-Broker-Common] Extend AuthenticationProviderToken UT Coverages

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -37,7 +37,7 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
     final static String HTTP_HEADER_NAME = "Authorization";
     final static String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
 
-    // When simmetric key is configured
+    // When symmetric key is configured
     final static String CONF_TOKEN_SECRET_KEY = "tokenSecretKey";
 
     // When public/private key pair is configured
@@ -92,7 +92,7 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
     }
 
     private String validateToken(final String token) throws AuthenticationException {
-        if(StringUtils.isNotBlank(token)) {
+        if (StringUtils.isNotBlank(token)) {
             return token;
         } else {
             throw new AuthenticationException("Blank token found");

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -293,6 +293,18 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @Test(expectedExceptions = IOException.class)
+    public void testInitializeWhenSecretKeyFilePathIsInvalid() throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY,
+                "file://" + "invalid_secret_key_file");
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setProperties(properties);
+
+        new AuthenticationProviderToken().initialize(conf);
+    }
+
     @Test(expectedExceptions = AuthenticationException.class)
     public void testAuthenticateWhenNoJwtPassed() throws AuthenticationException {
         AuthenticationProviderToken provider = new AuthenticationProviderToken();

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -293,18 +293,6 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
-    @Test(expectedExceptions = IOException.class)
-    public void testInitializeWhenSecretKeyFilePathIsInvalid() throws IOException {
-        Properties properties = new Properties();
-        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY,
-                "file://" + "invalid_secret_key_file");
-
-        ServiceConfiguration conf = new ServiceConfiguration();
-        conf.setProperties(properties);
-
-        new AuthenticationProviderToken().initialize(conf);
-    }
-
     @Test(expectedExceptions = AuthenticationException.class)
     public void testAuthenticateWhenNoJwtPassed() throws AuthenticationException {
         AuthenticationProviderToken provider = new AuthenticationProviderToken();
@@ -417,5 +405,29 @@ public class AuthenticationProviderTokenTest {
 
         AuthenticationProviderToken provider = new AuthenticationProviderToken();
         provider.initialize(conf);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void testInitializeWhenSecretKeyFilePathIsInvalid() throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY,
+                "file://" + "invalid_secret_key_file");
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setProperties(properties);
+
+        new AuthenticationProviderToken().initialize(conf);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void testInitializeWhenPublicKeyFilePathIsInvalid() throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_PUBLIC_KEY,
+                "file://" + "invalid_public_key_file");
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setProperties(properties);
+
+        new AuthenticationProviderToken().initialize(conf);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
@@ -25,7 +25,6 @@ import com.google.common.base.Charsets;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwt;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -44,7 +43,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
-import javax.naming.AuthenticationException;
 
 import lombok.Cleanup;
 


### PR DESCRIPTION
### Motivation
This PR aims to extend `AuthenticationProviderToken` UT Coverages.

### Modifications
1- Added new UTs when Secret/Public Key Path is invalid.
2- Removed the unused imports. 
3- Post Review comment of #3239 is addressed.