### PR TITLE
Add BC Testing for prior client versions

### DIFF
--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.pulsar.tests</groupId>
+        <artifactId>tests-parent</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bc_2_0_0</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache Pulsar :: Tests :: Backwards Client Compatibility 2.0.0-rc1-incubating</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>2.0.0-rc1-incubating</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- only run tests when -DintegrationTests is specified //-->
+                    <skipTests>true</skipTests>
+                    <systemPropertyVariables>
+                        <currentVersion>${project.version}</currentVersion>
+                        <maven.buildDirectory>${project.build.directory}</maven.buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>integrationTests</id>
+            <activation>
+                <property>
+                    <name>integrationTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>testRetryCount</name>
+                                    <value>0</value>
+                                </property>
+                                <property>
+                                    <name>listener</name>
+                                    <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener</value>
+                                </property>
+                            </properties>
+                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                                -Dio.netty.leakDetectionLevel=advanced
+                            </argLine>
+                            <skipTests>false</skipTests>
+                            <suiteXmlFiles>
+                                <file>src/test/resources/pulsar.xml</file>
+                            </suiteXmlFiles>
+                            <forkCount>1</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/PulsarContainer.java
+++ b/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/PulsarContainer.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+public class PulsarContainer extends GenericContainer<PulsarContainer> {
+
+    public static final int PULSAR_PORT = 6650;
+    public static final int BROKER_HTTP_PORT = 8080;
+    public static final String DEFAULT_IMAGE_NAME = "apachepulsar/pulsar-test-latest-version:latest";
+
+    public PulsarContainer() {
+        this(DEFAULT_IMAGE_NAME);
+    }
+
+    public PulsarContainer(final String pulsarVersion) {
+        super(pulsarVersion);
+        withExposedPorts(BROKER_HTTP_PORT, PULSAR_PORT);
+        withCommand("/pulsar/bin/pulsar standalone");
+        waitingFor(new HttpWaitStrategy()
+                .forPort(BROKER_HTTP_PORT)
+                .forStatusCode(200)
+                .forPath("/admin/v2/namespaces/public/default")
+                .withStartupTimeout(Duration.of(300, SECONDS)));
+    }
+
+    public String getPlainTextPulsarBrokerUrl() {
+        return String.format("pulsar://%s:%s", this.getContainerIpAddress(), this.getMappedPort(PULSAR_PORT));
+    }
+
+}

--- a/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class SmokeTest {
+
+    private PulsarContainer pulsarContainer;
+
+    @BeforeClass
+    public void setup(){
+        pulsarContainer = new PulsarContainer();
+        pulsarContainer.start();
+    }
+
+    @Test
+    public void checkMessages() throws PulsarClientException {
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsarContainer.getPlainTextPulsarBrokerUrl())
+                .build();
+
+        final String inputTopic = "input";
+
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(inputTopic)
+                .enableBatching(false)
+                .create();
+
+        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(inputTopic)
+                .subscriptionName("test-subs")
+                .ackTimeout(10, TimeUnit.SECONDS)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscribe();
+
+        producer.send("Hello!");
+        Message<String> message = consumer.receive(10, TimeUnit.SECONDS);
+
+        Assert.assertEquals(message.getValue(), "Hello!");
+
+    }
+
+    @AfterClass
+    public void cleanup(){
+        pulsarContainer.stop();
+    }
+
+}

