### PR TITLE
CPP Client - Error out Lookup request after operation timeout.

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -695,7 +695,8 @@ void ClientConnection::handleIncomingCommand() {
                     PendingLookupRequestsMap::iterator it =
                         pendingLookupRequests_.find(partitionMetadataResponse.request_id());
                     if (it != pendingLookupRequests_.end()) {
-                        LookupDataResultPromisePtr lookupDataPromise = it->second;
+                        it->second.timer->cancel();
+                        LookupDataResultPromisePtr lookupDataPromise = it->second.promise;
                         pendingLookupRequests_.erase(it);
                         numOfPendingLookupRequest_--;
                         lock.unlock();
@@ -779,7 +780,8 @@ void ClientConnection::handleIncomingCommand() {
                     PendingLookupRequestsMap::iterator it =
                         pendingLookupRequests_.find(lookupTopicResponse.request_id());
                     if (it != pendingLookupRequests_.end()) {
-                        LookupDataResultPromisePtr lookupDataPromise = it->second;
+                        it->second.timer->cancel();
+                        LookupDataResultPromisePtr lookupDataPromise = it->second.promise;
                         pendingLookupRequests_.erase(it);
                         numOfPendingLookupRequest_--;
                         lock.unlock();
@@ -1082,7 +1084,14 @@ void ClientConnection::newLookup(const SharedBuffer& cmd, const uint64_t request
         promise->setFailed(ResultTooManyLookupRequestException);
         return;
     }
-    pendingLookupRequests_.insert(std::make_pair(requestId, promise));
+    LookupRequestData requestData;
+    requestData.timer = executor_->createDeadlineTimer();
+    requestData.timer->expires_from_now(operationsTimeout_);
+    requestData.timer->async_wait(
+        boost::bind(&ClientConnection::handleLookupTimeout, shared_from_this(), _1, requestData));
+    requestData.promise = promise;
+
+    pendingLookupRequests_.insert(std::make_pair(requestId, requestData));
     numOfPendingLookupRequest_++;
     lock.unlock();
     sendCommand(cmd);
@@ -1194,6 +1203,13 @@ void ClientConnection::handleRequestTimeout(const boost::system::error_code& ec,
     }
 }
 
+void ClientConnection::handleLookupTimeout(const boost::system::error_code& ec,
+                                           LookupRequestData pendingRequestData) {
+    if (!ec) {
+        pendingRequestData.promise->setFailed(ResultTimeout);
+    }
+}
+
 void ClientConnection::handleKeepAliveTimeout() {
     if (isClosed()) {
         return;
@@ -1270,7 +1286,7 @@ void ClientConnection::close() {
 
     for (PendingLookupRequestsMap::iterator it = pendingLookupRequests.begin();
          it != pendingLookupRequests.end(); ++it) {
-        it->second->setFailed(ResultConnectError);
+        it->second.promise->setFailed(ResultConnectError);
     }
 
     for (PendingConsumerStatsMap::iterator it = pendingConsumerStatsMap.begin();

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -154,6 +154,11 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
         DeadlineTimerPtr timer;
     };
 
+    struct LookupRequestData {
+        LookupDataResultPromisePtr promise;
+        DeadlineTimerPtr timer;
+    };
+
     /*
      * handler for connectAsync
      * creates a ConnectionPtr which has a valid ClientConnection object
@@ -190,6 +195,8 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     void newLookup(const SharedBuffer& cmd, const uint64_t requestId, LookupDataResultPromisePtr promise);
 
     void handleRequestTimeout(const boost::system::error_code& ec, PendingRequestData pendingRequestData);
+
+    void handleLookupTimeout(const boost::system::error_code&, LookupRequestData);
 
     void handleKeepAliveTimeout();
 
@@ -259,7 +266,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     typedef std::map<long, PendingRequestData> PendingRequestsMap;
     PendingRequestsMap pendingRequests_;
 
-    typedef std::map<long, LookupDataResultPromisePtr> PendingLookupRequestsMap;
+    typedef std::map<long, LookupRequestData> PendingLookupRequestsMap;
     PendingLookupRequestsMap pendingLookupRequests_;
 
     typedef std::map<long, ProducerImplWeakPtr> ProducersMap;


### PR DESCRIPTION
### Motivation

Currently, if the Broker gets stuck or unresponsive and doesn't respond to `CommandLookup` or `CommandPartitionMetadata` then we should fail the lookup after operationTimeout so that the request can go to other brokers.

### Modifications

Added a new timeout function and a new structure to store timer for requestData.
