### PR TITLE
Replaced boost::lexical_cast with std::to_string

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -388,7 +388,7 @@ void ClientConnection::tcpConnectAsync() {
     }
 
     LOG_DEBUG(cnxString_ << "Connecting to " << service_url.host() << ":" << service_url.port());
-    tcp::resolver::query query(service_url.host(), boost::lexical_cast<std::string>(service_url.port()));
+    tcp::resolver::query query(service_url.host(), std::to_string(service_url.port()));
     resolver_->async_resolve(
         query, boost::bind(&ClientConnection::handleResolve, shared_from_this(),
                            boost::asio::placeholders::error, boost::asio::placeholders::iterator));

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -34,7 +34,6 @@
 #include <json/reader.h>
 
 #include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/xpressive/xpressive.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -84,7 +83,7 @@ ZTSClient::ZTSClient(std::map<std::string, std::string> &params) {
     roleHeader_ = params.find("roleHeader") == params.end() ? DEFAULT_ROLE_HEADER : params["roleHeader"];
     tokenExpirationTime_ = DEFAULT_TOKEN_EXPIRATION_TIME_SEC;
     if (params.find("tokenExpirationTime") != params.end()) {
-        tokenExpirationTime_ = boost::lexical_cast<int>(params["tokenExpirationTime"]);
+        tokenExpirationTime_ = std::stoi(params["tokenExpirationTime"]);
         if (tokenExpirationTime_ < MIN_TOKEN_EXPIRATION_TIME_SEC) {
             LOG_WARN(tokenExpirationTime_ << " is too small as a token expiration time. "
                                           << MIN_TOKEN_EXPIRATION_TIME_SEC << " is set instead of it.");
@@ -181,8 +180,8 @@ const std::string ZTSClient::getPrincipalToken() const {
     unsignedTokenString += ";n=" + tenantService_;
     unsignedTokenString += ";h=" + std::string(host);
     unsignedTokenString += ";a=" + getSalt();
-    unsignedTokenString += ";t=" + boost::lexical_cast<std::string>(t);
-    unsignedTokenString += ";e=" + boost::lexical_cast<std::string>(t + tokenExpirationTime_);
+    unsignedTokenString += ";t=" + std::to_string(t);
+    unsignedTokenString += ";e=" + std::to_string(t + tokenExpirationTime_);
     unsignedTokenString += ";k=" + keyId_;
 
     LOG_DEBUG("Created unsigned principal token: " << unsignedTokenString);

--- a/pulsar-client-cpp/perf/PerfConsumer.cc
+++ b/pulsar-client-cpp/perf/PerfConsumer.cc
@@ -192,13 +192,13 @@ void startPerfConsumer(const Arguments& args) {
     for (int i = 0; i < args.numTopics; i++) {
         std::string topic =
                 (args.numTopics == 1) ?
-                        args.topic : args.topic + "-" + boost::lexical_cast<std::string>(i);
+                        args.topic : args.topic + "-" + std::to_string(i);
         LOG_INFO("Adding " << args.numConsumers << " consumers on topic " << topic);
 
         for (int j = 0; j < args.numConsumers; j++) {
             std::string subscriberName;
             if (args.numConsumers > 1) {
-                subscriberName = args.subscriberName + "-" + boost::lexical_cast<std::string>(j);
+                subscriberName = args.subscriberName + "-" + std::to_string(j);
             } else {
                 subscriberName = args.subscriberName;
             }

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -168,7 +168,7 @@ void startPerfProducer(const Arguments& args, pulsar::ProducerConfiguration &pro
     for (int i = 0; i < args.numTopics; i++) {
         std::string topic =
                 (args.numTopics == 1) ?
-                        args.topic : args.topic + "-" + boost::lexical_cast<std::string>(i);
+                        args.topic : args.topic + "-" + std::to_string(i);
         LOG_INFO("Adding " << args.numProducers << " producers on topic " << topic);
 
         for (int j = 0; j < args.numProducers; j++) {

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -19,7 +19,6 @@
 #include "pulsar/Authentication.h"
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
@@ -44,7 +43,7 @@ static const std::string clientPrivateKeyPath =
 static void sendCallBackTls(Result r, const Message& msg) {
     ASSERT_EQ(r, ResultOk);
     std::string prefix = "test-tls-message-";
-    std::string messageContent = prefix + boost::lexical_cast<std::string>(globalTestTlsMessagesCounter++);
+    std::string messageContent = prefix + std::to_string(globalTestTlsMessagesCounter++);
     ASSERT_EQ(messageContent, msg.getDataAsString());
     LOG_DEBUG("Received publish acknowledgement for " << msg.getDataAsString());
 }
@@ -98,11 +97,9 @@ TEST(AuthPluginTest, testTls) {
     // Send Asynchronously
     std::string prefix = "test-tls-message-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBackTls);
         LOG_INFO("sending message " << messageContent);
     }
@@ -110,10 +107,10 @@ TEST(AuthPluginTest, testTls) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_INFO("Received Message with [ content - "
                  << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }

--- a/pulsar-client-cpp/tests/AuthTokenTest.cc
+++ b/pulsar-client-cpp/tests/AuthTokenTest.cc
@@ -21,7 +21,6 @@
 
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
@@ -92,11 +91,9 @@ TEST(AuthPluginToken, testToken) {
     // Send Asynchronously
     std::string prefix = "test-token-message-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, NULL);
         LOG_INFO("sending message " << messageContent);
     }
@@ -108,10 +105,10 @@ TEST(AuthPluginToken, testToken) {
         Result res = consumer.receive(receivedMsg);
         ASSERT_EQ(ResultOk, res);
 
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_INFO("Received Message with [ content - "
                  << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
@@ -148,11 +145,9 @@ TEST(AuthPluginToken, testTokenWithHttpUrl) {
     // Send Asynchronously
     std::string prefix = "test-token-message-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, NULL);
         LOG_INFO("sending message " << messageContent);
     }
@@ -164,10 +159,10 @@ TEST(AuthPluginToken, testTokenWithHttpUrl) {
         Result res = consumer.receive(receivedMsg);
         ASSERT_EQ(ResultOk, res);
 
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_INFO("Received Message with [ content - "
                  << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -18,7 +18,6 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <boost/lexical_cast.hpp>
 #include <lib/LogUtils.h>
 #include <pulsar/MessageBuilder.h>
 #include <lib/Commands.h>
@@ -64,7 +63,7 @@ static void sendCallBack(Result r, const Message& msg, std::string prefix, int* 
     static boost::mutex sendMutex_;
     sendMutex_.lock();
     ASSERT_EQ(r, ResultOk);
-    std::string messageContent = prefix + boost::lexical_cast<std::string>(*count);
+    std::string messageContent = prefix + std::to_string(*count);
     ASSERT_EQ(messageContent, msg.getDataAsString());
     LOG_DEBUG("Received publish acknowledgement for " << msg.getDataAsString());
     *count += 1;
@@ -183,11 +182,9 @@ TEST(BasicEndToEndTest, testBatchMessages) {
     std::string prefix = "msg-batch-";
     int msgCount = 0;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -195,12 +192,11 @@ TEST(BasicEndToEndTest, testBatchMessages) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_INFO("Received Message with [ content - "
                  << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]");
-        LOG_INFO("msg-index " << receivedMsg.getProperty("msgIndex") << ", expected "
-                              << boost::lexical_cast<std::string>(i));
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        LOG_INFO("msg-index " << receivedMsg.getProperty("msgIndex") << ", expected " << std::to_string(i));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
@@ -400,10 +396,8 @@ TEST(BasicEndToEndTest, testProduceAndConsumeAfterClientClose) {
     LOG_INFO("Publishing 10 messages synchronously");
     int numMsg = 0;
     for (; numMsg < 10; numMsg++) {
-        Message msg = MessageBuilder()
-                          .setContent(msgContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(numMsg))
-                          .build();
+        Message msg =
+            MessageBuilder().setContent(msgContent).setProperty("msgIndex", std::to_string(numMsg)).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
 
@@ -413,7 +407,7 @@ TEST(BasicEndToEndTest, testProduceAndConsumeAfterClientClose) {
         consumer.receive(msgReceived, 1000);
         LOG_DEBUG("Received message :" << msgReceived.getMessageId());
         ASSERT_EQ(msgContent, msgReceived.getDataAsString());
-        ASSERT_EQ(boost::lexical_cast<std::string>(i), msgReceived.getProperty("msgIndex"));
+        ASSERT_EQ(std::to_string(i), msgReceived.getProperty("msgIndex"));
         ASSERT_EQ(ResultOk, consumer.acknowledgeCumulative(msgReceived));
     }
 
@@ -421,10 +415,8 @@ TEST(BasicEndToEndTest, testProduceAndConsumeAfterClientClose) {
     ASSERT_EQ(ResultOk, client.close());
 
     LOG_INFO("Trying to publish a message after closing the client");
-    Message msg = MessageBuilder()
-                      .setContent(msgContent)
-                      .setProperty("msgIndex", boost::lexical_cast<std::string>(numMsg))
-                      .build();
+    Message msg =
+        MessageBuilder().setContent(msgContent).setProperty("msgIndex", std::to_string(numMsg)).build();
 
     ASSERT_EQ(ResultAlreadyClosed, producer.send(msg));
 
@@ -1010,11 +1002,9 @@ TEST(BasicEndToEndTest, testStatsLatencies) {
     std::string prefix = "msg-stats-";
     int count = 0;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, 15, 2 * 1e3, &count));
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -1077,10 +1067,10 @@ TEST(BasicEndToEndTest, testStatsLatencies) {
     ConsumerStatsImplPtr consumerStatsImplPtr = PulsarFriend::getConsumerStatsPtr(consumer);
 
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalReceivedMsgMap()), i);
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalAckedMsgMap()), i - 1);
@@ -1158,11 +1148,9 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
     int numOfMessages = 10;
     std::string propertyName = "msgIndex";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = "msg-" + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty(propertyName, boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = "msg-" + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty(propertyName, std::to_string(i)).build();
         if (i % 3 == 1) {
             ProducerImpl& pImpl = PulsarFriend::getProducerImpl(producer);
             ClientConnectionPtr clientConnectionPtr;
@@ -1202,9 +1190,8 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
     ASSERT_EQ(receivedMsgIndex.size(), 10);
 
     for (int i = 0; i < numOfMessages; i++) {
-        ASSERT_TRUE(receivedMsgContent.find("msg-" + boost::lexical_cast<std::string>(i)) !=
-                    receivedMsgContent.end());
-        ASSERT_TRUE(receivedMsgIndex.find(boost::lexical_cast<std::string>(i)) != receivedMsgIndex.end());
+        ASSERT_TRUE(receivedMsgContent.find("msg-" + std::to_string(i)) != receivedMsgContent.end());
+        ASSERT_TRUE(receivedMsgIndex.find(std::to_string(i)) != receivedMsgIndex.end());
     }
 }
 
@@ -2089,7 +2076,7 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerAutoDiscovery) {
 TEST(BasicEndToEndTest, testSyncFlushBatchMessages) {
     ClientConfiguration config;
     Client client(lookupUrl);
-    std::string topicName = "test-flush-batch-messages-" + boost::lexical_cast<std::string>(time(NULL));
+    std::string topicName = "test-flush-batch-messages-" + std::to_string(time(NULL));
     std::string subName = "subscription-name";
     Producer producer;
 
@@ -2127,11 +2114,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessages) {
     std::string prefix = "msg-batch-async";
     int msgCount = 0;
     for (int i = 0; i < numOfMessages / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2143,11 +2128,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessages) {
 
     // Send Asynchronously of the other half the messages
     for (int i = numOfMessages / 2; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2159,11 +2142,11 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessages) {
     // receive all the messages.
     int i = 1;
     while (consumer.receive(receivedMsg, 1000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_INFO("Received Message with [ content - "
                  << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]"
                  << "property = " << receivedMsg.getProperty("msgIndex"));
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
@@ -2172,11 +2155,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessages) {
     // Send sync of half the messages, this will triggerFlush, and could get the messages.
     prefix = "msg-batch-sync";
     for (int i = 0; i < numOfMessages / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.send(msg);
         LOG_INFO("sync sending message " << messageContent);
     }
@@ -2245,11 +2226,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     // Send asynchronously of first part the messages
     std::string prefix = "msg-batch-async";
     for (int i = 0; i < numOfMessages / numberOfPartitions / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, simpleCallback);
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2259,11 +2238,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     ASSERT_EQ(ResultTimeout, consumer[0].receive(m, 5000));
 
     for (int i = numOfMessages / numberOfPartitions / 2; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, simpleCallback);
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2279,11 +2256,9 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     // Sync send of first part of the messages, this will triggerFlush, and could get the messages.
     prefix = "msg-batch-sync";
     for (int i = 0; i < numOfMessages / numberOfPartitions / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.send(msg);
         LOG_DEBUG("sync sending message " << messageContent);
     }
@@ -2363,11 +2338,9 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
     std::string prefix = "msg-batch-async";
     int msgCount = 0;
     for (int i = 0; i < numOfMessages / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2388,11 +2361,9 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
 
     // Send Asynchronously of another round of the messages
     for (int i = numOfMessages / 2; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2465,11 +2436,9 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     // Send asynchronously of first part the messages
     std::string prefix = "msg-batch-async";
     for (int i = 0; i < numOfMessages / 2; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, simpleCallback);
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2494,11 +2463,9 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
 
     // send message again.
     for (int i = numOfMessages / 2; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, simpleCallback);
         LOG_DEBUG("async sending message " << messageContent);
     }
@@ -2667,11 +2634,9 @@ TEST(BasicEndToEndTest, testBatchMessagesReceiveAsync) {
     std::string prefix = "msg-batch-";
     int msgCount = 0;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, &msgCount));
         LOG_DEBUG("sending message " << messageContent);
     }

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -18,7 +18,6 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <boost/lexical_cast.hpp>
 #include <lib/LogUtils.h>
 #include <pulsar/MessageBuilder.h>
 #include <lib/Commands.h>
@@ -81,7 +80,7 @@ TEST(BatchMessageTest, testProducerConfig) {
 }
 
 TEST(BatchMessageTest, testProducerTimeout) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testProducerTimeout";
+    std::string testName = std::to_string(epochTime) + "testProducerTimeout";
 
     ClientConfiguration clientConf;
     clientConf.setStatsIntervalInSeconds(1);
@@ -128,11 +127,11 @@ TEST(BatchMessageTest, testProducerTimeout) {
     // Send Asynchronously
     std::string prefix = "msg-batch-test-produce-timeout-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder()
                           .setContent(messageContent)
                           .setProperty("type", "batch")
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
+                          .setProperty("msgIndex", std::to_string(i))
                           .build();
         LOG_DEBUG("sending message " << messageContent);
         clock_t start, end;
@@ -155,10 +154,10 @@ TEST(BatchMessageTest, testProducerTimeout) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(receivedMsg.getProperty("type"), "batch");
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
@@ -168,7 +167,7 @@ TEST(BatchMessageTest, testProducerTimeout) {
 }
 
 TEST(BatchMessageTest, testBatchSizeInBytes) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testBatchSizeInBytes";
+    std::string testName = std::to_string(epochTime) + "testBatchSizeInBytes";
     globalTestBatchMessagesCounter = 0;
 
     Client client(lookupUrl);
@@ -212,11 +211,9 @@ TEST(BatchMessageTest, testBatchSizeInBytes) {
     // Send Asynchronously
     std::string prefix = "12345678";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         ASSERT_EQ(producerStatsImplPtr->getNumMsgsSent(), i + 1);
         ASSERT_LT(PulsarFriend::sum(producerStatsImplPtr->getSendMap()), i + 1);
@@ -228,11 +225,11 @@ TEST(BatchMessageTest, testBatchSizeInBytes) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
         ASSERT_LT(pulsar::PulsarFriend::getBatchIndex(receivedMsg.getMessageId()), 2);
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
@@ -249,7 +246,7 @@ TEST(BatchMessageTest, testBatchSizeInBytes) {
 }
 
 TEST(BatchMessageTest, testSmallReceiverQueueSize) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testSmallReceiverQueueSize";
+    std::string testName = std::to_string(epochTime) + "testSmallReceiverQueueSize";
     globalTestBatchMessagesCounter = 0;
 
     ClientConfiguration clientConf;
@@ -301,11 +298,9 @@ TEST(BatchMessageTest, testSmallReceiverQueueSize) {
     // Send Asynchronously
     std::string prefix = testName;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         ASSERT_EQ(producerStatsImplPtr->getTotalMsgsSent(), i + 1);
         ASSERT_LE(PulsarFriend::sum(producerStatsImplPtr->getTotalSendMap()), i + 1);
@@ -316,10 +311,10 @@ TEST(BatchMessageTest, testSmallReceiverQueueSize) {
     int i = 0;
     for (i = 0; i < numOfMessages; i++) {
         consumer.receive(receivedMsg);
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
@@ -348,7 +343,7 @@ TEST(BatchMessageTest, testSmallReceiverQueueSize) {
 }
 
 TEST(BatchMessageTest, testIndividualAck) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testIndividualAck";
+    std::string testName = std::to_string(epochTime) + "testIndividualAck";
 
     ClientConfiguration clientConfig;
     clientConfig.setStatsIntervalInSeconds(1);
@@ -395,11 +390,9 @@ TEST(BatchMessageTest, testIndividualAck) {
     // Send Asynchronously
     std::string prefix = testName;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -407,10 +400,10 @@ TEST(BatchMessageTest, testIndividualAck) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Ack every 2nd message
         if (i % 2 == 0) {
@@ -431,10 +424,10 @@ TEST(BatchMessageTest, testIndividualAck) {
 
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Ack every first 5 and 10th message
         if (i <= 5 || i == 10) {
@@ -453,11 +446,10 @@ TEST(BatchMessageTest, testIndividualAck) {
 
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i + numOfMessages / 2);
+        std::string expectedMessageContent = prefix + std::to_string(i + numOfMessages / 2);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"),
-                  boost::lexical_cast<std::string>(i++ + numOfMessages / 2));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++ + numOfMessages / 2));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Ack first 4 message only
         if (i <= 4) {
@@ -476,11 +468,10 @@ TEST(BatchMessageTest, testIndividualAck) {
 
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i + numOfMessages / 2);
+        std::string expectedMessageContent = prefix + std::to_string(i + numOfMessages / 2);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"),
-                  boost::lexical_cast<std::string>(i++ + numOfMessages / 2));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++ + numOfMessages / 2));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Ack all
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
@@ -503,7 +494,7 @@ TEST(BatchMessageTest, testIndividualAck) {
 }
 
 TEST(BatchMessageTest, testCumulativeAck) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testCumulativeAck";
+    std::string testName = std::to_string(epochTime) + "testCumulativeAck";
 
     ClientConfiguration clientConfig;
     clientConfig.setStatsIntervalInSeconds(100);
@@ -553,11 +544,9 @@ TEST(BatchMessageTest, testCumulativeAck) {
     // Send Asynchronously
     std::string prefix = testName;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -566,10 +555,10 @@ TEST(BatchMessageTest, testCumulativeAck) {
     int i = 0;
     ConsumerStatsImplPtr consumerStatsImplPtr = PulsarFriend::getConsumerStatsPtr(consumer);
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Cumm. Ack 7th message
         if (i == 7) {
@@ -602,10 +591,10 @@ TEST(BatchMessageTest, testCumulativeAck) {
     consumerStatsImplPtr = PulsarFriend::getConsumerStatsPtr(consumer);
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i + 5);
+        std::string expectedMessageContent = prefix + std::to_string(i + 5);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++ + 5));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++ + 5));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Ack 10th message
         if (i == 10) {
@@ -632,7 +621,7 @@ TEST(BatchMessageTest, testCumulativeAck) {
 }
 
 TEST(BatchMessageTest, testMixedAck) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testMixedAck";
+    std::string testName = std::to_string(epochTime) + "testMixedAck";
 
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
@@ -676,11 +665,9 @@ TEST(BatchMessageTest, testMixedAck) {
     // Send Asynchronously
     std::string prefix = testName;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -688,10 +675,10 @@ TEST(BatchMessageTest, testMixedAck) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Cumm. Ack 14th message
         if (i == 14) {
@@ -712,10 +699,10 @@ TEST(BatchMessageTest, testMixedAck) {
 
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i + 10);
+        std::string expectedMessageContent = prefix + std::to_string(i + 10);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++ + 10));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++ + 10));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         // Cumm Ack 9th message
         if (i == 4) {
@@ -740,7 +727,7 @@ TEST(BatchMessageTest, testMixedAck) {
 // Also testing Cumulative Ack test case where greatestCumulativeAck returns
 // MessageId()
 TEST(BatchMessageTest, testPermits) {
-    std::string testName = boost::lexical_cast<std::string>(epochTime) + "testPermits";
+    std::string testName = std::to_string(epochTime) + "testPermits";
 
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
@@ -787,11 +774,9 @@ TEST(BatchMessageTest, testPermits) {
     // Send Asynchronously
     std::string prefix = testName;
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -801,10 +786,10 @@ TEST(BatchMessageTest, testPermits) {
     Message receivedMsg;
     int i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledgeCumulative(receivedMsg));
         ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
@@ -824,11 +809,9 @@ TEST(BatchMessageTest, testPermits) {
     globalTestBatchMessagesCounter = 0;
     // Send Asynchronously
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBack);
         LOG_DEBUG("sending message " << messageContent);
     }
@@ -839,10 +822,10 @@ TEST(BatchMessageTest, testPermits) {
 
     i = 0;
     while (consumer.receive(receivedMsg, 5000) == ResultOk) {
-        std::string expectedMessageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string expectedMessageContent = prefix + std::to_string(i);
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = "
                                                        << receivedMsg.getMessageId() << "]");
-        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i++));
+        ASSERT_EQ(receivedMsg.getProperty("msgIndex"), std::to_string(i++));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
         ASSERT_EQ(ResultOk, consumer.acknowledgeCumulative(receivedMsg));
     }
@@ -855,12 +838,12 @@ TEST(BatchMessageTest, testPermits) {
 
 TEST(BatchMessageTest, testPartitionedTopics) {
     Client client(lookupUrl);
-    std::string topicName = "persistent://public/default/test-partitioned-batch-messages-" +
-                            boost::lexical_cast<std::string>(epochTime);
+    std::string topicName =
+        "persistent://public/default/test-partitioned-batch-messages-" + std::to_string(epochTime);
 
     // call admin api to make it partitioned
     std::string url = adminUrl + "admin/v2/persistent/public/default/test-partitioned-batch-messages-" +
-                      boost::lexical_cast<std::string>(epochTime) + "/partitions";
+                      std::to_string(epochTime) + "/partitions";
     int res = makePutRequest(url, "7");
 
     LOG_DEBUG("res = " << res);
@@ -907,11 +890,9 @@ TEST(BatchMessageTest, testPartitionedTopics) {
     // Send Asynchronously
     std::string prefix = "msg-batch-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
-        Message msg = MessageBuilder()
-                          .setContent(messageContent)
-                          .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
-                          .build();
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty("msgIndex", std::to_string(i)).build();
         producer.sendAsync(msg, &sendCallBackExpectingErrors);
         LOG_DEBUG("sending message " << messageContent);
     }

--- a/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
+++ b/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
@@ -19,7 +19,6 @@
 #include <pulsar/Client.h>
 
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 
 #include "HttpHelper.h"
 
@@ -33,8 +32,8 @@ static std::string adminUrl = "http://localhost:8080/";
 TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
     Client client(serviceUrl);
 
-    std::string topicName = "persistent://public/dedup-1/testProducerSequenceAfterReconnect-" +
-                            boost::lexical_cast<std::string>(time(NULL));
+    std::string topicName =
+        "persistent://public/dedup-1/testProducerSequenceAfterReconnect-" + std::to_string(time(NULL));
 
     // call admin api to create namespace and enable deduplication
     std::string url = adminUrl + "admin/v2/namespaces/public/dedup-1";
@@ -64,7 +63,7 @@ TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
     ASSERT_EQ(producer.getLastSequenceId(), -1L);
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(producer.send(msg), ResultOk);
         ASSERT_EQ(producer.getLastSequenceId(), i);
@@ -76,7 +75,7 @@ TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
     ASSERT_EQ(producer.getLastSequenceId(), 9);
 
     for (int i = 10; i < 20; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(producer.send(msg), ResultOk);
         ASSERT_EQ(producer.getLastSequenceId(), i);
@@ -88,8 +87,8 @@ TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
 TEST(ClientDeduplicationTest, testProducerDeduplication) {
     Client client(adminUrl);
 
-    std::string topicName = "persistent://public/dedup-2/testProducerDeduplication-" +
-                            boost::lexical_cast<std::string>(time(NULL));
+    std::string topicName =
+        "persistent://public/dedup-2/testProducerDeduplication-" + std::to_string(time(NULL));
 
     std::string url = adminUrl + "admin/v2/namespaces/public/dedup-2";
     int res = makePutRequest(url, R"({"replication_clusters": ["standalone"]})");
@@ -131,7 +130,7 @@ TEST(ClientDeduplicationTest, testProducerDeduplication) {
     for (int i = 0; i < 3; i++) {
         consumer.receive(msg);
 
-        ASSERT_EQ(msg.getDataAsString(), "my-message-" + boost::lexical_cast<std::string>(i));
+        ASSERT_EQ(msg.getDataAsString(), "my-message-" + std::to_string(i));
         consumer.acknowledge(msg);
     }
 

--- a/pulsar-client-cpp/tests/ConsumerStatsTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerStatsTest.cc
@@ -18,7 +18,6 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <boost/lexical_cast.hpp>
 #include <lib/LogUtils.h>
 #include <lib/Commands.h>
 #include "boost/date_time/posix_time/posix_time.hpp"
@@ -58,7 +57,7 @@ void simpleCallbackFunction(Result result, BrokerConsumerStats brokerConsumerSta
 }
 TEST(ConsumerStatsTest, testBacklogInfo) {
     long epochTime = time(NULL);
-    std::string testName = "testBacklogInfo-" + boost::lexical_cast<std::string>(epochTime);
+    std::string testName = "testBacklogInfo-" + std::to_string(epochTime);
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
     std::string subName = "subscription-name";
@@ -86,7 +85,7 @@ TEST(ConsumerStatsTest, testBacklogInfo) {
 
     std::string prefix = testName + "-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -96,7 +95,7 @@ TEST(ConsumerStatsTest, testBacklogInfo) {
         boost::bind(simpleCallbackFunction, _1, _2, ResultOk, numOfMessages, ConsumerExclusive));
 
     for (int i = numOfMessages; i < (numOfMessages * 2); i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -113,7 +112,7 @@ TEST(ConsumerStatsTest, testBacklogInfo) {
 
 TEST(ConsumerStatsTest, testFailure) {
     long epochTime = time(NULL);
-    std::string testName = "testFailure-" + boost::lexical_cast<std::string>(epochTime);
+    std::string testName = "testFailure-" + std::to_string(epochTime);
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
     std::string subName = "subscription-name";
@@ -142,7 +141,7 @@ TEST(ConsumerStatsTest, testFailure) {
 
     std::string prefix = testName + "-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -158,7 +157,7 @@ TEST(ConsumerStatsTest, testFailure) {
 
 TEST(ConsumerStatsTest, testCachingMechanism) {
     long epochTime = time(NULL);
-    std::string testName = "testCachingMechanism-" + boost::lexical_cast<std::string>(epochTime);
+    std::string testName = "testCachingMechanism-" + std::to_string(epochTime);
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
     std::string subName = "subscription-name";
@@ -189,7 +188,7 @@ TEST(ConsumerStatsTest, testCachingMechanism) {
 
     std::string prefix = testName + "-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -200,7 +199,7 @@ TEST(ConsumerStatsTest, testCachingMechanism) {
     ASSERT_EQ(consumerStats.getMsgBacklog(), numOfMessages);
 
     for (int i = numOfMessages; i < (numOfMessages * 2); i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -233,7 +232,7 @@ TEST(ConsumerStatsTest, testCachingMechanism) {
 
 TEST(ConsumerStatsTest, testAsyncCallOnPartitionedTopic) {
     long epochTime = time(NULL);
-    std::string testName = "testAsyncCallOnPartitionedTopic-" + boost::lexical_cast<std::string>(epochTime);
+    std::string testName = "testAsyncCallOnPartitionedTopic-" + std::to_string(epochTime);
     Client client(lookupUrl);
     std::string topicName = "persistent://public/default/" + testName;
     std::string subName = "subscription-name";
@@ -275,7 +274,7 @@ TEST(ConsumerStatsTest, testAsyncCallOnPartitionedTopic) {
 
     std::string prefix = testName + "-";
     for (int i = 0; i < numOfMessages; i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }
@@ -286,7 +285,7 @@ TEST(ConsumerStatsTest, testAsyncCallOnPartitionedTopic) {
 
     // Now we have 10 messages per partition
     for (int i = numOfMessages; i < (numOfMessages * 2); i++) {
-        std::string messageContent = prefix + boost::lexical_cast<std::string>(i);
+        std::string messageContent = prefix + std::to_string(i);
         Message msg = MessageBuilder().build();
         producer.send(msg);
     }

--- a/pulsar-client-cpp/tests/ReaderTest.cc
+++ b/pulsar-client-cpp/tests/ReaderTest.cc
@@ -19,7 +19,6 @@
 #include <pulsar/Client.h>
 
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 
 #include <string>
 
@@ -43,7 +42,7 @@ TEST(ReaderTest, testSimpleReader) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -53,7 +52,7 @@ TEST(ReaderTest, testSimpleReader) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -71,7 +70,7 @@ TEST(ReaderTest, testReaderAfterMessagesWerePublished) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -85,7 +84,7 @@ TEST(ReaderTest, testReaderAfterMessagesWerePublished) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -103,7 +102,7 @@ TEST(ReaderTest, testMultipleReaders) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -120,7 +119,7 @@ TEST(ReaderTest, testMultipleReaders) {
         ASSERT_EQ(ResultOk, reader1.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -129,7 +128,7 @@ TEST(ReaderTest, testMultipleReaders) {
         ASSERT_EQ(ResultOk, reader2.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -148,7 +147,7 @@ TEST(ReaderTest, testReaderOnLastMessage) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -158,7 +157,7 @@ TEST(ReaderTest, testReaderOnLastMessage) {
     ASSERT_EQ(ResultOk, client.createReader(topicName, MessageId::latest(), readerConf, reader));
 
     for (int i = 10; i < 20; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -168,7 +167,7 @@ TEST(ReaderTest, testReaderOnLastMessage) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -186,7 +185,7 @@ TEST(ReaderTest, testReaderOnSpecificMessage) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -202,7 +201,7 @@ TEST(ReaderTest, testReaderOnSpecificMessage) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
 
         lastMessageId = msg.getMessageId();
@@ -216,7 +215,7 @@ TEST(ReaderTest, testReaderOnSpecificMessage) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -241,7 +240,7 @@ TEST(ReaderTest, testReaderOnSpecificMessageWithBatches) {
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConf, producer));
 
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         producer.sendAsync(msg, NULL);
     }
@@ -262,7 +261,7 @@ TEST(ReaderTest, testReaderOnSpecificMessageWithBatches) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
 
         msg.getMessageId().serialize(lastMessageId);
@@ -278,7 +277,7 @@ TEST(ReaderTest, testReaderOnSpecificMessageWithBatches) {
         ASSERT_EQ(ResultOk, reader2.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string expected = "my-message-" + std::to_string(i);
         ASSERT_EQ(expected, content);
     }
 
@@ -312,7 +311,7 @@ TEST(ReaderTest, testReaderReachEndOfTopic) {
 
     // 3. produce 10 messages.
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -327,7 +326,7 @@ TEST(ReaderTest, testReaderReachEndOfTopic) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(readMessageCount);
+        std::string expected = "my-message-" + std::to_string(readMessageCount);
         ASSERT_EQ(expected, content);
         reader.hasMessageAvailable(hasMessageAvailable);
     }
@@ -338,7 +337,7 @@ TEST(ReaderTest, testReaderReachEndOfTopic) {
     // 5. produce another 10 messages, expect hasMessageAvailable return true,
     //    and after read these 10 messages out, it return false.
     for (int i = 10; i < 20; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
@@ -351,7 +350,7 @@ TEST(ReaderTest, testReaderReachEndOfTopic) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(readMessageCount);
+        std::string expected = "my-message-" + std::to_string(readMessageCount);
         ASSERT_EQ(expected, content);
         reader.hasMessageAvailable(hasMessageAvailable);
     }
@@ -385,7 +384,7 @@ TEST(ReaderTest, testReaderReachEndOfTopicMessageWithoutBatches) {
 
     // 3. produce 10 messages in batches way.
     for (int i = 0; i < 10; i++) {
-        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        std::string content = "my-message-" + std::to_string(i);
         Message msg = MessageBuilder().setContent(content).build();
         producer.sendAsync(msg, NULL);
     }
@@ -405,7 +404,7 @@ TEST(ReaderTest, testReaderReachEndOfTopicMessageWithoutBatches) {
         ASSERT_EQ(ResultOk, reader.readNext(msg));
 
         std::string content = msg.getDataAsString();
-        std::string expected = "my-message-" + boost::lexical_cast<std::string>(readMessageCount);
+        std::string expected = "my-message-" + std::to_string(readMessageCount);
         ASSERT_EQ(expected, content);
         reader.hasMessageAvailable(hasMessageAvailable);
         msg.getMessageId().serialize(lastMessageId);


### PR DESCRIPTION
### Motivation

Use C++11 `std::to_string` and `std::stoi` instead of `boost::lexical_cast`