### PR TITLE
 refactor AuthorizationProvider interface to allow custom logic for determining super user

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -36,6 +36,14 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 public interface AuthorizationProvider extends Closeable {
 
     /**
+     * Check if specified role is a super user
+     * @param role the role to check
+     * @return a CompletableFuture containing a boolean in which true means the role is a super user
+     * and false if it is not
+     */
+    CompletableFuture<Boolean> isSuperUser(String role);
+
+    /**
      * Perform initialization for the authorization provider
      *
      * @param config

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -41,12 +41,15 @@ public interface AuthorizationProvider extends Closeable {
      * @return a CompletableFuture containing a boolean in which true means the role is a super user
      * and false if it is not
      */
-    CompletableFuture<Boolean> isSuperUser(String role);
+    default CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+        Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
+        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
+    }
 
     /**
      * Perform initialization for the authorization provider
      *
-     * @param config
+     * @param conf
      *            broker config object
      * @param configCache
      *            pulsar zk configuration cache service

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -73,9 +73,9 @@ public class AuthorizationService {
     }
 
     public CompletableFuture<Boolean> isSuperUser(String user) {
-            if (provider != null) {
-               return provider.isSuperUser(user);
-            }
+        if (provider != null) {
+           return provider.isSuperUser(user);
+        }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
 
@@ -176,9 +176,7 @@ public class AuthorizationService {
         if (provider != null) {
             return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
-                    CompletableFuture<Boolean> future = new CompletableFuture<>();
-                    future.complete(true);
-                    return future;
+                    return CompletableFuture.completedFuture(true);
                 } else {
                     return provider.canProduceAsync(topicName, role, authenticationData);
                 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -203,9 +203,7 @@ public class AuthorizationService {
         if (provider != null) {
             return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
-                    CompletableFuture<Boolean> future = new CompletableFuture<>();
-                    future.complete(true);
-                    return future;
+                    return CompletableFuture.completedFuture(true);
                 } else {
                     return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
                 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -74,7 +74,7 @@ public class AuthorizationService {
 
     public CompletableFuture<Boolean> isSuperUser(String user) {
         if (provider != null) {
-           return provider.isSuperUser(user);
+           return provider.isSuperUser(user, conf);
         }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
@@ -174,7 +174,7 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
         if (provider != null) {
-            return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
+            return provider.isSuperUser(role, conf).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
                     return CompletableFuture.completedFuture(true);
                 } else {
@@ -201,7 +201,7 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
         if (provider != null) {
-            return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
+            return provider.isSuperUser(role, conf).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
                     return CompletableFuture.completedFuture(true);
                 } else {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -18,12 +18,6 @@
  */
 package org.apache.pulsar.broker.authorization;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.pulsar.zookeeper.ZooKeeperCache.cacheTimeOutInSec;
