### PR TITLE
Support set publish time on broker side

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
+import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.NonPersistentPublisherStats;
 import org.apache.pulsar.common.policies.data.PublisherStats;
@@ -148,12 +149,17 @@ public class Producer {
             return;
         }
 
-        if (topic.isEncryptionRequired()) {
+        headersAndPayload.markReaderIndex();
+        MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
+        headersAndPayload.resetReaderIndex();
 
+        if (msgMetadata.getPublishTime() == Constants.PUBLISH_TIME_UNSET_MS) {
             headersAndPayload.markReaderIndex();
-            MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
+            Commands.modifyMessageMetadata(headersAndPayload, newPublishOnMetadata(msgMetadata));
             headersAndPayload.resetReaderIndex();
+        }
 
+        if (topic.isEncryptionRequired()) {
             // Check whether the message is encrypted or not
             if (msgMetadata.getEncryptionKeysCount() < 1) {
                 log.warn("[{}] Messages must be encrypted", getTopic().getName());
@@ -169,6 +175,10 @@ public class Producer {
         startPublishOperation();
         topic.publishMessage(headersAndPayload,
                 MessagePublishContext.get(this, sequenceId, msgIn, headersAndPayload.readableBytes(), batchSize));
+    }
+
+    private static MessageMetadata newPublishOnMetadata(MessageMetadata msgMetadata) {
+        return msgMetadata.toBuilder().setPublishTime(System.currentTimeMillis()).build();
     }
 
     private boolean verifyChecksum(ByteBuf headersAndPayload) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
+import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.DateFormatter;
@@ -344,7 +345,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     sequenceId = msgMetadataBuilder.getSequenceId();
                 }
                 if (!msgMetadataBuilder.hasPublishTime()) {
-                    msgMetadataBuilder.setPublishTime(System.currentTimeMillis());
+                    msgMetadataBuilder.setPublishTime(Constants.PUBLISH_TIME_UNSET_MS);
 
                     checkArgument(!msgMetadataBuilder.hasProducerName());
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Constants.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Constants.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.naming;
 
 public class Constants {
 
+    public static final long PUBLISH_TIME_UNSET_MS = 1000000000000L;
     public static final String GLOBAL_CLUSTER = "global";
 
     private Constants() {}


### PR DESCRIPTION
### Motivation

Since #3155 there is a real need not to depend on client side clock for publish time field on message metadata.

This change sets a default value for publish time field at client side in order to be able to be identified by broker easily and set newly calculated time on it. If time was normally set by the client on publish time, this update will be just ignored by broker.

### Modifications

[pulsar-broker]
  - Read message metadata for produced messages in order to know whether the
    message was set onto default value and should be updated with time
    calculated by broker.
  - Add method to return previous metadata with publish time set by broker.

[pulsar-client]
  - ProducerImpl client side set a default fixed size value for publish time.

[pulsar-common]
  - Add modifyMessageMetadata method on Commands in order to update new modified
    fields on payload.

The default constant value used to set the undefined number of milliseconds since epoch is going to be 13 decimal digits, the method currentTimeMillis will always return 13 decimal digits assuming the broker has the current time set correctly.

So we are safe with the assumption that the return value is 13 decimal digits for more than the next two centuries.

### Result

Any client which set publish time with default value will be updated by broker with current time.

### TODO

Once this change is accepted:

- [ ] Add proper tests
- [ ] Add default publish time on the rest of clients.