### PR TITLE
Update command usage for pulsar-perf cli command (#2895)

### DIFF
--- a/site/_data/cli/pulsar-perf.yaml
+++ b/site/_data/cli/pulsar-perf.yaml
@@ -22,6 +22,7 @@ description: |
 commands:
 - name: consume
   description: Run a consumer
+  argument: topic_name
   options:
   - flags: --auth_params
     description: Authentication parameters in the form of `key1:val1,key2:val2`
@@ -56,6 +57,7 @@ commands:
     default: 100
   - flags: -u, --service-url
     description: Pulsar service URL
+    default: 'http://localhost:8080/'
   - flags: -s, --size
     description: Message size (in bytes)
     default: 1024
@@ -67,6 +69,7 @@ commands:
     default: 0
 - name: produce
   description: Run a producer
+  argument: topic_name
   options:
   - flags: --auth_params
     description: Authentication parameters in the form of `key1:val1,key2:val2`
@@ -102,6 +105,7 @@ commands:
     default: 100
   - flags: -u, --service-url
     description: Pulsar service URL
+    default: 'http://localhost:8080/'
   - flags: -s, --size
     description: Message size (in bytes)
     default: 1024
@@ -113,13 +117,21 @@ commands:
     default: 0
 - name: monitor-brokers
   description: Continuously receive broker data and/or load reports
+  argument: --connect-string arg
   options:
   - flags: --connect-string
     description: A connection string for one or more ZooKeeper servers
 - name: simulation-client
   description: Run a simulation server acting as a Pulsar client. Uses the client configuration specified in `conf/client.conf`.
+  argument: --port arg --service-url arg
+  options:
+  - flags: --port
+    description: Port to listen on for controller
+  - flags: --service-url
+    description: Pulsar Service URL
 - name: simulation-controller
   description: Run a simulation controller to give commands to servers
+  argument: --client-port arg --clients arg --cluster arg
   options:
   - flags: --client-port
     description: The port that the clients are listening on


### PR DESCRIPTION
### Motivation
Fix for issue: #2895

### Changes
As all required argument already have required flag for JCommander, update the documentation for pulsar-perf to add required argument to command usage,
 eg: `pulsar-perf consume options topic_name`
Also document default service url for consumer and producer command as specified in code.
Add options for `simulation-client` command as they're missing before.

