### PR TITLE
[pulsar-client] Replace ProducerConfig by ConsumerConfig in PulsarKafkaConsumer

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -151,7 +151,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         strategy = getStrategy(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
         log.info("Offset reset strategy has been assigned value {}", strategy);
 
-        String serviceUrl = config.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG).get(0);
+        String serviceUrl = config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG).get(0);
 
         this.properties = new Properties();
         config.originals().forEach((k, v) -> properties.put(k, v));


### PR DESCRIPTION
### Motivation

It is better to use ConsumerConfig instead of ProducerConfig in PulsarKafkaConsumer.

### Modifications

Replace ProducerConfig by ConsumerConfig in PulsarKafkaConsumer.