### PR TITLE
Fix incomplete documentation in cookbooks-retention-expiry

### DIFF
--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -279,6 +279,6 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 #### Java
 
 ```java
-admin.namespaces().get
+admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 


### PR DESCRIPTION
The sample for method getNamespaceMessageTTL is incomplete which supposed to be ```admin.namespaces().getNamespaceMessageTTL(namespace)``` instead of ```admin.namespaces().get```.

