### PR TITLE
Removed remaining import and usages of boost::shared_ptr

### DIFF
--- a/pulsar-client-cpp/lib/Authentication.cc
+++ b/pulsar-client-cpp/lib/Authentication.cc
@@ -29,7 +29,6 @@
 #include <iostream>
 #include <dlfcn.h>
 #include <cstdlib>
-#include <boost/make_shared.hpp>
 #include <boost/thread.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
@@ -19,7 +19,6 @@
 #include "BinaryProtoLookupService.h"
 #include "SharedBuffer.h"
 
-#include <boost/shared_ptr.hpp>
 #include <lib/TopicName.h>
 
 #include <boost/bind.hpp>

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -513,7 +513,6 @@ void ClientConnection::processIncomingBuffer() {
         } else {
             handleIncomingCommand();
         }
-
     }
     if (incomingBuffer_.readableBytes() > 0) {
         // We still have 1 to 3 bytes from the next frame

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -20,7 +20,6 @@
 
 #include "PulsarApi.pb.h"
 
-#include <boost/shared_ptr.hpp>
 #include <boost/array.hpp>
 #include <iostream>
 #include <algorithm>
@@ -514,8 +513,8 @@ void ClientConnection::processIncomingBuffer() {
         } else {
             handleIncomingCommand();
         }
-    }
 
