### PR TITLE
Fix: NPE in pulsar source close

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -142,12 +142,14 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
     @Override
     public void close() throws Exception {
-        inputConsumers.forEach(consumer -> {
-            try {
-                consumer.close();
-            } catch (PulsarClientException e) {
-            }
-        });
+        if (inputConsumers != null ) {
+            inputConsumers.forEach(consumer -> {
+                try {
+                    consumer.close();
+                } catch (PulsarClientException e) {
+                }
+            });
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Motivation

The following NPE could happen in pulsar source:

```
java.lang.NullPointerException: null
at org.apache.pulsar.functions.source.PulsarSource.close(PulsarSource.java:145) ~[org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.close(JavaInstanceRunnable.java:457) [org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:281) [org.apache.pulsar-pulsar-functions-instance-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
```