### PR TITLE
Fix: Bug in function triggering

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -114,7 +114,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
         if (message instanceof TopicMessageImpl) {
             topicName = ((TopicMessageImpl<?>) message).getTopicName();
         } else {
-            topicName = consumer.getTopic();
+            topicName = message.getTopicName();
         }
 
         Record<T> record = PulsarRecord.<T>builder()

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -107,19 +107,10 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
     @Override
     public void received(Consumer<T> consumer, Message<T> message) {
-        String topicName;
-
-        // If more than one topics are being read than the Message return by the consumer will be TopicMessageImpl
-        // If there is only topic being read then the Message returned by the consumer wil be MessageImpl
-        if (message instanceof TopicMessageImpl) {
-            topicName = ((TopicMessageImpl<?>) message).getTopicName();
-        } else {
-            topicName = message.getTopicName();
-        }
 
         Record<T> record = PulsarRecord.<T>builder()
                 .message(message)
-                .topicName(topicName)
+                .topicName(message.getTopicName())
                 .ackFunction(() -> {
                     if (pulsarSourceConfig
                             .getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -81,6 +81,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -89,6 +90,7 @@ import org.apache.pulsar.common.functions.WorkerInfo;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.io.SourceConfig;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -1037,15 +1039,16 @@ public abstract class ComponentImpl {
                         && msg.getProperties().containsKey("__pfn_input_topic__")) {
                     MessageId newMsgId = MessageId.fromByteArray(
                             Base64.getDecoder().decode((String) msg.getProperties().get("__pfn_input_msg_id__")));
+
                     if (msgId.equals(newMsgId)
-                            && msg.getProperties().get("__pfn_input_topic__").equals(inputTopicToWrite)) {
+                            && msg.getProperties().get("__pfn_input_topic__").equals(TopicName.get(inputTopicToWrite).toString())) {
                        return new String(msg.getData());
                     }
                 }
                 curTime = System.currentTimeMillis();
             }
-            throw new RestException(Status.REQUEST_TIMEOUT, "Requeste Timed Out");
-        } catch (Exception e) {
+            throw new RestException(Status.REQUEST_TIMEOUT, "Request Timed Out");
+        } catch (IOException e) {
             throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
         } finally {
             if (reader != null) {


### PR DESCRIPTION
### Motivation

Triggering a Python function is currently not working and all requests will time out. This is due to the fact that we recently changed the method of getting the input topic name of a message to "message.topic_name()" to support topic patterns.  This will return the full topic name e.g. "persistent://public/default/foo" even if the input topic is just "foo". 

I have modified the logic that checks this in the triggering code to check for the full name of the topic