### PR TITLE
Fixed KEYS URL in download page.

### DIFF
--- a/site2/website/pages/en/download.js
+++ b/site2/website/pages/en/download.js
@@ -89,7 +89,7 @@ class Download extends React.Component {
             <MarkdownBlock>
               You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files.
               We provide OpenPGP signatures for every release file. This signature should be matched against the
-              [KEYS](https://www.apache.org/dist/incubator/pulsar/KEYS) file which contains the OpenPGP keys of
+              [KEYS](https://www.apache.org/dist/pulsar/KEYS) file which contains the OpenPGP keys of
               Pulsar's Release Managers. We also provide `SHA-512` checksums for every release file.
               After you download the file, you should calculate a checksum for your download, and make sure it is
               the same as ours.


### PR DESCRIPTION
### Motivation

Link was pointing to old incubator address.