### PR TITLE
Clear-out old inbound cnx stats when repl producer disconnects

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1211,12 +1211,10 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
             // Add incoming msg rates
             PublisherStats pubStats = topicStatsHelper.remotePublishersStats.get(replicator.getRemoteCluster());
-            if (pubStats != null) {
-                rStat.msgRateIn = pubStats.msgRateIn;
-                rStat.msgThroughputIn = pubStats.msgThroughputIn;
-                rStat.inboundConnection = pubStats.getAddress();
-                rStat.inboundConnectedSince = pubStats.getConnectedSince();
-            }
+            rStat.msgRateIn = pubStats != null ? pubStats.msgRateIn : 0;
+            rStat.msgThroughputIn = pubStats != null ? pubStats.msgThroughputIn : 0;
+            rStat.inboundConnection = pubStats != null ? pubStats.getAddress() : null;
+            rStat.inboundConnectedSince = pubStats != null ? pubStats.getConnectedSince() : null;
 
             topicStatsHelper.aggMsgRateOut += rStat.msgRateOut;
             topicStatsHelper.aggMsgThroughputOut += rStat.msgThroughputOut;


### PR DESCRIPTION
### Motivation

Right now, when remote replication-producer gets disconnected due to below `ProducerBlockedQuotaExceededError`, broker doesn't cleanup inbound repl-producer stats for the topic and it shows invalid stale inbound cnx stats until new producer gets created successfully.

```
20:10:28.628 [pulsar-io-21-2] WARN  org.apache.pulsar.broker.service.AbstractReplicator - [persistent://localsearch/global/ns/t1][east1 -> west1] Failed to create remote producer (org.apache.pulsar.client.api.PulsarClientException$ProducerBlockedQuotaExceededError: Cannot create producer on topic with backlog quota exceeded), retrying in 5
```

### Modifications

Clear-out old stale inbound-repl stats.

### Result

Broker will not show invalid stale repl-stats.