-
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -35,6 +29,14 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.pulsar.zookeeper.ZooKeeperCache.cacheTimeOutInSec;
 
 /**
  * Authorization service that manages pluggable authorization provider and authorize requests accordingly.
@@ -68,6 +70,13 @@ public class AuthorizationService {
         } else {
             log.info("Authorization is disabled");
         }
+    }
+
+    public CompletableFuture<Boolean> isSuperUser(String user) {
+            if (provider != null) {
+               return provider.isSuperUser(user);
+            }
+        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
 
     /**
@@ -164,9 +173,16 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-
         if (provider != null) {
-            return provider.canProduceAsync(topicName, role, authenticationData);
+            return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
+                if (isSuperUser) {
+                    CompletableFuture<Boolean> future = new CompletableFuture<>();
+                    future.complete(true);
+                    return future;
+                } else {
+                    return provider.canProduceAsync(topicName, role, authenticationData);
+                }
+            });
         }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
@@ -187,7 +203,15 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
         if (provider != null) {
-            return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
+            return provider.isSuperUser(role).thenComposeAsync(isSuperUser -> {
+                if (isSuperUser) {
+                    CompletableFuture<Boolean> future = new CompletableFuture<>();
+                    future.complete(true);
+                    return future;
+                } else {
+                    return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
+                }
+            });
         }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -113,7 +113,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         log.debug("Policies node couldn't be found for topic : {}", topicName);
                     }
                 } else {
-                    if (isNotBlank(subscription) && !_isSuperUser(role)) {
+                    if (isNotBlank(subscription)) {
                         // validate if role is authorize to access subscription. (skip validatation if authorization
                         // list is empty)
                         Set<String> roles = policies.get().auth_policies.subscription_auth_roles.get(subscription);
@@ -324,12 +324,8 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     private CompletableFuture<Boolean> checkAuthorization(TopicName topicName, String role, AuthAction action) {
-        if (_isSuperUser(role)) {
-            return CompletableFuture.completedFuture(true);
-        } else {
-            return checkPermission(topicName, role, action)
-                    .thenApply(isPermission -> isPermission && checkCluster(topicName));
-        }
+        return checkPermission(topicName, role, action)
+                .thenApply(isPermission -> isPermission && checkCluster(topicName));
     }
 
     private boolean checkCluster(TopicName topicName) {
@@ -439,14 +435,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         future.complete(role != null && superUserRoles.contains(role) ? true : false);
         return future;
-    }
-
-    private boolean _isSuperUser(String role) {
-        try {
-            return isSuperUser(role).get();
-        } catch (InterruptedException | ExecutionException e) {
-           throw new RuntimeException(e);
-        }
     }
 
     @Override

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -421,19 +421,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         return false;
     }
 
-    /**
-     * Super user roles are allowed to do anything, used for replication primarily
-     *
-     * @param role
-     *            the app id used to receive messages from the topic.
-     */
-
-
-    @Override
-    public CompletableFuture<Boolean> isSuperUser(String role) {
-        Set<String> superUserRoles = conf.getSuperUserRoles();
-        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
-    }
 
     @Override
     public void close() throws IOException {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -432,9 +432,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> isSuperUser(String role) {
         Set<String> superUserRoles = conf.getSuperUserRoles();
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        future.complete(role != null && superUserRoles.contains(role) ? true : false);
-        return future;
+        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -168,7 +168,6 @@ public abstract class PulsarWebResource {
      */
     protected void validateSuperUserAccess() {
         if (config().isAuthenticationEnabled()) {
-
             String appId = clientAppId();
             if(log.isDebugEnabled()) {
                 log.debug("[{}] Check super user access: Authenticated: {} -- Role: {}", uri.getRequestUri(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -490,7 +490,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(), Mockito.any());
 
         // Test producer creation
         resetChannel();
@@ -520,7 +520,7 @@ public class ServerCnxTest {
         providerField.set(authorizationService, authorizationProvider);
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
-        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(),  Mockito.any());
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).checkPermission(any(TopicName.class), Mockito.anyString(),
                 any(AuthAction.class));
 
@@ -548,7 +548,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).isSuperUser(Mockito.anyString(),  Mockito.any());
 
         // Test producer creation
         resetChannel();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -490,7 +490,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(false).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString());
 
         // Test producer creation
         resetChannel();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -519,8 +519,8 @@ public class ServerCnxTest {
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
-        doReturn(true).when(brokerService).isAuthorizationEnabled();
-        doReturn(false).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(true)).when(brokerService).isAuthorizationEnabled();
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString());
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).checkPermission(any(TopicName.class), Mockito.anyString(),
                 any(AuthAction.class));
 
@@ -548,7 +548,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(true).when(authorizationProvider).isSuperUser(Mockito.anyString());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).isSuperUser(Mockito.anyString());
 
         // Test producer creation
         resetChannel();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -519,7 +519,7 @@ public class ServerCnxTest {
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
-        doReturn(CompletableFuture.completedFuture(true)).when(brokerService).isAuthorizationEnabled();
+        doReturn(true).when(brokerService).isAuthorizationEnabled();
         doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString());
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).checkPermission(any(TopicName.class), Mockito.anyString(),
                 any(AuthAction.class));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -402,13 +402,24 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
     public static class TestAuthorizationProvider implements AuthorizationProvider {
 
+        public ServiceConfiguration conf;
+
         @Override
         public void close() throws IOException {
             // No-op
         }
 
         @Override
+        public CompletableFuture<Boolean> isSuperUser(String role) {
+            Set<String> superUserRoles = conf.getSuperUserRoles();
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            future.complete(role != null && superUserRoles.contains(role) ? true : false);
+            return future;
+        }
+
+        @Override
         public void initialize(ServiceConfiguration conf, ConfigurationCacheService configCache) throws IOException {
+            this.conf = conf;
             // No-op
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -410,8 +410,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> isSuperUser(String role) {
-            Set<String> superUserRoles = conf.getSuperUserRoles();
+        public CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+            Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
             return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -412,9 +412,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         @Override
         public CompletableFuture<Boolean> isSuperUser(String role) {
             Set<String> superUserRoles = conf.getSuperUserRoles();
-            CompletableFuture<Boolean> future = new CompletableFuture<>();
-            future.complete(role != null && superUserRoles.contains(role) ? true : false);
-            return future;
+            return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
         }
 
         @Override


### PR DESCRIPTION
### Motivation

Currently the logic for determining if a role is a super user is not pluggable.  Thus, users have to specify who is a super using the the configuration of a broker which is hard coded.  

Making the logic of determining if a role is a super user pluggable while allow users more flexibility in setting super users which can be a dynamic list of users held in an external source.

### Modifications

Made the mechanism of determining super users pluggable