### PR TITLE
Bump testcontainers version to fix log dumping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@ flexible messaging model and an intuitive client API.</description>
     <arquillian-junit.version>1.1.14.Final</arquillian-junit.version>
     <cassandra.version>3.6.0</cassandra.version>
     <disruptor.version>3.4.0</disruptor.version>
-    <testcontainers.version>1.8.0</testcontainers.version>
+    <testcontainers.version>1.10.5</testcontainers.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
The previous version was using a version of docker-java which didn't
handle gzip compression well. So if the docker api returned an
response that was gzip compressed, it wouldn't be decompressed and
then log dumping would gzip it again, and then tar zxvf wouldn't
handle it.

See https://github.com/docker-java/docker-java/issues/1079.
