### PR TITLE
[Documentation] Document how to change Bookkeeper Zk root config

### DIFF
--- a/content/docs/en/administration-zk-bk/index.html
+++ b/content/docs/en/administration-zk-bk/index.html
@@ -229,6 +229,11 @@ designed to use multiple devices:</p>
 <blockquote>
 <p>Consult the official <a href="http://bookkeeper.apache.org">BookKeeper docs</a> for more information about BookKeeper.</p>
 </blockquote>
+<blockquote>
+<p>
+To change the zookeeper root path used by Bookkeeper, use zkLedgersRootPath=/MY-PREFIX/ledgers instead of zkServers=localhost:2181/MY-PREFIX
+</p>
+</blockquote>
 <h2><a class="anchor" aria-hidden="true" id="bookkeeper-persistence-policies"></a><a href="#bookkeeper-persistence-policies" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>BookKeeper persistence policies</h2>
 <p>In Pulsar, you can set <em>persistence policies</em>, at the namespace level, that determine how BookKeeper handles persistent storage of messages. Policies determine four things:</p>
 <ul>
@@ -350,7 +355,6 @@ admin.namespaces().setPersistence(namespace, policies);
                 });
               </script><script>
               var search = docsearch({
-                
                 apiKey: 'd226a455cecdd4bc18a554c1b47e5b52',
                 indexName: 'apache_pulsar',
                 inputSelector: '#search_input_react',


### PR DESCRIPTION
### Motivation
Using ```zkServers=zk1:2181/myroot``` current is resulting in Bookie start failure. This PR documents the correct way to configure zookeeper root for Bookkeeper when using Pulsar.

### Modifications

- Adding doc line to https://pulsar.apache.org/docs/en/administration-zk-bk/

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)

