### PR TITLE
CPP Client - Turning switch case warnings into errors.

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT C_STANDARD)
     set(C_STANDARD "-std=c11")
 endif(NOT C_STANDARD)
 
-set(CMAKE_CXX_FLAGS " -msse4.2 -mpclmul -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS " -msse4.2 -mpclmul -Werror=switch -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
 
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -57,6 +57,7 @@ enum Result
 
     ResultConsumerNotInitialized,         /// Consumer is not initialized
     ResultProducerNotInitialized,         /// Producer is not initialized
+    ResultProducerBusy,                   /// Producer with same name is already connected
     ResultTooManyLookupRequestException,  /// Too Many concurrent LookupRequest
 
     ResultInvalidTopicName,  /// Invalid topic name
@@ -73,7 +74,7 @@ enum Result
     ResultConsumerNotFound,                       /// Consumer not found
     ResultUnsupportedVersionError,  /// Error when an older client/version doesn't support a required feature
     ResultTopicTerminated,          /// Topic was already terminated
-    ResultCryptoError               /// Error when crypto operation fails
+    ResultCryptoError,              /// Error when crypto operation fails
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -103,6 +103,12 @@ static Result getResult(ServerError serverError) {
 
         case TopicTerminatedError:
             return ResultTopicTerminated;
+
+        case ProducerBusy:
+            return ResultProducerBusy;
+
+        case InvalidTopicName:
+            return ResultInvalidTopicName;
     }
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -453,6 +453,12 @@ std::string Commands::messageType(BaseCommand_Type type) {
         case BaseCommand::GET_TOPICS_OF_NAMESPACE_RESPONSE:
             return "GET_TOPICS_OF_NAMESPACE_RESPONSE";
             break;
+        case BaseCommand::GET_SCHEMA:
+            return "GET_SCHEMA";
+            break;
+        case BaseCommand::GET_SCHEMA_RESPONSE:
+            return "GET_SCHEMA_RESPONSE";
+            break;
     };
 }
 

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -125,6 +125,9 @@ const char* pulsar::strResult(Result result) {
 
         case ResultCryptoError:
             return "CryptoError";
+
+        case ResultProducerBusy:
+            return "ProducerBusy";
     };
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding


### PR DESCRIPTION
Turning missing switch case handling warnings into errors and handled a few missing cases.