### PR TITLE
Use equals to check if two strings are equal

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -205,10 +205,7 @@ public class PulsarAdminTool {
         }
 
         ++cmdPos;
-        boolean isLocalRun = false;
-        if (cmdPos < args.length) {
-            isLocalRun = "localrun" == args[cmdPos].toLowerCase();
-        }
+        boolean isLocalRun = cmdPos < args.length && "localrun".equals(args[cmdPos].toLowerCase());
 
         Function<PulsarAdminBuilder, ? extends PulsarAdmin> adminFactory;
         if (isLocalRun) {


### PR DESCRIPTION
Currently, we are using ```==``` to check if the user passed argument is ```localrun```. We'd better to use ```equals``` for string comparison.