### PR TITLE
Handle replication-cluster list change for peer-cluster when zk-watch…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -584,12 +584,26 @@ public abstract class NamespacesBase extends AdminResource {
         validateSuperUserAccess();
         Policies policies = getNamespacePolicies(namespaceName);
 
-        if (namespaceName.isGlobal()) {
-            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
-            validateGlobalNamespaceOwnership(namespaceName);
-        } else {
-            validateClusterOwnership(namespaceName.getCluster());
-            validateClusterForTenant(namespaceName.getTenant(), namespaceName.getCluster());
+        NamespaceBundle bundle = pulsar().getNamespaceService().getNamespaceBundleFactory().getBundle(namespaceName.toString(), bundleRange);
+        boolean isOwnedByLocalCluster = false;
+        try {
+            isOwnedByLocalCluster = pulsar().getNamespaceService().isNamespaceBundleOwned(bundle).get();
+        } catch (Exception e) {
+            if(log.isDebugEnabled()) {
+                log.debug("Failed to validate cluster ownership for {}-{}, {}", namespaceName.toString(), bundleRange, e.getMessage(), e);
+            }
+        }
+        
+        // validate namespace ownership only if namespace is not owned by local-cluster (it happens when broker doesn't
+        // receive replication-cluster change watch and still owning bundle
+        if (!isOwnedByLocalCluster) {
+            if (namespaceName.isGlobal()) {
+                // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+                validateGlobalNamespaceOwnership(namespaceName);
+            } else {
+                validateClusterOwnership(namespaceName.getCluster());
+                validateClusterForTenant(namespaceName.getTenant(), namespaceName.getCluster());
+            }
         }
 
         validatePoliciesReadOnlyAccess();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicies;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -87,6 +88,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.apache.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_POLICIES_ROOT;
 import static org.apache.pulsar.broker.web.PulsarWebResource.joinPath;
 import static org.apache.pulsar.common.naming.NamespaceBundleFactory.getBundlesData;
@@ -405,6 +407,10 @@ public class NamespaceService {
             checkNotNull(candidateBroker);
 
             if (pulsar.getWebServiceAddress().equals(candidateBroker)) {
+                // invalidate namespace policies and try to load latest policies to avoid data-discrepancy if broker
+                // doesn't receive watch on policies changes
+                final String policyPath = AdminResource.path(POLICIES, bundle.getNamespaceObject().toString());
+                pulsar.getConfigurationCache().policiesCache().invalidate(policyPath);
                 // Load manager decided that the local broker should try to become the owner
                 ownershipCache.tryAcquiringOwnership(bundle).thenAccept(ownerInfo -> {
                     if (ownerInfo.isDisabled()) {
@@ -519,11 +525,27 @@ public class NamespaceService {
     }
 
     public void unloadNamespaceBundle(NamespaceBundle bundle) throws Exception {
+        // unload namespace bundle
         unloadNamespaceBundle(bundle, 5, TimeUnit.MINUTES);
     }
 
     public void unloadNamespaceBundle(NamespaceBundle bundle, long timeout, TimeUnit timeoutUnit) throws Exception {
         checkNotNull(ownershipCache.getOwnedBundle(bundle)).handleUnloadRequest(pulsar, timeout, timeoutUnit);
+    }
+
+    public CompletableFuture<Boolean> isNamespaceBundleOwned(NamespaceBundle bundle) {
+        String bundlePath = ServiceUnitZkUtils.path(bundle);
+        CompletableFuture<Boolean> isExistFuture = new CompletableFuture<Boolean>();
+        pulsar.getLocalZkCache().getZooKeeper().exists(bundlePath, false, (rc, path, ctx, stat) -> {
+            if (rc == Code.OK.intValue()) {
+                isExistFuture.complete(true);
+            } else if (rc == Code.NONODE.intValue()) {
+                isExistFuture.complete(false);
+            } else {
+                isExistFuture.completeExceptionally(KeeperException.create(rc));
+            }
+        }, null);
+        return isExistFuture;
     }
 
     public Map<String, NamespaceOwnershipStatus> getOwnedNameSpacesStatus() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
@@ -31,6 +32,9 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.NamespaceBundles;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -76,8 +80,13 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
      * @param protocol
      * @throws Exception
      */
-    @Test(dataProvider = "lookupType")
+    @Test(dataProvider = "lookupType", timeOut = 10000)
     public void testPeerClusterTopicLookup(String protocol) throws Exception {
+
+        // clean up peer-clusters
+        admin1.clusters().updatePeerClusterNames("r1", null);
+        admin1.clusters().updatePeerClusterNames("r2", null);
+        admin1.clusters().updatePeerClusterNames("r3", null);
 
         final String serviceUrl = protocol.equalsIgnoreCase("http") ? pulsar3.getWebServiceAddress()
                 : pulsar3.getBrokerServiceUrl();
@@ -148,19 +157,90 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
     }
 
-	@Test
-	public void testGetPeerClusters() throws Exception {
-		final String mainClusterName = "r1";
-		assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), null);
-		LinkedHashSet<String> peerClusters = Sets.newLinkedHashSet(Lists.newArrayList("r2", "r3"));
-		admin1.clusters().updatePeerClusterNames(mainClusterName, peerClusters);
-		retryStrategically((test) -> {
-			try {
-				return admin1.clusters().getPeerClusterNames(mainClusterName).size() == 1;
-			} catch (PulsarAdminException e) {
-				return false;
-			}
-		}, 5, 100);
-		assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), peerClusters);
-	}
+    @Test(timeOut = 10000)
+    public void testGetPeerClusters() throws Exception {
+
+        // clean up peer-clusters
+        admin1.clusters().updatePeerClusterNames("r1", null);
+        admin1.clusters().updatePeerClusterNames("r2", null);
+        admin1.clusters().updatePeerClusterNames("r3", null);
+
+        final String mainClusterName = "r1";
+        assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), null);
+        LinkedHashSet<String> peerClusters = Sets.newLinkedHashSet(Lists.newArrayList("r2", "r3"));
+        admin1.clusters().updatePeerClusterNames(mainClusterName, peerClusters);
+        retryStrategically((test) -> {
+            try {
+                return admin1.clusters().getPeerClusterNames(mainClusterName).size() == 1;
+            } catch (PulsarAdminException e) {
+                return false;
+            }
+        }, 5, 100);
+        assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), peerClusters);
+    }
+	
+    /**
+     * Removing local cluster from the replication-cluster should make sure that bundle should not be loaded by the
+     * cluster even if owner broker doesn't receive the watch to avoid lookup-conflict between peer-cluster.
+     * 
+     * @throws Exception
+     */
+    @Test(timeOut = 10000)
+    public void testPeerClusterInReplicationClusterListChange() throws Exception {
+
+        // clean up peer-clusters
+        admin1.clusters().updatePeerClusterNames("r1", null);
+        admin1.clusters().updatePeerClusterNames("r2", null);
+        admin1.clusters().updatePeerClusterNames("r3", null);
+        
+        final String serviceUrl = pulsar3.getBrokerServiceUrl();
+        final String namespace1 = "pulsar/global/peer-change-repl-ns";
+        admin1.namespaces().createNamespace(namespace1);
+        // add replication cluster
+        admin1.namespaces().setNamespaceReplicationClusters(namespace1, Sets.newHashSet("r1"));
+        admin1.clusters().updatePeerClusterNames("r3", null);
+        // disable tls as redirection url is prepared according tls configuration
+        pulsar1.getConfiguration().setTlsEnabled(false);
+        pulsar2.getConfiguration().setTlsEnabled(false);
+        pulsar3.getConfiguration().setTlsEnabled(false);
+
+        final String topic1 = "persistent://" + namespace1 + "/topic1";
+
+        PulsarClient client3 = PulsarClient.builder().serviceUrl(serviceUrl).statsInterval(0, TimeUnit.SECONDS).build();
+        // set peer-clusters : r3->r1
+        admin1.clusters().updatePeerClusterNames("r3", Sets.newLinkedHashSet(Lists.newArrayList("r1")));
+        admin1.clusters().updatePeerClusterNames("r1", Sets.newLinkedHashSet(Lists.newArrayList("r3")));
+        Producer<byte[]> producer = client3.newProducer().topic(topic1).create();
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topic1).get();
+        assertNotNull(topic);
+        pulsar1.getBrokerService().updateRates();
+        // get stats for topic1 using cluster-r3's admin3
+        TopicStats stats = admin1.topics().getStats(topic1);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        stats = admin3.topics().getStats(topic1);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        producer.close();
+
+        // change the repl cluster to peer-cluster r3 from r1
+        admin1.namespaces().setNamespaceReplicationClusters(namespace1, Sets.newHashSet("r3"));
+        NamespaceBundles bundles = pulsar1.getNamespaceService().getNamespaceBundleFactory()
+                .getBundles(NamespaceName.get(namespace1));
+        NamespaceBundle bundle = bundles.getBundles().get(0);
+        retryStrategically((test) -> {
+            try {
+                return !pulsar1.getNamespaceService().isNamespaceBundleOwned(bundle).get();
+            } catch (Exception e) {
+                return false;
+            }
+        }, 5, 200);
+
+        assertFalse(pulsar1.getNamespaceService().isNamespaceBundleOwned(bundle).get());
+        // topic should be unloaded from broker1
+        assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topic1));
+
+        client3.close();
+    }
+
 }


### PR DESCRIPTION
### Motivation

Addressing: #3425

### Issue
There could be possible data-loss when user is using peer-cluster feature and changes replication cluster from peer1-cluster to peer2-cluster. 

- Sometimes, broker never receives a zk-watch for namespace policies change so, if replication cluster list has been changed then there is a possibility that broker which is owning bundle of that namespace, might not see the change and still serving the namespace bundle.
- if the replication cluster has been changed from peer-cluster1 to peer-cluster2 then peer-cluster1 will continue to serve namespace and will not redirect lookup-request to peer-cluster2. in that case there will be ownership discrepancy and peer-cluster2 might not receive the traffic which will cause in data-loss.

### Fix
- this issue happens when one of broker doesn't receive the zk-watch.
- To fix the issue, whichever broker receives the watch, that unloads the namespace if it's already owned by local cluster and broker invalidates namespace-policy cache before owning the namespace bundle to avoid any discrepancy.