### PR TITLE
[Pulsar-Client] Add minor Schema fixes

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -40,8 +40,7 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
     }
 
     private void ensureSchemaInitialized() {
-        checkState(null != schema,
-                "Schema is not initialized before used");
+        checkState(null != schema,"Schema is not initialized before used");
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -40,7 +40,7 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
     }
 
     private void ensureSchemaInitialized() {
-        checkState(null != schema,"Schema is not initialized before used");
+        checkState(null != schema, "Schema is not initialized before used");
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
-
 import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.pulsar.client.api.Schema;
@@ -41,7 +40,8 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
     }
 
     private void ensureSchemaInitialized() {
-        checkState(null != schema, "Schema is not initialized before used");
+        checkState(null != schema,
+                "Schema is not initialized before used");
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -69,7 +69,6 @@ public class JSONSchema<T> implements Schema<T>{
 
     @Override
     public byte[] encode(T message) throws SchemaSerializationException {
-
         try {
             return objectMapper.writeValueAsBytes(message);
         } catch (JsonProcessingException e) {
@@ -82,7 +81,7 @@ public class JSONSchema<T> implements Schema<T>{
         try {
             return objectMapper.readValue(bytes, this.pojo);
         } catch (IOException e) {
-            throw new RuntimeException(new SchemaSerializationException(e));
+            throw new SchemaSerializationException(e);
         }
     }
 
@@ -102,12 +101,12 @@ public class JSONSchema<T> implements Schema<T>{
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(objectMapper);
-            JsonSchema jsonBackwardsCompatibileSchema = schemaGen.generateSchema(pojo);
+            JsonSchema jsonBackwardsCompatibleSchema = schemaGen.generateSchema(pojo);
             backwardsCompatibleSchemaInfo = new SchemaInfo();
             backwardsCompatibleSchemaInfo.setName("");
             backwardsCompatibleSchemaInfo.setProperties(properties);
             backwardsCompatibleSchemaInfo.setType(SchemaType.JSON);
-            backwardsCompatibleSchemaInfo.setSchema(objectMapper.writeValueAsBytes(jsonBackwardsCompatibileSchema));
+            backwardsCompatibleSchemaInfo.setSchema(objectMapper.writeValueAsBytes(jsonBackwardsCompatibleSchema));
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
@@ -47,7 +47,7 @@ class GenericJsonSchema extends GenericSchema {
         try {
             return objectMapper.writeValueAsBytes(gjr.getJsonNode().toString());
         } catch (IOException ioe) {
-            throw new RuntimeException(new SchemaSerializationException(ioe));
+            throw new SchemaSerializationException(ioe);
         }
     }
 
@@ -57,7 +57,7 @@ class GenericJsonSchema extends GenericSchema {
             JsonNode jn = objectMapper.readTree(new String(bytes, UTF_8));
             return new GenericJsonRecord(fields, jn);
         } catch (IOException ioe) {
-            throw new RuntimeException(new SchemaSerializationException(ioe));
+            throw new SchemaSerializationException(ioe);
         }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Bar;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.DerivedFoo;
@@ -117,7 +118,6 @@ public class JSONSchemaTest {
 
     @Test
     public void testCorrectPolymorphism() {
-
         Bar bar = new Bar();
         bar.setField1(true);
 
@@ -160,8 +160,11 @@ public class JSONSchemaTest {
         JSONSchema<SchemaTestUtils.DerivedDerivedFoo> derivedDerivedJsonSchema
                 = JSONSchema.of(SchemaTestUtils.DerivedDerivedFoo.class);
         Assert.assertEquals(derivedDerivedJsonSchema.decode(derivedDerivedJsonSchema.encode(derivedDerivedFoo)), derivedDerivedFoo);
+    }
 
-
-
+    @Test(expectedExceptions = SchemaSerializationException.class)
+    public void testDecodeWithInvalidContent() {
+        JSONSchema<Foo> jsonSchema = JSONSchema.of(Foo.class);
+        jsonSchema.decode(new byte[0]);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
@@ -41,7 +41,6 @@ public class SchemaInfo {
     @EqualsAndHashCode.Exclude
     private String name;
 
-
     /**
      * The schema data in AVRO JSON format
      */


### PR DESCRIPTION
### Motivation
This PR aims to cover some of minor `Schema` fixes.

### Modifications
1- `SchemaSerializationException` already extends `RuntimeException` so `RuntimeException` wraps look redundant.
2- Fixes variable name
3- Fixes redundant line breaks

### Test
1- Adding a new UT for `SchemaSerializationException` case on `JSONSchema.decode()` function