### PR TITLE
Fix: Empty exception message in java functions can cause an NPE

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStatsManager.java
@@ -326,7 +326,7 @@ public class FunctionStatsManager implements AutoCloseable {
         // report exception throw prometheus
         if (userExceptionRateLimiter.tryAcquire()) {
             String[] exceptionMetricsLabels = Arrays.copyOf(metricsLabels, metricsLabels.length + 2);
-            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage();
+            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage() != null ? ex.getMessage() : "";
             exceptionMetricsLabels[exceptionMetricsLabels.length - 1] = String.valueOf(ts);
             userExceptions.labels(exceptionMetricsLabels).set(1.0);
         }
@@ -340,7 +340,7 @@ public class FunctionStatsManager implements AutoCloseable {
         // report exception throw prometheus
         if (sysExceptionRateLimiter.tryAcquire()) {
             String[] exceptionMetricsLabels = Arrays.copyOf(metricsLabels, metricsLabels.length + 2);
-            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage();
+            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage() != null ? ex.getMessage() : "";
             exceptionMetricsLabels[exceptionMetricsLabels.length - 1] = String.valueOf(ts);
             sysExceptions.labels(exceptionMetricsLabels).set(1.0);
         }
@@ -354,7 +354,7 @@ public class FunctionStatsManager implements AutoCloseable {
         // report exception throw prometheus
         if (sourceExceptionRateLimiter.tryAcquire()) {
             String[] exceptionMetricsLabels = Arrays.copyOf(metricsLabels, metricsLabels.length + 2);
-            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage();
+            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage() != null ? ex.getMessage() : "";
             exceptionMetricsLabels[exceptionMetricsLabels.length - 1] = String.valueOf(ts);
             sourceExceptions.labels(exceptionMetricsLabels).set(1.0);
         }
@@ -368,7 +368,7 @@ public class FunctionStatsManager implements AutoCloseable {
         // report exception throw prometheus
         if (sinkExceptionRateLimiter.tryAcquire()) {
             String[] exceptionMetricsLabels = Arrays.copyOf(metricsLabels, metricsLabels.length + 2);
-            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage();
+            exceptionMetricsLabels[exceptionMetricsLabels.length - 2] = ex.getMessage() != null ? ex.getMessage() : "";
             exceptionMetricsLabels[exceptionMetricsLabels.length - 1] = String.valueOf(ts);
             sinkExceptions.labels(exceptionMetricsLabels).set(1.0);
         }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStatsManager.java
@@ -320,9 +320,7 @@ public class FunctionStatsManager implements AutoCloseable {
 
     public void addUserException(Exception ex) {
         long ts = System.currentTimeMillis();
-        InstanceCommunication.FunctionStatus.ExceptionInformation info =
-                    InstanceCommunication.FunctionStatus.ExceptionInformation.newBuilder()
-                    .setExceptionString(ex.getMessage()).setMsSinceEpoch(ts).build();
+        InstanceCommunication.FunctionStatus.ExceptionInformation info = getExceptionInfo(ex, ts);
         latestUserExceptions.add(info);
 
         // report exception throw prometheus
@@ -336,9 +334,7 @@ public class FunctionStatsManager implements AutoCloseable {
 
     public void addSystemException(Throwable ex) {
         long ts = System.currentTimeMillis();
-        InstanceCommunication.FunctionStatus.ExceptionInformation info =
-                InstanceCommunication.FunctionStatus.ExceptionInformation.newBuilder()
-                        .setExceptionString(ex.getMessage()).setMsSinceEpoch(ts).build();
+        InstanceCommunication.FunctionStatus.ExceptionInformation info = getExceptionInfo(ex, ts);
         latestSystemExceptions.add(info);
 
         // report exception throw prometheus
@@ -352,9 +348,7 @@ public class FunctionStatsManager implements AutoCloseable {
 
     public void addSourceException(Throwable ex) {
         long ts = System.currentTimeMillis();
-        InstanceCommunication.FunctionStatus.ExceptionInformation info =
-                InstanceCommunication.FunctionStatus.ExceptionInformation.newBuilder()
-                        .setExceptionString(ex.getMessage()).setMsSinceEpoch(ts).build();
+        InstanceCommunication.FunctionStatus.ExceptionInformation info = getExceptionInfo(ex, ts);
         latestSourceExceptions.add(info);
 
         // report exception throw prometheus
@@ -368,9 +362,7 @@ public class FunctionStatsManager implements AutoCloseable {
 
     public void addSinkException(Throwable ex) {
         long ts = System.currentTimeMillis();
-        InstanceCommunication.FunctionStatus.ExceptionInformation info =
-                InstanceCommunication.FunctionStatus.ExceptionInformation.newBuilder()
-                        .setExceptionString(ex.getMessage()).setMsSinceEpoch(ts).build();
+        InstanceCommunication.FunctionStatus.ExceptionInformation info = getExceptionInfo(ex, ts);
         latestSinkExceptions.add(info);
 
         // report exception throw prometheus
@@ -380,6 +372,16 @@ public class FunctionStatsManager implements AutoCloseable {
             exceptionMetricsLabels[exceptionMetricsLabels.length - 1] = String.valueOf(ts);
             sinkExceptions.labels(exceptionMetricsLabels).set(1.0);
         }
+    }
+
+    private InstanceCommunication.FunctionStatus.ExceptionInformation getExceptionInfo(Throwable th, long ts) {
+        InstanceCommunication.FunctionStatus.ExceptionInformation.Builder exceptionInfoBuilder =
+                InstanceCommunication.FunctionStatus.ExceptionInformation.newBuilder().setMsSinceEpoch(ts);
+        String msg = th.getMessage();
+        if (msg != null) {
+            exceptionInfoBuilder.setExceptionString(msg);
+        }
+        return exceptionInfoBuilder.build();
     }
 
     public void incrTotalReceived() {


### PR DESCRIPTION
### Motivation

The following NPE could happen if Exception message is null

```
java.lang.NullPointerException: null
at org.apache.pulsar.functions.proto.InstanceCommunication$FunctionStatus$ExceptionInformation$Builder.setExceptionString(InstanceCommunication.java:911) ~[org.apache.pulsar-pulsar-functions-proto-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.FunctionStatsManager.addSourceException(FunctionStatsManager.java:357) ~[org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.FunctionStatsManager.incrSourceExceptions(FunctionStatsManager.java:410) ~[org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.readInput(JavaInstanceRunnable.java:434) ~[org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:228) [org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
``