### PR TITLE
Remove global zookeeper option in code base

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -631,8 +631,5 @@ gcsManagedLedgerOffloadServiceAccountKeyFile=
 
 ### --- Deprecated config variables --- ###
 
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=
-
 # Deprecated - Enable TLS when talking with other clusters to replicate messages
 replicationTlsEnabled=false

--- a/conf/discovery.conf
+++ b/conf/discovery.conf
@@ -77,9 +77,3 @@ tlsKeyFilePath=
 # Specify whether Client certificates are required for TLS
 # Reject the Connection if the Client Certificate is not trusted.
 tlsRequireTrustedClientCertOnConnect=false
-
-
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -179,9 +179,3 @@ tokenSecretKey=
 # tokenPublicKey=data:base64,xxxxxxxxx
 # tokenPublicKey=file:///my/public.key
 tokenPublicKey=
-
-
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -38,7 +38,7 @@
 # Configuration file of settings used in zookeeper server
 # PULSAR_ZK_CONF=
 
-# Configuration file of settings used in global zookeeper server
+# Configuration file of settings used in configuration store server
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -38,7 +38,7 @@
 # Configuration file of settings used in zookeeper server
 # PULSAR_ZK_CONF=
 
-# Configuration file of settings used in global zookeeper server
+# Configuration file of settings used in configuration store server
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -428,11 +428,6 @@ exposeTopicLevelMetricsInPrometheus=true
 # Enable topic level metrics
 exposePublisherStats=true
 
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=
-
 
 ### --- BookKeeper Configuration --- #####
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -110,9 +110,3 @@ tlsTrustCertsFilePath=
 # Specify whether Client certificates are required for TLS
 # Reject the Connection if the Client Certificate is not trusted.
 tlsRequireTrustedClientCertOnConnect=false
-
-
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -509,8 +509,3 @@ s3ManagedLedgerOffloadMaxBlockSizeInBytes=67108864
 
 # For Amazon S3 ledger offload, Read buffer size in bytes (1MB by default)
 s3ManagedLedgerOffloadReadBufferSizeInBytes=1048576
-
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers={{ zookeeper_servers }}

--- a/deployment/terraform-ansible/templates/proxy.conf
+++ b/deployment/terraform-ansible/templates/proxy.conf
@@ -115,9 +115,3 @@ tlsHostnameVerificationEnabled=false
 # Whether client certificates are required for TLS. Connections are rejected if the client
 # certificate isn't trusted.
 tlsRequireTrustedClientCertOnConnect=false
-
-
-### --- Deprecated config variables --- ###
-
-# Deprecated. Use configurationStoreServers
-globalZookeeperServers=

--- a/deployment/terraform-ansible/templates/pulsar_env.sh
+++ b/deployment/terraform-ansible/templates/pulsar_env.sh
@@ -38,7 +38,7 @@
 # Configuration file of settings used in zookeeper server
 # PULSAR_ZK_CONF=
 
-# Configuration file of settings used in global zookeeper server
+# Configuration file of settings used in configuration store server
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -82,15 +82,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "The Zookeeper quorum connection string (as a comma-separated list)"
     )
     private String zookeeperServers;
