### PR TITLE
create_topic_with_check_namespaces_cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -234,6 +234,19 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
+    protected void validateGlobalNamespaceOwnership(String property, String namespace) {
+        try {
+            this.namespaceName = NamespaceName.get(property, namespace);
+            validateGlobalNamespaceOwnership(this.namespaceName);
+        } catch (IllegalArgumentException e) {
+            throw new RestException(Status.PRECONDITION_FAILED, "Tenant name or namespace is not valid");
+        } catch (RestException re) {
+            throw new RestException(Status.PRECONDITION_FAILED, "Namespace does not have any clusters configured");
+        } catch (Exception e) {
+            log.warn("Failed to validate global cluster configuration : ns={}  emsg={}", namespace, e.getMessage());
+            throw new RestException(Status.SERVICE_UNAVAILABLE, "Failed to validate global cluster configuration");
+        }
+    }
     @Deprecated
     protected void validateNamespaceName(String property, String cluster, String namespace) {
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -107,10 +107,13 @@ public class NonPersistentTopics extends PersistentTopics {
     @Path("/{tenant}/{namespace}/{topic}/partitions")
     @ApiOperation(value = "Create a partitioned topic.", notes = "It needs to be called before creating a producer on a partitioned topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
-            @ApiResponse(code = 409, message = "Partitioned topic already exists") })
+            @ApiResponse(code = 409, message = "Partitioned topic already exists"),
+            @ApiResponse(code = 412, message = "Failed Reason : Name is invalid or Namespace does not have any clusters configured"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")})
     public void createPartitionedTopic(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic, int numPartitions,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        validateGlobalNamespaceOwnership(tenant,namespace);
         validateTopicName(tenant, namespace, encodedTopic);
         validateAdminAccessForTenant(topicName.getTenant());
         if (numPartitions <= 1) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -129,11 +129,13 @@ public class PersistentTopics extends PersistentTopicsBase {
     @ApiResponses(value = {
         @ApiResponse(code = 403, message = "Don't have admin permission"),
         @ApiResponse(code = 409, message = "Partitioned topic already exist"),
-        @ApiResponse(code = 412, message = "Partitioned topic name is invalid")
+        @ApiResponse(code = 412, message = "Failed Reason : Name is invalid or Namespace does not have any clusters configured"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")
     })
     public void createPartitionedTopic(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic, int numPartitions,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        validateGlobalNamespaceOwnership(tenant,namespace);
         validatePartitionedTopicName(tenant, namespace, encodedTopic);
         internalCreatePartitionedTopic(numPartitions, authoritative);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -130,7 +130,7 @@ public class PersistentTopics extends PersistentTopicsBase {
         @ApiResponse(code = 403, message = "Don't have admin permission"),
         @ApiResponse(code = 409, message = "Partitioned topic already exist"),
         @ApiResponse(code = 412, message = "Failed Reason : Name is invalid or Namespace does not have any clusters configured"),
-            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")
+        @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")
     })
     public void createPartitionedTopic(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic, int numPartitions,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -878,4 +878,29 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         // Global cluster, if there, should be omitted from the results
         assertEquals(admin.clusters().getClusters(), Lists.newArrayList(cluster));
     }
+    /**
+     * verifies cluster has been set before create topic
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testClusterIsReadyBeforeCreateTopic() throws PulsarAdminException {
+        final String topicName = "partitionedTopic";
+        final int partitions = 4;
+        final String persistentPartitionedTopicName = "persistent://prop-xyz/ns2/" + topicName;
+        final String NonPersistentPartitionedTopicName = "non-persistent://prop-xyz/ns2/" + topicName;
+
+        // init tenant and namespace without cluster
+        admin.namespaces().createNamespace("prop-xyz/ns2");
+        try {
+            admin.topics().createPartitionedTopic(persistentPartitionedTopicName, partitions);
+            Assert.fail("should have failed due to Namespace does not have any clusters configured");
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+        }
+        try {
+            admin.topics().createPartitionedTopic(NonPersistentPartitionedTopicName, partitions);
+            Assert.fail("should have failed due to Namespace does not have any clusters configured");
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

add check namespaces already have the cluster assigned when create topic.

**the old way**:
creating topic will not check  if namespaces have broker cluster assigned, but after you created topic successfully , and ran **./pulsar-admin topics list tenant/namespace**, it will prompt **Namespace does not have any clusters configured : local_cluster=** and show nothing.

**the good way**:
check the namespace has already assigned to broker cluster when you are trying to create the topic.

### Modifications

NonPersistentTopics.java and PersistentTopics.java for admin v2 interface

### Result

After your change, what will change.
