### PR TITLE
add support get getTopicName for CPP/Python clients

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -122,6 +122,11 @@ class Message {
      */
     uint64_t getEventTimestamp() const;
 
+    /**
+     * Get the topic Name from which this message originated from
+     */
+    const std::string& getTopicName() const;
+
    private:
     typedef boost::shared_ptr<MessageImpl> MessageImplPtr;
     MessageImplPtr impl_;

--- a/pulsar-client-cpp/include/pulsar/MessageId.h
+++ b/pulsar-client-cpp/include/pulsar/MessageId.h
@@ -52,7 +52,7 @@ class MessageId {
     void serialize(std::string& result) const;
 
     /**
-     * Get the topic Name
+     * Get the topic Name from which this message originated from
      */
     const std::string& getTopicName() const;
 

--- a/pulsar-client-cpp/lib/Message.cc
+++ b/pulsar-client-cpp/lib/Message.cc
@@ -111,6 +111,13 @@ const std::string& Message::getPartitionKey() const {
     return impl_->getPartitionKey();
 }
 
+const std::string& Message::getTopicName() const {
+    if (!impl_) {
+        return emptyString;
+    }
+    return impl_->getTopicName();
+}
+
 uint64_t Message::getPublishTimestamp() const { return impl_ ? impl_->getPublishTimestamp() : 0ull; }
 
 uint64_t Message::getEventTimestamp() const { return impl_ ? impl_->getEventTimestamp() : 0ull; }

--- a/pulsar-client-cpp/lib/MessageImpl.h
+++ b/pulsar-client-cpp/lib/MessageImpl.h
@@ -52,7 +52,7 @@ class MessageImpl {
     uint64_t getEventTimestamp() const;
 
     /**
-     * Get a valid topicName
+     * Get the topic Name from which this message originated from
      */
     const std::string& getTopicName();
 

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -179,6 +179,12 @@ class Message:
         """
         return self._message.message_id()
 
+    def topic_name(self):
+        """
+        Get the topic Name from which this message originated from
+        """
+        return self._message.topic_name()
+
 
 class Authentication:
     """

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -66,6 +66,12 @@ boost::python::object Message_data(const Message& msg) {
     return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
 }
 
+std::string Topic_name_str(const Message& msg) {
+    std::stringstream ss;
+    ss << msg.getTopicName();
+    return ss.str();
+}
+
 const MessageId& Message_getMessageId(const Message& msg) {
     return msg.getMessageId();
 }
@@ -117,5 +123,6 @@ void export_message() {
             .def("event_timestamp", &Message::getEventTimestamp)
             .def("message_id", &Message_getMessageId, return_value_policy<copy_const_reference>())
             .def("__str__", &Message_str)
+            .def("topic_name", &Topic_name_str)
             ;
 }


### PR DESCRIPTION
### Motivation

Currently getTopicName method is not exposed in Python API.

Add support for getting the topic name of a message via Python API.  Also expose getTopicName via Message class in CPP API

