### PR TITLE
Add Windowfunction interface to functions api

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowContext.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.windowing;
+package org.apache.pulsar.functions.api;
 
 import org.slf4j.Logger;
 

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
@@ -30,5 +30,5 @@ public interface WindowFunction<I, O> {
      * Process the input.
      * @return the output
      */
-    O process(Collection<I> input, WindowContext context) throws Exception;
+    O process(Collection<Record<I>> input, WindowContext context) throws Exception;
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
@@ -21,11 +21,8 @@ package org.apache.pulsar.functions.api;
 import java.util.Collection;
 
 /**
- * This is the core interface of the function api. The process is called
- * for every message of the input topic of the function. The incoming input bytes
- * are converted to the input type I for simple Java types(String, Integer, Boolean,
- * Map, and List types) and for org.Json type. If this serialization approach does not
- * meet your needs, you can use the byte stream handler defined in RawRequestHandler.
+ * This is the interface of the windowed function api. The process method is called
+ * for every triggered window.
  */
 @FunctionalInterface
 public interface WindowFunction<I, O> {

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/WindowFunction.java
@@ -16,20 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.api.examples;
-
-import lombok.extern.slf4j.Slf4j;
+package org.apache.pulsar.functions.api;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 /**
- * Example Function that acts on a window of tuples at a time rather than per tuple basis.
+ * This is the core interface of the function api. The process is called
+ * for every message of the input topic of the function. The incoming input bytes
+ * are converted to the input type I for simple Java types(String, Integer, Boolean,
+ * Map, and List types) and for org.Json type. If this serialization approach does not
+ * meet your needs, you can use the byte stream handler defined in RawRequestHandler.
  */
-@Slf4j
-public class WindowFunction implements Function <Collection<Integer>, Integer> {
-    @Override
-    public Integer apply(Collection<Integer> integers) {
-        return integers.stream().reduce(0, (x, y) -> x + y);
-    }
+@FunctionalInterface
+public interface WindowFunction<I, O> {
+    /**
+     * Process the input.
+     * @return the output
+     */
+    O process(Collection<I> input, WindowContext context) throws Exception;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowContextImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.windowing;
 
 import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.WindowContext;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
@@ -80,13 +80,7 @@ public class WindowFunctionExecutor<I, O> implements Function<I, O> {
                 throw new IllegalArgumentException("Window function must take a collection as input");
             }
         } else if (userClassObject instanceof WindowFunction) {
-            Class<?>[] typeArgs = TypeResolver.resolveRawArguments(
-                    WindowFunction.class, userClassObject.getClass());
-            if (typeArgs[0].equals(Collection.class)) {
-                windowFunction = (WindowFunction) userClassObject;
-            } else {
-                throw new IllegalArgumentException("Window function must take a collection as input");
-            }
+            windowFunction = (WindowFunction) userClassObject;
         } else {
             throw new IllegalArgumentException("Window function does not implement the correct interface");
         }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
@@ -24,9 +24,8 @@ import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
 
 import org.apache.pulsar.common.functions.WindowConfig;
-import org.apache.pulsar.functions.utils.WindowConfigUtils;
+import org.apache.pulsar.functions.api.WindowContext;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
@@ -50,10 +50,10 @@ public class WindowFunctionExecutorTest {
 
     private static class TestWindowFunctionExecutor extends WindowFunctionExecutor<Long, Long> {
 
-        List<Window<Long>> windows = new ArrayList<>();
+        List<Window<Record<Long>>> windows = new ArrayList<>();
 
         @Override
-        public Long process(Window<Long> inputWindow, WindowContext context) throws Exception {
+        public Long process(Window<Record<Long>> inputWindow, WindowContext context) throws Exception {
             windows.add(inputWindow);
             return null;
         }
@@ -149,22 +149,26 @@ public class WindowFunctionExecutorTest {
     public void testExecuteWithTs() throws Exception {
         long[] timestamps = {603, 605, 607, 618, 626, 636};
         for (long ts : timestamps) {
+            Record<?> record = Mockito.mock(Record.class);
+            Mockito.doReturn(Optional.of("test-topic")).when(record).getTopicName();
+            Mockito.doReturn(record).when(context).getCurrentRecord();
+            Mockito.doReturn(ts).when(record).getValue();
             testWindowedPulsarFunction.process(ts, context);
         }
         testWindowedPulsarFunction.waterMarkEventGenerator.run();
         assertEquals(3, testWindowedPulsarFunction.windows.size());
-        Window<Long> first = testWindowedPulsarFunction.windows.get(0);
+        Window<Record<Long>> first = testWindowedPulsarFunction.windows.get(0);
         assertArrayEquals(
                 new long[]{603, 605, 607},
-                new long[]{first.get().get(0), first.get().get(1), first.get().get(2)});
+                new long[]{first.get().get(0).getValue(), first.get().get(1).getValue(), first.get().get(2).getValue()});
 
-        Window<Long> second = testWindowedPulsarFunction.windows.get(1);
+        Window<Record<Long>> second = testWindowedPulsarFunction.windows.get(1);
         assertArrayEquals(
                 new long[]{603, 605, 607, 618},
-                new long[]{second.get().get(0), second.get().get(1), second.get().get(2), second.get().get(3)});
+                new long[]{second.get().get(0).getValue(), second.get().get(1).getValue(), second.get().get(2).getValue(), second.get().get(3).getValue()});
 
-        Window<Long> third = testWindowedPulsarFunction.windows.get(2);
-        assertArrayEquals(new long[]{618, 626}, new long[]{third.get().get(0), third.get().get(1)});
+        Window<Record<Long>> third = testWindowedPulsarFunction.windows.get(2);
+        assertArrayEquals(new long[]{618, 626}, new long[]{third.get().get(0).getValue(), third.get().get(1).getValue()});
     }
 
     @Test
@@ -206,6 +210,10 @@ public class WindowFunctionExecutorTest {
 
         for (long ts : timestamps) {
             events.add(ts);
+            Record<?> record = Mockito.mock(Record.class);
+            Mockito.doReturn(Optional.of("test-topic")).when(record).getTopicName();
+            Mockito.doReturn(record).when(context).getCurrentRecord();
+            Mockito.doReturn(ts).when(record).getValue();
             testWindowedPulsarFunction.process(ts, context);
 
             //Update the watermark to this timestamp

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/AddWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/AddWindowFunction.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.examples;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * Example Function that acts on a window of tuples at a time rather than per tuple basis.
+ */
+@Slf4j
+public class AddWindowFunction implements Function <Collection<Integer>, Integer> {
+    @Override
+    public Integer apply(Collection<Integer> integers) {
+        return integers.stream().reduce(0, (x, y) -> x + y);
+    }
+}

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ContextWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ContextWindowFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.api.examples;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.api.WindowContext;
 import org.apache.pulsar.functions.api.WindowFunction;
 
@@ -30,7 +31,11 @@ import java.util.Collection;
 @Slf4j
 public class ContextWindowFunction implements WindowFunction<Integer, Integer> {
     @Override
-    public Integer process(Collection<Integer> integers, WindowContext context) {
-        return integers.stream().reduce(0, (x, y) -> x + y);
+    public Integer process(Collection<Record<Integer>> integers, WindowContext context) {
+        Integer retval = 0;
+        for (Record<Integer> record : integers) {
+            retval += record.getValue();
+        }
+        return retval;
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ContextWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/ContextWindowFunction.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.examples;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
+
+import java.util.Collection;
+
+/**
+ * Example Function that acts on a window of tuples at a time rather than per tuple basis.
+ */
+@Slf4j
+public class ContextWindowFunction implements WindowFunction<Integer, Integer> {
+    @Override
+    public Integer process(Collection<Integer> integers, WindowContext context) {
+        return integers.stream().reduce(0, (x, y) -> x + y);
+    }
+}

--- a/pulsar-functions/java-examples/src/main/resources/example-window-function-config.yaml
+++ b/pulsar-functions/java-examples/src/main/resources/example-window-function-config.yaml
@@ -20,7 +20,7 @@
 tenant: "test"
 namespace: "test-namespace"
 name: "example"
-className: "org.apache.pulsar.functions.api.examples.WindowFunction"
+className: "org.apache.pulsar.functions.api.examples.AddWindowFunction"
 inputs: ["test_src"]
 userConfig:
   "PublishTopic": "test_result"


### PR DESCRIPTION
### Motivation
Currently we support windowed functions but these functions have to be java.util.Function. However simple java.util.Function cannot fetch any kind of meta data about the function since it lacks any kind of context handle. This pr introduces the WindowFunction as anologous to the Function interface which exposes the Context interface.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
