### PR TITLE
Issue 3457: Do not set HierarchicalLedgerManagerFactory explicitly

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -403,7 +403,7 @@ pageLimit=0
 # Ledger Manager Class
 # What kind of ledger manager is used to manage how ledgers are stored, managed
 # and garbage collected. Try to read 'BookKeeper Internals' for detail info.
-ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
+# ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
 
 # @Drepcated - `ledgerManagerType` is deprecated in favor of using `ledgerManagerFactoryClass`.
 # ledgerManagerType=hierarchical

--- a/deployment/terraform-ansible/templates/bookkeeper.conf
+++ b/deployment/terraform-ansible/templates/bookkeeper.conf
@@ -403,7 +403,7 @@ pageLimit=0
 # Ledger Manager Class
 # What kind of ledger manager is used to manage how ledgers are stored, managed
 # and garbage collected. Try to read 'BookKeeper Internals' for detail info.
-ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
+# ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
 
 # @Drepcated - `ledgerManagerType` is deprecated in favor of using `ledgerManagerFactoryClass`.
 # ledgerManagerType=hierarchical

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -146,7 +146,6 @@ public class PulsarClusterMetadataSetup {
 
         // Format BookKeeper ledger storage metadata
         ServerConfiguration bkConf = new ServerConfiguration();
-        bkConf.setLedgerManagerFactoryClass(HierarchicalLedgerManagerFactory.class);
         bkConf.setZkServers(arguments.zookeeper);
         bkConf.setZkTimeout(arguments.zkSessionTimeoutMillis);
         if (localZk.exists("/ledgers", false) == null // only format if /ledgers doesn't exist

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -27,7 +27,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping;
 import org.apache.pulsar.zookeeper.ZkIsolatedBookieEnsemblePlacementPolicy;
 import org.apache.pulsar.zookeeper.ZooKeeperCache;
@@ -56,7 +55,6 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setNumChannelsPerBookie(16);
         bkConf.setUseV2WireProtocol(conf.isBookkeeperUseV2WireProtocol());
         bkConf.setEnableDigestTypeAutodetection(true);
-        bkConf.setLedgerManagerFactoryClassName(HierarchicalLedgerManagerFactory.class.getName());
         if (conf.isBookkeeperClientHealthCheckEnabled()) {
             bkConf.enableBookieHealthCheck();
             bkConf.setBookieHealthCheckInterval(conf.getBookkeeperHealthCheckIntervalSec(), TimeUnit.SECONDS);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -51,7 +51,6 @@ import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -161,7 +160,6 @@ public class ManagedLedgerWriter {
 
         ClientConfiguration bkConf = new ClientConfiguration();
         bkConf.setUseV2WireProtocol(true);
-        bkConf.setLedgerManagerFactoryClass(HierarchicalLedgerManagerFactory.class);
         bkConf.setAddEntryTimeout(30);
         bkConf.setReadEntryTimeout(30);
         bkConf.setThrottleValue(0);

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -352,7 +352,6 @@ public class LocalBookkeeperEnsemble {
     public void start() throws Exception {
         LOG.debug("Local ZK/BK starting ...");
         ServerConfiguration conf = new ServerConfiguration();
-        conf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
         // Use minimal configuration requiring less memory for unit tests
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         conf.setProperty("dbStorage_writeCacheMaxSizeMb", 2);
@@ -376,7 +375,6 @@ public class LocalBookkeeperEnsemble {
 
     public void startStandalone(ServerConfiguration conf, boolean enableStreamStorage) throws Exception {
         LOG.debug("Local ZK/BK starting ...");
-        conf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
         conf.setAdvertisedAddress(advertisedAddress);
 
         runZookeeper(1000);


### PR DESCRIPTION
- Do not set HierarchicalLedgerManagerFactory explicitly, this way BookKeeper will auto detect the LedgerManagerFactory from the existing cluster
- The default in BookKeeper 4.7+ is still HierarchicalLedgerManagerFactory

Signed-off-by: Enrico Olivelli <eolivelli@apache.org>

Fixes #3457 

### Motivation

- Do not set HierarchicalLedgerManagerFactory explicitly, this way BookKeeper will auto detect the LedgerManagerFactory from the existing cluster
- The default in BookKeeper 4.7+ is still HierarchicalLedgerManagerFactory

### Modifications
- Do not set HierarchicalLedgerManagerFactory explicitly, this way BookKeeper will auto detect the LedgerManagerFactory from the existing cluster
- The default in BookKeeper 4.7+ is still HierarchicalLedgerManagerFactory

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes

