### PR TITLE
CPP Client - Removing boost dependencies from interface.

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Authentication.h
+++ b/pulsar-client-cpp/include/pulsar/Authentication.h
@@ -22,10 +22,9 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <pulsar/Result.h>
-#include <boost/make_shared.hpp>
-#include <boost/function.hpp>
+#include <functional>
 
 #pragma GCC visibility push(default)
 
@@ -50,8 +49,8 @@ class AuthenticationDataProvider {
     AuthenticationDataProvider();
 };
 
-typedef boost::shared_ptr<AuthenticationDataProvider> AuthenticationDataPtr;
-typedef boost::shared_ptr<Authentication> AuthenticationPtr;
+typedef std::shared_ptr<AuthenticationDataProvider> AuthenticationDataPtr;
+typedef std::shared_ptr<Authentication> AuthenticationPtr;
 typedef std::map<std::string, std::string> ParamMap;
 
 class Authentication {
@@ -115,7 +114,7 @@ class AuthTls : public Authentication {
     AuthenticationDataPtr authDataTls_;
 };
 
-typedef boost::function<std::string()> TokenSupplier;
+typedef std::function<std::string()> TokenSupplier;
 
 /**
  * Token based implementation of Pulsar client authentication

--- a/pulsar-client-cpp/include/pulsar/BrokerConsumerStats.h
+++ b/pulsar-client-cpp/include/pulsar/BrokerConsumerStats.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <pulsar/Result.h>
 #include <functional>
+#include <memory>
 #include <pulsar/ConsumerType.h>
 
 #pragma GCC visibility push(default)

--- a/pulsar-client-cpp/include/pulsar/BrokerConsumerStats.h
+++ b/pulsar-client-cpp/include/pulsar/BrokerConsumerStats.h
@@ -19,11 +19,10 @@
 #ifndef PULSAR_CPP_BROKERCONSUMERSTATS_H
 #define PULSAR_CPP_BROKERCONSUMERSTATS_H
 
-#include <boost/date_time/posix_time/ptime.hpp>
 #include <string.h>
 #include <iostream>
 #include <pulsar/Result.h>
-#include <boost/function.hpp>
+#include <functional>
 #include <pulsar/ConsumerType.h>
 
 #pragma GCC visibility push(default)
@@ -34,10 +33,10 @@ class PulsarWrapper;
 /* @note: isValid() or getXXX() methods are not allowed on an invalid BrokerConsumerStats */
 class BrokerConsumerStats {
    private:
-    boost::shared_ptr<BrokerConsumerStatsImplBase> impl_;
+    std::shared_ptr<BrokerConsumerStatsImplBase> impl_;
 
    public:
-    explicit BrokerConsumerStats(boost::shared_ptr<BrokerConsumerStatsImplBase> impl);
+    explicit BrokerConsumerStats(std::shared_ptr<BrokerConsumerStatsImplBase> impl);
 
     BrokerConsumerStats();
 
@@ -81,12 +80,12 @@ class BrokerConsumerStats {
     virtual uint64_t getMsgBacklog() const;
 
     /** @deprecated */
-    boost::shared_ptr<BrokerConsumerStatsImplBase> getImpl() const;
+    std::shared_ptr<BrokerConsumerStatsImplBase> getImpl() const;
 
     friend class PulsarWrapper;
     friend std::ostream &operator<<(std::ostream &os, const BrokerConsumerStats &obj);
 };
-typedef boost::function<void(Result result, BrokerConsumerStats brokerConsumerStats)>
+typedef std::function<void(Result result, BrokerConsumerStats brokerConsumerStats)>
     BrokerConsumerStatsCallback;
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -32,11 +32,11 @@
 #pragma GCC visibility push(default)
 
 namespace pulsar {
-typedef boost::function<void(Result, Producer)> CreateProducerCallback;
-typedef boost::function<void(Result, Consumer)> SubscribeCallback;
-typedef boost::function<void(Result, Reader)> ReaderCallback;
-typedef boost::function<void(Result, const std::vector<std::string>&)> GetPartitionsCallback;
-typedef boost::function<void(Result)> CloseCallback;
+typedef std::function<void(Result, Producer)> CreateProducerCallback;
+typedef std::function<void(Result, Consumer)> SubscribeCallback;
+typedef std::function<void(Result, Reader)> ReaderCallback;
+typedef std::function<void(Result, const std::vector<std::string>&)> GetPartitionsCallback;
+typedef std::function<void(Result)> CloseCallback;
 
 class ClientImpl;
 class PulsarFriend;
@@ -206,11 +206,11 @@ class Client {
    private:
     Client(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration,
            bool poolConnections);
-    Client(const boost::shared_ptr<ClientImpl>);
+    Client(const std::shared_ptr<ClientImpl>);
 
     friend class PulsarFriend;
     friend class PulsarWrapper;
-    boost::shared_ptr<ClientImpl> impl_;
+    std::shared_ptr<ClientImpl> impl_;
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
@@ -151,7 +151,7 @@ class ClientConfiguration {
 
    private:
     const AuthenticationPtr& getAuthPtr() const;
-    boost::shared_ptr<ClientConfigurationImpl> impl_;
+    std::shared_ptr<ClientConfigurationImpl> impl_;
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -19,7 +19,6 @@
 #ifndef CONSUMER_HPP_
 #define CONSUMER_HPP_
 
-#include <boost/date_time/posix_time/ptime.hpp>
 #include <iostream>
 #include <pulsar/BrokerConsumerStats.h>
 #include <pulsar/ConsumerConfiguration.h>
@@ -29,6 +28,7 @@ namespace pulsar {
 class PulsarWrapper;
 class ConsumerImplBase;
 class PulsarFriend;
+typedef std::shared_ptr<ConsumerImplBase> ConsumerImplBasePtr;
 /**
  *
  */
@@ -236,7 +236,6 @@ class Consumer {
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
 
    private:
-    typedef boost::shared_ptr<ConsumerImplBase> ConsumerImplBasePtr;
     ConsumerImplBasePtr impl_;
     explicit Consumer(ConsumerImplBasePtr);
 

--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -19,8 +19,8 @@
 #ifndef PULSAR_CONSUMERCONFIGURATION_H_
 #define PULSAR_CONSUMERCONFIGURATION_H_
 
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>
+#include <memory>
 #include <pulsar/Result.h>
 #include <pulsar/ConsumerType.h>
 #include <pulsar/Message.h>
@@ -35,10 +35,10 @@ class Consumer;
 class PulsarWrapper;
 
 /// Callback definition for non-data operation
-typedef boost::function<void(Result result)> ResultCallback;
+typedef std::function<void(Result result)> ResultCallback;
 
 /// Callback definition for MessageListener
-typedef boost::function<void(Consumer consumer, const Message& msg)> MessageListener;
+typedef std::function<void(Consumer consumer, const Message& msg)> MessageListener;
 
 class ConsumerConfigurationImpl;
 
@@ -215,7 +215,7 @@ class ConsumerConfiguration {
     friend class PulsarWrapper;
 
    private:
-    boost::shared_ptr<ConsumerConfigurationImpl> impl_;
+    std::shared_ptr<ConsumerConfigurationImpl> impl_;
 };
 }  // namespace pulsar
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/CryptoKeyReader.h
+++ b/pulsar-client-cpp/include/pulsar/CryptoKeyReader.h
@@ -62,7 +62,7 @@ class CryptoKeyReader {
 
 }; /* namespace pulsar */
 
-typedef boost::shared_ptr<CryptoKeyReader> CryptoKeyReaderPtr;
+typedef std::shared_ptr<CryptoKeyReader> CryptoKeyReaderPtr;
 }  // namespace pulsar
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/EncryptionKeyInfo.h
+++ b/pulsar-client-cpp/include/pulsar/EncryptionKeyInfo.h
@@ -19,7 +19,7 @@
 #ifndef ENCRYPTIONKEYINFO_H_
 #define ENCRYPTIONKEYINFO_H_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <iostream>
 #include <map>
 
@@ -30,7 +30,7 @@ namespace pulsar {
 class EncryptionKeyInfoImpl;
 class PulsarWrapper;
 
-typedef boost::shared_ptr<EncryptionKeyInfoImpl> EncryptionKeyInfoImplPtr;
+typedef std::shared_ptr<EncryptionKeyInfoImpl> EncryptionKeyInfoImplPtr;
 
 class EncryptionKeyInfo {
     /*

--- a/pulsar-client-cpp/include/pulsar/Logger.h
+++ b/pulsar-client-cpp/include/pulsar/Logger.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #pragma GCC visibility push(default)
 
@@ -48,6 +48,6 @@ class LoggerFactory {
     virtual Logger* getLogger(const std::string& fileName) = 0;
 };
 
-typedef boost::shared_ptr<LoggerFactory> LoggerFactoryPtr;
+typedef std::shared_ptr<LoggerFactory> LoggerFactoryPtr;
 }  // namespace pulsar
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "MessageId.h"
 
@@ -128,7 +128,7 @@ class Message {
     const std::string& getTopicName() const;
 
    private:
-    typedef boost::shared_ptr<MessageImpl> MessageImplPtr;
+    typedef std::shared_ptr<MessageImpl> MessageImplPtr;
     MessageImplPtr impl_;
 
     Message(MessageImplPtr& impl);

--- a/pulsar-client-cpp/include/pulsar/MessageBuilder.h
+++ b/pulsar-client-cpp/include/pulsar/MessageBuilder.h
@@ -120,7 +120,7 @@ class MessageBuilder {
    private:
     MessageBuilder(const MessageBuilder&);
     void checkMetadata();
-    static boost::shared_ptr<MessageImpl> createMessageImpl();
+    static std::shared_ptr<MessageImpl> createMessageImpl();
     Message::MessageImplPtr impl_;
 
     friend class PulsarWrapper;

--- a/pulsar-client-cpp/include/pulsar/MessageId.h
+++ b/pulsar-client-cpp/include/pulsar/MessageId.h
@@ -21,7 +21,7 @@
 
 #include <iosfwd>
 #include <stdint.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 //#include <lib/MessageIdImpl.h>
 
 #pragma GCC visibility push(default)
@@ -95,7 +95,7 @@ class MessageId {
     int32_t batchIndex() const;
     int32_t partition() const;
 
-    typedef boost::shared_ptr<MessageIdImpl> MessageIdImplPtr;
+    typedef std::shared_ptr<MessageIdImpl> MessageIdImplPtr;
     MessageIdImplPtr impl_;
 };
 }  // namespace pulsar

--- a/pulsar-client-cpp/include/pulsar/MessageRoutingPolicy.h
+++ b/pulsar-client-cpp/include/pulsar/MessageRoutingPolicy.h
@@ -22,7 +22,7 @@
 #include <pulsar/DeprecatedException.h>
 #include <pulsar/Message.h>
 #include <pulsar/TopicMetadata.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #pragma GCC visibility push(default)
 
@@ -50,7 +50,7 @@ class MessageRoutingPolicy {
     }
 };
 
-typedef boost::shared_ptr<MessageRoutingPolicy> MessageRoutingPolicyPtr;
+typedef std::shared_ptr<MessageRoutingPolicy> MessageRoutingPolicyPtr;
 }  // namespace pulsar
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/Producer.h
+++ b/pulsar-client-cpp/include/pulsar/Producer.h
@@ -20,7 +20,7 @@
 #define PRODUCER_HPP_
 
 #include <pulsar/ProducerConfiguration.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <stdint.h>
 
 #pragma GCC visibility push(default)
@@ -30,7 +30,8 @@ class ProducerImplBase;
 class PulsarWrapper;
 class PulsarFriend;
 
-typedef boost::function<void(Result)> FlushCallback;
+typedef std::function<void(Result)> FlushCallback;
+typedef std::shared_ptr<ProducerImplBase> ProducerImplBasePtr;
 
 class Producer {
    public:
@@ -140,7 +141,6 @@ class Producer {
     void closeAsync(CloseCallback callback);
 
    private:
-    typedef boost::shared_ptr<ProducerImplBase> ProducerImplBasePtr;
     explicit Producer(ProducerImplBasePtr);
 
     friend class ClientImpl;

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -22,7 +22,7 @@
 #include <pulsar/MessageRoutingPolicy.h>
 #include <pulsar/Result.h>
 #include <pulsar/Message.h>
-#include <boost/function.hpp>
+#include <functional>
 #include <pulsar/ProducerCryptoFailureAction.h>
 #include <pulsar/CryptoKeyReader.h>
 #include <pulsar/Schema.h>
@@ -33,8 +33,8 @@
 
 namespace pulsar {
 
-typedef boost::function<void(Result, const Message& msg)> SendCallback;
-typedef boost::function<void(Result)> CloseCallback;
+typedef std::function<void(Result, const Message& msg)> SendCallback;
+typedef std::function<void(Result)> CloseCallback;
 
 class ProducerConfigurationImpl;
 class PulsarWrapper;
@@ -187,7 +187,7 @@ class ProducerConfiguration {
 
    private:
     struct Impl;
-    boost::shared_ptr<ProducerConfigurationImpl> impl_;
+    std::shared_ptr<ProducerConfigurationImpl> impl_;
 };
 }  // namespace pulsar
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -29,7 +29,7 @@ class PulsarWrapper;
 class PulsarFriend;
 class ReaderImpl;
 
-typedef boost::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
+typedef std::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
 
 /**
  * A Reader can be used to scan through all the messages currently available in a topic.
@@ -84,7 +84,7 @@ class Reader {
     Result hasMessageAvailable(bool& hasMessageAvailable);
 
    private:
-    typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;
+    typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
     ReaderImplPtr impl_;
     explicit Reader(ReaderImplPtr);
 

--- a/pulsar-client-cpp/include/pulsar/ReaderConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ReaderConfiguration.h
@@ -19,8 +19,8 @@
 #ifndef PULSAR_READER_CONFIGURATION_H_
 #define PULSAR_READER_CONFIGURATION_H_
 
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>
+#include <memory>
 #include <pulsar/Result.h>
 #include <pulsar/Message.h>
 #include <pulsar/Schema.h>
@@ -32,10 +32,10 @@ class Reader;
 class PulsarWrapper;
 
 /// Callback definition for non-data operation
-typedef boost::function<void(Result result)> ResultCallback;
+typedef std::function<void(Result result)> ResultCallback;
 
 /// Callback definition for MessageListener
-typedef boost::function<void(Reader reader, const Message& msg)> ReaderListener;
+typedef std::function<void(Reader reader, const Message& msg)> ReaderListener;
 
 class ReaderConfigurationImpl;
 
@@ -106,7 +106,7 @@ class ReaderConfiguration {
     bool isReadCompacted() const;
 
    private:
-    boost::shared_ptr<ReaderConfigurationImpl> impl_;
+    std::shared_ptr<ReaderConfigurationImpl> impl_;
 };
 }  // namespace pulsar
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/include/pulsar/Schema.h
+++ b/pulsar-client-cpp/include/pulsar/Schema.h
@@ -21,7 +21,7 @@
 #include <map>
 
 #include <iosfwd>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #pragma GCC visibility push(default)
 
@@ -149,7 +149,7 @@ class SchemaInfo {
     const StringMap &getProperties() const;
 
    private:
-    typedef boost::shared_ptr<SchemaInfoImpl> SchemaInfoImplPtr;
+    typedef std::shared_ptr<SchemaInfoImpl> SchemaInfoImplPtr;
     SchemaInfoImplPtr impl_;
 };
 

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -106,7 +106,7 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
 
     // bind keeps a copy of the parameters
     SendCallback callback = std::bind(&BatchMessageContainer::batchMessageCallBack, std::placeholders::_1,
-                                        messagesContainerListPtr_, flushCallback);
+                                      messagesContainerListPtr_, flushCallback);
 
     producer_.sendMessage(msg, callback);
     clear();

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include "BatchMessageContainer.h"
+#include <memory>
 
 namespace pulsar {
 
@@ -104,7 +105,7 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
     msg.impl_ = impl_;
 
     // bind keeps a copy of the parameters
-    SendCallback callback = boost::bind(&BatchMessageContainer::batchMessageCallBack, _1,
+    SendCallback callback = std::bind(&BatchMessageContainer::batchMessageCallBack, std::placeholders::_1,
                                         messagesContainerListPtr_, flushCallback);
 
     producer_.sendMessage(msg, callback);

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -52,7 +52,7 @@ class BatchMessageContainer {
         SendCallback sendCallback_;
     };
     typedef std::vector<MessageContainer> MessageContainerList;
-    typedef boost::shared_ptr<MessageContainerList> MessageContainerListPtr;
+    typedef std::shared_ptr<MessageContainerList> MessageContainerListPtr;
 
     BatchMessageContainer(ProducerImpl& producer);
 

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
@@ -54,8 +54,8 @@ Future<Result, LookupDataResultPtr> BinaryProtoLookupService::lookupAsync(const 
     std::string lookupName = topicName->toString();
     LookupDataResultPromisePtr promise = std::make_shared<LookupDataResultPromise>();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, shared_from_this(), lookupName, false,
-                                   std::placeholders::_1, std::placeholders::_2, promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, shared_from_this(),
+                                 lookupName, false, std::placeholders::_1, std::placeholders::_2, promise));
     return promise->getFuture();
 }
 
@@ -72,8 +72,9 @@ Future<Result, LookupDataResultPtr> BinaryProtoLookupService::getPartitionMetada
     }
     std::string lookupName = topicName->toString();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendPartitionMetadataLookupRequest, shared_from_this(),
-                                   lookupName, std::placeholders::_1, std::placeholders::_2, promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendPartitionMetadataLookupRequest,
+                                 shared_from_this(), lookupName, std::placeholders::_1, std::placeholders::_2,
+                                 promise));
     return promise->getFuture();
 }
 
@@ -88,8 +89,9 @@ void BinaryProtoLookupService::sendTopicLookupRequest(const std::string& topicNa
     ClientConnectionPtr conn = clientCnx.lock();
     uint64_t requestId = newRequestId();
     conn->newTopicLookup(topicName, authoritative, requestId, lookupPromise);
-    lookupPromise->getFuture().addListener(
-        std::bind(&BinaryProtoLookupService::handleLookup, shared_from_this(), topicName, std::placeholders::_1, std::placeholders::_2, clientCnx, promise));
+    lookupPromise->getFuture().addListener(std::bind(&BinaryProtoLookupService::handleLookup,
+                                                     shared_from_this(), topicName, std::placeholders::_1,
+                                                     std::placeholders::_2, clientCnx, promise));
 }
 
 void BinaryProtoLookupService::handleLookup(const std::string& topicName, Result result,
@@ -105,8 +107,9 @@ void BinaryProtoLookupService::handleLookup(const std::string& topicName, Result
                 data->shouldProxyThroughServiceUrl() ? serviceUrl_ : logicalAddress;
             Future<Result, ClientConnectionWeakPtr> future =
                 cnxPool_.getConnectionAsync(logicalAddress, physicalAddress);
-            future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, shared_from_this(), topicName,
-                                           data->isAuthoritative(), std::placeholders::_1, std::placeholders::_2, promise));
+            future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest,
+                                         shared_from_this(), topicName, data->isAuthoritative(),
+                                         std::placeholders::_1, std::placeholders::_2, promise));
         } else {
             LOG_DEBUG("Lookup response for " << topicName << ", lookup-broker-url " << data->getBrokerUrl());
             promise->setValue(data);
@@ -129,9 +132,9 @@ void BinaryProtoLookupService::sendPartitionMetadataLookupRequest(const std::str
     ClientConnectionPtr conn = clientCnx.lock();
     uint64_t requestId = newRequestId();
     conn->newPartitionedMetadataLookup(topicName, requestId, lookupPromise);
-    lookupPromise->getFuture().addListener(
-        std::bind(&BinaryProtoLookupService::handlePartitionMetadataLookup, shared_from_this(), topicName, std::placeholders::_1, std::placeholders::_2,
-                    clientCnx, promise));
+    lookupPromise->getFuture().addListener(std::bind(&BinaryProtoLookupService::handlePartitionMetadataLookup,
+                                                     shared_from_this(), topicName, std::placeholders::_1,
+                                                     std::placeholders::_2, clientCnx, promise));
 }
 
 void BinaryProtoLookupService::handlePartitionMetadataLookup(const std::string& topicName, Result result,
@@ -162,8 +165,9 @@ Future<Result, NamespaceTopicsPtr> BinaryProtoLookupService::getTopicsOfNamespac
     }
     std::string namespaceName = nsName->toString();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest, shared_from_this(),
-                                   namespaceName, std::placeholders::_1, std::placeholders::_2, promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest,
+                                 shared_from_this(), namespaceName, std::placeholders::_1,
+                                 std::placeholders::_2, promise));
     return promise->getFuture();
 }
 
@@ -180,8 +184,8 @@ void BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest(const std::string
     LOG_DEBUG("sendGetTopicsOfNamespaceRequest. requestId: " << requestId << " nsName: " << nsName);
 
     conn->newGetTopicsOfNamespace(nsName, requestId)
-        .addListener(
-            std::bind(&BinaryProtoLookupService::getTopicsOfNamespaceListener, shared_from_this(), std::placeholders::_1, std::placeholders::_2, promise));
+        .addListener(std::bind(&BinaryProtoLookupService::getTopicsOfNamespaceListener, shared_from_this(),
+                               std::placeholders::_1, std::placeholders::_2, promise));
 }
 
 void BinaryProtoLookupService::getTopicsOfNamespaceListener(Result result, NamespaceTopicsPtr topicsPtr,

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
@@ -54,8 +54,8 @@ Future<Result, LookupDataResultPtr> BinaryProtoLookupService::lookupAsync(const 
     std::string lookupName = topicName->toString();
     LookupDataResultPromisePtr promise = std::make_shared<LookupDataResultPromise>();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, shared_from_this(),
-                                 lookupName, false, std::placeholders::_1, std::placeholders::_2, promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, this, lookupName, false,
+                                 std::placeholders::_1, std::placeholders::_2, promise));
     return promise->getFuture();
 }
 
@@ -72,9 +72,8 @@ Future<Result, LookupDataResultPtr> BinaryProtoLookupService::getPartitionMetada
     }
     std::string lookupName = topicName->toString();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendPartitionMetadataLookupRequest,
-                                 shared_from_this(), lookupName, std::placeholders::_1, std::placeholders::_2,
-                                 promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendPartitionMetadataLookupRequest, this,
+                                 lookupName, std::placeholders::_1, std::placeholders::_2, promise));
     return promise->getFuture();
 }
 
@@ -89,9 +88,9 @@ void BinaryProtoLookupService::sendTopicLookupRequest(const std::string& topicNa
     ClientConnectionPtr conn = clientCnx.lock();
     uint64_t requestId = newRequestId();
     conn->newTopicLookup(topicName, authoritative, requestId, lookupPromise);
-    lookupPromise->getFuture().addListener(std::bind(&BinaryProtoLookupService::handleLookup,
-                                                     shared_from_this(), topicName, std::placeholders::_1,
-                                                     std::placeholders::_2, clientCnx, promise));
+    lookupPromise->getFuture().addListener(std::bind(&BinaryProtoLookupService::handleLookup, this, topicName,
+                                                     std::placeholders::_1, std::placeholders::_2, clientCnx,
+                                                     promise));
 }
 
 void BinaryProtoLookupService::handleLookup(const std::string& topicName, Result result,
@@ -107,9 +106,9 @@ void BinaryProtoLookupService::handleLookup(const std::string& topicName, Result
                 data->shouldProxyThroughServiceUrl() ? serviceUrl_ : logicalAddress;
             Future<Result, ClientConnectionWeakPtr> future =
                 cnxPool_.getConnectionAsync(logicalAddress, physicalAddress);
-            future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest,
-                                         shared_from_this(), topicName, data->isAuthoritative(),
-                                         std::placeholders::_1, std::placeholders::_2, promise));
+            future.addListener(std::bind(&BinaryProtoLookupService::sendTopicLookupRequest, this, topicName,
+                                         data->isAuthoritative(), std::placeholders::_1,
+                                         std::placeholders::_2, promise));
         } else {
             LOG_DEBUG("Lookup response for " << topicName << ", lookup-broker-url " << data->getBrokerUrl());
             promise->setValue(data);
@@ -133,7 +132,7 @@ void BinaryProtoLookupService::sendPartitionMetadataLookupRequest(const std::str
     uint64_t requestId = newRequestId();
     conn->newPartitionedMetadataLookup(topicName, requestId, lookupPromise);
     lookupPromise->getFuture().addListener(std::bind(&BinaryProtoLookupService::handlePartitionMetadataLookup,
-                                                     shared_from_this(), topicName, std::placeholders::_1,
+                                                     this, topicName, std::placeholders::_1,
                                                      std::placeholders::_2, clientCnx, promise));
 }
 
@@ -165,9 +164,8 @@ Future<Result, NamespaceTopicsPtr> BinaryProtoLookupService::getTopicsOfNamespac
     }
     std::string namespaceName = nsName->toString();
     Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(serviceUrl_, serviceUrl_);
-    future.addListener(std::bind(&BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest,
-                                 shared_from_this(), namespaceName, std::placeholders::_1,
-                                 std::placeholders::_2, promise));
+    future.addListener(std::bind(&BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest, this,
+                                 namespaceName, std::placeholders::_1, std::placeholders::_2, promise));
     return promise->getFuture();
 }
 
@@ -184,7 +182,7 @@ void BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest(const std::string
     LOG_DEBUG("sendGetTopicsOfNamespaceRequest. requestId: " << requestId << " nsName: " << nsName);
 
     conn->newGetTopicsOfNamespace(nsName, requestId)
-        .addListener(std::bind(&BinaryProtoLookupService::getTopicsOfNamespaceListener, shared_from_this(),
+        .addListener(std::bind(&BinaryProtoLookupService::getTopicsOfNamespaceListener, this,
                                std::placeholders::_1, std::placeholders::_2, promise));
 }
 

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.h
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.h
@@ -29,7 +29,8 @@
 namespace pulsar {
 class LookupDataResult;
 
-class BinaryProtoLookupService : public LookupService, public std::enable_shared_from_this<BinaryProtoLookupService> {
+class BinaryProtoLookupService : public LookupService,
+                                 public std::enable_shared_from_this<BinaryProtoLookupService> {
    public:
     /*
      * constructor

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.h
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.h
@@ -29,7 +29,7 @@
 namespace pulsar {
 class LookupDataResult;
 
-class BinaryProtoLookupService : public LookupService {
+class BinaryProtoLookupService : public LookupService, public std::enable_shared_from_this<BinaryProtoLookupService> {
    public:
     /*
      * constructor
@@ -72,7 +72,7 @@ class BinaryProtoLookupService : public LookupService {
 
     uint64_t newRequestId();
 };
-typedef boost::shared_ptr<BinaryProtoLookupService> BinaryProtoLookupServicePtr;
+typedef std::shared_ptr<BinaryProtoLookupService> BinaryProtoLookupServicePtr;
 }  // namespace pulsar
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.h
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.h
@@ -29,8 +29,7 @@
 namespace pulsar {
 class LookupDataResult;
 
-class BinaryProtoLookupService : public LookupService,
-                                 public std::enable_shared_from_this<BinaryProtoLookupService> {
+class BinaryProtoLookupService : public LookupService {
    public:
     /*
      * constructor

--- a/pulsar-client-cpp/lib/BrokerConsumerStats.cc
+++ b/pulsar-client-cpp/lib/BrokerConsumerStats.cc
@@ -20,11 +20,11 @@
 #include <lib/BrokerConsumerStatsImplBase.h>
 
 namespace pulsar {
-BrokerConsumerStats::BrokerConsumerStats(boost::shared_ptr<BrokerConsumerStatsImplBase> impl) : impl_(impl) {}
+BrokerConsumerStats::BrokerConsumerStats(std::shared_ptr<BrokerConsumerStatsImplBase> impl) : impl_(impl) {}
 
 BrokerConsumerStats::BrokerConsumerStats() {}
 
-boost::shared_ptr<BrokerConsumerStatsImplBase> BrokerConsumerStats::getImpl() const { return impl_; }
+std::shared_ptr<BrokerConsumerStatsImplBase> BrokerConsumerStats::getImpl() const { return impl_; }
 
 bool BrokerConsumerStats::isValid() const { return impl_->isValid(); }
 

--- a/pulsar-client-cpp/lib/BrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/BrokerConsumerStatsImpl.h
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <iostream>
 #include <pulsar/Result.h>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/date_time/microsec_time_clock.hpp>
 #include <pulsar/BrokerConsumerStats.h>
 #include <lib/BrokerConsumerStatsImplBase.h>

--- a/pulsar-client-cpp/lib/BrokerConsumerStatsImplBase.h
+++ b/pulsar-client-cpp/lib/BrokerConsumerStatsImplBase.h
@@ -20,6 +20,7 @@
 #define PULSAR_CPP_BROKERCONSUMERSTATSIMPLBASE_H
 
 #include <pulsar/BrokerConsumerStats.h>
+#include <boost/date_time/posix_time/ptime.hpp>
 
 namespace pulsar {
 class BrokerConsumerStatsImplBase {
@@ -63,7 +64,7 @@ class BrokerConsumerStatsImplBase {
     /** Returns the Number of messages in the subscription backlog */
     virtual uint64_t getMsgBacklog() const = 0;
 };
-typedef boost::shared_ptr<BrokerConsumerStatsImplBase> BrokerConsumerStatsImplBasePtr;
+typedef std::shared_ptr<BrokerConsumerStatsImplBase> BrokerConsumerStatsImplBasePtr;
 }  // namespace pulsar
 
 #endif  // PULSAR_CPP_BROKERCONSUMERSTATSIMPLBASE_H

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -20,8 +20,7 @@
 #include <pulsar/Client.h>
 #include <utility>
 
-#include <boost/make_shared.hpp>
-#include <boost/smart_ptr.hpp>
+#include <memory>
 
 #include "ClientImpl.h"
 #include "Utils.h"
@@ -32,17 +31,17 @@ DECLARE_LOG_OBJECT()
 
 namespace pulsar {
 
-Client::Client(const boost::shared_ptr<ClientImpl> impl) : impl_(impl) {}
+Client::Client(const std::shared_ptr<ClientImpl> impl) : impl_(impl) {}
 
 Client::Client(const std::string& serviceUrl)
-    : impl_(boost::make_shared<ClientImpl>(serviceUrl, ClientConfiguration(), true)) {}
+    : impl_(std::make_shared<ClientImpl>(serviceUrl, ClientConfiguration(), true)) {}
 
 Client::Client(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration)
-    : impl_(boost::make_shared<ClientImpl>(serviceUrl, clientConfiguration, true)) {}
+    : impl_(std::make_shared<ClientImpl>(serviceUrl, clientConfiguration, true)) {}
 
 Client::Client(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration,
                bool poolConnections)
-    : impl_(boost::make_shared<ClientImpl>(serviceUrl, clientConfiguration, poolConnections)) {}
+    : impl_(std::make_shared<ClientImpl>(serviceUrl, clientConfiguration, poolConnections)) {}
 
 Result Client::createProducer(const std::string& topic, Producer& producer) {
     return createProducer(topic, ProducerConfiguration(), producer);

--- a/pulsar-client-cpp/lib/ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/ClientConfiguration.cc
@@ -20,7 +20,7 @@
 
 namespace pulsar {
 
-ClientConfiguration::ClientConfiguration() : impl_(boost::make_shared<ClientConfigurationImpl>()) {}
+ClientConfiguration::ClientConfiguration() : impl_(std::make_shared<ClientConfigurationImpl>()) {}
 
 ClientConfiguration::~ClientConfiguration() {}
 

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -322,7 +322,7 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
                 }
             }
             tlsSocket_->async_handshake(boost::asio::ssl::stream<tcp::socket>::client,
-            		boost::bind(&ClientConnection::handleHandshake, shared_from_this(),
+                                        boost::bind(&ClientConnection::handleHandshake, shared_from_this(),
                                                     boost::asio::placeholders::error));
         } else {
             handleHandshake(boost::system::errc::make_error_code(boost::system::errc::success));
@@ -346,7 +346,7 @@ void ClientConnection::handleHandshake(const boost::system::error_code& err) {
     SharedBuffer buffer = Commands::newConnect(authentication_, logicalAddress_, connectingThroughProxy);
     // Send CONNECT command to broker
     asyncWrite(buffer.const_asio_buffer(),
-    		boost::bind(&ClientConnection::handleSentPulsarConnect, shared_from_this(),
+               boost::bind(&ClientConnection::handleSentPulsarConnect, shared_from_this(),
                            boost::asio::placeholders::error, buffer));
 }
 
@@ -407,7 +407,7 @@ void ClientConnection::handleResolve(const boost::system::error_code& err,
         LOG_DEBUG(cnxString_ << "Resolved hostname " << endpointIterator->host_name()  //
                              << " to " << endpointIterator->endpoint());
         socket_->async_connect(*endpointIterator++,
-        		boost::bind(&ClientConnection::handleTcpConnected, shared_from_this(),
+                               boost::bind(&ClientConnection::handleTcpConnected, shared_from_this(),
                                            boost::asio::placeholders::error, endpointIterator));
     } else {
         LOG_WARN(cnxString_ << "No IP address found");
@@ -420,7 +420,7 @@ void ClientConnection::readNextCommand() {
     const static uint32_t minReadSize = sizeof(uint32_t);
     asyncReceive(incomingBuffer_.asio_buffer(),
                  customAllocReadHandler(
-                		 boost::bind(&ClientConnection::handleRead, shared_from_this(), _1, _2, minReadSize)));
+                     boost::bind(&ClientConnection::handleRead, shared_from_this(), _1, _2, minReadSize)));
 }
 
 void ClientConnection::handleRead(const boost::system::error_code& err, size_t bytesTransferred,
@@ -527,7 +527,8 @@ void ClientConnection::processIncomingBuffer() {
         uint32_t minReadSize = sizeof(uint32_t) - incomingBuffer_.readableBytes();
 
         asyncReceive(incomingBuffer_.asio_buffer(),
-                     customAllocReadHandler(boost::bind(&ClientConnection::handleRead, shared_from_this(), _1, _2, minReadSize)));
+                     customAllocReadHandler(boost::bind(&ClientConnection::handleRead, shared_from_this(), _1,
+                                                        _2, minReadSize)));
         return;
     }
 
@@ -1132,7 +1133,7 @@ void ClientConnection::sendMessage(const OpSendMsg& opSend) {
 
         // Write immediately to socket
         asyncWrite(buffer, customAllocWriteHandler(
-        		boost::bind(&ClientConnection::handleSendPair, shared_from_this(), _1)));
+                               boost::bind(&ClientConnection::handleSendPair, shared_from_this(), _1)));
     } else {
         // Queue to send later
         pendingWriteBuffers_.push_back(opSend);
@@ -1169,7 +1170,7 @@ void ClientConnection::sendPendingCommands() {
             SharedBuffer buffer = boost::any_cast<SharedBuffer>(any);
             asyncWrite(buffer.const_asio_buffer(),
                        customAllocWriteHandler(
-                    		   boost::bind(&ClientConnection::handleSend, shared_from_this(), _1, buffer)));
+                           boost::bind(&ClientConnection::handleSend, shared_from_this(), _1, buffer)));
         } else {
             assert(any.type() == typeid(OpSendMsg));
 
@@ -1178,7 +1179,7 @@ void ClientConnection::sendPendingCommands() {
                                                         op.sequenceId_, getChecksumType(), op.msg_);
 
             asyncWrite(buffer, customAllocWriteHandler(
-            		boost::bind(&ClientConnection::handleSendPair, shared_from_this(), _1)));
+                                   boost::bind(&ClientConnection::handleSendPair, shared_from_this(), _1)));
         }
     } else {
         // No more pending writes
@@ -1239,7 +1240,7 @@ void ClientConnection::handleKeepAliveTimeout() {
 
         keepAliveTimer_->expires_from_now(boost::posix_time::seconds(KeepAliveIntervalInSeconds));
         keepAliveTimer_->async_wait(
-        		boost::bind(&ClientConnection::handleKeepAliveTimeout, shared_from_this()));
+            boost::bind(&ClientConnection::handleKeepAliveTimeout, shared_from_this()));
     }
 }
 

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -53,16 +53,16 @@ class PulsarFriend;
 class ExecutorService;
 
 class ClientConnection;
-typedef boost::shared_ptr<ClientConnection> ClientConnectionPtr;
-typedef boost::weak_ptr<ClientConnection> ClientConnectionWeakPtr;
+typedef std::shared_ptr<ClientConnection> ClientConnectionPtr;
+typedef std::weak_ptr<ClientConnection> ClientConnectionWeakPtr;
 
 class ProducerImpl;
-typedef boost::shared_ptr<ProducerImpl> ProducerImplPtr;
-typedef boost::weak_ptr<ProducerImpl> ProducerImplWeakPtr;
+typedef std::shared_ptr<ProducerImpl> ProducerImplPtr;
+typedef std::weak_ptr<ProducerImpl> ProducerImplWeakPtr;
 
 class ConsumerImpl;
-typedef boost::shared_ptr<ConsumerImpl> ConsumerImplPtr;
-typedef boost::weak_ptr<ConsumerImpl> ConsumerImplWeakPtr;
+typedef std::shared_ptr<ConsumerImpl> ConsumerImplPtr;
+typedef std::weak_ptr<ConsumerImpl> ConsumerImplWeakPtr;
 
 class LookupDataResult;
 
@@ -77,7 +77,7 @@ struct ResponseData {
 
 typedef boost::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
 
-class ClientConnection : public boost::enable_shared_from_this<ClientConnection> {
+class ClientConnection : public std::enable_shared_from_this<ClientConnection> {
     enum State
     {
         Pending,

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -26,7 +26,7 @@
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/function.hpp>
+#include <functional>
 #include <string>
 #include <vector>
 #include <deque>
@@ -75,7 +75,7 @@ struct ResponseData {
     std::string schemaVersion;
 };
 
-typedef boost::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
+typedef std::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
 
 class ClientConnection : public std::enable_shared_from_this<ClientConnection> {
     enum State
@@ -87,10 +87,10 @@ class ClientConnection : public std::enable_shared_from_this<ClientConnection> {
     };
 
    public:
-    typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> TlsSocketPtr;
-    typedef boost::shared_ptr<ClientConnection> ConnectionPtr;
-    typedef boost::function<void(const boost::system::error_code&, ConnectionPtr)> ConnectionListener;
+    typedef std::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
+    typedef std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> TlsSocketPtr;
+    typedef std::shared_ptr<ClientConnection> ConnectionPtr;
+    typedef std::function<void(const boost::system::error_code&, ConnectionPtr)> ConnectionListener;
     typedef std::vector<ConnectionListener>::iterator ListenerIterator;
 
     /*

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -165,7 +165,7 @@ void ClientImpl::handleCreateProducer(const Result result, const LookupDataResul
         ProducerImplBasePtr producer;
         if (partitionMetadata->getPartitions() > 1) {
             producer = std::make_shared<PartitionedProducerImpl>(shared_from_this(), topicName,
-                                                                   partitionMetadata->getPartitions(), conf);
+                                                                 partitionMetadata->getPartitions(), conf);
         } else {
             producer = std::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
         }
@@ -361,11 +361,11 @@ void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr 
                 callback(ResultInvalidConfiguration, Consumer());
                 return;
             }
-            consumer = std::make_shared<PartitionedConsumerImpl>(
-                shared_from_this(), consumerName, topicName, partitionMetadata->getPartitions(), conf);
+            consumer = std::make_shared<PartitionedConsumerImpl>(shared_from_this(), consumerName, topicName,
+                                                                 partitionMetadata->getPartitions(), conf);
         } else {
-            consumer = std::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(),
-                                                        consumerName, conf);
+            consumer =
+                std::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(), consumerName, conf);
         }
         consumer->getConsumerCreatedFuture().addListener(
             boost::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), _1, _2, callback, consumer));

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -117,7 +117,7 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
         LOG_DEBUG("Using HTTP Lookup");
         lookupServicePtr_ =
             std::make_shared<HTTPLookupService>(boost::cref(serviceUrl_), boost::cref(clientConfiguration_),
-                                                  boost::cref(clientConfiguration_.getAuthPtr()));
+                                                boost::cref(clientConfiguration_.getAuthPtr()));
     } else {
         LOG_DEBUG("Using Binary Lookup");
         lookupServicePtr_ =
@@ -154,8 +154,9 @@ void ClientImpl::createProducerAsync(const std::string& topic, ProducerConfigura
             return;
         }
     }
-    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(std::bind(
-        &ClientImpl::handleCreateProducer, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, conf, callback));
+    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
+        std::bind(&ClientImpl::handleCreateProducer, shared_from_this(), std::placeholders::_1,
+                  std::placeholders::_2, topicName, conf, callback));
 }
 
 void ClientImpl::handleCreateProducer(const Result result, const LookupDataResultPtr partitionMetadata,
@@ -170,7 +171,8 @@ void ClientImpl::handleCreateProducer(const Result result, const LookupDataResul
             producer = std::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
         }
         producer->getProducerCreatedFuture().addListener(
-            std::bind(&ClientImpl::handleProducerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, producer));
+            std::bind(&ClientImpl::handleProducerCreated, shared_from_this(), std::placeholders::_1,
+                      std::placeholders::_2, callback, producer));
         Lock lock(mutex_);
         producers_.push_back(producer);
         lock.unlock();
@@ -205,8 +207,8 @@ void ClientImpl::createReaderAsync(const std::string& topic, const MessageId& st
 
     MessageId msgId(startMessageId);
     lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
-        std::bind(&ClientImpl::handleReaderMetadataLookup, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, msgId,
-                    conf, callback));
+        std::bind(&ClientImpl::handleReaderMetadataLookup, shared_from_this(), std::placeholders::_1,
+                  std::placeholders::_2, topicName, msgId, conf, callback));
 }
 
 void ClientImpl::handleReaderMetadataLookup(const Result result, const LookupDataResultPtr partitionMetadata,
@@ -226,7 +228,7 @@ void ClientImpl::handleReaderMetadataLookup(const Result result, const LookupDat
     }
 
     ReaderImplPtr reader = std::make_shared<ReaderImpl>(shared_from_this(), topicName->toString(), conf,
-                                                          getListenerExecutorProvider()->get(), callback);
+                                                        getListenerExecutorProvider()->get(), callback);
     reader->start(startMessageId);
 
     Lock lock(mutex_);
@@ -254,8 +256,8 @@ void ClientImpl::subscribeWithRegexAsync(const std::string& regexPattern, const 
     NamespaceNamePtr nsName = topicNamePtr->getNamespaceName();
 
     lookupServicePtr_->getTopicsOfNamespaceAsync(nsName).addListener(
-        std::bind(&ClientImpl::createPatternMultiTopicsConsumer, shared_from_this(), std::placeholders::_1, std::placeholders::_2, regexPattern,
-                    consumerName, conf, callback));
+        std::bind(&ClientImpl::createPatternMultiTopicsConsumer, shared_from_this(), std::placeholders::_1,
+                  std::placeholders::_2, regexPattern, consumerName, conf, callback));
 }
 
 void ClientImpl::createPatternMultiTopicsConsumer(const Result result, const NamespaceTopicsPtr topics,
@@ -275,7 +277,8 @@ void ClientImpl::createPatternMultiTopicsConsumer(const Result result, const Nam
             shared_from_this(), regexPattern, *matchTopics, consumerName, conf, lookupServicePtr_);
 
         consumer->getConsumerCreatedFuture().addListener(
-            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
+            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1,
+                      std::placeholders::_2, callback, consumer));
         Lock lock(mutex_);
         consumers_.push_back(consumer);
         lock.unlock();
@@ -313,8 +316,9 @@ void ClientImpl::subscribeAsync(const std::vector<std::string>& topics, const st
     ConsumerImplBasePtr consumer = std::make_shared<MultiTopicsConsumerImpl>(
         shared_from_this(), topics, consumerName, topicNamePtr, conf, lookupServicePtr_);
 
-    consumer->getConsumerCreatedFuture().addListener(
-        std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
+    consumer->getConsumerCreatedFuture().addListener(std::bind(&ClientImpl::handleConsumerCreated,
+                                                               shared_from_this(), std::placeholders::_1,
+                                                               std::placeholders::_2, callback, consumer));
     consumers_.push_back(consumer);
     lock.unlock();
     consumer->start();
@@ -342,8 +346,9 @@ void ClientImpl::subscribeAsync(const std::string& topic, const std::string& con
         }
     }
 
-    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(std::bind(
-        &ClientImpl::handleSubscribe, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, consumerName, conf, callback));
+    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
+        std::bind(&ClientImpl::handleSubscribe, shared_from_this(), std::placeholders::_1,
+                  std::placeholders::_2, topicName, consumerName, conf, callback));
 }
 
 void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr partitionMetadata,
@@ -368,7 +373,8 @@ void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr 
                 std::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(), consumerName, conf);
         }
         consumer->getConsumerCreatedFuture().addListener(
-            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
+            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1,
+                      std::placeholders::_2, callback, consumer));
         Lock lock(mutex_);
         consumers_.push_back(consumer);
         lock.unlock();
@@ -387,8 +393,9 @@ void ClientImpl::handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr co
 
 Future<Result, ClientConnectionWeakPtr> ClientImpl::getConnection(const std::string& topic) {
     Promise<Result, ClientConnectionWeakPtr> promise;
-    lookupServicePtr_->lookupAsync(topic).addListener(
-        std::bind(&ClientImpl::handleLookup, shared_from_this(), std::placeholders::_1, std::placeholders::_2, promise));
+    lookupServicePtr_->lookupAsync(topic).addListener(std::bind(&ClientImpl::handleLookup, shared_from_this(),
+                                                                std::placeholders::_1, std::placeholders::_2,
+                                                                promise));
     return promise.getFuture();
 }
 
@@ -402,7 +409,8 @@ void ClientImpl::handleLookup(Result result, LookupDataResultPtr data,
             data->shouldProxyThroughServiceUrl() ? serviceUrl_ : logicalAddress;
         Future<Result, ClientConnectionWeakPtr> future =
             pool_.getConnectionAsync(logicalAddress, physicalAddress);
-        future.addListener(std::bind(&ClientImpl::handleNewConnection, shared_from_this(), std::placeholders::_1, std::placeholders::_2, promise));
+        future.addListener(std::bind(&ClientImpl::handleNewConnection, shared_from_this(),
+                                     std::placeholders::_1, std::placeholders::_2, promise));
     } else {
         promise.setFailed(result);
     }
@@ -453,7 +461,8 @@ void ClientImpl::getPartitionsForTopicAsync(const std::string& topic, GetPartiti
         }
     }
     lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
-        std::bind(&ClientImpl::handleGetPartitions, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, callback));
+        std::bind(&ClientImpl::handleGetPartitions, shared_from_this(), std::placeholders::_1,
+                  std::placeholders::_2, topicName, callback));
 }
 
 void ClientImpl::closeAsync(CloseCallback callback) {
@@ -476,8 +485,8 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     for (ProducersList::iterator it = producers.begin(); it != producers.end(); ++it) {
         ProducerImplBasePtr producer = it->lock();
         if (producer && !producer->isClosed()) {
-            producer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(), std::placeholders::_1,
-                                             numberOfOpenHandlers, callback));
+            producer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(),
+                                           std::placeholders::_1, numberOfOpenHandlers, callback));
         } else {
             // Since the connection is already closed
             (*numberOfOpenHandlers)--;
@@ -487,8 +496,8 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     for (ConsumersList::iterator it = consumers.begin(); it != consumers.end(); ++it) {
         ConsumerImplBasePtr consumer = it->lock();
         if (consumer && !consumer->isClosed()) {
-            consumer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(), std::placeholders::_1,
-                                             numberOfOpenHandlers, callback));
+            consumer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(),
+                                           std::placeholders::_1, numberOfOpenHandlers, callback));
         } else {
             // Since the connection is already closed
             (*numberOfOpenHandlers)--;

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -85,11 +85,11 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
       state_(Open),
       serviceUrl_(serviceUrl),
       clientConfiguration_(detectTls(serviceUrl, clientConfiguration)),
-      ioExecutorProvider_(boost::make_shared<ExecutorServiceProvider>(clientConfiguration_.getIOThreads())),
+      ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getIOThreads())),
       listenerExecutorProvider_(
-          boost::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
+          std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
       partitionListenerExecutorProvider_(
-          boost::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
+          std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
       pool_(clientConfiguration_, ioExecutorProvider_, clientConfiguration_.getAuthPtr(), poolConnections),
       producerIdGenerator_(0),
       consumerIdGenerator_(0),
@@ -116,12 +116,12 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
     if (serviceUrl_.compare(0, 4, "http") == 0) {
         LOG_DEBUG("Using HTTP Lookup");
         lookupServicePtr_ =
-            boost::make_shared<HTTPLookupService>(boost::cref(serviceUrl_), boost::cref(clientConfiguration_),
+            std::make_shared<HTTPLookupService>(boost::cref(serviceUrl_), boost::cref(clientConfiguration_),
                                                   boost::cref(clientConfiguration_.getAuthPtr()));
     } else {
         LOG_DEBUG("Using Binary Lookup");
         lookupServicePtr_ =
-            boost::make_shared<BinaryProtoLookupService>(boost::ref(pool_), boost::ref(serviceUrl));
+            std::make_shared<BinaryProtoLookupService>(boost::ref(pool_), boost::ref(serviceUrl));
     }
 }
 
@@ -154,8 +154,8 @@ void ClientImpl::createProducerAsync(const std::string& topic, ProducerConfigura
             return;
         }
     }
-    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(boost::bind(
-        &ClientImpl::handleCreateProducer, shared_from_this(), _1, _2, topicName, conf, callback));
+    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(std::bind(
+        &ClientImpl::handleCreateProducer, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, conf, callback));
 }
 
 void ClientImpl::handleCreateProducer(const Result result, const LookupDataResultPtr partitionMetadata,
@@ -170,7 +170,7 @@ void ClientImpl::handleCreateProducer(const Result result, const LookupDataResul
             producer = std::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
         }
         producer->getProducerCreatedFuture().addListener(
-            boost::bind(&ClientImpl::handleProducerCreated, shared_from_this(), _1, _2, callback, producer));
+            std::bind(&ClientImpl::handleProducerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, producer));
         Lock lock(mutex_);
         producers_.push_back(producer);
         lock.unlock();
@@ -205,7 +205,7 @@ void ClientImpl::createReaderAsync(const std::string& topic, const MessageId& st
 
     MessageId msgId(startMessageId);
     lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
-        boost::bind(&ClientImpl::handleReaderMetadataLookup, shared_from_this(), _1, _2, topicName, msgId,
+        std::bind(&ClientImpl::handleReaderMetadataLookup, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, msgId,
                     conf, callback));
 }
 
@@ -225,7 +225,7 @@ void ClientImpl::handleReaderMetadataLookup(const Result result, const LookupDat
         return;
     }
 
-    ReaderImplPtr reader = boost::make_shared<ReaderImpl>(shared_from_this(), topicName->toString(), conf,
+    ReaderImplPtr reader = std::make_shared<ReaderImpl>(shared_from_this(), topicName->toString(), conf,
                                                           getListenerExecutorProvider()->get(), callback);
     reader->start(startMessageId);
 
@@ -254,7 +254,7 @@ void ClientImpl::subscribeWithRegexAsync(const std::string& regexPattern, const 
     NamespaceNamePtr nsName = topicNamePtr->getNamespaceName();
 
     lookupServicePtr_->getTopicsOfNamespaceAsync(nsName).addListener(
-        boost::bind(&ClientImpl::createPatternMultiTopicsConsumer, shared_from_this(), _1, _2, regexPattern,
+        std::bind(&ClientImpl::createPatternMultiTopicsConsumer, shared_from_this(), std::placeholders::_1, std::placeholders::_2, regexPattern,
                     consumerName, conf, callback));
 }
 
@@ -275,7 +275,7 @@ void ClientImpl::createPatternMultiTopicsConsumer(const Result result, const Nam
             shared_from_this(), regexPattern, *matchTopics, consumerName, conf, lookupServicePtr_);
 
         consumer->getConsumerCreatedFuture().addListener(
-            boost::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), _1, _2, callback, consumer));
+            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
         Lock lock(mutex_);
         consumers_.push_back(consumer);
         lock.unlock();
@@ -314,7 +314,7 @@ void ClientImpl::subscribeAsync(const std::vector<std::string>& topics, const st
         shared_from_this(), topics, consumerName, topicNamePtr, conf, lookupServicePtr_);
 
     consumer->getConsumerCreatedFuture().addListener(
-        boost::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), _1, _2, callback, consumer));
+        std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
     consumers_.push_back(consumer);
     lock.unlock();
     consumer->start();
@@ -342,8 +342,8 @@ void ClientImpl::subscribeAsync(const std::string& topic, const std::string& con
         }
     }
 
-    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(boost::bind(
-        &ClientImpl::handleSubscribe, shared_from_this(), _1, _2, topicName, consumerName, conf, callback));
+    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(std::bind(
+        &ClientImpl::handleSubscribe, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, consumerName, conf, callback));
 }
 
 void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr partitionMetadata,
@@ -368,7 +368,7 @@ void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr 
                 std::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(), consumerName, conf);
         }
         consumer->getConsumerCreatedFuture().addListener(
-            boost::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), _1, _2, callback, consumer));
+            std::bind(&ClientImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, callback, consumer));
         Lock lock(mutex_);
         consumers_.push_back(consumer);
         lock.unlock();
@@ -388,7 +388,7 @@ void ClientImpl::handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr co
 Future<Result, ClientConnectionWeakPtr> ClientImpl::getConnection(const std::string& topic) {
     Promise<Result, ClientConnectionWeakPtr> promise;
     lookupServicePtr_->lookupAsync(topic).addListener(
-        boost::bind(&ClientImpl::handleLookup, this, _1, _2, promise));
+        std::bind(&ClientImpl::handleLookup, shared_from_this(), std::placeholders::_1, std::placeholders::_2, promise));
     return promise.getFuture();
 }
 
@@ -402,7 +402,7 @@ void ClientImpl::handleLookup(Result result, LookupDataResultPtr data,
             data->shouldProxyThroughServiceUrl() ? serviceUrl_ : logicalAddress;
         Future<Result, ClientConnectionWeakPtr> future =
             pool_.getConnectionAsync(logicalAddress, physicalAddress);
-        future.addListener(boost::bind(&ClientImpl::handleNewConnection, this, _1, _2, promise));
+        future.addListener(std::bind(&ClientImpl::handleNewConnection, shared_from_this(), std::placeholders::_1, std::placeholders::_2, promise));
     } else {
         promise.setFailed(result);
     }
@@ -453,7 +453,7 @@ void ClientImpl::getPartitionsForTopicAsync(const std::string& topic, GetPartiti
         }
     }
     lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
-        boost::bind(&ClientImpl::handleGetPartitions, shared_from_this(), _1, _2, topicName, callback));
+        std::bind(&ClientImpl::handleGetPartitions, shared_from_this(), std::placeholders::_1, std::placeholders::_2, topicName, callback));
 }
 
 void ClientImpl::closeAsync(CloseCallback callback) {
@@ -471,12 +471,12 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     lock.unlock();
 
     LOG_INFO("Closing Pulsar client");
-    SharedInt numberOfOpenHandlers = boost::make_shared<int>(producers.size() + consumers.size());
+    SharedInt numberOfOpenHandlers = std::make_shared<int>(producers.size() + consumers.size());
 
     for (ProducersList::iterator it = producers.begin(); it != producers.end(); ++it) {
         ProducerImplBasePtr producer = it->lock();
         if (producer && !producer->isClosed()) {
-            producer->closeAsync(boost::bind(&ClientImpl::handleClose, shared_from_this(), _1,
+            producer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(), std::placeholders::_1,
                                              numberOfOpenHandlers, callback));
         } else {
             // Since the connection is already closed
@@ -487,7 +487,7 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     for (ConsumersList::iterator it = consumers.begin(); it != consumers.end(); ++it) {
         ConsumerImplBasePtr consumer = it->lock();
         if (consumer && !consumer->isClosed()) {
-            consumer->closeAsync(boost::bind(&ClientImpl::handleClose, shared_from_this(), _1,
+            consumer->closeAsync(std::bind(&ClientImpl::handleClose, shared_from_this(), std::placeholders::_1,
                                              numberOfOpenHandlers, callback));
         } else {
             // Since the connection is already closed

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -164,10 +164,10 @@ void ClientImpl::handleCreateProducer(const Result result, const LookupDataResul
     if (!result) {
         ProducerImplBasePtr producer;
         if (partitionMetadata->getPartitions() > 1) {
-            producer = boost::make_shared<PartitionedProducerImpl>(shared_from_this(), topicName,
+            producer = std::make_shared<PartitionedProducerImpl>(shared_from_this(), topicName,
                                                                    partitionMetadata->getPartitions(), conf);
         } else {
-            producer = boost::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
+            producer = std::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
         }
         producer->getProducerCreatedFuture().addListener(
             boost::bind(&ClientImpl::handleProducerCreated, shared_from_this(), _1, _2, callback, producer));
@@ -271,7 +271,7 @@ void ClientImpl::createPatternMultiTopicsConsumer(const Result result, const Nam
         NamespaceTopicsPtr matchTopics =
             PatternMultiTopicsConsumerImpl::topicsPatternFilter(*topics, pattern);
 
-        consumer = boost::make_shared<PatternMultiTopicsConsumerImpl>(
+        consumer = std::make_shared<PatternMultiTopicsConsumerImpl>(
             shared_from_this(), regexPattern, *matchTopics, consumerName, conf, lookupServicePtr_);
 
         consumer->getConsumerCreatedFuture().addListener(
@@ -310,7 +310,7 @@ void ClientImpl::subscribeAsync(const std::vector<std::string>& topics, const st
         topicNamePtr = TopicName::get(consumerTopicNameStream.str());
     }
 
-    ConsumerImplBasePtr consumer = boost::make_shared<MultiTopicsConsumerImpl>(
+    ConsumerImplBasePtr consumer = std::make_shared<MultiTopicsConsumerImpl>(
         shared_from_this(), topics, consumerName, topicNamePtr, conf, lookupServicePtr_);
 
     consumer->getConsumerCreatedFuture().addListener(
@@ -361,10 +361,10 @@ void ClientImpl::handleSubscribe(const Result result, const LookupDataResultPtr 
                 callback(ResultInvalidConfiguration, Consumer());
                 return;
             }
-            consumer = boost::make_shared<PartitionedConsumerImpl>(
+            consumer = std::make_shared<PartitionedConsumerImpl>(
                 shared_from_this(), consumerName, topicName, partitionMetadata->getPartitions(), conf);
         } else {
-            consumer = boost::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(),
+            consumer = std::make_shared<ConsumerImpl>(shared_from_this(), topicName->toString(),
                                                         consumerName, conf);
         }
         consumer->getConsumerCreatedFuture().addListener(

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -36,8 +36,8 @@ namespace pulsar {
 
 class ClientImpl;
 class PulsarFriend;
-typedef boost::shared_ptr<ClientImpl> ClientImplPtr;
-typedef boost::weak_ptr<ClientImpl> ClientImplWeakPtr;
+typedef std::shared_ptr<ClientImpl> ClientImplPtr;
+typedef std::weak_ptr<ClientImpl> ClientImplWeakPtr;
 
 class ReaderImpl;
 typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;
@@ -45,7 +45,7 @@ typedef boost::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
 const std::string generateRandomName();
 
-class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
+class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
    public:
     ClientImpl(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration,
                bool poolConnections);
@@ -151,9 +151,6 @@ class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
 
     friend class Client;
 };
-
-typedef boost::shared_ptr<ClientImpl> ClientImplPtr;
-
 } /* namespace pulsar */
 
 #endif /* LIB_CLIENTIMPL_H_ */

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -40,8 +40,8 @@ typedef std::shared_ptr<ClientImpl> ClientImplPtr;
 typedef std::weak_ptr<ClientImpl> ClientImplWeakPtr;
 
 class ReaderImpl;
-typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;
-typedef boost::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
+typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
+typedef std::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
 const std::string generateRandomName();
 
@@ -111,7 +111,7 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
     void handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumerWeakPtr,
                                SubscribeCallback callback, ConsumerImplBasePtr consumer);
 
-    typedef boost::shared_ptr<int> SharedInt;
+    typedef std::shared_ptr<int> SharedInt;
 
     void handleClose(Result result, SharedInt remaining, ResultCallback callback);
 

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -31,7 +31,7 @@ using namespace pulsar;
 
 namespace pulsar {
 
-typedef boost::shared_ptr<proto::MessageMetadata> MessageMetadataPtr;
+typedef std::shared_ptr<proto::MessageMetadata> MessageMetadataPtr;
 
 /**
  * Construct buffers ready to send for Pulsar client commands.

--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -22,7 +22,7 @@ namespace pulsar {
 
 const static std::string emptyString;
 
-ConsumerConfiguration::ConsumerConfiguration() : impl_(boost::make_shared<ConsumerConfigurationImpl>()) {}
+ConsumerConfiguration::ConsumerConfiguration() : impl_(std::make_shared<ConsumerConfigurationImpl>()) {}
 
 ConsumerConfiguration::~ConsumerConfiguration() {}
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -712,7 +712,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     Lock lock(mutex_);
     if (state_ != Ready) {
         lock.unlock();
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -722,7 +722,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     if (!cnx) {
         lock.unlock();
         // If connection is gone, also the consumer is closed on the broker side
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultOk);
         }
         return;
@@ -733,7 +733,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     if (!client) {
         lock.unlock();
         // Client was already destroyed
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultOk);
         }
         return;
@@ -744,7 +744,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     int requestId = client->newRequestId();
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseConsumer(consumerId_, requestId), requestId);
-    if (!callback.empty()) {
+    if (!callback) {
         future.addListener(boost::bind(&ConsumerImpl::handleClose, shared_from_this(), _1, callback));
     }
 }
@@ -849,7 +849,7 @@ void ConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callb
         BrokerConsumerStatsImpl brokerConsumerStats = brokerConsumerStats_;
         lock.unlock();
         callback(ResultOk,
-                 BrokerConsumerStats(boost::make_shared<BrokerConsumerStatsImpl>(brokerConsumerStats_)));
+                 BrokerConsumerStats(std::make_shared<BrokerConsumerStatsImpl>(brokerConsumerStats_)));
         return;
     }
     lock.unlock();
@@ -885,8 +885,8 @@ void ConsumerImpl::brokerConsumerStatsListener(Result res, BrokerConsumerStatsIm
         brokerConsumerStats_ = brokerConsumerStats;
     }
 
-    if (!callback.empty()) {
-        callback(res, BrokerConsumerStats(boost::make_shared<BrokerConsumerStatsImpl>(brokerConsumerStats)));
+    if (!callback) {
+        callback(res, BrokerConsumerStats(std::make_shared<BrokerConsumerStatsImpl>(brokerConsumerStats)));
     }
 }
 
@@ -904,7 +904,7 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     if (state_ == Closed || state_ == Closing) {
         lock.unlock();
         LOG_ERROR(getName() << "Client connection already closed.");
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -920,7 +920,7 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
         Future<Result, ResponseData> future =
             cnx->sendRequestWithId(Commands::newSeek(consumerId_, requestId, msgId), requestId);
 
-        if (!callback.empty()) {
+        if (!callback) {
             future.addListener(boost::bind(&ConsumerImpl::handleSeek, shared_from_this(), _1, callback));
         }
         return;

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -142,7 +142,8 @@ void ConsumerImpl::connectionOpened(const ClientConnectionPtr& cnx) {
                                               consumerName_, subscriptionMode_, startMessageId_,
                                               readCompacted_, config_.getProperties(), config_.getSchema());
     cnx->sendRequestWithId(cmd, requestId)
-        .addListener(std::bind(&ConsumerImpl::handleCreateConsumer, shared_from_this(), cnx, std::placeholders::_1));
+        .addListener(
+            std::bind(&ConsumerImpl::handleCreateConsumer, shared_from_this(), cnx, std::placeholders::_1));
 }
 
 void ConsumerImpl::connectionFailed(Result result) {
@@ -237,7 +238,8 @@ void ConsumerImpl::unsubscribeAsync(ResultCallback callback) {
         int requestId = client->newRequestId();
         SharedBuffer cmd = Commands::newUnsubscribe(consumerId_, requestId);
         cnx->sendRequestWithId(cmd, requestId)
-            .addListener(std::bind(&ConsumerImpl::handleUnsubscribe, shared_from_this(), std::placeholders::_1, callback));
+            .addListener(std::bind(&ConsumerImpl::handleUnsubscribe, shared_from_this(),
+                                   std::placeholders::_1, callback));
     } else {
         Result result = ResultNotConnected;
         lock.unlock();
@@ -727,8 +729,8 @@ void ConsumerImpl::statsCallback(Result res, ResultCallback callback, proto::Com
 }
 
 void ConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCallback callback) {
-    ResultCallback cb =
-        std::bind(&ConsumerImpl::statsCallback, shared_from_this(), std::placeholders::_1, callback, proto::CommandAck_AckType_Individual);
+    ResultCallback cb = std::bind(&ConsumerImpl::statsCallback, shared_from_this(), std::placeholders::_1,
+                                  callback, proto::CommandAck_AckType_Individual);
     if (msgId.batchIndex() != -1 &&
         !batchAcknowledgementTracker_.isBatchReady(msgId, proto::CommandAck_AckType_Individual)) {
         cb(ResultOk);
@@ -738,8 +740,8 @@ void ConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCallback callb
 }
 
 void ConsumerImpl::acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) {
-    ResultCallback cb =
-        std::bind(&ConsumerImpl::statsCallback, shared_from_this(), std::placeholders::_1, callback, proto::CommandAck_AckType_Cumulative);
+    ResultCallback cb = std::bind(&ConsumerImpl::statsCallback, shared_from_this(), std::placeholders::_1,
+                                  callback, proto::CommandAck_AckType_Cumulative);
     if (msgId.batchIndex() != -1 &&
         !batchAcknowledgementTracker_.isBatchReady(msgId, proto::CommandAck_AckType_Cumulative)) {
         MessageId messageId = batchAcknowledgementTracker_.getGreatestCumulativeAckReady(msgId);
@@ -825,7 +827,8 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseConsumer(consumerId_, requestId), requestId);
     if (!callback) {
-        future.addListener(std::bind(&ConsumerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback));
+        future.addListener(
+            std::bind(&ConsumerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback));
     }
 
     // fail pendingReceive callback
@@ -946,8 +949,8 @@ void ConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callb
                                 << ", requestId - " << requestId);
 
             cnx->newConsumerStats(consumerId_, requestId)
-                .addListener(std::bind(&ConsumerImpl::brokerConsumerStatsListener, shared_from_this(), std::placeholders::_1,
-                                         std::placeholders::_2, callback));
+                .addListener(std::bind(&ConsumerImpl::brokerConsumerStatsListener, shared_from_this(),
+                                       std::placeholders::_1, std::placeholders::_2, callback));
             return;
         } else {
             LOG_ERROR(getName() << " Operation not supported since server protobuf version "
@@ -1004,7 +1007,8 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
             cnx->sendRequestWithId(Commands::newSeek(consumerId_, requestId, msgId), requestId);
 
         if (!callback) {
-            future.addListener(std::bind(&ConsumerImpl::handleSeek, shared_from_this(), std::placeholders::_1, callback));
+            future.addListener(
+                std::bind(&ConsumerImpl::handleSeek, shared_from_this(), std::placeholders::_1, callback));
         }
         return;
     }
@@ -1074,7 +1078,7 @@ void ConsumerImpl::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback
 
             cnx->newGetLastMessageId(consumerId_, requestId)
                 .addListener(std::bind(&ConsumerImpl::brokerGetLastMessageIdListener, shared_from_this(),
-                                         std::placeholders::_1, std::placeholders::_2, callback));
+                                       std::placeholders::_1, std::placeholders::_2, callback));
         } else {
             LOG_ERROR(getName() << " Operation not supported since server protobuf version "
                                 << cnx->getServerProtocolVersion() << " is older than proto::v12");

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -851,7 +851,9 @@ void ConsumerImpl::handleClose(Result result, ResultCallback callback) {
         LOG_ERROR(getName() << "Failed to close consumer: " << result);
     }
 
-    callback(result);
+    if (callback) {
+    	callback(result);
+    }
 }
 
 const std::string& ConsumerImpl::getName() const { return consumerStr_; }

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -794,7 +794,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     Lock lock(mutex_);
     if (state_ != Ready) {
         lock.unlock();
-        if (!callback) {
+        if (callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -804,7 +804,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     if (!cnx) {
         lock.unlock();
         // If connection is gone, also the consumer is closed on the broker side
-        if (!callback) {
+        if (callback) {
             callback(ResultOk);
         }
         return;
@@ -815,7 +815,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     if (!client) {
         lock.unlock();
         // Client was already destroyed
-        if (!callback) {
+        if (callback) {
             callback(ResultOk);
         }
         return;
@@ -826,7 +826,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     int requestId = client->newRequestId();
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseConsumer(consumerId_, requestId), requestId);
-    if (!callback) {
+    if (callback) {
         future.addListener(
             std::bind(&ConsumerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback));
     }
@@ -971,7 +971,7 @@ void ConsumerImpl::brokerConsumerStatsListener(Result res, BrokerConsumerStatsIm
         brokerConsumerStats_ = brokerConsumerStats;
     }
 
-    if (!callback) {
+    if (callback) {
         callback(res, BrokerConsumerStats(std::make_shared<BrokerConsumerStatsImpl>(brokerConsumerStats)));
     }
 }
@@ -990,7 +990,7 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     if (state_ == Closed || state_ == Closing) {
         lock.unlock();
         LOG_ERROR(getName() << "Client connection already closed.");
-        if (!callback) {
+        if (callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -1006,7 +1006,7 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
         Future<Result, ResponseData> future =
             cnx->sendRequestWithId(Commands::newSeek(consumerId_, requestId, msgId), requestId);
 
-        if (!callback) {
+        if (callback) {
             future.addListener(
                 std::bind(&ConsumerImpl::handleSeek, shared_from_this(), std::placeholders::_1, callback));
         }
@@ -1061,7 +1061,7 @@ void ConsumerImpl::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback
     if (state_ == Closed || state_ == Closing) {
         lock.unlock();
         LOG_ERROR(getName() << "Client connection already closed.");
-        if (!callback) {
+        if (callback) {
             callback(ResultAlreadyClosed, MessageId());
         }
         return;

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -852,7 +852,7 @@ void ConsumerImpl::handleClose(Result result, ResultCallback callback) {
     }
 
     if (callback) {
-    	callback(result);
+        callback(result);
     }
 }
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -50,11 +50,8 @@ class UnAckedMessageTracker;
 class ExecutorService;
 class ConsumerImpl;
 class BatchAcknowledgementTracker;
-typedef boost::shared_ptr<ConsumerImpl> ConsumerImplPtr;
-typedef boost::weak_ptr<ConsumerImpl> ConsumerImplWeakPtr;
 typedef boost::shared_ptr<MessageCrypto> MessageCryptoPtr;
 typedef boost::function<void(Result result, MessageId messageId)> BrokerGetLastMessageIdCallback;
-typedef boost::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
 
 enum ConsumerTopicType
 {
@@ -64,7 +61,7 @@ enum ConsumerTopicType
 
 class ConsumerImpl : public ConsumerImplBase,
                      public HandlerBase,
-                     public boost::enable_shared_from_this<ConsumerImpl> {
+                     public std::enable_shared_from_this<ConsumerImpl> {
    public:
     ConsumerImpl(const ClientImplPtr client, const std::string& topic, const std::string& subscription,
                  const ConsumerConfiguration&,

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -50,8 +50,8 @@ class UnAckedMessageTracker;
 class ExecutorService;
 class ConsumerImpl;
 class BatchAcknowledgementTracker;
-typedef boost::shared_ptr<MessageCrypto> MessageCryptoPtr;
-typedef boost::function<void(Result result, MessageId messageId)> BrokerGetLastMessageIdCallback;
+typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
+typedef std::function<void(Result result, MessageId messageId)> BrokerGetLastMessageIdCallback;
 
 enum ConsumerTopicType
 {

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -24,8 +24,7 @@
 namespace pulsar {
 class ConsumerImplBase;
 
-typedef boost::weak_ptr<ConsumerImplBase> ConsumerImplBaseWeakPtr;
-typedef boost::shared_ptr<ConsumerImplBase> ConsumerImplBasePtr;
+typedef std::weak_ptr<ConsumerImplBase> ConsumerImplBaseWeakPtr;
 
 class ConsumerImplBase {
    public:

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -22,7 +22,7 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/function.hpp>
+#include <functional>
 
 namespace pulsar {
 
@@ -38,11 +38,11 @@ ExecutorService::~ExecutorService() { close(); }
  *  @ returns shared_ptr to this socket
  */
 SocketPtr ExecutorService::createSocket() {
-    return boost::make_shared<boost::asio::ip::tcp::socket>(boost::ref(io_service_));
+    return std::make_shared<boost::asio::ip::tcp::socket>(boost::ref(io_service_));
 }
 
 TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx) {
-    return boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> >(
+    return std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> >(
         new boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>(*socket, ctx));
 }
 
@@ -51,11 +51,11 @@ TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, boost::asio::ss
  *  @returns shraed_ptr to resolver object
  */
 TcpResolverPtr ExecutorService::createTcpResolver() {
-    return boost::make_shared<boost::asio::ip::tcp::resolver>(boost::ref(io_service_));
+    return std::make_shared<boost::asio::ip::tcp::resolver>(boost::ref(io_service_));
 }
 
 DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
-    return boost::make_shared<boost::asio::deadline_timer>(boost::ref(io_service_));
+    return std::make_shared<boost::asio::deadline_timer>(boost::ref(io_service_));
 }
 
 void ExecutorService::close() {
@@ -64,7 +64,7 @@ void ExecutorService::close() {
     worker_.join();
 }
 
-void ExecutorService::postWork(boost::function<void(void)> task) { io_service_.post(task); }
+void ExecutorService::postWork(std::function<void(void)> task) { io_service_.post(task); }
 
 /////////////////////
 
@@ -76,7 +76,7 @@ ExecutorServicePtr ExecutorServiceProvider::get() {
 
     int idx = executorIdx_++ % executors_.size();
     if (!executors_[idx]) {
-        executors_[idx] = boost::make_shared<ExecutorService>();
+        executors_[idx] = std::make_shared<ExecutorService>();
     }
 
     return executors_[idx];

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -22,17 +22,17 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
 
 #pragma GCC visibility push(default)
 
 namespace pulsar {
-typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> > TlsSocketPtr;
-typedef boost::shared_ptr<boost::asio::ip::tcp::resolver> TcpResolverPtr;
-typedef boost::shared_ptr<boost::asio::deadline_timer> DeadlineTimerPtr;
+typedef std::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
+typedef std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> > TlsSocketPtr;
+typedef std::shared_ptr<boost::asio::ip::tcp::resolver> TcpResolverPtr;
+typedef std::shared_ptr<boost::asio::deadline_timer> DeadlineTimerPtr;
 class ExecutorService : private boost::noncopyable {
     friend class ClientConnection;
 
@@ -44,7 +44,7 @@ class ExecutorService : private boost::noncopyable {
     TlsSocketPtr createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx);
     TcpResolverPtr createTcpResolver();
     DeadlineTimerPtr createDeadlineTimer();
-    void postWork(boost::function<void(void)> task);
+    void postWork(std::function<void(void)> task);
     void close();
 
    private:
@@ -73,7 +73,7 @@ class ExecutorService : private boost::noncopyable {
     boost::asio::detail::thread worker_;
 };
 
-typedef boost::shared_ptr<ExecutorService> ExecutorServicePtr;
+typedef std::shared_ptr<ExecutorService> ExecutorServicePtr;
 
 class ExecutorServiceProvider {
    public:
@@ -91,7 +91,7 @@ class ExecutorServiceProvider {
     typedef boost::unique_lock<boost::mutex> Lock;
 };
 
-typedef boost::shared_ptr<ExecutorServiceProvider> ExecutorServiceProviderPtr;
+typedef std::shared_ptr<ExecutorServiceProvider> ExecutorServiceProviderPtr;
 }  // namespace pulsar
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -19,7 +19,7 @@
 #ifndef LIB_FUTURE_H_
 #define LIB_FUTURE_H_
 
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -41,13 +41,13 @@ struct InternalState {
     Type value;
     bool complete;
 
-    std::list<typename boost::function<void(Result, const Type&)> > listeners;
+    std::list<typename std::function<void(Result, const Type&)> > listeners;
 };
 
 template <typename Result, typename Type>
 class Future {
    public:
-    typedef boost::function<void(Result, const Type&)> ListenerCallback;
+    typedef std::function<void(Result, const Type&)> ListenerCallback;
 
     Future& addListener(ListenerCallback callback) {
         InternalState<Result, Type>* state = state_.get();
@@ -79,10 +79,10 @@ class Future {
     }
 
    private:
-    typedef boost::shared_ptr<InternalState<Result, Type> > InternalStatePtr;
+    typedef std::shared_ptr<InternalState<Result, Type> > InternalStatePtr;
     Future(InternalStatePtr state) : state_(state) {}
 
-    boost::shared_ptr<InternalState<Result, Type> > state_;
+    std::shared_ptr<InternalState<Result, Type> > state_;
 
     template <typename U, typename V>
     friend class Promise;
@@ -91,7 +91,7 @@ class Future {
 template <typename Result, typename Type>
 class Promise {
    public:
-    Promise() : state_(boost::make_shared<InternalState<Result, Type> >()) {}
+    Promise() : state_(std::make_shared<InternalState<Result, Type> >()) {}
 
     bool setValue(const Type& value) {
         InternalState<Result, Type>* state = state_.get();
@@ -147,8 +147,8 @@ class Promise {
     Future<Result, Type> getFuture() const { return Future<Result, Type>(state_); }
 
    private:
-    typedef boost::function<void(Result, const Type&)> ListenerCallback;
-    boost::shared_ptr<InternalState<Result, Type> > state_;
+    typedef std::function<void(Result, const Type&)> ListenerCallback;
+    std::shared_ptr<InternalState<Result, Type> > state_;
 };
 
 class Void {};

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -72,8 +72,8 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::lookupAsync(const std::st
     }
 
     executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleLookupHTTPRequest,
-                                                   shared_from_this(), promise, completeUrlStream.str(),
-                                                   Lookup));
+                                                 shared_from_this(), promise, completeUrlStream.str(),
+                                                 Lookup));
     return promise.getFuture();
 }
 
@@ -94,8 +94,8 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::getPartitionMetadataAsync
     }
 
     executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleLookupHTTPRequest,
-                                                   shared_from_this(), promise, completeUrlStream.str(),
-                                                   PartitionMetaData));
+                                                 shared_from_this(), promise, completeUrlStream.str(),
+                                                 PartitionMetaData));
     return promise.getFuture();
 }
 
@@ -113,7 +113,7 @@ Future<Result, NamespaceTopicsPtr> HTTPLookupService::getTopicsOfNamespaceAsync(
     }
 
     executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleNamespaceTopicsHTTPRequest,
-                                                   shared_from_this(), promise, completeUrlStream.str()));
+                                                 shared_from_this(), promise, completeUrlStream.str()));
     return promise.getFuture();
 }
 

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -37,7 +37,7 @@ HTTPLookupService::CurlInitializer HTTPLookupService::curlInitializer;
 HTTPLookupService::HTTPLookupService(const std::string &lookupUrl,
                                      const ClientConfiguration &clientConfiguration,
                                      const AuthenticationPtr &authData)
