### PR TITLE
allow users to set the image pull policy for kubernetes runtime

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -117,6 +117,7 @@ class KubernetesRuntime implements Runtime {
     private final String jobNamespace;
     private final Map<String, String> customLabels;
     private final String pulsarDockerImageName;
+    private final String imagePullPolicy;
     private final String pulsarRootDir;
     private final String userCodePkgUrl;
     private final String originalCodeFileName;
@@ -133,6 +134,7 @@ class KubernetesRuntime implements Runtime {
                       String pythonDependencyRepository,
                       String pythonExtraDependencyRepository,
                       String pulsarDockerImageName,
+                      String imagePullPolicy,
                       String pulsarRootDir,
                       InstanceConfig instanceConfig,
                       String instanceFile,
@@ -152,6 +154,7 @@ class KubernetesRuntime implements Runtime {
         this.jobNamespace = jobNamespace;
         this.customLabels = customLabels;
         this.pulsarDockerImageName = pulsarDockerImageName;
+        this.imagePullPolicy = imagePullPolicy;
         this.pulsarRootDir = pulsarRootDir;
         this.userCodePkgUrl = userCodePkgUrl;
         this.originalCodeFileName = pulsarRootDir + "/" + originalCodeFileName;
@@ -614,6 +617,7 @@ class KubernetesRuntime implements Runtime {
 
         // set up the container images
         container.setImage(pulsarDockerImageName);
+        container.setImagePullPolicy(imagePullPolicy);
 
         // set up the container command
         container.setCommand(instanceCommand);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
@@ -57,6 +57,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         private String k8Uri;
         private String jobNamespace;
         private String pulsarDockerImageName;
+        private String imagePullPolicy;
         private String pulsarRootDir;
         private String pulsarAdminUrl;
         private String pulsarServiceUrl;
@@ -86,6 +87,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     public KubernetesRuntimeFactory(String k8Uri,
                                     String jobNamespace,
                                     String pulsarDockerImageName,
+                                    String imagePullPolicy,
                                     String pulsarRootDir,
                                     Boolean submittingInsidePod,
                                     Boolean installUserCodeDependencies,
@@ -112,6 +114,11 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             this.kubernetesInfo.setPulsarDockerImageName(pulsarDockerImageName);
         } else {
             this.kubernetesInfo.setPulsarDockerImageName("apachepulsar/pulsar");
+        }
+        if (!isEmpty(imagePullPolicy)) {
+            this.kubernetesInfo.setImagePullPolicy(imagePullPolicy);
+        } else {
+            this.kubernetesInfo.setImagePullPolicy("IfNotPresent");
         }
         if (!isEmpty(pulsarRootDir)) {
             this.kubernetesInfo.setPulsarRootDir(pulsarRootDir);
@@ -176,6 +183,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             this.kubernetesInfo.getPythonDependencyRepository(),
             this.kubernetesInfo.getPythonExtraDependencyRepository(),
             this.kubernetesInfo.getPulsarDockerImageName(),
+            this.kubernetesInfo.imagePullPolicy,
             this.kubernetesInfo.getPulsarRootDir(),
             instanceConfig,
             instanceFile,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
@@ -131,6 +131,7 @@ public class KubernetesRuntimeFactoryTest {
             null,
             null,
             null,
+            null,
             pulsarRootDir,
             false,
             true,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -140,6 +140,7 @@ public class KubernetesRuntimeTest {
             null,
             null,
             null,
+            null,
             pulsarRootDir,
             false,
             true,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -150,6 +150,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     workerConfig.getKubernetesContainerFactory().getK8Uri(),
                     workerConfig.getKubernetesContainerFactory().getJobNamespace(),
                     workerConfig.getKubernetesContainerFactory().getPulsarDockerImageName(),
+                    workerConfig.getKubernetesContainerFactory().getImagePullPolicy(),
                     workerConfig.getKubernetesContainerFactory().getPulsarRootDir(),
                     workerConfig.getKubernetesContainerFactory().getSubmittingInsidePod(),
                     workerConfig.getKubernetesContainerFactory().getInstallUserCodeDependencies(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -344,10 +344,15 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "The docker image used to run function instance. By default it is `apachepulsar/pulsar`"
         )
         private String pulsarDockerImageName;
+
         @FieldContext(
-            doc = "The root directory of pulsar home directory in the pulsar docker image specified"
-                + " `pulsarDockerImageName`. By default it is under `/pulsar`. If you are using your own"
-                + " customized image in `pulsarDockerImageName`, you need to set this setting accordingly"
+                doc = "The image pull policy for image used to run function instance. By default it is `IfNotPresent`"
+        )
+        private String imagePullPolicy;
+        @FieldContext(
+                doc = "The root directory of pulsar home directory in the pulsar docker image specified"
+                        + " `pulsarDockerImageName`. By default it is under `/pulsar`. If you are using your own"
+                        + " customized image in `pulsarDockerImageName`, you need to set this setting accordingly"
         )
         private String pulsarRootDir;
         @FieldContext(


### PR DESCRIPTION
### Motivation

Currently there is no way to modify the the image pull policy for the kubernetes runtime. Users may want to adjust the setting to suit their  deployment environment

### Modifications

Add a config that allows users the specify the image pull policy