+    }
     if (incomingBuffer_.readableBytes() > 0) {
         // We still have 1 to 3 bytes from the next frame
         assert(incomingBuffer_.readableBytes() < sizeof(uint32_t));

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -24,7 +24,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/any.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <functional>
 #include <string>

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -24,7 +24,6 @@
 #include "BinaryProtoLookupService.h"
 #include "ConnectionPool.h"
 #include "LookupDataResult.h"
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <lib/TopicName.h>
 #include "ProducerImplBase.h"

--- a/pulsar-client-cpp/lib/CompressionCodec.h
+++ b/pulsar-client-cpp/lib/CompressionCodec.h
@@ -19,8 +19,6 @@
 #ifndef LIB_COMPRESSIONCODEC_H_
 #define LIB_COMPRESSIONCODEC_H_
 
-#include <boost/smart_ptr.hpp>
-
 #include <pulsar/Producer.h>
 
 #include "SharedBuffer.h"

--- a/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
@@ -20,7 +20,6 @@
 #define LIB_CONSUMERCONFIGURATIONIMPL_H_
 
 #include <pulsar/ConsumerConfiguration.h>
-#include <boost/make_shared.hpp>
 
 namespace pulsar {
 struct ConsumerConfigurationImpl {

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -24,9 +24,7 @@
 #include "pulsar/Result.h"
 #include "UnboundedBlockingQueue.h"
 #include "HandlerBase.h"
-#include "boost/enable_shared_from_this.hpp"
 #include "ClientConnection.h"
-#include <boost/shared_ptr.hpp>
 #include "lib/UnAckedMessageTrackerEnabled.h"
 #include "Commands.h"
 #include "ExecutorService.h"

--- a/pulsar-client-cpp/lib/EncryptionKeyInfoImpl.h
+++ b/pulsar-client-cpp/lib/EncryptionKeyInfoImpl.h
@@ -19,7 +19,6 @@
 #ifndef LIB_ENCRYPTIONKEYINFOIMPL_H_
 #define LIB_ENCRYPTIONKEYINFOIMPL_H_
 
-#include <boost/shared_ptr.hpp>
 #include <iostream>
 #include <map>
 

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -21,8 +21,8 @@
 #include <boost/ref.hpp>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 #include <functional>
+#include <memory>
 
 namespace pulsar {
 

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -19,7 +19,7 @@
 #ifndef _PULSAR_EXECUTOR_SERVICE_HEADER_
 #define _PULSAR_EXECUTOR_SERVICE_HEADER_
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <functional>
@@ -63,7 +63,7 @@ class ExecutorService : private boost::noncopyable {
      * it will keep it running in the background so we don't have to take care of it
      */
     typedef boost::asio::io_service::work BackgroundWork;
-    boost::scoped_ptr<BackgroundWork> work_;
+    std::unique_ptr<BackgroundWork> work_;
 
     /*
      * worker thread which runs until work object is destroyed, it's running io_service::run in

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -20,10 +20,8 @@
 #define LIB_FUTURE_H_
 
 #include <functional>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
-#include <boost/make_shared.hpp>
 
 #include <list>
 

--- a/pulsar-client-cpp/lib/HandlerBase.h
+++ b/pulsar-client-cpp/lib/HandlerBase.h
@@ -21,7 +21,7 @@
 #include "Backoff.h"
 #include "ClientImpl.h"
 #include "ClientConnection.h"
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/asio.hpp>
 #include <string>
 #include <boost/date_time/local_time/local_time.hpp>

--- a/pulsar-client-cpp/lib/Latch.cc
+++ b/pulsar-client-cpp/lib/Latch.cc
@@ -18,8 +18,6 @@
  */
 #include "Latch.h"
 
-#include <boost/make_shared.hpp>
-
 namespace pulsar {
 
 struct CountIsZero {

--- a/pulsar-client-cpp/lib/Latch.h
+++ b/pulsar-client-cpp/lib/Latch.h
@@ -19,7 +19,7 @@
 #ifndef LIB_LATCH_H_
 #define LIB_LATCH_H_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
 

--- a/pulsar-client-cpp/lib/Message.cc
+++ b/pulsar-client-cpp/lib/Message.cc
@@ -19,9 +19,6 @@
 #include <pulsar/Message.h>
 #include <pulsar/MessageBuilder.h>
 
-#include <boost/make_shared.hpp>
-#include <boost/smart_ptr.hpp>
-
 #include "PulsarApi.pb.h"
 
 #include "MessageImpl.h"

--- a/pulsar-client-cpp/lib/MessageBuilder.cc
+++ b/pulsar-client-cpp/lib/MessageBuilder.cc
@@ -18,7 +18,7 @@
  */
 #include <pulsar/MessageBuilder.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include "MessageImpl.h"
 #include "SharedBuffer.h"

--- a/pulsar-client-cpp/lib/MessageId.cc
+++ b/pulsar-client-cpp/lib/MessageId.cc
@@ -26,7 +26,7 @@
 #include <limits>
 #include <tuple>
 #include <math.h>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 namespace pulsar {
 

--- a/pulsar-client-cpp/lib/MessageImpl.h
+++ b/pulsar-client-cpp/lib/MessageImpl.h
@@ -24,8 +24,6 @@
 #include "SharedBuffer.h"
 #include "PulsarApi.pb.h"
 
-#include <boost/scoped_ptr.hpp>
-
 using namespace pulsar;
 namespace pulsar {
 

--- a/pulsar-client-cpp/lib/MessageRouterBase.h
+++ b/pulsar-client-cpp/lib/MessageRouterBase.h
@@ -19,15 +19,14 @@
 #ifndef PULSAR_CPP_MESSAGEROUTERBASE_H
 #define PULSAR_CPP_MESSAGEROUTERBASE_H
 
-#include <boost/interprocess/smart_ptr/unique_ptr.hpp>
-#include <boost/checked_delete.hpp>
+#include <memory>
 
 #include <pulsar/MessageRoutingPolicy.h>
 #include <pulsar/ProducerConfiguration.h>
 #include "Hash.h"
 
 namespace pulsar {
-typedef boost::interprocess::unique_ptr<Hash, boost::checked_deleter<Hash> > HashPtr;
+typedef std::unique_ptr<Hash> HashPtr;
 
 class MessageRouterBase : public MessageRoutingPolicy {
    public:

--- a/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsBrokerConsumerStatsImpl.h
@@ -26,8 +26,7 @@
 #include <functional>
 #include <boost/date_time/microsec_time_clock.hpp>
 #include <lib/BrokerConsumerStatsImpl.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+
 #pragma GCC visibility push(default)
 namespace pulsar {
 class MultiTopicsBrokerConsumerStatsImpl : public BrokerConsumerStatsImplBase {

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -23,9 +23,8 @@
 #include "BlockingQueue.h"
 #include <vector>
 #include <queue>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
-#include "boost/enable_shared_from_this.hpp"
+
 #include "ConsumerImplBase.h"
 #include "lib/UnAckedMessageTrackerDisabled.h"
 #include <lib/Latch.h>

--- a/pulsar-client-cpp/lib/NamespaceName.cc
+++ b/pulsar-client-cpp/lib/NamespaceName.cc
@@ -21,7 +21,7 @@
 #include "LogUtils.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <sstream>

--- a/pulsar-client-cpp/lib/NamespaceName.h
+++ b/pulsar-client-cpp/lib/NamespaceName.h
@@ -22,7 +22,6 @@
 #include "ServiceUnitId.h"
 
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 #pragma GCC visibility push(default)
 namespace pulsar {

--- a/pulsar-client-cpp/lib/NamespaceName.h
+++ b/pulsar-client-cpp/lib/NamespaceName.h
@@ -21,6 +21,7 @@
 
 #include "ServiceUnitId.h"
 
+#include <memory>
 #include <string>
 
 #pragma GCC visibility push(default)

--- a/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedBrokerConsumerStatsImpl.h
@@ -26,8 +26,7 @@
 #include <functional>
 #include <boost/date_time/microsec_time_clock.hpp>
 #include <lib/BrokerConsumerStatsImpl.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+
 #pragma GCC visibility push(default)
 namespace pulsar {
 class PartitionedBrokerConsumerStatsImpl : public BrokerConsumerStatsImplBase {

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -22,9 +22,8 @@
 #include "ClientImpl.h"
 #include <vector>
 #include <queue>
-#include <boost/shared_ptr.hpp>
+
 #include <boost/thread/mutex.hpp>
-#include "boost/enable_shared_from_this.hpp"
 #include "ConsumerImplBase.h"
 #include "lib/UnAckedMessageTrackerDisabled.h"
 #include <lib/Latch.h>

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -19,8 +19,7 @@
 #include "ProducerImpl.h"
 #include "ClientImpl.h"
 #include <vector>
-#include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
+
 #include <boost/thread/mutex.hpp>
 #include <pulsar/MessageRoutingPolicy.h>
 #include <pulsar/TopicMetadata.h>
@@ -93,7 +92,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     const TopicNamePtr topicName_;
     const std::string topic_;
 
-    boost::scoped_ptr<TopicMetadata> topicMetadata_;
+    std::unique_ptr<TopicMetadata> topicMetadata_;
 
     unsigned int numProducersCreated_;
 

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -20,7 +20,7 @@
 #define LIB_PRODUCERCONFIGURATIONIMPL_H_
 
 #include <pulsar/ProducerConfiguration.h>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include "Utils.h"
 

--- a/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
@@ -20,7 +20,6 @@
 #define LIB_READERCONFIGURATIONIMPL_H_
 
 #include <pulsar/ReaderConfiguration.h>
-#include <boost/make_shared.hpp>
 
 namespace pulsar {
 struct ReaderConfigurationImpl {

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -22,8 +22,6 @@
 
 #include "ConsumerImpl.h"
 
-#include <boost/shared_ptr.hpp>
-
 namespace pulsar {
 
 class ReaderImpl;

--- a/pulsar-client-cpp/lib/Schema.cc
+++ b/pulsar-client-cpp/lib/Schema.cc
@@ -20,8 +20,7 @@
 
 #include <iostream>
 #include <map>
-#include <boost/make_shared.hpp>
-#include <include/pulsar/Schema.h>
+#include <memory>
 
 #pragma GCC visibility push(default)
 

--- a/pulsar-client-cpp/lib/ServiceUnitId.h
+++ b/pulsar-client-cpp/lib/ServiceUnitId.h
@@ -19,9 +19,6 @@
 #ifndef _PULSAR_SERVICE_UNIT_ID_HEADER_
 #define _PULSAR_SERVICE_UNIT_ID_HEADER_
 
-#include <string>
-#include <boost/shared_ptr.hpp>
-
 class ServiceUnitId {
    public:
     virtual ~ServiceUnitId() {}

--- a/pulsar-client-cpp/lib/SharedBuffer.h
+++ b/pulsar-client-cpp/lib/SharedBuffer.h
@@ -21,8 +21,6 @@
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/pulsar-client-cpp/lib/TopicName.cc
+++ b/pulsar-client-cpp/lib/TopicName.cc
@@ -19,12 +19,12 @@
 #include "NamedEntity.h"
 #include "LogUtils.h"
 #include "PartitionedProducerImpl.h"
+#include "TopicName.h"
 
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/find.hpp>
-#include <boost/make_shared.hpp>
-#include <lib/TopicName.h>
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <sstream>

--- a/pulsar-client-cpp/lib/TopicName.h
+++ b/pulsar-client-cpp/lib/TopicName.h
@@ -25,7 +25,6 @@
 #include <string>
 #include <curl/curl.h>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
 
 #pragma GCC visibility push(default)
 

--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerInterface.h
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerInterface.h
@@ -49,6 +49,6 @@ class UnAckedMessageTrackerInterface {
     virtual void removeTopicMessage(const std::string& topic) = 0;
 };
 
-typedef boost::scoped_ptr<UnAckedMessageTrackerInterface> UnAckedMessageTrackerScopedPtr;
+typedef std::unique_ptr<UnAckedMessageTrackerInterface> UnAckedMessageTrackerScopedPtr;
 }  // namespace pulsar
 #endif /* LIB_UNACKEDMESSAGETRACKERINTERFACE_H_ */

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -33,13 +33,12 @@
 #include <json/reader.h>
 
 #include <boost/ref.hpp>
-#include <boost/make_shared.hpp>
 
 DECLARE_LOG_OBJECT()
 
 namespace pulsar {
 AuthDataAthenz::AuthDataAthenz(ParamMap& params) {
-    ztsClient_ = boost::make_shared<ZTSClient>(boost::ref(params));
+    ztsClient_ = std::make_shared<ZTSClient>(boost::ref(params));
     LOG_DEBUG("AuthDataAthenz is construted.")
 }
 

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.h
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.h
@@ -38,7 +38,7 @@ class AuthDataAthenz : public AuthenticationDataProvider {
     ~AuthDataAthenz();
 
    private:
-    boost::shared_ptr<ZTSClient> ztsClient_;
+    std::shared_ptr<ZTSClient> ztsClient_;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/c/c_structs.h
+++ b/pulsar-client-cpp/lib/c/c_structs.h
@@ -21,11 +21,11 @@
 #include <pulsar/c/result.h>
 #include <pulsar/Client.h>
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <boost/bind.hpp>
 
 struct _pulsar_client {
-    boost::scoped_ptr<pulsar::Client> client;
+    std::unique_ptr<pulsar::Client> client;
 };
 
 struct _pulsar_client_configuration {

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -22,8 +22,7 @@ DECLARE_LOG_OBJECT()
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/scoped_array.hpp>
-#include <boost/make_shared.hpp>
+
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
@@ -40,7 +39,7 @@ namespace po = boost::program_options;
 #include "RateLimiter.h"
 #include <pulsar/MessageBuilder.h>
 #include <pulsar/Authentication.h>
-typedef boost::shared_ptr<pulsar::RateLimiter> RateLimiterPtr;
+typedef std::shared_ptr<pulsar::RateLimiter> RateLimiterPtr;
 
 struct Arguments {
     std::string authParams;
@@ -162,7 +161,7 @@ void runProducer(const Arguments& args, std::string topicName, int threadIndex,
 void startPerfProducer(const Arguments& args, pulsar::ProducerConfiguration &producerConf, pulsar::Client &client) {
     RateLimiterPtr limiter;
     if (args.rate != -1) {
-        limiter = boost::make_shared<pulsar::RateLimiter>(args.rate);
+        limiter = std::make_shared<pulsar::RateLimiter>(args.rate);
     }
 
     producerList.resize(args.numTopics * args.numProducers);

--- a/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
+++ b/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
@@ -20,8 +20,6 @@
 #include <pulsar/Client.h>
 
 #include <gtest/gtest.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 #include <Future.h>
 #include <Utils.h>
 #include "ConnectionPool.h"


### PR DESCRIPTION
### Motivation

In #3374 most of usages of `boost::shared_ptr` were converted into `std::shared_ptr`. Fixed few remaining and removed all the includes to `boost/shared_ptr.hpp`.