-    : executorProvider_(boost::make_shared<ExecutorServiceProvider>(NUMBER_OF_LOOKUP_THREADS)),
+    : executorProvider_(std::make_shared<ExecutorServiceProvider>(NUMBER_OF_LOOKUP_THREADS)),
       authenticationPtr_(authData),
       lookupTimeoutInSeconds_(clientConfiguration.getOperationTimeoutSeconds()),
       isUseTls_(clientConfiguration.isUseTls()),
@@ -53,7 +53,7 @@ HTTPLookupService::HTTPLookupService(const std::string &lookupUrl,
 
 Future<Result, LookupDataResultPtr> HTTPLookupService::lookupAsync(const std::string &topic) {
     LookupPromise promise;
-    boost::shared_ptr<TopicName> topicName = TopicName::get(topic);
+    std::shared_ptr<TopicName> topicName = TopicName::get(topic);
     if (!topicName) {
         LOG_ERROR("Unable to parse topic - " << topic);
         promise.setFailed(ResultInvalidTopicName);
@@ -71,7 +71,7 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::lookupAsync(const std::st
                           << topicName->getEncodedLocalName();
     }
 
-    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleLookupHTTPRequest,
+    executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleLookupHTTPRequest,
                                                    shared_from_this(), promise, completeUrlStream.str(),
                                                    Lookup));
     return promise.getFuture();
@@ -93,7 +93,7 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::getPartitionMetadataAsync
                           << '/' << PARTITION_METHOD_NAME;
     }
 
-    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleLookupHTTPRequest,
+    executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleLookupHTTPRequest,
                                                    shared_from_this(), promise, completeUrlStream.str(),
                                                    PartitionMetaData));
     return promise.getFuture();
@@ -112,7 +112,7 @@ Future<Result, NamespaceTopicsPtr> HTTPLookupService::getTopicsOfNamespaceAsync(
                           << "destinations";
     }
 
-    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleNamespaceTopicsHTTPRequest,
+    executorProvider_->get()->postWork(std::bind(&HTTPLookupService::handleNamespaceTopicsHTTPRequest,
                                                    shared_from_this(), promise, completeUrlStream.str()));
     return promise.getFuture();
 }
@@ -272,7 +272,7 @@ LookupDataResultPtr HTTPLookupService::parsePartitionData(const std::string &jso
                                                                  << "\nInput Json = " << json);
         return LookupDataResultPtr();
     }
-    LookupDataResultPtr lookupDataResultPtr = boost::make_shared<LookupDataResult>();
+    LookupDataResultPtr lookupDataResultPtr = std::make_shared<LookupDataResult>();
     lookupDataResultPtr->setPartitions(root.get("partitions", 0).asInt());
     LOG_INFO("parsePartitionData = " << *lookupDataResultPtr);
     return lookupDataResultPtr;
