### PR TITLE
 fix  website build cp command is not a directory error

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -44,4 +44,4 @@ CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 
 DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -e CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID} -e CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY} -v $ROOT_DIR:/pulsar $IMAGE"
 
-$DOCKER_CMD bash -l -c 'cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && cp -R ./build/pulsar/* /pulsar/generated-site/content'
+$DOCKER_CMD bash -l -c 'cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && rm -rf /pulsar/generated-site/content && mkdir -p /pulsar/generated-site/content && cp -R ./build/pulsar/* /pulsar/generated-site/content'


### PR DESCRIPTION
### Motivation

 website build keeps failing, cp: target '/pulsar/generated-site/content' is not a directory  

### Modifications

 rm -rf /pulsar/generated-site/content , if this dir not exists, no command errors occur. But this dir is exists, deletes existing files.

mkdir -p /pulsar/generated-site/content, if this dir exists, no command errors occur. But this dir not exists, create dir.

### Verifying this change

- [ ✔️] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
