### PR TITLE
[docs] Fix broken link in the dashboard's readme

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -25,4 +25,4 @@ Pulsar dashboard is a web application that monitors
 a complete instance of Pulsar and gives insights
 about about all the topics.
 
-See [docs/Dashboard.md](https://github.com/apache/pulsar/blob/master/docs/Dashboard.md) for more information.
+See [site2/docs/administration-dashboard.md](https://github.com/apache/pulsar/blob/master/site2/docs/administration-dashboard.md) for more information.


### PR DESCRIPTION
### Modifications

I think the link in the readme has been broken for quite some time.