### PR TITLE
Issue #3332: fix httplookup issue for get ns/topics in cpp

### DIFF
--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -310,18 +310,21 @@ LookupDataResultPtr HTTPLookupService::parseLookupData(const std::string &json) 
 NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string &json) {
     Json::Value root;
     Json::Reader reader;
+    LOG_INFO("GetNamespaceTopics json = " << json);
+
+    // passed in json is like: ["topic1", "topic2"...]
+    // root will be an array of topics
     if (!reader.parse(json, root, false)) {
         LOG_ERROR("Failed to parse json of Topics of Namespace: " << reader.getFormatedErrorMessages()
                                                                   << "\nInput Json = " << json);
         return NamespaceTopicsPtr();
     }
 
-    Json::Value topicsArray = root["topics"];
     std::set<std::string> topicSet;
     // get all topics
-    for (int i = 0; i < topicsArray.size(); i++) {
+    for (int i = 0; i < root.size(); i++) {
         // remove partition part
-        const std::string &topicName = topicsArray[i].asString();
+        const std::string &topicName = root[i].asString();
         int pos = topicName.find("-partition-");
         std::string filteredName = topicName.substr(0, pos);
 

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -310,7 +310,7 @@ LookupDataResultPtr HTTPLookupService::parseLookupData(const std::string &json) 
 NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string &json) {
     Json::Value root;
     Json::Reader reader;
-    LOG_INFO("GetNamespaceTopics json = " << json);
+    LOG_DEBUG("GetNamespaceTopics json = " << json);
 
     // passed in json is like: ["topic1", "topic2"...]
     // root will be an array of topics

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1756,7 +1756,7 @@ TEST(BasicEndToEndTest, testPatternTopicsConsumerInvalid) {
 // verify PatternMultiTopicsConsumer subscribed matched topics,
 // and only receive messages from matched topics.
 TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerPubSub) {
-    Client client(lookupUrl);
+    Client client(adminUrl);
     std::string pattern = "persistent://public/default/patternMultiTopicsConsumer.*";
 
     std::string subName = "testPatternMultiTopicsConsumer";


### PR DESCRIPTION
Fixes #3332

### Motivation

In http request to get ns/topics, it will return an array of topics,
```
$ curl -L 'http://127.0.0.1:8080/admin/v2/namespaces/foo/bar/topics'
["persistent://foo/bar/test-aa","persistent://foo/bar/test-ab"]
```
But in cpp method `HTTPLookupService::parseNamespaceTopicsData`, it is expecting a json of item 
like: `{"topics": ["topic1", "topic2"] }`. This may be caused by the response format changes.

### Modifications

- change cpp method `HTTPLookupService::parseNamespaceTopicsData` to following current http response data format.
- changed cpp test `testPatternMultiTopicsConsumerPubSub` to use http adminUrl, to protect this part of cpp code.

### Verifying this change
cpp unit tests passed, especially for test `testPatternMultiTopicsConsumerPubSub`