### PR TITLE
Some settings of WebSocket proxy are not effective

### DIFF
--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -47,13 +47,13 @@ bindAddress=0.0.0.0
 clusterName=
 
 # Number of IO threads in Pulsar Client used in WebSocket proxy
-numIoThreads=8
+webSocketNumIoThreads=8
 
 # Number of threads to use in HTTP server. Default is Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=
 
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
-connectionsPerBroker=8
+webSocketConnectionsPerBroker=8
 
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
@@ -82,7 +82,7 @@ authorizationAllowWildcardsMatching=false
 superUserRoles=
 
 # Authentication settings of the proxy itself. Used to connect to brokers
-brokerClientTlsEnabled=false;
+brokerClientTlsEnabled=false
 brokerClientAuthenticationPlugin=
 brokerClientAuthenticationParameters=
 brokerClientTrustCertsFilePath=

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyConfigurationTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.proxy;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+
+import org.apache.bookkeeper.test.PortManager;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.websocket.WebSocketService;
+import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ProxyConfigurationTest extends ProducerConsumerBase {
+    private WebSocketProxyConfiguration config;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+
+        config = new WebSocketProxyConfiguration();
+        config.setWebServicePort(PortManager.nextFreePort());
+        config.setClusterName("test");
+        config.setConfigurationStoreServers("dummy-zk-servers");
+    }
+
+    @AfterMethod
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "setProxyConfig")
+    public Object[][] setProxyConfig() {
+        return new Object[][] { {2, 1}, {4, 2} };
+    }
+
+    @Test(dataProvider = "setProxyConfig", timeOut = 10000)
+    public void configTest(int numIoThreads, int connectionsPerBroker) throws Exception {
+        config.setWebSocketNumIoThreads(numIoThreads);
+        config.setWebSocketConnectionsPerBroker(connectionsPerBroker);
+        WebSocketService service = spy(new WebSocketService(config));
+        doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
+        service.start();
+
+        PulsarClientImpl client = (PulsarClientImpl) service.getPulsarClient();
+        assertEquals(client.getConfiguration().getNumIoThreads(), numIoThreads);
+        assertEquals(client.getConfiguration().getConnectionsPerBroker(), connectionsPerBroker);
+
+        service.close();
+    }
+}

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -90,13 +90,13 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String brokerClientTrustCertsFilePath = "";
 
     // Number of IO threads in Pulsar Client used in WebSocket proxy
-    private int numIoThreads = Runtime.getRuntime().availableProcessors();
+    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
 
     // Number of threads to use in HTTP server
     private int numHttpServerThreads = Runtime.getRuntime().availableProcessors();
 
     // Number of connections per Broker in Pulsar Client used in WebSocket proxy
-    private int connectionsPerBroker = Runtime.getRuntime().availableProcessors();
+    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
     // Time in milliseconds that idle WebSocket session times out
     private int webSocketSessionIdleTimeoutMillis = 300000;
 
@@ -292,12 +292,22 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.brokerClientAuthenticationParameters = brokerClientAuthenticationParameters;
     }
 
+    @Deprecated
     public int getNumIoThreads() {
-        return numIoThreads;
+        return getWebSocketNumIoThreads();
     }
 
+    @Deprecated
     public void setNumIoThreads(int numIoThreads) {
-        this.numIoThreads = numIoThreads;
+        setWebSocketNumIoThreads(numIoThreads);
+    }
+
+    public int getWebSocketNumIoThreads() {
+        return webSocketNumIoThreads;
+    }
+
+    public void setWebSocketNumIoThreads(int webSocketNumIoThreads) {
+        this.webSocketNumIoThreads = webSocketNumIoThreads;
     }
 
     public int getNumHttpServerThreads() {
@@ -308,12 +318,22 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.numHttpServerThreads = numHttpServerThreads;
     }
 
+    @Deprecated
     public int getConnectionsPerBroker() {
-        return connectionsPerBroker;
+        return getWebSocketConnectionsPerBroker();
     }
 
+    @Deprecated
     public void setConnectionsPerBroker(int connectionsPerBroker) {
-        this.connectionsPerBroker = connectionsPerBroker;
+        setWebSocketConnectionsPerBroker(connectionsPerBroker);
+    }
+
+    public int getWebSocketConnectionsPerBroker() {
+        return webSocketConnectionsPerBroker;
+    }
+
+    public void setWebSocketConnectionsPerBroker(int webSocketConnectionsPerBroker) {
+        this.webSocketConnectionsPerBroker = webSocketConnectionsPerBroker;
     }
 
     public int getWebSocketSessionIdleTimeoutMillis() {


### PR DESCRIPTION
### Motivation

There are `numIoThreads` and `connectionsPerBroker` in the WebSocket proxy settings, but even if specifying these values, the actual number of threads or connections does not change from the number of CPU cores.

This is because the `WebSocketProxyConfiguration` object is converted to a `ServiceConfiguration` object and these settings can not be acquired. `numIoThreads` and `connectionsPerBroker` are not declared in the `ServiceConfiguration` class, but `webSocketNumIoThreads` and `webSocketConnectionsPerBroker` are declared.
https://github.com/apache/pulsar/blob/2ccf7ff2a6c16f1b16342aa4529d5197195bad9d/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java#L86-L90
https://github.com/apache/pulsar/blob/2ccf7ff2a6c16f1b16342aa4529d5197195bad9d/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java#L179-L185

### Modifications

Renamed the fields of `WebSocketProxyConfiguration` as follows and made them match the field names of `ServiceConfiguration`.

- numIoThreads -> webSocketNumIoThreads
- connectionsPerBroker -> webSocketConnectionsPerBroker

### Result

These settings become effective.