### PR TITLE
Fix REST API document link

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -357,7 +357,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
 ```
 
 ###### Java

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -147,7 +147,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -173,7 +173,7 @@ cl2
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/replication
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -207,7 +207,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/backlogQuota
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
 ```
 
 ###### Java
@@ -238,7 +238,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
 ```
 
 ###### Java
@@ -264,7 +264,7 @@ N/A
 ###### REST
 
 ```
-DELETE /admin/v2/namespaces/{tenant}/{namespace}/backlogQuota
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
 ```
 
 ###### Java
@@ -298,7 +298,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/persistence
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
 ```
 
 ###### Java
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/persistence
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
 ```
 
 ###### Java
@@ -357,7 +357,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/v2/namespaces/{tenant}/{namespace}/unload
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespaceBundle}
 ```
 
 ###### Java
@@ -384,7 +384,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/messageTTL
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
 ```
 
 ###### Java
@@ -411,13 +411,13 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/messageTTL
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
 ```
 
 ###### Java
 
 ```java
-admin.namespaces().getNamespaceReplicationClusters(namespace)
+admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 
 
@@ -438,7 +438,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
 ```
 
 ###### Java
@@ -465,7 +465,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/clearBacklog
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
 ```
 
 ###### Java
@@ -492,7 +492,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
 ```
 
 ###### Java
@@ -519,7 +519,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/retention
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
 ```
 
 ###### Java
@@ -549,7 +549,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/retention
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
 ```
 
 ###### Java
@@ -577,7 +577,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/dispatchRate
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
 ```
 
 ###### Java
@@ -607,7 +607,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/dispatchRate
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
 ```
 
 ###### Java


### PR DESCRIPTION
Currently, most of REST API showcases are not linked to the API document in namespaces document.  