### PR TITLE
Upgrade BouncyCastle to 1.60

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -546,9 +546,9 @@ Public Domain (CC0) -- licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.55.jar
-    - org.bouncycastle-bcprov-jdk15on-1.55.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.59.jar
+    - org.bouncycastle-bcpkix-jdk15on-1.60.jar
+    - org.bouncycastle-bcprov-jdk15on-1.60.jar
+    - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
-    <bouncycastle.version>1.55</bouncycastle.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <jackson.version>2.9.7</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
@@ -542,7 +542,7 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>jersey-hk2</artifactId>
@@ -762,7 +762,7 @@ flexible messaging model and an intuitive client API.</description>
           </exclusion>
         </exclusions>
       </dependency>
-      
+
       <dependency>
         <groupId>io.jsonwebtoken</groupId>
         <artifactId>jjwt-api</artifactId>
@@ -794,6 +794,12 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-ext-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -487,5 +487,5 @@ Public Domain (CC0) -- licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk15on-1.55.jar
-    - bcprov-jdk15on-1.55.jar
+    - bcpkix-jdk15on-1.60.jar
+    - bcprov-jdk15on-1.60.jar


### PR DESCRIPTION
### Motivation

As reported in #3493, there are security vulnerabilities in BouncyCastle 1.55. Updating to latest available version which has fixes for all these CVEs.