### PR TITLE
fix dep to make build compatible with jdk11

### DIFF
--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -60,6 +60,10 @@
                     <groupId>org.openjdk.jol</groupId>
                     <artifactId>jol-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
### Motivation

```
[ERROR] Failed to execute goal on project pulsar-presto-distribution: Could not resolve dependencies for project org.apache.pulsar:pulsar-presto-distribution:jar:2.3.0-SNAPSHOT: Could not find artifact com.sun:tools:jar:1.8 at specified path /home/y/libexec64/jdk64-11.0.1/../lib/tools.jar -> [Help 1]
```

### Modifications

exclude the system jar as it will be anyway available in classpath and will not conflict for jdk-11 build.

### Result

`pulsar-presto-distribution` maven build doesn't fail with jdk-11.
