### PR TITLE
Fix race condition: broker not scheduling read for active consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -62,7 +62,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
     private int readBatchSize;
     private final Backoff readFailureBackoff = new Backoff(15, TimeUnit.SECONDS, 1, TimeUnit.MINUTES, 0, TimeUnit.MILLISECONDS);
     private final ServiceConfiguration serviceConfig;
-    private ScheduledFuture<?> readOnActiveConsumerTask = null;
+    private volatile ScheduledFuture<?> readOnActiveConsumerTask = null;
 
     private final RedeliveryTracker redeliveryTracker;
 


### PR DESCRIPTION
### Motivation

Right now, `readOnActiveConsumerTask` is not thread-safe and it's being updated into different thread.  and one thread updates it to null but at the same time new active consumer gets connected on second thread then second thread will find `readOnActiveConsumerTask` non-null which avoids read-scheduling for new active consumer.

### Result

It will fix possible race condition when multiple consumers try to connect to fail-over subscription.