### PR TITLE
Fix consumer stats log error.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -131,8 +131,8 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                 if ((currentNumMsgsReceived | currentNumBytesReceived | currentNumReceiveFailed | currentNumAcksSent
                         | currentNumAcksFailed) != 0) {
                     log.info(
-                            "[{}] [{}] [{}] Prefetched messages: {} --- Consume throughput: {} msgs/s --- "
-                                    + "Throughput received: {} msg/s --- {} Mbit/s --- "
+                            "[{}] [{}] [{}] Prefetched messages: {} --- "
+                                    + "Consume throughput received: {} msgs/s --- {} Mbit/s --- "
                                     + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- " + "Failed acks: {}",
                             consumer.getTopic(), consumer.getSubscription(), consumer.consumerName,
                             consumer.incomingMessages.size(), THROUGHPUT_FORMAT.format(receivedMsgsRate),


### PR DESCRIPTION
### Motivation

Fix consumer stats log error like this:
```
[persistent://platform/resume/c.profile.content-partition-0] [platform.solr.gateway-share-prod] [51064] Prefetched messages: 0 --- Consume throughput: 1.77 msgs/s --- Throughput received: 0.01 msg/s --- 1.77 Mbit/s --- Ack sent rate: 0 ack/s --- Failed messages: 0 --- Failed acks: {}
```
You will see  after `Consume throughput:` value isn't correct. 

### Modifications

Fix the log output which has 10 placeholder but use 9 value to fill them. 

Delete the redundant placeholder.

### Result

Consumer stats log will display like:

```
[persistent://platform/resume/c.profile.content-partition-0] [platform.solr.gateway-share-prod] [51064] Prefetched messages: 0 --- Consume throughput received: 1.77 msg/s --- 0.01 Mbit/s --- Ack sent rate: 1.77 ack/s --- Failed messages: 0 --- Failed acks: 0
```

UT passed