--- a/tests/bc_2_0_0/src/test/resources/pulsar.xml
+++ b/tests/bc_2_0_0/src/test/resources/pulsar.xml
@@ -1,0 +1,30 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Standalone Tests" verbose="2" annotations="JDK">
+    <test name="pulsar-standalone-suite" preserve-order="true" >
+        <classes>
+            <class name="org.apache.pulsar.tests.integration.SmokeTest" />
+        </classes>
+    </test>
+</suite>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.pulsar.tests</groupId>
+        <artifactId>tests-parent</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bc_2_0_1</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache Pulsar :: Tests :: Backwards Client Compatibility 2.0.1-incubating</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>2.0.1-incubating</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- only run tests when -DintegrationTests is specified //-->
+                    <skipTests>true</skipTests>
+                    <systemPropertyVariables>
+                        <currentVersion>${project.version}</currentVersion>
+                        <maven.buildDirectory>${project.build.directory}</maven.buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>integrationTests</id>
+            <activation>
+                <property>
+                    <name>integrationTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>testRetryCount</name>
+                                    <value>0</value>
+                                </property>
+                                <property>
+                                    <name>listener</name>
+                                    <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener</value>
+                                </property>
+                            </properties>
+                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                                -Dio.netty.leakDetectionLevel=advanced
+                            </argLine>
+                            <skipTests>false</skipTests>
+                            <suiteXmlFiles>
+                                <file>src/test/resources/pulsar.xml</file>
+                            </suiteXmlFiles>
+                            <forkCount>1</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/PulsarContainer.java
+++ b/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/PulsarContainer.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+public class PulsarContainer extends GenericContainer<PulsarContainer> {
+
+    public static final int PULSAR_PORT = 6650;
+    public static final int BROKER_HTTP_PORT = 8080;
+    public static final String DEFAULT_IMAGE_NAME = "apachepulsar/pulsar-test-latest-version:latest";
+
+    public PulsarContainer() {
+        this(DEFAULT_IMAGE_NAME);
+    }
+
+    public PulsarContainer(final String pulsarVersion) {
+        super(pulsarVersion);
+        withExposedPorts(BROKER_HTTP_PORT, PULSAR_PORT);
+        withCommand("/pulsar/bin/pulsar standalone");
+        waitingFor(new HttpWaitStrategy()
+                .forPort(BROKER_HTTP_PORT)
+                .forStatusCode(200)
+                .forPath("/admin/v2/namespaces/public/default")
+                .withStartupTimeout(Duration.of(300, SECONDS)));
+    }
+
+    public String getPlainTextPulsarBrokerUrl() {
+        return String.format("pulsar://%s:%s", this.getContainerIpAddress(), this.getMappedPort(PULSAR_PORT));
+    }
+
+}

--- a/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class SmokeTest {
+
+    private PulsarContainer pulsarContainer;
+
+    @BeforeClass
+    public void setup(){
+        pulsarContainer = new PulsarContainer();
+        pulsarContainer.start();
+    }
+
+    @Test
+    public void checkMessages() throws PulsarClientException {
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsarContainer.getPlainTextPulsarBrokerUrl())
+                .build();
+
+        final String inputTopic = "input";
+
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(inputTopic)
+                .enableBatching(false)
+                .create();
+
+        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(inputTopic)
+                .subscriptionName("test-subs")
+                .ackTimeout(10, TimeUnit.SECONDS)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscribe();
+
+        producer.send("Hello!");
+        Message<String> message = consumer.receive(10, TimeUnit.SECONDS);
+
+        Assert.assertEquals(message.getValue(), "Hello!");
+
+    }
+
+    @AfterClass
+    public void cleanup(){
+        pulsarContainer.stop();
+    }
+
+}

--- a/tests/bc_2_0_1/src/test/resources/pulsar.xml
+++ b/tests/bc_2_0_1/src/test/resources/pulsar.xml
@@ -1,0 +1,30 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Standalone Tests" verbose="2" annotations="JDK">
+    <test name="pulsar-standalone-suite" preserve-order="true" >
+        <classes>
+            <class name="org.apache.pulsar.tests.integration.SmokeTest" />
+        </classes>
+    </test>
+</suite>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,6 +37,8 @@
     <module>pulsar-kafka-compat-client-test</module>
     <module>pulsar-storm-test</module>
     <module>pulsar-spark-test</module>
+    <module>bc_2_0_0</module>
+    <module>bc_2_0_1</module>
   </modules>
   <build>
     <plugins>


### PR DESCRIPTION
Add a simple test harness linked to pulsar client 2.2.0 for backwards compatibility testing.