### PR TITLE
Adding config auto.offset.reset to PulsarKafkaConsumer

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -164,12 +164,13 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     private OffsetResetStrategy getStrategy(final String strategy) {
-    	if (strategy.equals("earliest")) {
-    		return OffsetResetStrategy.EARLIEST;
-    	} else if (strategy.equals("latest")) {
-    		return OffsetResetStrategy.LATEST;
-    	} else {
-    		return OffsetResetStrategy.NONE;
+    	switch(strategy) {
+    		case "earliest":
+    			return OffsetResetStrategy.EARLIEST;
+    		case "latest":
+    			return OffsetResetStrategy.LATEST;
+    		default:
+    			throw new IllegalArgumentException("Strategy given by the user is not valid");
     	}
     }
     
@@ -523,7 +524,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     		seekToBeginning(Collections.singleton(partition));
     	} else {
     		seekToEnd(Collections.singleton(partition));
-    	}
+    	} 
     }
     
     @Override

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -147,6 +147,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         groupId = config.getString(ConsumerConfig.GROUP_ID_CONFIG);
         isAutoCommit = config.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
         strategy = getStrategy(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+        log.info("Offset reset strategy has been assigned value {}", strategy);
 
         String serviceUrl = config.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG).get(0);
 
@@ -325,6 +326,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
                 TopicPartition tp = new TopicPartition(topic, partition);
                 if (lastReceivedOffset.get(tp) == null) {
+                	log.info("When polling offsets, invalid offsets were detected. Resetting topic partition {}", tp);
                 	resetOffsets(tp);
                 }
 
