### PR TITLE
Clean up and correct properties to producer and consumers created by Functions/Sinks/Sources

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -95,6 +95,7 @@ class ContextImpl implements Context, SinkContext, SourceContext {
         userMetricsLabelNames = Arrays.copyOf(ComponentStatsManager.metricsLabelNames, ComponentStatsManager.metricsLabelNames.length + 1);
         userMetricsLabelNames[ComponentStatsManager.metricsLabelNames.length] = "metric";
     }
+    private final Utils.ComponentType componentType;
 
     public ContextImpl(InstanceConfig config, Logger logger, PulsarClient client, List<String> inputTopics,
                        SecretsProvider secretsProvider, CollectorRegistry collectorRegistry, String[] metricsLabels,
@@ -148,6 +149,7 @@ class ContextImpl implements Context, SinkContext, SourceContext {
                 .quantile(0.99, 0.01)
                 .quantile(0.999, 0.01)
                 .register(collectorRegistry);
+        this.componentType = componentType;
     }
 
     public void setCurrentMessageContext(Record<?> record) {
@@ -307,7 +309,15 @@ class ContextImpl implements Context, SinkContext, SourceContext {
         if (producer == null) {
             try {
                 Producer<O> newProducer = ((ProducerBuilderImpl<O>) producerBuilder.clone())
-                        .schema(schema).topic(topicName).create();
+                        .schema(schema)
+                        .topic(topicName)
+                        .properties(InstanceUtils.getProperties(componentType,
+                                Utils.getFullyQualifiedInstanceId(
+                                        this.config.getFunctionDetails().getTenant(),
+                                        this.config.getFunctionDetails().getNamespace(),
+                                        this.config.getFunctionDetails().getName(),
+                                        this.config.getInstanceId())))
+                        .create();
 
                 Producer<O> existingProducer = (Producer<O>) publishProducers.putIfAbsent(topicName, newProducer);
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.functions.instance.stats.SourceStatsManager;
 import org.apache.pulsar.functions.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.secretsprovider.SecretsProvider;
 import org.apache.pulsar.functions.source.TopicSchema;
+import org.apache.pulsar.functions.utils.FunctionDetailsUtils;
 import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
@@ -312,11 +313,11 @@ class ContextImpl implements Context, SinkContext, SourceContext {
                         .schema(schema)
                         .topic(topicName)
                         .properties(InstanceUtils.getProperties(componentType,
-                                Utils.getFullyQualifiedInstanceId(
+                                FunctionDetailsUtils.getFullyQualifiedName(
                                         this.config.getFunctionDetails().getTenant(),
                                         this.config.getFunctionDetails().getNamespace(),
-                                        this.config.getFunctionDetails().getName(),
-                                        this.config.getInstanceId())))
+                                        this.config.getFunctionDetails().getName()),
+                                this.config.getInstanceId()))
                         .create();
 
                 Producer<O> existingProducer = (Producer<O>) publishProducers.putIfAbsent(topicName, newProducer);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
@@ -36,6 +36,9 @@ import org.apache.pulsar.functions.utils.Reflections;
 import net.jodah.typetools.TypeResolver;
 import org.apache.pulsar.functions.utils.Utils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @UtilityClass
 public class InstanceUtils {
     public static SerDe<?> initializeSerDe(String serdeClassName, ClassLoader clsLoader, Class<?> typeArg,
@@ -102,5 +105,22 @@ public class InstanceUtils {
             return FUNCTION;
         }
         return SINK;
+    }
+
+    public static Map<String, String> getProperties(Utils.ComponentType componentType, String fullyQualifiedInstanceId) {
+        Map<String, String> properties = new HashMap<>();
+        switch (componentType) {
+            case FUNCTION:
+                properties.put("application", "pulsar-function");
+                break;
+            case SOURCE:
+                properties.put("application", "pulsar-source");
+                break;
+            case SINK:
+                properties.put("application", "pulsar-sink");
+                break;
+        }
+        properties.put("id", fullyQualifiedInstanceId);
+        return properties;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
@@ -107,7 +107,8 @@ public class InstanceUtils {
         return SINK;
     }
 
-    public static Map<String, String> getProperties(Utils.ComponentType componentType, String fullyQualifiedInstanceId) {
+    public static Map<String, String> getProperties(Utils.ComponentType componentType,
+                                                    String fullyQualifiedName, int instanceId) {
         Map<String, String> properties = new HashMap<>();
         switch (componentType) {
             case FUNCTION:
@@ -120,7 +121,8 @@ public class InstanceUtils {
                 properties.put("application", "pulsar-sink");
                 break;
         }
-        properties.put("id", fullyQualifiedInstanceId);
+        properties.put("id", fullyQualifiedName);
+        properties.put("instance_id", String.valueOf(instanceId));
         return properties;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -56,13 +56,12 @@ public class PulsarSink<T> implements Sink<T> {
 
     private final PulsarClient client;
     private final PulsarSinkConfig pulsarSinkConfig;
+    private final Map<String, String> properties;
 
     @VisibleForTesting
     PulsarSinkProcessor<T> pulsarSinkProcessor;
 
     private final TopicSchema topicSchema;
-    private final String fullyQualifiedInstanceId;
-    private final Utils.ComponentType componentType;
 
     private interface PulsarSinkProcessor<T> {
 
@@ -99,7 +98,7 @@ public class PulsarSink<T> implements Sink<T> {
                 builder.producerName(producerName);
             }
 
-            return builder.properties(InstanceUtils.getProperties(componentType, fullyQualifiedInstanceId)).create();
+            return builder.properties(properties).create();
         }
 
         protected Producer<T> getProducer(String destinationTopic) {
@@ -209,13 +208,11 @@ public class PulsarSink<T> implements Sink<T> {
         }
     }
 
-    public PulsarSink(PulsarClient client, PulsarSinkConfig pulsarSinkConfig, String fullyQualifiedInstanceId, Utils.ComponentType
-            componentType) {
+    public PulsarSink(PulsarClient client, PulsarSinkConfig pulsarSinkConfig, Map<String, String> properties) {
         this.client = client;
         this.pulsarSinkConfig = pulsarSinkConfig;
         this.topicSchema = new TopicSchema(client);
-        this.fullyQualifiedInstanceId = fullyQualifiedInstanceId;
-        this.componentType = componentType;
+        this.properties = properties;
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -47,19 +47,16 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
     private final PulsarClient pulsarClient;
     private final PulsarSourceConfig pulsarSourceConfig;
+    private final Map<String, String> properties;
     private List<String> inputTopics;
     private List<Consumer<T>> inputConsumers;
     private final TopicSchema topicSchema;
-    private final String fullyQualifiedInstanceId;
-    private final Utils.ComponentType componentType;
 
-    public PulsarSource(PulsarClient pulsarClient, PulsarSourceConfig pulsarConfig,
-                        String fullyQualifiedInstanceId, Utils.ComponentType componentType) {
+    public PulsarSource(PulsarClient pulsarClient, PulsarSourceConfig pulsarConfig, Map<String, String> properties) {
         this.pulsarClient = pulsarClient;
         this.pulsarSourceConfig = pulsarConfig;
         this.topicSchema = new TopicSchema(pulsarClient);
-        this.fullyQualifiedInstanceId = fullyQualifiedInstanceId;
-        this.componentType = componentType;
+        this.properties = properties;
     }
 
     @Override
@@ -84,7 +81,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             } else {
                 cb.topic(topic);
             }
-            cb.properties(InstanceUtils.getProperties(componentType, fullyQualifiedInstanceId));
+            cb.properties(properties);
 
             if (pulsarSourceConfig.getTimeoutMs() != null) {
                 cb.ackTimeout(pulsarSourceConfig.getTimeoutMs(), TimeUnit.MILLISECONDS);

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -148,11 +148,11 @@ class ContextImpl(pulsar.Context):
         batching_max_publish_delay_ms=1,
         max_pending_messages=100000,
         compression_type=pulsar_compression_type,
-        properties=util.get_properties(util.getFullyQualifiedInstanceId(
+        properties=util.get_properties(util.getFullyQualifiedFunctionName(
           self.instance_config.function_details.tenant,
           self.instance_config.function_details.namespace,
-          self.instance_config.function_details.name,
-          self.instance_config.instance_id))
+          self.instance_config.function_details.name),
+          self.instance_config.instance_id)
       )
 
     if serde_class_name not in self.publish_serializers:

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -147,7 +147,12 @@ class ContextImpl(pulsar.Context):
         batching_enabled=True,
         batching_max_publish_delay_ms=1,
         max_pending_messages=100000,
-        compression_type=pulsar_compression_type
+        compression_type=pulsar_compression_type,
+        properties=util.get_properties(util.getFullyQualifiedInstanceId(
+          self.instance_config.function_details.tenant,
+          self.instance_config.function_details.namespace,
+          self.instance_config.function_details.name,
+          self.instance_config.instance_id))
       )
 
     if serde_class_name not in self.publish_serializers:

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -128,7 +128,6 @@ class PythonInstance(object):
       self.instance_config.function_details.namespace,
       self.instance_config.function_details.name,
       self.instance_config.instance_id))
-    Log.info("properties: %s - %s", properties, type(properties))
 
     for topic, serde in self.instance_config.function_details.source.topicsToSerDeClassName.items():
       if not serde:

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -122,6 +122,14 @@ class PythonInstance(object):
     subscription_name = str(self.instance_config.function_details.tenant) + "/" + \
                         str(self.instance_config.function_details.namespace) + "/" + \
                         str(self.instance_config.function_details.name)
+
+    properties = util.get_properties(util.getFullyQualifiedInstanceId(
+      self.instance_config.function_details.tenant,
+      self.instance_config.function_details.namespace,
+      self.instance_config.function_details.name,
+      self.instance_config.instance_id))
+    Log.info("properties: %s - %s", properties, type(properties))
+
     for topic, serde in self.instance_config.function_details.source.topicsToSerDeClassName.items():
       if not serde:
         serde_kclass = util.import_class(os.path.dirname(self.user_code), DEFAULT_SERIALIZER)
@@ -133,7 +141,8 @@ class PythonInstance(object):
         str(topic), subscription_name,
         consumer_type=mode,
         message_listener=partial(self.message_listener, self.input_serdes[topic]),
-        unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None
+        unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
+        properties=properties
       )
 
     for topic, consumer_conf in self.instance_config.function_details.source.inputSpecs.items():
@@ -148,14 +157,16 @@ class PythonInstance(object):
           re.compile(str(topic)), subscription_name,
           consumer_type=mode,
           message_listener=partial(self.message_listener, self.input_serdes[topic]),
-          unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None
+          unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
+          properties=properties
         )
       else:
         self.consumers[topic] = self.pulsar_client.subscribe(
           str(topic), subscription_name,
           consumer_type=mode,
           message_listener=partial(self.message_listener, self.input_serdes[topic]),
-          unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None
+          unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
+          properties=properties
         )
 
     function_kclass = util.import_class(os.path.dirname(self.user_code), self.instance_config.function_details.className)
@@ -271,7 +282,13 @@ class PythonInstance(object):
         # set send timeout to be infinity to prevent potential deadlock with consumer
         # that might happen when consumer is blocked due to unacked messages
         send_timeout_millis=0,
-        max_pending_messages=100000)
+        max_pending_messages=100000,
+        properties=util.get_properties(util.getFullyQualifiedInstanceId(
+                        self.instance_config.function_details.tenant,
+                        self.instance_config.function_details.namespace,
+                        self.instance_config.function_details.name,
+                        self.instance_config.instance_id))
+      )
 
   def message_listener(self, serde, consumer, message):
     # increment number of received records from source

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -123,11 +123,11 @@ class PythonInstance(object):
                         str(self.instance_config.function_details.namespace) + "/" + \
                         str(self.instance_config.function_details.name)
 
-    properties = util.get_properties(util.getFullyQualifiedInstanceId(
-      self.instance_config.function_details.tenant,
-      self.instance_config.function_details.namespace,
-      self.instance_config.function_details.name,
-      self.instance_config.instance_id))
+    properties = util.get_properties(util.getFullyQualifiedFunctionName(
+                        self.instance_config.function_details.tenant,
+                        self.instance_config.function_details.namespace,
+                        self.instance_config.function_details.name),
+                        self.instance_config.instance_id)
 
     for topic, serde in self.instance_config.function_details.source.topicsToSerDeClassName.items():
       if not serde:
@@ -282,11 +282,11 @@ class PythonInstance(object):
         # that might happen when consumer is blocked due to unacked messages
         send_timeout_millis=0,
         max_pending_messages=100000,
-        properties=util.get_properties(util.getFullyQualifiedInstanceId(
+        properties=util.get_properties(util.getFullyQualifiedFunctionName(
                         self.instance_config.function_details.tenant,
                         self.instance_config.function_details.namespace,
-                        self.instance_config.function_details.name,
-                        self.instance_config.instance_id))
+                        self.instance_config.function_details.name),
+                        self.instance_config.instance_id)
       )
 
   def message_listener(self, serde, consumer, message):

--- a/pulsar-functions/instance/src/main/python/util.py
+++ b/pulsar-functions/instance/src/main/python/util.py
@@ -68,6 +68,12 @@ def import_class_from_path(from_path, full_class_name):
 def getFullyQualifiedFunctionName(tenant, namespace, name):
   return "%s/%s/%s" % (tenant, namespace, name)
 
+def getFullyQualifiedInstanceId(tenant, namespace, name, instance_id):
+    return "%s/%s/%s:%s" % (tenant, namespace, name, instance_id)
+
+def get_properties(fullyQualifiedInstanceId):
+    return {"application": "pulsar-function", "id": str(fullyQualifiedInstanceId)}
+
 class FixedTimer():
 
     def __init__(self, t, hFunction):

--- a/pulsar-functions/instance/src/main/python/util.py
+++ b/pulsar-functions/instance/src/main/python/util.py
@@ -71,8 +71,8 @@ def getFullyQualifiedFunctionName(tenant, namespace, name):
 def getFullyQualifiedInstanceId(tenant, namespace, name, instance_id):
     return "%s/%s/%s:%s" % (tenant, namespace, name, instance_id)
 
-def get_properties(fullyQualifiedInstanceId):
-    return {"application": "pulsar-function", "id": str(fullyQualifiedInstanceId)}
+def get_properties(fullyQualifiedName, instanceId):
+    return {"application": "pulsar-function", "id": str(fullyQualifiedName), "instance_id": str(instanceId)}
 
 class FixedTimer():
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -160,7 +160,7 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         try {
             Schema schema = pulsarSink.initializeSchema();
@@ -178,7 +178,7 @@ public class PulsarSinkTest {
         // set type to be inconsistent to that of SerDe
         pulsarConfig.setTypeClassName(Integer.class.getName());
         pulsarConfig.setSerdeClassName(TestSerDe.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>());
         try {
             pulsarSink.initializeSchema();
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
@@ -200,7 +200,7 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         try {
             pulsarSink.initializeSchema();
@@ -219,7 +219,7 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
         pulsarConfig.setSerdeClassName(TopicSchema.DEFAULT_SERDE);
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         try {
             pulsarSink.initializeSchema();
@@ -235,7 +235,7 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
         pulsarConfig.setSerdeClassName(ComplexSerDe.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         try {
             pulsarSink.initializeSchema();
@@ -259,7 +259,7 @@ public class PulsarSinkTest {
         /** test At-least-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
-        PulsarSink pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSink pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>());
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 
@@ -316,7 +316,7 @@ public class PulsarSinkTest {
         /** test At-most-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATMOST_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>());
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 
@@ -373,7 +373,7 @@ public class PulsarSinkTest {
         /** test Effectively-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>());
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -101,6 +101,7 @@ public class PulsarSinkTest {
         doReturn(producerBuilder).when(producerBuilder).topic(anyString());
         doReturn(producerBuilder).when(producerBuilder).producerName(anyString());
         doReturn(producerBuilder).when(producerBuilder).property(anyString(), anyString());
+        doReturn(producerBuilder).when(producerBuilder).properties(any());
         doReturn(producerBuilder).when(producerBuilder).sendTimeout(anyInt(), any());
         
         CompletableFuture completableFuture = new CompletableFuture<>();

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.instance.SinkRecord;
 import org.apache.pulsar.functions.source.TopicSchema;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.io.core.SinkContext;
 import org.mockito.ArgumentMatcher;
 import org.testng.Assert;
@@ -158,7 +159,7 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         try {
             Schema schema = pulsarSink.initializeSchema();
@@ -176,7 +177,7 @@ public class PulsarSinkTest {
         // set type to be inconsistent to that of SerDe
         pulsarConfig.setTypeClassName(Integer.class.getName());
         pulsarConfig.setSerdeClassName(TestSerDe.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
         try {
             pulsarSink.initializeSchema();
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
@@ -198,7 +199,7 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         try {
             pulsarSink.initializeSchema();
@@ -217,7 +218,7 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
         pulsarConfig.setSerdeClassName(TopicSchema.DEFAULT_SERDE);
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         try {
             pulsarSink.initializeSchema();
@@ -233,7 +234,7 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
         pulsarConfig.setSerdeClassName(ComplexSerDe.class.getName());
-        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         try {
             pulsarSink.initializeSchema();
@@ -257,7 +258,7 @@ public class PulsarSinkTest {
         /** test At-least-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
-        PulsarSink pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test");
+        PulsarSink pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 
@@ -314,7 +315,7 @@ public class PulsarSinkTest {
         /** test At-most-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATMOST_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test");
+        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 
@@ -371,7 +372,7 @@ public class PulsarSinkTest {
         /** test Effectively-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test");
+        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -126,7 +126,7 @@ public class PulsarSourceTest {
         PulsarSourceConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         try {
             pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
@@ -152,7 +152,7 @@ public class PulsarSourceTest {
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TestSerDe.class.getName()).build());
         pulsarConfig.setTopicSchema(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, new HashMap<>());
         try {
             pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
@@ -177,7 +177,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TopicSchema.DEFAULT_SERDE).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
     }
@@ -193,7 +193,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TopicSchema.DEFAULT_SERDE).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
     }
@@ -206,7 +206,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(ComplexSerDe.class.getName()).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, new HashMap<>());
 
         pulsarSource.setupConsumerConfigs();
     }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.io.core.SourceContext;
 import org.testng.annotations.Test;
 
@@ -125,7 +126,7 @@ public class PulsarSourceTest {
         PulsarSourceConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test");
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         try {
             pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
@@ -151,7 +152,7 @@ public class PulsarSourceTest {
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TestSerDe.class.getName()).build());
         pulsarConfig.setTopicSchema(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test");
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
         try {
             pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
@@ -176,7 +177,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TopicSchema.DEFAULT_SERDE).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test");
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
     }
@@ -192,7 +193,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TopicSchema.DEFAULT_SERDE).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test");
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
     }
@@ -205,7 +206,7 @@ public class PulsarSourceTest {
         consumerConfigs.put("persistent://sample/standalone/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(ComplexSerDe.class.getName()).build());
         pulsarConfig.setTopicSchema(consumerConfigs);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test");
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, "test", Utils.ComponentType.FUNCTION);
 
         pulsarSource.setupConsumerConfigs();
     }


### PR DESCRIPTION
### Motivation

The metadata specified in producers and consumers created by functions, sinks, and sources can help with debugging.  

This PR aims improving that aspect as well as add the metadata to python functions as well

### Modifications
Example of what the meta looks like:

```
        "metadata" : {
          "instance_id" : "0",
          "application" : "pulsar-function",
          "id" : "public/default/test2"
        }
```