@@ -299,7 +299,7 @@ LookupDataResultPtr HTTPLookupService::parseLookupData(const std::string &json) 
         return LookupDataResultPtr();
     }
 
-    LookupDataResultPtr lookupDataResultPtr = boost::make_shared<LookupDataResult>();
+    LookupDataResultPtr lookupDataResultPtr = std::make_shared<LookupDataResult>();
     lookupDataResultPtr->setBrokerUrl(brokerUrl);
     lookupDataResultPtr->setBrokerUrlTls(brokerUrlTls);
 
@@ -332,7 +332,7 @@ NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string
     }
 
     NamespaceTopicsPtr topicsResultPtr =
-        boost::make_shared<std::vector<std::string>>(topicSet.begin(), topicSet.end());
+        std::make_shared<std::vector<std::string>>(topicSet.begin(), topicSet.end());
 
     return topicsResultPtr;
 }

--- a/pulsar-client-cpp/lib/HTTPLookupService.h
+++ b/pulsar-client-cpp/lib/HTTPLookupService.h
@@ -29,7 +29,7 @@
 #include <lib/Version.h>
 
 namespace pulsar {
-class HTTPLookupService : public LookupService, public boost::enable_shared_from_this<HTTPLookupService> {
+class HTTPLookupService : public LookupService, public std::enable_shared_from_this<HTTPLookupService> {
     class CurlInitializer {
        public:
         CurlInitializer() {

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -53,7 +53,7 @@ void HandlerBase::grabCnx() {
     LOG_INFO(getName() << "Getting connection from pool");
     ClientImplPtr client = client_.lock();
     Future<Result, ClientConnectionWeakPtr> future = client->getConnection(topic_);
-    future.addListener(boost::bind(&HandlerBase::handleNewConnection, _1, _2, get_weak_from_this()));
+    future.addListener(std::bind(&HandlerBase::handleNewConnection, std::placeholders::_1, std::placeholders::_2, get_weak_from_this()));
 }
 
 void HandlerBase::handleNewConnection(Result result, ClientConnectionWeakPtr connection,
@@ -130,7 +130,7 @@ void HandlerBase::scheduleReconnection(HandlerBasePtr handler) {
         handler->timer_->expires_from_now(delay);
         // passing shared_ptr here since time_ will get destroyed, so tasks will be cancelled
         // so we will not run into the case where grabCnx is invoked on out of scope handler
-        handler->timer_->async_wait(boost::bind(&HandlerBase::handleTimeout, _1, handler));
+        handler->timer_->async_wait(std::bind(&HandlerBase::handleTimeout, std::placeholders::_1, handler));
     }
 }
 

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -53,7 +53,8 @@ void HandlerBase::grabCnx() {
     LOG_INFO(getName() << "Getting connection from pool");
     ClientImplPtr client = client_.lock();
     Future<Result, ClientConnectionWeakPtr> future = client->getConnection(topic_);
-    future.addListener(std::bind(&HandlerBase::handleNewConnection, std::placeholders::_1, std::placeholders::_2, get_weak_from_this()));
+    future.addListener(std::bind(&HandlerBase::handleNewConnection, std::placeholders::_1,
+                                 std::placeholders::_2, get_weak_from_this()));
 }
 
 void HandlerBase::handleNewConnection(Result result, ClientConnectionWeakPtr connection,

--- a/pulsar-client-cpp/lib/HandlerBase.h
+++ b/pulsar-client-cpp/lib/HandlerBase.h
@@ -36,8 +36,8 @@ ptime now();
 int64_t currentTimeMillis();
 
 class HandlerBase;
-typedef boost::weak_ptr<HandlerBase> HandlerBaseWeakPtr;
-typedef boost::shared_ptr<HandlerBase> HandlerBasePtr;
+typedef std::weak_ptr<HandlerBase> HandlerBaseWeakPtr;
+typedef std::shared_ptr<HandlerBase> HandlerBasePtr;
 
 class HandlerBase {
    public:

--- a/pulsar-client-cpp/lib/Latch.cc
+++ b/pulsar-client-cpp/lib/Latch.cc
@@ -30,7 +30,7 @@ struct CountIsZero {
     bool operator()() const { return count_ == 0; }
 };
 
-Latch::Latch(int count) : state_(boost::make_shared<InternalState>()) { state_->count = count; }
+Latch::Latch(int count) : state_(std::make_shared<InternalState>()) { state_->count = count; }
 
 void Latch::countdown() {
     Lock lock(state_->mutex);

--- a/pulsar-client-cpp/lib/Latch.h
+++ b/pulsar-client-cpp/lib/Latch.h
@@ -47,9 +47,9 @@ class Latch {
     };
 
     typedef boost::unique_lock<boost::mutex> Lock;
-    boost::shared_ptr<InternalState> state_;
+    std::shared_ptr<InternalState> state_;
 };
-typedef boost::shared_ptr<Latch> LatchPtr;
+typedef std::shared_ptr<Latch> LatchPtr;
 } /* namespace pulsar */
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/lib/LookupDataResult.h
+++ b/pulsar-client-cpp/lib/LookupDataResult.h
@@ -24,9 +24,9 @@
 
 namespace pulsar {
 class LookupDataResult;
-typedef boost::shared_ptr<LookupDataResult> LookupDataResultPtr;
+typedef std::shared_ptr<LookupDataResult> LookupDataResultPtr;
 typedef Promise<Result, LookupDataResultPtr> LookupDataResultPromise;
-typedef boost::shared_ptr<LookupDataResultPromise> LookupDataResultPromisePtr;
+typedef std::shared_ptr<LookupDataResultPromise> LookupDataResultPromisePtr;
 
 class LookupDataResult {
    public:

--- a/pulsar-client-cpp/lib/LookupService.h
+++ b/pulsar-client-cpp/lib/LookupService.h
@@ -26,9 +26,9 @@
 #include <lib/TopicName.h>
 
 namespace pulsar {
-typedef boost::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
+typedef std::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
 typedef Promise<Result, NamespaceTopicsPtr> NamespaceTopicsPromise;
-typedef boost::shared_ptr<Promise<Result, NamespaceTopicsPtr>> NamespaceTopicsPromisePtr;
+typedef std::shared_ptr<Promise<Result, NamespaceTopicsPtr>> NamespaceTopicsPromisePtr;
 
 class LookupService {
    public:
@@ -56,7 +56,7 @@ class LookupService {
     virtual ~LookupService() {}
 };
 
-typedef boost::shared_ptr<LookupService> LookupServicePtr;
+typedef std::shared_ptr<LookupService> LookupServicePtr;
 
 }  // namespace pulsar
 #endif  // PULSAR_CPP_LOOKUPSERVICE_H

--- a/pulsar-client-cpp/lib/Message.cc
+++ b/pulsar-client-cpp/lib/Message.cc
@@ -64,7 +64,7 @@ Message::Message(MessageImplPtr& impl) : impl_(impl) {}
 
 Message::Message(const proto::CommandMessage& msg, proto::MessageMetadata& metadata, SharedBuffer& payload,
                  int32_t partition)
-    : impl_(boost::make_shared<MessageImpl>()) {
+    : impl_(std::make_shared<MessageImpl>()) {
     impl_->messageId =
         MessageId(partition, msg.message_id().ledgerid(), msg.message_id().entryid(), /* batchId */
                   -1);
@@ -74,7 +74,7 @@ Message::Message(const proto::CommandMessage& msg, proto::MessageMetadata& metad
 
 Message::Message(const MessageId& messageID, proto::MessageMetadata& metadata, SharedBuffer& payload,
                  proto::SingleMessageMetadata& singleMetadata, const std::string& topicName)
-    : impl_(boost::make_shared<MessageImpl>()) {
+    : impl_(std::make_shared<MessageImpl>()) {
     impl_->messageId = messageID;
     impl_->metadata = metadata;
     impl_->payload = payload;

--- a/pulsar-client-cpp/lib/MessageBuilder.cc
+++ b/pulsar-client-cpp/lib/MessageBuilder.cc
@@ -35,7 +35,7 @@ namespace pulsar {
 
 ObjectPool<MessageImpl, 100000> messagePool;
 
-boost::shared_ptr<MessageImpl> MessageBuilder::createMessageImpl() { return messagePool.create(); }
+std::shared_ptr<MessageImpl> MessageBuilder::createMessageImpl() { return messagePool.create(); }
 
 MessageBuilder::MessageBuilder() { impl_ = createMessageImpl(); }
 

--- a/pulsar-client-cpp/lib/MessageId.cc
+++ b/pulsar-client-cpp/lib/MessageId.cc
@@ -31,7 +31,7 @@
 namespace pulsar {
 
 MessageId::MessageId() {
-    static const MessageIdImplPtr emptyMessageId = boost::make_shared<MessageIdImpl>();
+    static const MessageIdImplPtr emptyMessageId = std::make_shared<MessageIdImpl>();
     impl_ = emptyMessageId;
 }
 
@@ -41,7 +41,7 @@ MessageId& MessageId::operator=(const MessageId& m) {
 }
 
 MessageId::MessageId(int32_t partition, int64_t ledgerId, int64_t entryId, int32_t batchIndex)
-    : impl_(boost::make_shared<MessageIdImpl>(partition, ledgerId, entryId, batchIndex)) {}
+    : impl_(std::make_shared<MessageIdImpl>(partition, ledgerId, entryId, batchIndex)) {}
 
 const MessageId& MessageId::earliest() {
     static const MessageId _earliest(-1, -1, -1, -1);

--- a/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
@@ -86,7 +86,7 @@ class MultiTopicsBrokerConsumerStatsImpl : public BrokerConsumerStatsImplBase {
 
     friend std::ostream &operator<<(std::ostream &os, const MultiTopicsBrokerConsumerStatsImpl &obj);
 };
-typedef boost::shared_ptr<MultiTopicsBrokerConsumerStatsImpl> MultiTopicsBrokerConsumerStatsPtr;
+typedef std::shared_ptr<MultiTopicsBrokerConsumerStatsImpl> MultiTopicsBrokerConsumerStatsPtr;
 }  // namespace pulsar
 #pragma GCC visibility pop
 #endif  // PULSAR_CPP_MULTITOPICSBROKERCONSUMERSTATSIMPL_H

--- a/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <vector>
 #include <pulsar/Result.h>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/date_time/microsec_time_clock.hpp>
 #include <lib/BrokerConsumerStatsImpl.h>
 #include <boost/shared_ptr.hpp>

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -423,7 +423,7 @@ void MultiTopicsConsumerImpl::handleSingleConsumerClose(Result result, std::stri
         }
 
         multiTopicsConsumerCreatedPromise_.setFailed(ResultUnknownError);
-        if (!callback) {
+        if (callback) {
             callback(result);
         }
         return;

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -178,7 +178,7 @@ void MultiTopicsConsumerImpl::subscribeTopicPartitions(const Result result,
     if (numPartitions == 1) {
         // We don't have to add partition-n suffix
         consumer = std::make_shared<ConsumerImpl>(client_, topicName->toString(), subscriptionName_, config,
-                                                    internalListenerExecutor, NonPartitioned);
+                                                  internalListenerExecutor, NonPartitioned);
         consumer->getConsumerCreatedFuture().addListener(
             boost::bind(&MultiTopicsConsumerImpl::handleSingleConsumerCreated, shared_from_this(), _1, _2,
                         partitionsNeedCreate, topicSubResultPromise));
@@ -189,8 +189,8 @@ void MultiTopicsConsumerImpl::subscribeTopicPartitions(const Result result,
     } else {
         for (int i = 0; i < numPartitions; i++) {
             std::string topicPartitionName = topicName->getTopicPartitionName(i);
-            consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_,
-                                                        config, internalListenerExecutor, Partitioned);
+            consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_, config,
+                                                      internalListenerExecutor, Partitioned);
             consumer->getConsumerCreatedFuture().addListener(
                 boost::bind(&MultiTopicsConsumerImpl::handleSingleConsumerCreated, shared_from_this(), _1, _2,
                             partitionsNeedCreate, topicSubResultPromise));

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -150,7 +150,7 @@ void MultiTopicsConsumerImpl::subscribeTopicPartitions(const Result result,
         return;
     }
 
-    boost::shared_ptr<ConsumerImpl> consumer;
+    std::shared_ptr<ConsumerImpl> consumer;
     ConsumerConfiguration config;
     ExecutorServicePtr internalListenerExecutor = client_->getPartitionListenerExecutorProvider()->get();
 
@@ -177,7 +177,7 @@ void MultiTopicsConsumerImpl::subscribeTopicPartitions(const Result result,
 
     if (numPartitions == 1) {
         // We don't have to add partition-n suffix
-        consumer = boost::make_shared<ConsumerImpl>(client_, topicName->toString(), subscriptionName_, config,
+        consumer = std::make_shared<ConsumerImpl>(client_, topicName->toString(), subscriptionName_, config,
                                                     internalListenerExecutor, NonPartitioned);
         consumer->getConsumerCreatedFuture().addListener(
             boost::bind(&MultiTopicsConsumerImpl::handleSingleConsumerCreated, shared_from_this(), _1, _2,
@@ -189,7 +189,7 @@ void MultiTopicsConsumerImpl::subscribeTopicPartitions(const Result result,
     } else {
         for (int i = 0; i < numPartitions; i++) {
             std::string topicPartitionName = topicName->getTopicPartitionName(i);
-            consumer = boost::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_,
+            consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_,
                                                         config, internalListenerExecutor, Partitioned);
             consumer->getConsumerCreatedFuture().addListener(
                 boost::bind(&MultiTopicsConsumerImpl::handleSingleConsumerCreated, shared_from_this(), _1, _2,
@@ -417,7 +417,7 @@ void MultiTopicsConsumerImpl::handleSingleConsumerClose(Result result, std::stri
         }
 
         multiTopicsConsumerCreatedPromise_.setFailed(ResultUnknownError);
-        if (!callback.empty()) {
+        if (!callback) {
             callback(result);
         }
         return;
@@ -597,7 +597,7 @@ void MultiTopicsConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCal
         return;
     }
     MultiTopicsBrokerConsumerStatsPtr statsPtr =
-        boost::make_shared<MultiTopicsBrokerConsumerStatsImpl>(numberTopicPartitions_->load());
+        std::make_shared<MultiTopicsBrokerConsumerStatsImpl>(numberTopicPartitions_->load());
     LatchPtr latchPtr = boost::make_shared<Latch>(numberTopicPartitions_->load());
     int size = consumers_.size();
     lock.unlock();

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -33,7 +33,7 @@
 #include <lib/NamespaceName.h>
 
 namespace pulsar {
-typedef boost::shared_ptr<Promise<Result, Consumer>> ConsumerSubResultPromisePtr;
+typedef std::shared_ptr<Promise<Result, Consumer>> ConsumerSubResultPromisePtr;
 
 class MultiTopicsConsumerImpl;
 class MultiTopicsConsumerImpl : public ConsumerImplBase,
@@ -73,7 +73,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, MultiTopicsBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     // return first topic name when all topics name valid, or return null pointer
-    static boost::shared_ptr<TopicName> topicNamesValid(const std::vector<std::string>& topics);
+    static std::shared_ptr<TopicName> topicNamesValid(const std::vector<std::string>& topics);
     void unsubscribeOneTopicAsync(const std::string& topic, ResultCallback callback);
     Future<Result, Consumer> subscribeOneTopicAsync(const std::string& topic);
     // not supported
@@ -91,7 +91,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     std::map<std::string, int> topicsPartitions_;
     boost::mutex mutex_;
     MultiTopicsConsumerState state_;
-    boost::shared_ptr<std::atomic<int>> numberTopicPartitions_;
+    std::shared_ptr<std::atomic<int>> numberTopicPartitions_;
     LookupServicePtr lookupServicePtr_;
     BlockingQueue<Message> messages_;
     ExecutorServicePtr listenerExecutor_;
@@ -113,17 +113,17 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     void receiveMessages();
 
     void handleOneTopicSubscribed(Result result, Consumer consumer, const std::string& topic,
-                                  boost::shared_ptr<std::atomic<int>> topicsNeedCreate);
+                                  std::shared_ptr<std::atomic<int>> topicsNeedCreate);
     void subscribeTopicPartitions(const Result result, const LookupDataResultPtr partitionMetadata,
                                   TopicNamePtr topicName, const std::string& consumerName,
                                   ConsumerConfiguration conf,
                                   ConsumerSubResultPromisePtr topicSubResultPromise);
     void handleSingleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumerImplBaseWeakPtr,
-                                     boost::shared_ptr<std::atomic<int>> partitionsNeedCreate,
+                                     std::shared_ptr<std::atomic<int>> partitionsNeedCreate,
                                      ConsumerSubResultPromisePtr topicSubResultPromise);
-    void handleUnsubscribedAsync(Result result, boost::shared_ptr<std::atomic<int>> consumerUnsubed,
+    void handleUnsubscribedAsync(Result result, std::shared_ptr<std::atomic<int>> consumerUnsubed,
                                  ResultCallback callback);
-    void handleOneTopicUnsubscribedAsync(Result result, boost::shared_ptr<std::atomic<int>> consumerUnsubed,
+    void handleOneTopicUnsubscribedAsync(Result result, std::shared_ptr<std::atomic<int>> consumerUnsubed,
                                          int numberPartitions, TopicNamePtr topicNamePtr,
                                          std::string& topicPartitionName, ResultCallback callback);
 };

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -34,11 +34,10 @@
 
 namespace pulsar {
 typedef boost::shared_ptr<Promise<Result, Consumer>> ConsumerSubResultPromisePtr;
-typedef boost::function<void(Result result)> ResultCallback;
 
 class MultiTopicsConsumerImpl;
 class MultiTopicsConsumerImpl : public ConsumerImplBase,
-                                public boost::enable_shared_from_this<MultiTopicsConsumerImpl> {
+                                public std::enable_shared_from_this<MultiTopicsConsumerImpl> {
    public:
     enum MultiTopicsConsumerState
     {

--- a/pulsar-client-cpp/lib/NamespaceName.cc
+++ b/pulsar-client-cpp/lib/NamespaceName.cc
@@ -30,7 +30,7 @@ DECLARE_LOG_OBJECT()
 namespace pulsar {
 
 std::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property, const std::string& cluster,
-                                                    const std::string& namespaceName) {
+                                                  const std::string& namespaceName) {
     if (validateNamespace(property, cluster, namespaceName)) {
         std::shared_ptr<NamespaceName> ptr(new NamespaceName(property, cluster, namespaceName));
         return ptr;
@@ -62,7 +62,7 @@ bool NamespaceName::validateNamespace(const std::string& property, const std::st
 }
 
 std::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property,
-                                                    const std::string& namespaceName) {
+                                                  const std::string& namespaceName) {
     if (validateNamespace(property, namespaceName)) {
         std::shared_ptr<NamespaceName> ptr(new NamespaceName(property, namespaceName));
         return ptr;

--- a/pulsar-client-cpp/lib/NamespaceName.cc
+++ b/pulsar-client-cpp/lib/NamespaceName.cc
@@ -29,14 +29,14 @@
 DECLARE_LOG_OBJECT()
 namespace pulsar {
 
-boost::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property, const std::string& cluster,
+std::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property, const std::string& cluster,
                                                     const std::string& namespaceName) {
     if (validateNamespace(property, cluster, namespaceName)) {
-        boost::shared_ptr<NamespaceName> ptr(new NamespaceName(property, cluster, namespaceName));
+        std::shared_ptr<NamespaceName> ptr(new NamespaceName(property, cluster, namespaceName));
         return ptr;
     } else {
         LOG_DEBUG("Returning a null NamespaceName object");
-        return boost::shared_ptr<NamespaceName>();
+        return std::shared_ptr<NamespaceName>();
     }
 }
 
@@ -61,14 +61,14 @@ bool NamespaceName::validateNamespace(const std::string& property, const std::st
     }
 }
 
-boost::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property,
+std::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property,
                                                     const std::string& namespaceName) {
     if (validateNamespace(property, namespaceName)) {
-        boost::shared_ptr<NamespaceName> ptr(new NamespaceName(property, namespaceName));
+        std::shared_ptr<NamespaceName> ptr(new NamespaceName(property, namespaceName));
         return ptr;
     } else {
         LOG_DEBUG("Returning a null NamespaceName object");
-        return boost::shared_ptr<NamespaceName>();
+        return std::shared_ptr<NamespaceName>();
     }
 }
 
@@ -89,8 +89,8 @@ bool NamespaceName::validateNamespace(const std::string& property, const std::st
     }
 }
 
-boost::shared_ptr<NamespaceName> NamespaceName::getNamespaceObject() {
-    return boost::shared_ptr<NamespaceName>(this);
+std::shared_ptr<NamespaceName> NamespaceName::getNamespaceObject() {
+    return std::shared_ptr<NamespaceName>(this);
 }
 
 bool NamespaceName::operator==(const NamespaceName& namespaceName) {

--- a/pulsar-client-cpp/lib/NamespaceName.h
+++ b/pulsar-client-cpp/lib/NamespaceName.h
@@ -29,13 +29,13 @@ namespace pulsar {
 
 class NamespaceName : public ServiceUnitId {
    public:
-    boost::shared_ptr<NamespaceName> getNamespaceObject();
+    std::shared_ptr<NamespaceName> getNamespaceObject();
     std::string getProperty();
     std::string getCluster();
     std::string getLocalName();
-    static boost::shared_ptr<NamespaceName> get(const std::string& property, const std::string& cluster,
+    static std::shared_ptr<NamespaceName> get(const std::string& property, const std::string& cluster,
                                                 const std::string& namespaceName);
-    static boost::shared_ptr<NamespaceName> get(const std::string& property,
+    static std::shared_ptr<NamespaceName> get(const std::string& property,
                                                 const std::string& namespaceName);
     bool operator==(const NamespaceName& namespaceName);
     bool isV2();
@@ -53,7 +53,7 @@ class NamespaceName : public ServiceUnitId {
     NamespaceName(const std::string& property, const std::string& namespace_);
 };
 
-typedef boost::shared_ptr<NamespaceName> NamespaceNamePtr;
+typedef std::shared_ptr<NamespaceName> NamespaceNamePtr;
 
 }  // namespace pulsar
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/lib/NamespaceName.h
+++ b/pulsar-client-cpp/lib/NamespaceName.h
@@ -34,9 +34,8 @@ class NamespaceName : public ServiceUnitId {
     std::string getCluster();
     std::string getLocalName();
     static std::shared_ptr<NamespaceName> get(const std::string& property, const std::string& cluster,
-                                                const std::string& namespaceName);
-    static std::shared_ptr<NamespaceName> get(const std::string& property,
-                                                const std::string& namespaceName);
+                                              const std::string& namespaceName);
+    static std::shared_ptr<NamespaceName> get(const std::string& property, const std::string& namespaceName);
     bool operator==(const NamespaceName& namespaceName);
     bool isV2();
     std::string toString();

--- a/pulsar-client-cpp/lib/ObjectPool.h
+++ b/pulsar-client-cpp/lib/ObjectPool.h
@@ -22,8 +22,7 @@
 #include <algorithm>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/thread/tss.hpp>
 
 namespace pulsar {
@@ -206,14 +205,14 @@ int Allocator<Type, MaxSize>::Impl::globalNodeCount_;
 
 template <typename Type, int MaxSize>
 class ObjectPool {
-    typedef boost::shared_ptr<Type> TypeSharedPtr;
+    typedef std::shared_ptr<Type> TypeSharedPtr;
 
     Allocator<Type, MaxSize> allocator_;
 
    public:
     ObjectPool() {}
 
-    TypeSharedPtr create() { return boost::allocate_shared<Type>(allocator_); }
+    TypeSharedPtr create() { return std::allocate_shared<Type>(allocator_); }
 
     ~ObjectPool() {
         struct Allocator<Type, MaxSize>::Impl::GlobalPool* poolEntry =

--- a/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <vector>
 #include <pulsar/Result.h>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/date_time/microsec_time_clock.hpp>
 #include <lib/BrokerConsumerStatsImpl.h>
 #include <boost/shared_ptr.hpp>

--- a/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
@@ -86,7 +86,7 @@ class PartitionedBrokerConsumerStatsImpl : public BrokerConsumerStatsImplBase {
 
     friend std::ostream &operator<<(std::ostream &os, const PartitionedBrokerConsumerStatsImpl &obj);
 };
-typedef boost::shared_ptr<PartitionedBrokerConsumerStatsImpl> PartitionedBrokerConsumerStatsPtr;
+typedef std::shared_ptr<PartitionedBrokerConsumerStatsImpl> PartitionedBrokerConsumerStatsPtr;
 }  // namespace pulsar
 #pragma GCC visibility pop
 #endif  // PULSAR_CPP_BROKERCONSUMERSTATSIMPL_H

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -264,7 +264,7 @@ void PartitionedConsumerImpl::handleSinglePartitionConsumerClose(Result result, 
         LOG_ERROR("Closing the consumer failed for partition - " << partitionIndex);
         lock.unlock();
         partitionedConsumerCreatedPromise_.setFailed(result);
-        if (!callback) {
+        if (callback) {
             callback(result);
         }
         return;
@@ -279,7 +279,7 @@ void PartitionedConsumerImpl::handleSinglePartitionConsumerClose(Result result, 
         lock.unlock();
         // set the producerCreatedPromise to failure
         partitionedConsumerCreatedPromise_.setFailed(ResultUnknownError);
-        if (!callback) {
+        if (callback) {
             callback(result);
         }
         return;

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -162,7 +162,7 @@ void PartitionedConsumerImpl::acknowledgeCumulativeAsync(const MessageId& msgId,
 
 void PartitionedConsumerImpl::start() {
     ExecutorServicePtr internalListenerExecutor = client_->getPartitionListenerExecutorProvider()->get();
-    boost::shared_ptr<ConsumerImpl> consumer;
+    std::shared_ptr<ConsumerImpl> consumer;
     ConsumerConfiguration config;
     // all the partitioned-consumer belonging to one partitioned topic should have same name
     config.setConsumerName(conf_.getConsumerName());
@@ -179,7 +179,7 @@ void PartitionedConsumerImpl::start() {
     // create consumer on each partition
     for (unsigned int i = 0; i < numPartitions_; i++) {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
-        consumer = boost::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_, config,
+        consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_, config,
                                                     internalListenerExecutor, Partitioned);
         consumer->getConsumerCreatedFuture().addListener(boost::bind(
             &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_from_this(), _1, _2, i));
@@ -240,7 +240,7 @@ void PartitionedConsumerImpl::handleSinglePartitionConsumerClose(Result result, 
         LOG_ERROR("Closing the consumer failed for partition - " << partitionIndex);
         lock.unlock();
         partitionedConsumerCreatedPromise_.setFailed(result);
-        if (!callback.empty()) {
+        if (!callback) {
             callback(result);
         }
         return;
@@ -255,7 +255,7 @@ void PartitionedConsumerImpl::handleSinglePartitionConsumerClose(Result result, 
         lock.unlock();
         // set the producerCreatedPromise to failure
         partitionedConsumerCreatedPromise_.setFailed(ResultUnknownError);
-        if (!callback.empty()) {
+        if (!callback) {
             callback(result);
         }
         return;
@@ -380,7 +380,7 @@ void PartitionedConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCal
         return;
     }
     PartitionedBrokerConsumerStatsPtr statsPtr =
-        boost::make_shared<PartitionedBrokerConsumerStatsImpl>(numPartitions_);
+        std::make_shared<PartitionedBrokerConsumerStatsImpl>(numPartitions_);
     LatchPtr latchPtr = boost::make_shared<Latch>(numPartitions_);
     ConsumerList consumerList = consumers_;
     lock.unlock();

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -180,7 +180,7 @@ void PartitionedConsumerImpl::start() {
     for (unsigned int i = 0; i < numPartitions_; i++) {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
         consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_, config,
-                                                    internalListenerExecutor, Partitioned);
+                                                  internalListenerExecutor, Partitioned);
         consumer->getConsumerCreatedFuture().addListener(boost::bind(
             &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_from_this(), _1, _2, i));
         consumer->setPartitionIndex(i);

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -132,7 +132,8 @@ void PartitionedConsumerImpl::unsubscribeAsync(ResultCallback callback) {
             LOG_DEBUG("Unsubcribing Consumer - " << index << " for Subscription - " << subscriptionName_
                                                  << " for Topic - " << topicName_->toString());
             (*consumer)->unsubscribeAsync(std::bind(&PartitionedConsumerImpl::handleUnsubscribeAsync,
-                                                      shared_from_this(), std::placeholders::_1, index++, callback));
+                                                    shared_from_this(), std::placeholders::_1, index++,
+                                                    callback));
         }
     }
 }
@@ -190,8 +191,8 @@ void PartitionedConsumerImpl::start() {
     config.setConsumerName(conf_.getConsumerName());
     config.setConsumerType(conf_.getConsumerType());
     config.setBrokerConsumerStatsCacheTimeInMs(conf_.getBrokerConsumerStatsCacheTimeInMs());
-    config.setMessageListener(
-        std::bind(&PartitionedConsumerImpl::messageReceived, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
+    config.setMessageListener(std::bind(&PartitionedConsumerImpl::messageReceived, shared_from_this(),
+                                        std::placeholders::_1, std::placeholders::_2));
 
     // Apply total limit of receiver queue size across partitions
     config.setReceiverQueueSize(
@@ -203,8 +204,9 @@ void PartitionedConsumerImpl::start() {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
         consumer = std::make_shared<ConsumerImpl>(client_, topicPartitionName, subscriptionName_, config,
                                                   internalListenerExecutor, Partitioned);
-        consumer->getConsumerCreatedFuture().addListener(std::bind(
-            &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, i));
+        consumer->getConsumerCreatedFuture().addListener(
+            std::bind(&PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_from_this(),
+                      std::placeholders::_1, std::placeholders::_2, i));
         consumer->setPartitionIndex(i);
         consumers_.push_back(consumer);
 
@@ -296,7 +298,8 @@ void PartitionedConsumerImpl::closeAsync(ResultCallback callback) {
         ConsumerImplPtr consumer = *i;
         if (!consumer->isClosed()) {
             consumer->closeAsync(std::bind(&PartitionedConsumerImpl::handleSinglePartitionConsumerClose,
-                                             shared_from_this(), std::placeholders::_1, consumerIndex, callback));
+                                           shared_from_this(), std::placeholders::_1, consumerIndex,
+                                           callback));
         } else {
             if (++consumerAlreadyClosed == consumers_.size()) {
                 // everything is closed already. so we are good.
@@ -436,8 +439,8 @@ void PartitionedConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCal
     lock.unlock();
     for (int i = 0; i < consumerList.size(); i++) {
         consumerList[i]->getBrokerConsumerStatsAsync(
-            std::bind(&PartitionedConsumerImpl::handleGetConsumerStats, shared_from_this(), std::placeholders::_1, std::placeholders::_2,
-                        latchPtr, statsPtr, i, callback));
+            std::bind(&PartitionedConsumerImpl::handleGetConsumerStats, shared_from_this(),
+                      std::placeholders::_1, std::placeholders::_2, latchPtr, statsPtr, i, callback));
     }
 }
 

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -102,7 +102,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     Promise<Result, ConsumerImplBaseWeakPtr> partitionedConsumerCreatedPromise_;
     UnAckedMessageTrackerScopedPtr unAckedMessageTrackerPtr_;
 };
-typedef boost::weak_ptr<PartitionedConsumerImpl> PartitionedConsumerImplWeakPtr;
-typedef boost::shared_ptr<PartitionedConsumerImpl> PartitionedConsumerImplPtr;
+typedef std::weak_ptr<PartitionedConsumerImpl> PartitionedConsumerImplWeakPtr;
+typedef std::shared_ptr<PartitionedConsumerImpl> PartitionedConsumerImplPtr;
 }  // namespace pulsar
 #endif  // PULSAR_PARTITIONED_CONSUMER_HEADER

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -33,7 +33,7 @@
 namespace pulsar {
 class PartitionedConsumerImpl;
 class PartitionedConsumerImpl : public ConsumerImplBase,
-                                public boost::enable_shared_from_this<PartitionedConsumerImpl> {
+                                public std::enable_shared_from_this<PartitionedConsumerImpl> {
    public:
     enum PartitionedConsumerState
     {

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -61,8 +61,8 @@ MessageRoutingPolicyPtr PartitionedProducerImpl::getMessageRouter() {
         case ProducerConfiguration::UseSinglePartition:
         default:
             unsigned int random = rand();
-            return std::make_shared<SinglePartitionMessageRouter>(
-                random % topicMetadata_->getNumPartitions(), conf_.getHashingScheme());
+            return std::make_shared<SinglePartitionMessageRouter>(random % topicMetadata_->getNumPartitions(),
+                                                                  conf_.getHashingScheme());
     }
 }
 

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -77,8 +77,8 @@ void PartitionedProducerImpl::start() {
     for (unsigned int i = 0; i < topicMetadata_->getNumPartitions(); i++) {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
         producer = std::make_shared<ProducerImpl>(client_, topicPartitionName, conf_);
-        producer->getProducerCreatedFuture().addListener(boost::bind(
-            &PartitionedProducerImpl::handleSinglePartitionProducerCreated, shared_from_this(), _1, _2, i));
+        producer->getProducerCreatedFuture().addListener(std::bind(
+            &PartitionedProducerImpl::handleSinglePartitionProducerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, i));
         producers_.push_back(producer);
         LOG_DEBUG("Creating Producer for single Partition - " << topicPartitionName);
     }
@@ -173,8 +173,8 @@ void PartitionedProducerImpl::closeAsync(CloseCallback closeCallback) {
     for (ProducerList::const_iterator i = producers_.begin(); i != producers_.end(); i++) {
         ProducerImplPtr prod = *i;
         if (!prod->isClosed()) {
-            prod->closeAsync(boost::bind(&PartitionedProducerImpl::handleSinglePartitionProducerClose,
-                                         shared_from_this(), _1, producerIndex, closeCallback));
+            prod->closeAsync(std::bind(&PartitionedProducerImpl::handleSinglePartitionProducerClose,
+                                         shared_from_this(), std::placeholders::_1, producerIndex, closeCallback));
         } else {
             producerAlreadyClosed++;
         }
@@ -249,10 +249,10 @@ void PartitionedProducerImpl::triggerFlush() {
 
 void PartitionedProducerImpl::flushAsync(FlushCallback callback) {
     if (!flushPromise_ || flushPromise_->isComplete()) {
-        flushPromise_ = boost::make_shared<Promise<Result, bool_type>>();
+        flushPromise_ = std::make_shared<Promise<Result, bool_type>>();
     } else {
         // already in flushing, register a listener callback
-        boost::function<void(Result, bool)> listenerCallback = [this, callback](Result result, bool_type v) {
+        std::function<void(Result, bool)> listenerCallback = [this, callback](Result result, bool_type v) {
             if (v) {
                 callback(ResultOk);
             } else {

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -41,7 +41,8 @@ PartitionedProducerImpl::PartitionedProducerImpl(ClientImplPtr client, const Top
       topic_(topicName_->toString()),
       conf_(config),
       state_(Pending),
-      topicMetadata_(new TopicMetadataImpl(numPartitions)) {
+      topicMetadata_(new TopicMetadataImpl(numPartitions)),
+      flushedPartitions_(0) {
     numProducersCreated_ = 0;
     cleanup_ = false;
     routerPolicy_ = getMessageRouter();

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -77,8 +77,9 @@ void PartitionedProducerImpl::start() {
     for (unsigned int i = 0; i < topicMetadata_->getNumPartitions(); i++) {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
         producer = std::make_shared<ProducerImpl>(client_, topicPartitionName, conf_);
-        producer->getProducerCreatedFuture().addListener(std::bind(
-            &PartitionedProducerImpl::handleSinglePartitionProducerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2, i));
+        producer->getProducerCreatedFuture().addListener(
+            std::bind(&PartitionedProducerImpl::handleSinglePartitionProducerCreated, shared_from_this(),
+                      std::placeholders::_1, std::placeholders::_2, i));
         producers_.push_back(producer);
         LOG_DEBUG("Creating Producer for single Partition - " << topicPartitionName);
     }
@@ -174,7 +175,8 @@ void PartitionedProducerImpl::closeAsync(CloseCallback closeCallback) {
         ProducerImplPtr prod = *i;
         if (!prod->isClosed()) {
             prod->closeAsync(std::bind(&PartitionedProducerImpl::handleSinglePartitionProducerClose,
-                                         shared_from_this(), std::placeholders::_1, producerIndex, closeCallback));
+                                       shared_from_this(), std::placeholders::_1, producerIndex,
+                                       closeCallback));
         } else {
             producerAlreadyClosed++;
         }

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -55,13 +55,13 @@ PartitionedProducerImpl::PartitionedProducerImpl(ClientImplPtr client, const Top
 MessageRoutingPolicyPtr PartitionedProducerImpl::getMessageRouter() {
     switch (conf_.getPartitionsRoutingMode()) {
         case ProducerConfiguration::RoundRobinDistribution:
-            return boost::make_shared<RoundRobinMessageRouter>(conf_.getHashingScheme());
+            return std::make_shared<RoundRobinMessageRouter>(conf_.getHashingScheme());
         case ProducerConfiguration::CustomPartition:
             return conf_.getMessageRouterPtr();
         case ProducerConfiguration::UseSinglePartition:
         default:
             unsigned int random = rand();
-            return boost::make_shared<SinglePartitionMessageRouter>(
+            return std::make_shared<SinglePartitionMessageRouter>(
                 random % topicMetadata_->getNumPartitions(), conf_.getHashingScheme());
     }
 }
@@ -72,11 +72,11 @@ const std::string& PartitionedProducerImpl::getTopic() const { return topic_; }
 
 // override
 void PartitionedProducerImpl::start() {
-    boost::shared_ptr<ProducerImpl> producer;
+    std::shared_ptr<ProducerImpl> producer;
     // create producer per partition
     for (unsigned int i = 0; i < topicMetadata_->getNumPartitions(); i++) {
         std::string topicPartitionName = topicName_->getTopicPartitionName(i);
-        producer = boost::make_shared<ProducerImpl>(client_, topicPartitionName, conf_);
+        producer = std::make_shared<ProducerImpl>(client_, topicPartitionName, conf_);
         producer->getProducerCreatedFuture().addListener(boost::bind(
             &PartitionedProducerImpl::handleSinglePartitionProducerCreated, shared_from_this(), _1, _2, i));
         producers_.push_back(producer);

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -29,7 +29,7 @@
 namespace pulsar {
 
 class PartitionedProducerImpl : public ProducerImplBase,
-                                public boost::enable_shared_from_this<PartitionedProducerImpl> {
+                                public std::enable_shared_from_this<PartitionedProducerImpl> {
    public:
     enum PartitionedProducerState
     {

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -121,7 +121,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     MessageRoutingPolicyPtr getMessageRouter();
 
     std::atomic<int> flushedPartitions_;
-    boost::shared_ptr<Promise<Result, bool_type>> flushPromise_;
+    std::shared_ptr<Promise<Result, bool_type>> flushPromise_;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
@@ -83,7 +83,7 @@ void PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace(const Result resu
 
     NamespaceTopicsPtr newTopics = PatternMultiTopicsConsumerImpl::topicsPatternFilter(*topics, pattern_);
     // get old topics in consumer:
-    NamespaceTopicsPtr oldTopics = boost::make_shared<std::vector<std::string>>();
+    NamespaceTopicsPtr oldTopics = std::make_shared<std::vector<std::string>>();
     for (std::map<std::string, int>::iterator it = topicsPartitions_.begin(); it != topicsPartitions_.end();
          it++) {
         oldTopics->push_back(it->first);
@@ -123,7 +123,7 @@ void PatternMultiTopicsConsumerImpl::onTopicsAdded(NamespaceTopicsPtr addedTopic
     }
     int topicsNumber = addedTopics->size();
 
-    boost::shared_ptr<std::atomic<int>> topicsNeedCreate = boost::make_shared<std::atomic<int>>(topicsNumber);
+    std::shared_ptr<std::atomic<int>> topicsNeedCreate = std::make_shared<std::atomic<int>>(topicsNumber);
     // subscribe for each passed in topic
     for (std::vector<std::string>::const_iterator itr = addedTopics->begin(); itr != addedTopics->end();
          itr++) {
@@ -134,7 +134,7 @@ void PatternMultiTopicsConsumerImpl::onTopicsAdded(NamespaceTopicsPtr addedTopic
 }
 
 void PatternMultiTopicsConsumerImpl::handleOneTopicAdded(const Result result, const std::string& topic,
-                                                         boost::shared_ptr<std::atomic<int>> topicsNeedCreate,
+                                                         std::shared_ptr<std::atomic<int>> topicsNeedCreate,
                                                          ResultCallback callback) {
     int previous = topicsNeedCreate->fetch_sub(1);
     assert(previous > 0);
@@ -161,7 +161,7 @@ void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedT
     }
     int topicsNumber = removedTopics->size();
 
-    boost::shared_ptr<std::atomic<int>> topicsNeedUnsub = boost::make_shared<std::atomic<int>>(topicsNumber);
+    std::shared_ptr<std::atomic<int>> topicsNeedUnsub = std::make_shared<std::atomic<int>>(topicsNumber);
     ResultCallback oneTopicUnsubscribedCallback = [this, topicsNeedUnsub, callback](Result result) {
         int previous = topicsNeedUnsub->fetch_sub(1);
         assert(previous > 0);
@@ -187,7 +187,7 @@ void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedT
 
 NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(const std::vector<std::string>& topics,
                                                                        const std::regex& pattern) {
-    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
+    NamespaceTopicsPtr topicsResultPtr = std::make_shared<std::vector<std::string>>();
 
     for (std::vector<std::string>::const_iterator itr = topics.begin(); itr != topics.end(); itr++) {
         if (std::regex_match(*itr, pattern)) {
@@ -199,7 +199,7 @@ NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(const std
 
 NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsListsMinus(std::vector<std::string>& list1,
                                                                     std::vector<std::string>& list2) {
-    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
+    NamespaceTopicsPtr topicsResultPtr = std::make_shared<std::vector<std::string>>();
     std::remove_copy_if(list1.begin(), list1.end(), std::back_inserter(*topicsResultPtr),
                         [&list2](const std::string& arg) {
                             return (std::find(list2.begin(), list2.end(), arg) != list2.end());

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
@@ -21,10 +21,10 @@
 #include "ConsumerImpl.h"
 #include "ClientImpl.h"
 #include <regex>
-#include "boost/enable_shared_from_this.hpp"
 #include <lib/TopicName.h>
 #include <lib/NamespaceName.h>
 #include "MultiTopicsConsumerImpl.h"
+#include <memory>
 
 namespace pulsar {
 
@@ -60,7 +60,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
    private:
     const std::string patternString_;
     const std::regex pattern_;
-    typedef boost::shared_ptr<boost::asio::deadline_timer> TimerPtr;
+    typedef std::shared_ptr<boost::asio::deadline_timer> TimerPtr;
     TimerPtr autoDiscoveryTimer_;
     bool autoDiscoveryRunning_;
 
@@ -69,7 +69,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
     void onTopicsAdded(NamespaceTopicsPtr addedTopics, ResultCallback callback);
     void onTopicsRemoved(NamespaceTopicsPtr removedTopics, ResultCallback callback);
     void handleOneTopicAdded(const Result result, const std::string& topic,
-                             boost::shared_ptr<std::atomic<int>> topicsNeedCreate, ResultCallback callback);
+                             std::shared_ptr<std::atomic<int>> topicsNeedCreate, ResultCallback callback);
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -22,7 +22,7 @@ namespace pulsar {
 
 const static std::string emptyString;
 
-ProducerConfiguration::ProducerConfiguration() : impl_(boost::make_shared<ProducerConfigurationImpl>()) {}
+ProducerConfiguration::ProducerConfiguration() : impl_(std::make_shared<ProducerConfigurationImpl>()) {}
 
 ProducerConfiguration::~ProducerConfiguration() {}
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -516,8 +516,9 @@ void ProducerImpl::handleClose(Result result, ResultCallback callback) {
     } else {
         LOG_ERROR(getName() << "Failed to close producer: " << strResult(result));
     }
-
-    callback(result);
+    if (callback) {
+    	callback(result);
+    }
 }
 
 Future<Result, ProducerImplBaseWeakPtr> ProducerImpl::getProducerCreatedFuture() {

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -463,7 +463,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
 
     if (state_ != Ready) {
         lock.unlock();
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -474,7 +474,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     ClientConnectionPtr cnx = getCnx().lock();
     if (!cnx) {
         lock.unlock();
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultOk);
         }
         return;
@@ -488,7 +488,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     ClientImplPtr client = client_.lock();
     if (!client) {
         // Client was already destroyed
-        if (!callback.empty()) {
+        if (!callback) {
             callback(ResultOk);
         }
         return;
@@ -496,7 +496,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     int requestId = client->newRequestId();
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseProducer(producerId_, requestId), requestId);
-    if (!callback.empty()) {
+    if (!callback) {
         future.addListener(boost::bind(&ProducerImpl::handleClose, shared_from_this(), _1, callback));
     }
 }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -82,8 +82,8 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
 
         dataKeyGenTImer_ = executor_->createDeadlineTimer();
         dataKeyGenTImer_->expires_from_now(boost::posix_time::seconds(dataKeyGenIntervalSec_));
-        dataKeyGenTImer_->async_wait(boost::bind(&pulsar::ProducerImpl::refreshEncryptionKey,
-                                                 shared_from_this(), boost::asio::placeholders::error));
+        dataKeyGenTImer_->async_wait(
+            boost::bind(&pulsar::ProducerImpl::refreshEncryptionKey, this, boost::asio::placeholders::error));
     }
 }
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -465,7 +465,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
 
     if (state_ != Ready) {
         lock.unlock();
-        if (!callback) {
+        if (callback) {
             callback(ResultAlreadyClosed);
         }
         return;
@@ -476,7 +476,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     ClientConnectionPtr cnx = getCnx().lock();
     if (!cnx) {
         lock.unlock();
-        if (!callback) {
+        if (callback) {
             callback(ResultOk);
         }
         return;
@@ -490,7 +490,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     ClientImplPtr client = client_.lock();
     if (!client) {
         // Client was already destroyed
-        if (!callback) {
+        if (callback) {
             callback(ResultOk);
         }
         return;
@@ -498,7 +498,7 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     int requestId = client->newRequestId();
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseProducer(producerId_, requestId), requestId);
-    if (!callback) {
+    if (callback) {
         future.addListener(
             std::bind(&ProducerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback));
     }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -517,7 +517,7 @@ void ProducerImpl::handleClose(Result result, ResultCallback callback) {
         LOG_ERROR(getName() << "Failed to close producer: " << strResult(result));
     }
     if (callback) {
-    	callback(result);
+        callback(result);
     }
 }
 

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -56,7 +56,7 @@ struct OpSendMsg {
 };
 
 class ProducerImpl : public HandlerBase,
-                     public boost::enable_shared_from_this<ProducerImpl>,
+                     public std::enable_shared_from_this<ProducerImpl>,
                      public ProducerImplBase {
    public:
     ProducerImpl(ClientImplPtr client, const std::string& topic,

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -38,8 +38,8 @@ typedef bool bool_type;
 
 class BatchMessageContainer;
 
-typedef boost::shared_ptr<BatchMessageContainer> BatchMessageContainerPtr;
-typedef boost::shared_ptr<MessageCrypto> MessageCryptoPtr;
+typedef std::shared_ptr<BatchMessageContainer> BatchMessageContainerPtr;
+typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
 
 class PulsarFriend;
 
@@ -151,7 +151,7 @@ class ProducerImpl : public HandlerBase,
     volatile int64_t lastSequenceIdPublished_;
     std::string schemaVersion_;
 
-    typedef boost::shared_ptr<boost::asio::deadline_timer> TimerPtr;
+    typedef std::shared_ptr<boost::asio::deadline_timer> TimerPtr;
     TimerPtr sendTimer_;
     void handleSendTimeout(const boost::system::error_code& err);
 
@@ -162,7 +162,7 @@ class ProducerImpl : public HandlerBase,
     MessageCryptoPtr msgCrypto_;
     DeadlineTimerPtr dataKeyGenTImer_;
     uint32_t dataKeyGenIntervalSec_;
-    boost::shared_ptr<Promise<Result, bool_type>> flushPromise_;
+    std::shared_ptr<Promise<Result, bool_type>> flushPromise_;
 };
 
 struct ProducerImplCmp {

--- a/pulsar-client-cpp/lib/ProducerImplBase.h
+++ b/pulsar-client-cpp/lib/ProducerImplBase.h
@@ -24,8 +24,7 @@
 namespace pulsar {
 class ProducerImplBase;
 
-typedef boost::weak_ptr<ProducerImplBase> ProducerImplBaseWeakPtr;
-typedef boost::shared_ptr<ProducerImplBase> ProducerImplBasePtr;
+typedef std::weak_ptr<ProducerImplBase> ProducerImplBaseWeakPtr;
 
 class ProducerImplBase {
    public:

--- a/pulsar-client-cpp/lib/ReaderConfiguration.cc
+++ b/pulsar-client-cpp/lib/ReaderConfiguration.cc
@@ -20,7 +20,7 @@
 
 namespace pulsar {
 
-ReaderConfiguration::ReaderConfiguration() : impl_(boost::make_shared<ReaderConfigurationImpl>()) {}
+ReaderConfiguration::ReaderConfiguration() : impl_(std::make_shared<ReaderConfigurationImpl>()) {}
 
 ReaderConfiguration::~ReaderConfiguration() {}
 

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -43,7 +43,7 @@ void ReaderImpl::start(const MessageId& startMessageId) {
         // Adapt the message listener to be a reader-listener
         readerListener_ = readerConf_.getReaderListener();
         consumerConf.setMessageListener(
-            boost::bind(&ReaderImpl::messageListener, shared_from_this(), _1, _2));
+            std::bind(&ReaderImpl::messageListener, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
     }
 
     std::string subscription = "reader-" + generateRandomName();
@@ -55,7 +55,7 @@ void ReaderImpl::start(const MessageId& startMessageId) {
         client_.lock(), topic_, subscription, consumerConf, ExecutorServicePtr(), NonPartitioned,
         Commands::SubscriptionModeNonDurable, Optional<MessageId>::of(startMessageId));
     consumer_->getConsumerCreatedFuture().addListener(
-        boost::bind(&ReaderImpl::handleConsumerCreated, shared_from_this(), _1, _2));
+        std::bind(&ReaderImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
     consumer_->start();
 }
 

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -51,7 +51,7 @@ void ReaderImpl::start(const MessageId& startMessageId) {
         subscription = readerConf_.getSubscriptionRolePrefix() + "-" + subscription;
     }
 
-    consumer_ = boost::make_shared<ConsumerImpl>(
+    consumer_ = std::make_shared<ConsumerImpl>(
         client_.lock(), topic_, subscription, consumerConf, ExecutorServicePtr(), NonPartitioned,
         Commands::SubscriptionModeNonDurable, Optional<MessageId>::of(startMessageId));
     consumer_->getConsumerCreatedFuture().addListener(

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -42,8 +42,8 @@ void ReaderImpl::start(const MessageId& startMessageId) {
     if (readerConf_.hasReaderListener()) {
         // Adapt the message listener to be a reader-listener
         readerListener_ = readerConf_.getReaderListener();
-        consumerConf.setMessageListener(
-            std::bind(&ReaderImpl::messageListener, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
+        consumerConf.setMessageListener(std::bind(&ReaderImpl::messageListener, shared_from_this(),
+                                                  std::placeholders::_1, std::placeholders::_2));
     }
 
     std::string subscription = "reader-" + generateRandomName();
@@ -54,8 +54,9 @@ void ReaderImpl::start(const MessageId& startMessageId) {
     consumer_ = std::make_shared<ConsumerImpl>(
         client_.lock(), topic_, subscription, consumerConf, ExecutorServicePtr(), NonPartitioned,
         Commands::SubscriptionModeNonDurable, Optional<MessageId>::of(startMessageId));
-    consumer_->getConsumerCreatedFuture().addListener(
-        std::bind(&ReaderImpl::handleConsumerCreated, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
+    consumer_->getConsumerCreatedFuture().addListener(std::bind(&ReaderImpl::handleConsumerCreated,
+                                                                shared_from_this(), std::placeholders::_1,
+                                                                std::placeholders::_2));
     consumer_->start();
 }
 

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -28,8 +28,8 @@ namespace pulsar {
 
 class ReaderImpl;
 
-typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;
-typedef boost::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
+typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
+typedef std::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
 class ReaderImpl : public std::enable_shared_from_this<ReaderImpl> {
    public:

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -31,7 +31,7 @@ class ReaderImpl;
 typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;
 typedef boost::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
-class ReaderImpl : public boost::enable_shared_from_this<ReaderImpl> {
+class ReaderImpl : public std::enable_shared_from_this<ReaderImpl> {
    public:
     ReaderImpl(const ClientImplPtr client, const std::string& topic, const ReaderConfiguration& conf,
                const ExecutorServicePtr listenerExecutor, ReaderCallback readerCreatedCallback);

--- a/pulsar-client-cpp/lib/Schema.cc
+++ b/pulsar-client-cpp/lib/Schema.cc
@@ -84,11 +84,11 @@ class SchemaInfoImpl {
         : type_(schemaType), name_(name), schema_(schema), properties_(properties) {}
 };
 
-SchemaInfo::SchemaInfo() : impl_(boost::make_shared<SchemaInfoImpl>()) {}
+SchemaInfo::SchemaInfo() : impl_(std::make_shared<SchemaInfoImpl>()) {}
 
 SchemaInfo::SchemaInfo(SchemaType schemaType, const std::string &name, const std::string &schema,
                        const StringMap &properties)
-    : impl_(boost::make_shared<SchemaInfoImpl>(schemaType, name, schema, properties)) {}
+    : impl_(std::make_shared<SchemaInfoImpl>(schemaType, name, schema, properties)) {}
 
 SchemaType SchemaInfo::getSchemaType() const { return impl_->type_; }
 

--- a/pulsar-client-cpp/lib/SharedBuffer.h
+++ b/pulsar-client-cpp/lib/SharedBuffer.h
@@ -188,7 +188,7 @@ class SharedBuffer {
     }
 
    private:
-    typedef boost::shared_ptr<detail::SharedBufferInternal> BufferPtr;
+    typedef std::shared_ptr<detail::SharedBufferInternal> BufferPtr;
 
     BufferPtr data_;
     char* ptr_;
@@ -200,7 +200,7 @@ class SharedBuffer {
         : data_(), ptr_(ptr), readIdx_(0), writeIdx_(size), capacity_(size) {}
 
     explicit SharedBuffer(size_t size)
-        : data_(boost::make_shared<detail::SharedBufferInternal>(size)),
+        : data_(std::make_shared<detail::SharedBufferInternal>(size)),
           ptr_(data_->ptr()),
           readIdx_(0),
           writeIdx_(0),

--- a/pulsar-client-cpp/lib/TopicName.cc
+++ b/pulsar-client-cpp/lib/TopicName.cc
@@ -182,17 +182,17 @@ bool TopicName::validate() {
     }
 }
 
-boost::shared_ptr<TopicName> TopicName::get(const std::string& topicName) {
-    boost::shared_ptr<TopicName> ptr(new TopicName());
+std::shared_ptr<TopicName> TopicName::get(const std::string& topicName) {
+    std::shared_ptr<TopicName> ptr(new TopicName());
     if (!ptr->init(topicName)) {
         LOG_ERROR("Topic name initialization failed");
-        return boost::shared_ptr<TopicName>();
+        return std::shared_ptr<TopicName>();
     }
     if (ptr->validate()) {
         return ptr;
     } else {
         LOG_ERROR("Topic name validation Failed - " << topicName);
-        return boost::shared_ptr<TopicName>();
+        return std::shared_ptr<TopicName>();
     }
 }
 

--- a/pulsar-client-cpp/lib/TopicName.h
+++ b/pulsar-client-cpp/lib/TopicName.h
@@ -39,7 +39,7 @@ class TopicName : public ServiceUnitId {
     std::string namespacePortion_;
     std::string localName_;
     bool isV2Topic_;
-    boost::shared_ptr<NamespaceName> namespaceName_;
+    std::shared_ptr<NamespaceName> namespaceName_;
 
    public:
     bool isV2Topic();
@@ -52,7 +52,7 @@ class TopicName : public ServiceUnitId {
     std::string getEncodedLocalName();
     std::string toString();
     NamespaceNamePtr getNamespaceName();
-    static boost::shared_ptr<TopicName> get(const std::string& topicName);
+    static std::shared_ptr<TopicName> get(const std::string& topicName);
     bool operator==(const TopicName& other);
     static std::string getEncodedName(const std::string& nameBeforeEncoding);
     const std::string getTopicPartitionName(unsigned int partition);
@@ -67,7 +67,7 @@ class TopicName : public ServiceUnitId {
     bool validate();
     bool init(const std::string& topicName);
 };
-typedef boost::shared_ptr<TopicName> TopicNamePtr;
+typedef std::shared_ptr<TopicName> TopicNamePtr;
 }  // namespace pulsar
 // end of namespace pulsar
 

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
@@ -35,7 +35,7 @@ void UnAckedMessageTrackerEnabled::timeoutHandler() {
     ExecutorServicePtr executorService = client_->getIOExecutorProvider()->get();
     timer_ = executorService->createDeadlineTimer();
     timer_->expires_from_now(boost::posix_time::milliseconds(timeoutMs_));
-    timer_->async_wait(boost::bind(&pulsar::UnAckedMessageTrackerEnabled::timeoutHandler, shared_from_this(),
+    timer_->async_wait(boost::bind(&pulsar::UnAckedMessageTrackerEnabled::timeoutHandler, this,
                                    boost::asio::placeholders::error));
 }
 

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
@@ -35,7 +35,7 @@ void UnAckedMessageTrackerEnabled::timeoutHandler() {
     ExecutorServicePtr executorService = client_->getIOExecutorProvider()->get();
     timer_ = executorService->createDeadlineTimer();
     timer_->expires_from_now(boost::posix_time::milliseconds(timeoutMs_));
-    timer_->async_wait(boost::bind(&pulsar::UnAckedMessageTrackerEnabled::timeoutHandler, this,
+    timer_->async_wait(boost::bind(&pulsar::UnAckedMessageTrackerEnabled::timeoutHandler, shared_from_this(),
                                    boost::asio::placeholders::error));
 }
 

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
@@ -21,8 +21,7 @@
 #include "lib/UnAckedMessageTrackerInterface.h"
 namespace pulsar {
 
-class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface,
-                                     public std::enable_shared_from_this<UnAckedMessageTrackerEnabled> {
+class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface {
    public:
     ~UnAckedMessageTrackerEnabled();
     UnAckedMessageTrackerEnabled(long timeoutMs, const ClientImplPtr, ConsumerImplBase&);

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
@@ -21,7 +21,8 @@
 #include "lib/UnAckedMessageTrackerInterface.h"
 namespace pulsar {
 
-class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface, public std::enable_shared_from_this<UnAckedMessageTrackerEnabled> {
+class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface,
+                                     public std::enable_shared_from_this<UnAckedMessageTrackerEnabled> {
    public:
     ~UnAckedMessageTrackerEnabled();
     UnAckedMessageTrackerEnabled(long timeoutMs, const ClientImplPtr, ConsumerImplBase&);

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.h
@@ -21,7 +21,7 @@
 #include "lib/UnAckedMessageTrackerInterface.h"
 namespace pulsar {
 
-class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface {
+class UnAckedMessageTrackerEnabled : public UnAckedMessageTrackerInterface, public std::enable_shared_from_this<UnAckedMessageTrackerEnabled> {
    public:
     ~UnAckedMessageTrackerEnabled();
     UnAckedMessageTrackerEnabled(long timeoutMs, const ClientImplPtr, ConsumerImplBase&);

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerInterface.h
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerInterface.h
@@ -19,7 +19,7 @@
 #ifndef LIB_UNACKEDMESSAGETRACKERINTERFACE_H_
 #define LIB_UNACKEDMESSAGETRACKERINTERFACE_H_
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 #include <algorithm>
 #include <utility>

--- a/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
@@ -125,7 +125,7 @@ class MessageRoutingPolicy : public pulsar::MessageRoutingPolicy {
 
 void pulsar_producer_configuration_set_message_router(pulsar_producer_configuration_t *conf,
                                                       pulsar_message_router router, void *ctx) {
-    conf->conf.setMessageRouter(boost::make_shared<MessageRoutingPolicy>(router, ctx));
+    conf->conf.setMessageRouter(std::make_shared<MessageRoutingPolicy>(router, ctx));
 }
 
 void pulsar_producer_configuration_set_block_if_queue_full(pulsar_producer_configuration_t *conf,

--- a/pulsar-client-cpp/lib/stats/ConsumerStatsBase.h
+++ b/pulsar-client-cpp/lib/stats/ConsumerStatsBase.h
@@ -32,7 +32,7 @@ class ConsumerStatsBase {
     virtual ~ConsumerStatsBase() {}
 };
 
-typedef boost::shared_ptr<ConsumerStatsBase> ConsumerStatsBasePtr;
+typedef std::shared_ptr<ConsumerStatsBase> ConsumerStatsBasePtr;
 }  // namespace pulsar
 
 #endif  // PULSAR_CONSUMER_STATS_BASE_HEADER

--- a/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.h
@@ -74,7 +74,7 @@ class ConsumerStatsImpl : public ConsumerStatsBase {
         return totalReceivedMsgMap_;
     }
 };
-typedef boost::shared_ptr<ConsumerStatsImpl> ConsumerStatsImplPtr;
+typedef std::shared_ptr<ConsumerStatsImpl> ConsumerStatsImplPtr;
 } /* namespace pulsar */
 
 #endif /* PULSAR_CONSUMER_STATS_IMPL_H_ */

--- a/pulsar-client-cpp/lib/stats/ProducerStatsBase.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsBase.h
@@ -31,7 +31,7 @@ class ProducerStatsBase {
     virtual ~ProducerStatsBase(){};
 };
 
-typedef boost::shared_ptr<ProducerStatsBase> ProducerStatsBasePtr;
+typedef std::shared_ptr<ProducerStatsBase> ProducerStatsBasePtr;
 }  // namespace pulsar
 
 #endif  // PULSAR_PRODUCER_STATS_BASE_HEADER

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -101,7 +101,7 @@ class ProducerStatsImpl : public boost::enable_shared_from_this<ProducerStatsImp
 
     inline LatencyAccumulator getTotalLatencyAccumulator() { return totalLatencyAccumulator_; }
 };
-typedef boost::shared_ptr<ProducerStatsImpl> ProducerStatsImplPtr;
+typedef std::shared_ptr<ProducerStatsImpl> ProducerStatsImplPtr;
 }  // namespace pulsar
 
 #endif  // PULSAR_PRODUCER_STATS_IMPL_HEADER

--- a/pulsar-client-cpp/perf/PerfConsumer.cc
+++ b/pulsar-client-cpp/perf/PerfConsumer.cc
@@ -182,7 +182,7 @@ void startPerfConsumer(const Arguments& args) {
     ConsumerConfiguration consumerConf;
     consumerConf.setMessageListener(messageListener);
     consumerConf.setReceiverQueueSize(args.receiverQueueSize);
-    boost::shared_ptr<EncKeyReader> keyReader = boost::make_shared<EncKeyReader>(args.encKeyValueFile);
+    std::shared_ptr<EncKeyReader> keyReader = std::make_shared<EncKeyReader>(args.encKeyValueFile);
     if (!args.encKeyName.empty()) {
         consumerConf.setCryptoKeyReader(keyReader);
     }

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -344,7 +344,7 @@ int main(int argc, char** argv) {
 
     // Block if queue is full else we will start seeing errors in sendAsync
     producerConf.setBlockIfQueueFull(true);
-    boost::shared_ptr<EncKeyReader> keyReader = boost::make_shared<EncKeyReader>(args.encKeyValueFile);
+    std::shared_ptr<EncKeyReader> keyReader = std::make_shared<EncKeyReader>(args.encKeyValueFile);
     if (!args.encKeyName.empty()) {
         producerConf.addEncryptionKey(args.encKeyName);
         producerConf.setCryptoKeyReader(keyReader);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -723,7 +723,7 @@ TEST(BasicEndToEndTest, testDuplicateConsumerCreationOnPartitionedTopic) {
     Producer producer;
     ProducerConfiguration producerConfiguration;
     producerConfiguration.setPartitionsRoutingMode(ProducerConfiguration::CustomPartition);
-    producerConfiguration.setMessageRouter(boost::make_shared<CustomRoutingPolicy>());
+    producerConfiguration.setMessageRouter(std::make_shared<CustomRoutingPolicy>());
 
     Result result = client.createProducer(topicName, producer);
     ASSERT_EQ(ResultOk, result);
@@ -1189,7 +1189,7 @@ TEST(BasicEndToEndTest, testRSAEncryption) {
     std::string subName = "my-sub-name";
     Producer producer;
 
-    boost::shared_ptr<EncKeyReader> keyReader = boost::make_shared<EncKeyReader>();
+    std::shared_ptr<EncKeyReader> keyReader = std::make_shared<EncKeyReader>();
     ProducerConfiguration conf;
     conf.setCompressionType(CompressionLZ4);
     conf.addEncryptionKey("client-rsa.pem");
@@ -1247,7 +1247,7 @@ TEST(BasicEndToEndTest, testEncryptionFailure) {
     std::string subName = "my-sub-name";
     Producer producer;
 
-    boost::shared_ptr<EncKeyReader> keyReader = boost::make_shared<EncKeyReader>();
+    std::shared_ptr<EncKeyReader> keyReader = std::make_shared<EncKeyReader>();
 
     ConsumerConfiguration consConfig;
 

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2138,6 +2138,8 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
 
         std::stringstream partitionedConsumerId;
         partitionedConsumerId << consumerId << i;
+        client.subscribe(partitionedTopicName.str(), partitionedConsumerId.str(), consConfig, consumer[i]);
+        consumer[i].unsubscribe();
         subscribeResult = client.subscribe(partitionedTopicName.str(), partitionedConsumerId.str(),
                                            consConfig, consumer[i]);
 
@@ -2254,6 +2256,8 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
     consumerConfig.setProperty("consumer-name", "test-consumer-name");
     consumerConfig.setProperty("consumer-id", "test-consumer-id");
     Promise<Result, Consumer> consumerPromise;
+    client.subscribe(topicName, subName, consumerConfig, consumer);
+    consumer.unsubscribe();
     client.subscribeAsync(topicName, subName, consumerConfig,
                           WaitForCallbackValue<Consumer>(consumerPromise));
     Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
@@ -2356,7 +2360,9 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
         partitionedConsumerId << consumerId << i;
         subscribeResult = client.subscribe(partitionedTopicName.str(), partitionedConsumerId.str(),
                                            consConfig, consumer[i]);
-
+        consumer[i].unsubscribe();
+        subscribeResult = client.subscribe(partitionedTopicName.str(), partitionedConsumerId.str(),
+                                           consConfig, consumer[i]);
         ASSERT_EQ(ResultOk, subscribeResult);
         ASSERT_EQ(consumer[i].getTopic(), partitionedTopicName.str());
     }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -688,7 +688,7 @@ TEST(BasicEndToEndTest, testSinglePartitionRoutingPolicy) {
 }
 
 TEST(BasicEndToEndTest, testNamespaceName) {
-    boost::shared_ptr<NamespaceName> nameSpaceName = NamespaceName::get("property", "bf1", "nameSpace");
+    std::shared_ptr<NamespaceName> nameSpaceName = NamespaceName::get("property", "bf1", "nameSpace");
     ASSERT_STREQ(nameSpaceName->getCluster().c_str(), "bf1");
     ASSERT_STREQ(nameSpaceName->getLocalName().c_str(), "nameSpace");
     ASSERT_STREQ(nameSpaceName->getProperty().c_str(), "property");

--- a/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
+++ b/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
@@ -34,11 +34,11 @@ DECLARE_LOG_OBJECT()
 using namespace pulsar;
 
 TEST(BinaryLookupServiceTest, basicLookup) {
-    ExecutorServiceProviderPtr service = boost::make_shared<ExecutorServiceProvider>(1);
+    ExecutorServiceProviderPtr service = std::make_shared<ExecutorServiceProvider>(1);
     AuthenticationPtr authData = AuthFactory::Disabled();
     std::string url = "pulsar://localhost:6650";
     ClientConfiguration conf;
-    ExecutorServiceProviderPtr ioExecutorProvider_(boost::make_shared<ExecutorServiceProvider>(1));
+    ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
     ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
     BinaryProtoLookupService lookupService(pool_, url);
 
@@ -97,10 +97,10 @@ TEST(BinaryLookupServiceTest, basicGetNamespaceTopics) {
     ASSERT_EQ(ResultOk, result);
 
     // 2.  call getTopicsOfNamespaceAsync
-    ExecutorServiceProviderPtr service = boost::make_shared<ExecutorServiceProvider>(1);
+    ExecutorServiceProviderPtr service = std::make_shared<ExecutorServiceProvider>(1);
     AuthenticationPtr authData = AuthFactory::Disabled();
     ClientConfiguration conf;
-    ExecutorServiceProviderPtr ioExecutorProvider_(boost::make_shared<ExecutorServiceProvider>(1));
+    ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
     ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
     BinaryProtoLookupService lookupService(pool_, url);
 

--- a/pulsar-client-cpp/tests/CMakeLists.txt
+++ b/pulsar-client-cpp/tests/CMakeLists.txt
@@ -26,4 +26,6 @@ add_executable(main ${TEST_SOURCES})
 
 target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
-target_link_libraries(main ${CLIENT_LIBS} pulsarShared ${GMOCK_LIBRARY_PATH} ${GTEST_LIBRARY_PATH})
+target_link_libraries(main ${CLIENT_LIBS} pulsarShared ${GMOCK_LIBRARY_PATH})
+
+#  ${GTEST_LIBRARY_PATH})

--- a/pulsar-client-cpp/tests/CMakeLists.txt
+++ b/pulsar-client-cpp/tests/CMakeLists.txt
@@ -26,6 +26,5 @@ add_executable(main ${TEST_SOURCES})
 
 target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
-target_link_libraries(main ${CLIENT_LIBS} pulsarShared ${GMOCK_LIBRARY_PATH})
+target_link_libraries(main ${CLIENT_LIBS} pulsarShared ${GMOCK_LIBRARY_PATH} ${GTEST_LIBRARY_PATH})
 
-#  ${GTEST_LIBRARY_PATH})

--- a/pulsar-client-cpp/tests/NamespaceNameTest.cc
+++ b/pulsar-client-cpp/tests/NamespaceNameTest.cc
@@ -33,7 +33,7 @@ TEST(NamespaceNameTest, testNamespaceName) {
 }
 
 TEST(NamespaceNameTest, testNamespaceNameV2) {
-	std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "namespace");
+    std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "namespace");
     ASSERT_EQ("property", nn1->getProperty());
     ASSERT_TRUE(nn1->getCluster().empty());
     ASSERT_EQ("namespace", nn1->getLocalName());

--- a/pulsar-client-cpp/tests/NamespaceNameTest.cc
+++ b/pulsar-client-cpp/tests/NamespaceNameTest.cc
@@ -22,23 +22,23 @@
 using namespace pulsar;
 
 TEST(NamespaceNameTest, testNamespaceName) {
-    boost::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "cluster", "namespace");
+    std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "cluster", "namespace");
     ASSERT_EQ("property", nn1->getProperty());
     ASSERT_EQ("cluster", nn1->getCluster());
     ASSERT_EQ("namespace", nn1->getLocalName());
     ASSERT_FALSE(nn1->isV2());
 
-    boost::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "cluster", "namespace");
+    std::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "cluster", "namespace");
     ASSERT_TRUE(*nn1 == *nn2);
 }
 
 TEST(NamespaceNameTest, testNamespaceNameV2) {
-    boost::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "namespace");
+	std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "namespace");
     ASSERT_EQ("property", nn1->getProperty());
     ASSERT_TRUE(nn1->getCluster().empty());
     ASSERT_EQ("namespace", nn1->getLocalName());
     ASSERT_TRUE(nn1->isV2());
 
-    boost::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "namespace");
+    std::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "namespace");
     ASSERT_TRUE(*nn1 == *nn2);
 }

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -34,7 +34,7 @@ class PulsarFriend {
 
     static ProducerStatsImplPtr getProducerStatsPtr(Producer producer) {
         ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
-        return boost::static_pointer_cast<ProducerStatsImpl>(producerImpl->producerStatsBasePtr_);
+        return std::static_pointer_cast<ProducerStatsImpl>(producerImpl->producerStatsBasePtr_);
     }
 
     template <typename T>
@@ -48,7 +48,7 @@ class PulsarFriend {
 
     static ConsumerStatsImplPtr getConsumerStatsPtr(Consumer consumer) {
         ConsumerImpl* consumerImpl = static_cast<ConsumerImpl*>(consumer.impl_.get());
-        return boost::static_pointer_cast<ConsumerStatsImpl>(consumerImpl->consumerStatsBasePtr_);
+        return std::static_pointer_cast<ConsumerStatsImpl>(consumerImpl->consumerStatsBasePtr_);
     }
 
     static ProducerImpl& getProducerImpl(Producer producer) {

--- a/pulsar-client-cpp/tests/TopicNameTest.cc
+++ b/pulsar-client-cpp/tests/TopicNameTest.cc
@@ -22,14 +22,14 @@
 using namespace pulsar;
 
 TEST(TopicNameTest, testLookup) {
-    boost::shared_ptr<TopicName> topicName = TopicName::get("persistent://pulsar/bf1/TESTNS.0/curveballapps");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://pulsar/bf1/TESTNS.0/curveballapps");
     std::string lookup_name = topicName->getLookupName();
     ASSERT_EQ(lookup_name, "persistent/pulsar/bf1/TESTNS.0/curveballapps");
 }
 
 TEST(TopicNameTest, testTopicName) {
     // Compare getters and setters
-    boost::shared_ptr<TopicName> topicName = TopicName::get("persistent://property/cluster/namespace/topic");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://property/cluster/namespace/topic");
     ASSERT_EQ("property", topicName->getProperty());
     ASSERT_EQ("cluster", topicName->getCluster());
     ASSERT_EQ("namespace", topicName->getNamespacePortion());
@@ -37,14 +37,14 @@ TEST(TopicNameTest, testTopicName) {
     ASSERT_EQ(TopicName::getEncodedName("topic"), topicName->getLocalName());
 
     // Compare == operator
-    boost::shared_ptr<TopicName> topicName1 = TopicName::get("persistent://p/c/n/d");
-    boost::shared_ptr<TopicName> topicName2 = TopicName::get("persistent://p/c/n/d");
+    std::shared_ptr<TopicName> topicName1 = TopicName::get("persistent://p/c/n/d");
+    std::shared_ptr<TopicName> topicName2 = TopicName::get("persistent://p/c/n/d");
     ASSERT_TRUE(*topicName1 == *topicName2);
 }
 
 TEST(TopicNameTest, testShortTopicName) {
     // "short-topic"
-    boost::shared_ptr<TopicName> tn1 = TopicName::get("short-topic");
+    std::shared_ptr<TopicName> tn1 = TopicName::get("short-topic");
     ASSERT_EQ("public", tn1->getProperty());
     ASSERT_EQ("", tn1->getCluster());
     ASSERT_EQ("default", tn1->getNamespacePortion());
@@ -52,7 +52,7 @@ TEST(TopicNameTest, testShortTopicName) {
     ASSERT_EQ(TopicName::getEncodedName("short-topic"), tn1->getLocalName());
 
     // tenant/namespace/topic
-    boost::shared_ptr<TopicName> tn2 = TopicName::get("tenant/namespace/short-topic");
+    std::shared_ptr<TopicName> tn2 = TopicName::get("tenant/namespace/short-topic");
     ASSERT_EQ("tenant", tn2->getProperty());
     ASSERT_EQ("", tn2->getCluster());
     ASSERT_EQ("namespace", tn2->getNamespacePortion());
@@ -60,17 +60,17 @@ TEST(TopicNameTest, testShortTopicName) {
     ASSERT_EQ(TopicName::getEncodedName("short-topic"), tn2->getLocalName());
 
     // tenant/cluster/namespace/topic
-    boost::shared_ptr<TopicName> tn3 = TopicName::get("tenant/cluster/namespace/short-topic");
+    std::shared_ptr<TopicName> tn3 = TopicName::get("tenant/cluster/namespace/short-topic");
     ASSERT_FALSE(tn3);
 
     // tenant/cluster
-    boost::shared_ptr<TopicName> tn4 = TopicName::get("tenant/cluster");
+    std::shared_ptr<TopicName> tn4 = TopicName::get("tenant/cluster");
     ASSERT_FALSE(tn4);
 }
 
 TEST(TopicNameTest, testTopicNameV2) {
     // v2 topic names doesn't have "cluster"
-    boost::shared_ptr<TopicName> tn1 = TopicName::get("persistent://tenant/namespace/short-topic");
+    std::shared_ptr<TopicName> tn1 = TopicName::get("persistent://tenant/namespace/short-topic");
     ASSERT_EQ("tenant", tn1->getProperty());
     ASSERT_EQ("", tn1->getCluster());
     ASSERT_EQ("namespace", tn1->getNamespacePortion());
@@ -80,7 +80,7 @@ TEST(TopicNameTest, testTopicNameV2) {
 
 TEST(TopicNameTest, testNonPersistentTopicNameV2) {
     // v2 topic names doesn't have "cluster"
-    boost::shared_ptr<TopicName> tn1 = TopicName::get("non-persistent://tenant/namespace/short-topic");
+    std::shared_ptr<TopicName> tn1 = TopicName::get("non-persistent://tenant/namespace/short-topic");
     ASSERT_EQ("tenant", tn1->getProperty());
     ASSERT_EQ("", tn1->getCluster());
     ASSERT_EQ("namespace", tn1->getNamespacePortion());
@@ -90,7 +90,7 @@ TEST(TopicNameTest, testNonPersistentTopicNameV2) {
 
 TEST(TopicNameTest, testTopicNameWithSlashes) {
     // Compare getters and setters
-    boost::shared_ptr<TopicName> topicName =
+    std::shared_ptr<TopicName> topicName =
         TopicName::get("persistent://property/cluster/namespace/topic/name/with/slash");
     ASSERT_EQ("property", topicName->getProperty());
     ASSERT_EQ("cluster", topicName->getCluster());
@@ -121,36 +121,36 @@ TEST(TopicNameTest, testTopicNameWithSlashes) {
 }
 TEST(TopicNameTest, testEmptyClusterName) {
     // Compare getters and setters
-    boost::shared_ptr<TopicName> topicName = TopicName::get("persistent://property//namespace/topic");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://property//namespace/topic");
 
     ASSERT_FALSE(topicName);
 }
 
 TEST(TopicNameTest, testExtraSlashes) {
-    boost::shared_ptr<TopicName> topicName = TopicName::get("persistent://property/cluster//namespace/topic");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://property/cluster//namespace/topic");
     ASSERT_FALSE(topicName);
     topicName = TopicName::get("persistent://property//cluster//namespace//topic");
     ASSERT_FALSE(topicName);
 }
 
 TEST(TopicNameTest, testIllegalCharacters) {
-    boost::shared_ptr<TopicName> topicName =
+    std::shared_ptr<TopicName> topicName =
         TopicName::get("persistent://prop!!!erty/cluster&)&Name/name%%%space/topic");
     ASSERT_FALSE(topicName);
 }
 
 TEST(TopicNameTest, testIllegalUrl) {
-    boost::shared_ptr<TopicName> topicName = TopicName::get("persistent:::/property/cluster/namespace/topic");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent:::/property/cluster/namespace/topic");
     ASSERT_FALSE(topicName);
 }
 
 TEST(TopicNameTest, testEmptyString) {
-    boost::shared_ptr<TopicName> topicName = TopicName::get("");
+    std::shared_ptr<TopicName> topicName = TopicName::get("");
     ASSERT_FALSE(topicName);
 }
 
 TEST(TopicNameTest, testExtraArguments) {
-    boost::shared_ptr<TopicName> topicName =
+    std::shared_ptr<TopicName> topicName =
         TopicName::get("persistent:::/property/cluster/namespace/topic/some/extra/args");
     ASSERT_FALSE(topicName);
 }


### PR DESCRIPTION
### Motivation

Want to remove boost dependencies from CPP Client interface.

### Modifications

Changed boost smart pointers and functions to std.

### Result

No change in the code logic.

@msb-at-yahoo - Thanks for the push on this.