@@ -515,6 +517,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     private SubscriptionInitialPosition resetOffsets(final TopicPartition partition) {
+    	log.info("Resetting partition {} and seeking to {} position", partition, strategy);
         if (strategy == SubscriptionInitialPosition.Earliest) {
             seekToBeginning(Collections.singleton(partition));
         } else {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -515,12 +515,12 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     private SubscriptionInitialPosition resetOffsets(final TopicPartition partition) {
-    	if (strategy == SubscriptionInitialPosition.Earliest) {
-    		seekToBeginning(Collections.singleton(partition));
-    	} else {
-    		seekToEnd(Collections.singleton(partition));
-    	} 
-    	return strategy;
+        if (strategy == SubscriptionInitialPosition.Earliest) {
+            seekToBeginning(Collections.singleton(partition));
+        } else {
+            seekToEnd(Collections.singleton(partition));
+        } 
+        return strategy;
     }
     
     @Override

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -511,19 +512,18 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     public long position(TopicPartition partition) {
         Long offset = lastReceivedOffset.get(partition);
         if (offset == null && strategy != OffsetResetStrategy.NONE) {
-        	resetOffsets(partition);
-        	// get most recent offset
-        	poll(0);
-        	return lastReceivedOffset.get(partition);
+        	return resetOffsets(partition).getValue();
         }
         return offset;
     }
 
-    private void resetOffsets(final TopicPartition partition) {
+    private SubscriptionInitialPosition resetOffsets(final TopicPartition partition) {
     	if (strategy == OffsetResetStrategy.EARLIEST) {
     		seekToBeginning(Collections.singleton(partition));
+    		return SubscriptionInitialPosition.Earliest;
     	} else {
     		seekToEnd(Collections.singleton(partition));
+    		return SubscriptionInitialPosition.Latest;
     	} 
     }
     

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -164,13 +164,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     private SubscriptionInitialPosition getStrategy(final String strategy) {
-    	switch(strategy) {
-    		case "earliest":
-    			return SubscriptionInitialPosition.Earliest;
-    		case "latest":
-    			return SubscriptionInitialPosition.Latest;
-    		default:
-    			throw new IllegalArgumentException("Strategy given by the user is not valid");
+        switch(strategy) {
+    	    case "earliest":
+    	        return SubscriptionInitialPosition.Earliest;
+    	    default:
+    		    return SubscriptionInitialPosition.Latest;
     	}
     }
     
@@ -511,7 +509,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     public long position(TopicPartition partition) {
         Long offset = lastReceivedOffset.get(partition);
         if (offset == null) {
-        	return resetOffsets(partition).getValue();
+            return resetOffsets(partition).getValue();
         }
         return offset;
     }

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -469,6 +469,12 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
+        if (partitions.isEmpty()) {
+            partitions = consumers.keySet();
+        }
+        lastCommittedOffset.clear();
+        lastReceivedOffset.clear();
+        
         for (TopicPartition tp : partitions) {
             org.apache.pulsar.client.api.Consumer<byte[]> c = consumers.get(tp);
             if (c == null) {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -508,10 +508,10 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     @Override
     public long position(TopicPartition partition) {
         Long offset = lastReceivedOffset.get(partition);
-        if (offset == null) {
+        if (offset == null && !unpolledPartitions.contains(partition)) {
             return resetOffsets(partition).getValue();
         }
-        return offset;
+        return unpolledPartitions.contains(partition) ? 0 : offset;
     }
 
     private SubscriptionInitialPosition resetOffsets(final TopicPartition partition) {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -66,7 +66,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 
 @Slf4j
 public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListener<byte[]> {
-     private static enum OffsetResetStrategy {EARLIEST, LATEST, NONE}
+    private static enum OffsetResetStrategy {EARLIEST, LATEST, NONE}
 
     private static final long serialVersionUID = 1L;
 
@@ -516,7 +516,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         	poll(0);
         	return lastReceivedOffset.get(partition);
         }
-        return offset != null ? offset : -1L;
+        return offset;
     }
 
     private void resetOffsets(final TopicPartition partition) {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -168,7 +168,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     	    case "earliest":
     	        return SubscriptionInitialPosition.Earliest;
     	    default:
-    		    return SubscriptionInitialPosition.Latest;
+                return SubscriptionInitialPosition.Latest;
     	}
     }
     

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -465,12 +465,6 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        if (partitions.isEmpty()) {
-            partitions = consumers.keySet();
-        }
-        lastCommittedOffset.clear();
-        lastReceivedOffset.clear();
-
         for (TopicPartition tp : partitions) {
             org.apache.pulsar.client.api.Consumer<byte[]> c = consumers.get(tp);
             if (c == null) {
@@ -490,9 +484,14 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
         if (partitions.isEmpty()) {
             partitions = consumers.keySet();
+            lastCommittedOffset.clear();
+            lastReceivedOffset.clear();
+        } else {
+            for (final TopicPartition partition : partitions) {
+                lastCommittedOffset.remove(partition);
+                lastReceivedOffset.remove(partition);
+            }
         }
-        lastCommittedOffset.clear();
-        lastReceivedOffset.clear();
 
         for (TopicPartition tp : partitions) {
             org.apache.pulsar.client.api.Consumer<byte[]> c = consumers.get(tp);

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -129,7 +129,7 @@ Properties:
 | Config property                         | Supported | Notes                                                                         |
 |:----------------------------------------|:----------|:------------------------------------------------------------------------------|
 | `acks`                                  | Ignored   | Durability and quorum writes are configured at the namespace level            |
-| `auto.offset.reset`			  | Yes       | Will throw an exception if this property is not defined (i.e. is none).	      |
+| `auto.offset.reset`			  | Yes       | Will have a default value of 'latest' if user does not give specific setting. |
 | `batch.size`                            | Ignored   |                                                                               |
 | `block.on.buffer.full`                  | Yes       | If true it will block producer, otherwise give error                          |
 | `bootstrap.servers`                     | Yes       | Needs to point to a single Pulsar service URL                                 |

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -129,6 +129,7 @@ Properties:
 | Config property                         | Supported | Notes                                                                         |
 |:----------------------------------------|:----------|:------------------------------------------------------------------------------|
 | `acks`                                  | Ignored   | Durability and quorum writes are configured at the namespace level            |
+| `auto.offset.reset`			  | Yes       | Will throw an exception if this property is not defined (i.e. is none).	      |
 | `batch.size`                            | Ignored   |                                                                               |
 | `block.on.buffer.full`                  | Yes       | If true it will block producer, otherwise give error                          |
 | `bootstrap.servers`                     | Yes       | Needs to point to a single Pulsar service URL                                 |


### PR DESCRIPTION
### Motivation

Currently, in KafkaConsumer, there is a new config which is called auto.offset.reset. It is currently ignored in PulsarKafkaConsumer, so we wish to implement it.

### Modifications

We added some new code which defined the behavior if auto.offset.reset == "earliest" or "latest".

### Result

It would automatically seek to the last offset or the first offset depending on the set config.