### PR TITLE
Fixed links to RPM/Deb package signature files

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -19,9 +19,9 @@ The Pulsar C++ client has been successfully tested on **MacOS** and **Linux**.
 
 | Link | Crypto files |
 |------|--------------|
-| [client]({{pulsar:rpm:client}}) | [asc]({{pulsar:rpm:client}}.asc), [sha512]({{pulsar:rpm:client}}.sha512) |
-| [client-debuginfo]({{pulsar:rpm:client-debuginfo}}) | [asc]({{pulsar:rpm:client-debuginfo}}.asc),  [sha512]({{pulsar:rpm:client-debuginfo}}.sha512) |
-| [client-devel]({{pulsar:rpm:client-devel}}) | [asc]({{pulsar:rpm:client-devel}}.asc),  [sha512]({{pulsar:rpm:client-devel}}.sha512) |
+| [client]({{pulsar:rpm:client}}) | [asc]({{pulsar:dist_rpm:client}}.asc), [sha512]({{pulsar:dist_rpm:client}}.sha512) |
+| [client-debuginfo]({{pulsar:rpm:client-debuginfo}}) | [asc]({{pulsar:dist_rpm:client-debuginfo}}.asc),  [sha512]({{pulsar:dist_rpm:client-debuginfo}}.sha512) |
+| [client-devel]({{pulsar:dist_rpm:client-devel}}) | [asc]({{pulsar:dist_rpm:client-devel}}.asc),  [sha512]({{pulsar:dist_rpm:client-devel}}.sha512) |
 
 To install a RPM package, download the RPM packages and install them using the following command:
 
@@ -33,8 +33,8 @@ $ rpm -ivh apache-pulsar-client*.rpm
 
 | Link | Crypto files |
 |------|--------------|
-| [client]({{pulsar:deb:client}}) | [asc]({{pulsar:deb:client}}.asc), [sha512]({{pulsar:deb:client}}.sha512) |
-| [client-devel]({{pulsar:deb:client-devel}}) | [asc]({{pulsar:deb:client-devel}}.asc),  [sha512]({{pulsar:deb:client-devel}}.sha512) |
+| [client]({{pulsar:deb:client}}) | [asc]({{pulsar:dist_deb:client}}.asc), [sha512]({{pulsar:dist_deb:client}}.sha512) |
+| [client-devel]({{pulsar:deb:client-devel}}) | [asc]({{pulsar:dist_deb:client-devel}}.asc),  [sha512]({{pulsar:dist_deb:client-devel}}.sha512) |
 
 To install a DEB package, download the DEB packages and install them using the following command:
 

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -66,6 +66,23 @@ function debReleaseUrl(version, type) {
     }
 }
 
+function rpmDistUrl(version, type) {
+  rpmVersion = version.replace('incubating', '1_incubating');
+  if (version.includes('incubating')) {
+      return `https://archive.apache.org/dist/incubator/pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}.x86_64.rpm`
+  } else {
+      return `https://archive.apache.org/dist/pulsar/pulsar-${version}/RPMS/apache-pulsar-client${type}-${rpmVersion}.x86_64.rpm`
+  }
+}
+
+function debDistUrl(version, type) {
+    if (version.includes('incubating')) {
+        return `https://archive.apache.org/dist/incubator/pulsar/pulsar-${version}/DEB/apache-pulsar-client${type}.deb`
+    } else {
+        return `https://archive.apache.org/dist/pulsar/pulsar-${version}/DEB/apache-pulsar-client${type}.deb`
+    }
+}
+
 function doReplace(options) {
   replace(options)
     .then(changes => {
@@ -98,6 +115,12 @@ const from = [
   /{{pulsar:rpm:client-devel}}/g,
   /{{pulsar:deb:client}}/g,
   /{{pulsar:deb:client-devel}}/g,
+
+  /{{pulsar:dist_rpm:client}}/g,
+  /{{pulsar:dist_rpm:client-debuginfo}}/g,
+  /{{pulsar:dist_rpm:client-devel}}/g,
+  /{{pulsar:dist_deb:client}}/g,
+  /{{pulsar:dist_deb:client-devel}}/g,
 ];
 
 const options = {
@@ -120,6 +143,12 @@ const options = {
     rpmReleaseUrl(`${latestVersion}`, "-devel"),
     debReleaseUrl(`${latestVersion}`, ""),
     debReleaseUrl(`${latestVersion}`, "-dev"),
+
+    rpmDistUrl(`${latestVersion}`, ""),
+    rpmDistUrl(`${latestVersion}`, "-debuginfo"),
+    rpmDistUrl(`${latestVersion}`, "-devel"),
+    debDistUrl(`${latestVersion}`, ""),
+    debDistUrl(`${latestVersion}`, "-dev"),
   ],
   dry: false
 };


### PR DESCRIPTION
### Motivation

Fixes #3370 . The links should point to ASF dist server as the source of truth for package signatures.