-    @Deprecated
-    @FieldContext(
-        category = CATEGORY_SERVER,
-        required = false,
-        deprecated = true,
-        doc = "Global Zookeeper quorum connection string (as a comma-separated list)."
-            + " Deprecated in favor of using `configurationStoreServers`"
-    )
-    private String globalZookeeperServers;
     @FieldContext(
         category = CATEGORY_SERVER,
         required = false,
@@ -1064,31 +1055,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int managedLedgerOffloadMaxThreads = 2;
 
-    /**
-     * @deprecated See {@link #getConfigurationStoreServers}
-     */
-    @Deprecated
-    public String getGlobalZookeeperServers() {
-        if (this.globalZookeeperServers == null || this.globalZookeeperServers.isEmpty()) {
-            // If the configuration is not set, assuming that the globalZK is not enabled and all data is in the same
-            // ZooKeeper cluster
-            return this.getZookeeperServers();
-        }
-        return globalZookeeperServers;
-    }
-
-    /**
-     * @deprecated See {@link #setConfigurationStoreServers(String)}
-     */
-    @Deprecated
-    public void setGlobalZookeeperServers(String globalZookeeperServers) {
-        this.globalZookeeperServers = globalZookeeperServers;
-    }
-
     public String getConfigurationStoreServers() {
-        if (this.configurationStoreServers == null || this.configurationStoreServers.isEmpty()) {
-            // If the configuration is not set, assuming that all data is in the same as globalZK cluster
-            return this.getGlobalZookeeperServers();
+        if (configurationStoreServers == null || configurationStoreServers.isEmpty()) {
+            return getZookeeperServers();
         }
         return configurationStoreServers;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -88,10 +88,6 @@ public class PulsarClusterMetadataSetup {
         }, description = "Local zookeeper session timeout ms")
         private int zkSessionTimeoutMillis = 30000;
 
-        @Parameter(names = { "-gzk",
-                "--global-zookeeper" }, description = "Global ZooKeeper quorum connection string", required = false, hidden = true)
-        private String globalZookeeper;
-
         @Parameter(names = { "-cs",
             "--configuration-store" }, description = "Configuration Store connection string", required = false)
         private String configurationStore;
@@ -120,20 +116,10 @@ public class PulsarClusterMetadataSetup {
             throw e;
         }
 
-        if (arguments.configurationStore == null && arguments.globalZookeeper == null) {
+        if (arguments.configurationStore == null) {
             System.err.println("Configuration store address argument is required (--configuration-store)");
             jcommander.usage();
             System.exit(1);
-        }
-
-        if (arguments.configurationStore != null && arguments.globalZookeeper != null) {
-            System.err.println("Configuration store argument (--configuration-store) supercedes the deprecated (--global-zookeeper) argument");
-            jcommander.usage();
-            System.exit(1);
-        }
-
-        if (arguments.configurationStore == null) {
-            arguments.configurationStore = arguments.globalZookeeper;
         }
 
         log.info("Setting up cluster {} with zk={} configuration-store ={}", arguments.cluster, arguments.zookeeper,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -159,7 +159,7 @@ public abstract class AdminResource extends PulsarWebResource {
      * zookeeper.
      *
      * @throws WebApplicationException
-     *             if broker has a read only access if broker is not connected to the global zookeeper
+     *             if broker has a read only access if broker is not connected to the configuration store
      */
     public void validatePoliciesReadOnlyAccess() {
         boolean arePoliciesReadOnly = true;
@@ -167,7 +167,7 @@ public abstract class AdminResource extends PulsarWebResource {
         try {
             arePoliciesReadOnly = globalZkCache().exists(POLICIES_READONLY_FLAG_PATH);
         } catch (Exception e) {
-            log.warn("Unable to fetch contents of [{}] from global zookeeper", POLICIES_READONLY_FLAG_PATH, e);
+            log.warn("Unable to fetch contents of [{}] from configuration store", POLICIES_READONLY_FLAG_PATH, e);
             throw new RestException(e);
         }
 
@@ -175,11 +175,11 @@ public abstract class AdminResource extends PulsarWebResource {
             log.debug("Policies are read-only. Broker cannot do read-write operations");
             throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
         } else {
-            // Make sure the broker is connected to the global zookeeper before writing. If not, throw an exception.
+            // Make sure the broker is connected to the configuration store before writing. If not, throw an exception.
             if (globalZkCache().getZooKeeper().getState() != States.CONNECTED) {
-                log.debug("Broker is not connected to the global zookeeper");
+                log.debug("Broker is not connected to the configuration store");
                 throw new RestException(Status.PRECONDITION_FAILED,
-                        "Broker needs to be connected to global zookeeper before making a read-write operation");
+                        "Broker needs to be connected to configuration store before making a read-write operation");
             } else {
                 // Do nothing, just log the message.
                 log.debug("Broker is allowed to make read-write operations");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
@@ -212,7 +212,7 @@ public class PulsarBrokerStarterTest {
      * if the property variables inside the given property file are correctly referred to that returned object.
      */
     @Test
-    public void testGlobalZooKeeperConfig() throws SecurityException, NoSuchMethodException, IOException,
+    public void testConfigurationStoreConfig() throws SecurityException, NoSuchMethodException, IOException,
             IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
         File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -22,9 +22,6 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Deprecated. Global zookeeper quorum connection string
-globalZookeeperServers=
-
 # Configuration Store connection string
 configurationStoreServers=
 

--- a/pulsar-client-cpp/test-conf/standalone.conf
+++ b/pulsar-client-cpp/test-conf/standalone.conf
@@ -22,8 +22,8 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
-globalZookeeperServers=
+# Configuration store connection string
+configurationStoreServers=
 
 brokerServicePort=8885
 

--- a/pulsar-client-cpp/tests/authentication.conf
+++ b/pulsar-client-cpp/tests/authentication.conf
@@ -22,9 +22,6 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Deprecated. Global Zookeeper quorum connection string
-globalZookeeperServers=
-
 # Configuration Store connection string
 configurationStoreServers=
 

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -22,9 +22,6 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Deprecated. Global Zookeeper quorum connection string
-globalZookeeperServers=
-
 # Configuration Store connection string
 configurationStoreServers=
 

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -36,9 +36,6 @@ public class ServiceConfig implements PulsarConfiguration {
 
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;
-    // Global-Zookeeper quorum connection string
-    @Deprecated
-    private String globalZookeeperServers;
     // Configuration Store connection string
     private String configurationStoreServers;
 
@@ -106,18 +103,8 @@ public class ServiceConfig implements PulsarConfiguration {
         this.zookeeperServers = zookeeperServers;
     }
 
-    @Deprecated
-    public String getGlobalZookeeperServers() {
-        return globalZookeeperServers;
-    }
-
-    @Deprecated
-    public void setGlobalZookeeperServers(String globalZookeeperServers) {
-        this.globalZookeeperServers = globalZookeeperServers;
-    }
-
     public String getConfigurationStoreServers() {
-        return null == configurationStoreServers ? getGlobalZookeeperServers() : configurationStoreServers;
+        return configurationStoreServers;
     }
 
     public void setConfigurationStoreServers(String configurationStoreServers) {

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
@@ -27,8 +27,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
-import org.apache.pulsar.discovery.service.DiscoveryService;
-import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 /**
@@ -61,63 +59,4 @@ public class DiscoveryServiceWebTest {
         server.stop();
         testConfigFile.delete();
     }
-
-    /**
-     * Test Configuration BackwardCompat for the change from globalzookeeper to configurationStore
-     */
-    @Test
-    public void testConfigurationBackwardCompat() throws Exception {
-        DiscoveryService service = Mockito.mock(DiscoveryService.class);
-
-        int port = nextFreePort();
-        File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
-        if (testConfigFile.exists()) {
-            testConfigFile.delete();
-        }
-        PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
-        printWriter.println("zookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter.println("globalZookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter.println("webServicePort=" + port);
-        printWriter.close();
-        testConfigFile.deleteOnExit();
-
-        ServiceConfig config = PulsarConfigurationLoader.create(testConfigFile.getAbsolutePath(), ServiceConfig.class);
-        // have zookeeperServers and globalZookeeperServers, config is valid
-        // should not throw IllegalArgumentException.
-        DiscoveryServiceStarter.checkConfig(config);
-
-
-        if (testConfigFile.exists()) {
-            testConfigFile.delete();
-        }
-        PrintWriter printWriter2 = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
-        printWriter2.println("zookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter2.println("configurationStoreServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter2.println("webServicePort=" + port);
-        printWriter2.close();
-        config = PulsarConfigurationLoader.create(testConfigFile.getAbsolutePath(), ServiceConfig.class);
-        // have zookeeperServers and configurationStoreServers, config is valid
-        // should not throw IllegalArgumentException.
-        DiscoveryServiceStarter.checkConfig(config);
-
-
-        if (testConfigFile.exists()) {
-            testConfigFile.delete();
-        }
-        PrintWriter printWriter3 = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
-        printWriter3.println("zookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter3.println("webServicePort=" + port);
-        printWriter3.close();
-        config = PulsarConfigurationLoader.create(testConfigFile.getAbsolutePath(), ServiceConfig.class);
-        // only have zookeeperServers
-        // should throw IllegalArgumentException.
-        try {
-            DiscoveryServiceStarter.checkConfig(config);
-        } catch (IllegalArgumentException e) {
-            // expected: configure error
-        }
-
-        testConfigFile.delete();
-    }
-
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -78,12 +78,6 @@ public class ProxyConfiguration implements PulsarConfiguration {
         doc = "Configuration store connection string (as a comma-separated list)"
     )
     private String configurationStoreServers;
-    @FieldContext(
-        category = CATEGORY_BROKER_DISCOVERY,
-        doc = "Global ZooKeeper quorum connection string (as a comma-separated list)"
-    )
-    @Deprecated
-    private String globalZookeeperServers;
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -52,10 +52,6 @@ public class ProxyServiceStarter {
     @Parameter(names = { "-zk", "--zookeeper-servers" }, description = "Local zookeeper connection string")
     private String zookeeperServers = "";
 
-    @Deprecated
-    @Parameter(names = { "-gzk", "--global-zookeeper-servers" }, description = "Global zookeeper connection string")
-    private String globalZookeeperServers = "";
-
     @Parameter(names = { "-cs", "--configuration-store-servers" },
         description = "Configuration store connection string")
     private String configurationStoreServers = "";
@@ -92,10 +88,6 @@ public class ProxyServiceStarter {
             config.setZookeeperServers(zookeeperServers);
         }
 
-        if (!isBlank(globalZookeeperServers)) {
-            // Use globalZookeeperServers from command line
-            config.setConfigurationStoreServers(globalZookeeperServers);
-        }
         if (!isBlank(configurationStoreServers)) {
             // Use configurationStoreServers from command line
             config.setConfigurationStoreServers(configurationStoreServers);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
@@ -70,7 +70,7 @@ public class UnauthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
         proxyConfig.setBrokerWebServiceURL(brokerUrl.toString());
         proxyConfig.setStatusFilePath(STATUS_FILE_PATH);
         proxyConfig.setZookeeperServers(DUMMY_VALUE);
-        proxyConfig.setGlobalZookeeperServers(DUMMY_VALUE);
+        proxyConfig.setConfigurationStoreServers(DUMMY_VALUE);
 
         webServer = new WebServer(proxyConfig, new AuthenticationService(
                                           PulsarConfigurationLoader.convertFrom(proxyConfig)));

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -52,8 +52,6 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String statusFilePath;
 
     // Configuration Store connection string
-    @Deprecated
-    private String globalZookeeperServers;
     private String configurationStoreServers;
     // Zookeeper session timeout in milliseconds
     private long zooKeeperSessionTimeoutMillis = 30000;
@@ -170,18 +168,8 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.statusFilePath = statusFilePath;
     }
 
-    @Deprecated
-    public String getGlobalZookeeperServers() {
-        return globalZookeeperServers;
-    }
-
-    @Deprecated
-    public void setGlobalZookeeperServers(String globalZookeeperServers) {
-        this.globalZookeeperServers = globalZookeeperServers;
-    }
-
     public String getConfigurationStoreServers() {
-        return null == configurationStoreServers ? getGlobalZookeeperServers() : configurationStoreServers;
+        return configurationStoreServers;
     }
 
     public void setConfigurationStoreServers(String configurationStoreServers) {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperCache.java
@@ -71,7 +71,7 @@ public class GlobalZooKeeperCache extends ZooKeeperCache implements Closeable {
             newSession.register(this);
             zkSession.set(newSession);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            LOG.error("Failed to establish global zookeeper session: {}", e.getMessage(), e);
+            LOG.error("Failed to establish configuration store session: {}", e.getMessage(), e);
             throw new IOException(e);
         }
     }
@@ -93,7 +93,7 @@ public class GlobalZooKeeperCache extends ZooKeeperCache implements Closeable {
     public <T> void process(WatchedEvent event, final CacheUpdater<T> updater) {
         synchronized (this) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("[{}] Got Global ZooKeeper WatchdEvent: EventType: {}, KeeperState: {}, path: {}",
+                LOG.debug("[{}] Got Configuration Store WatchedEvent: EventType: {}, KeeperState: {}, path: {}",
                         this.hashCode(), event.getType(), event.getState(), event.getPath());
             }
             if (event.getType() == Event.EventType.None) {


### PR DESCRIPTION
### Motivation

The option ```--global-zookeeper``` is deprecated in previous version. This PR will remove it and related code or replace it with the new name ```configuration store``` in our code base. See #3307 and #3305 .

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
