### PR TITLE
Functions of externally managed runtimes shouldn't need to restart when changing assignments

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -614,17 +614,24 @@ public class FunctionRuntimeManager implements AutoCloseable{
         // potential updates need to happen
         if (!existingAssignment.equals(assignment)) {
             FunctionRuntimeInfo functionRuntimeInfo = this.functionRuntimeInfoMap.get(fullyQualifiedInstanceId);
-            //stop function
-            if (functionRuntimeInfo != null) {
-                this.insertStopAction(functionRuntimeInfo);
-            }
-            // still assigned to me, need to restart
-            if (assignment.getWorkerId().equals(this.workerConfig.getWorkerId())) {
-                //start again
-                FunctionRuntimeInfo newFunctionRuntimeInfo = new FunctionRuntimeInfo();
-                newFunctionRuntimeInfo.setFunctionInstance(assignment.getInstance());
-                this.insertStartAction(newFunctionRuntimeInfo);
-                this.setFunctionRuntimeInfo(fullyQualifiedInstanceId, newFunctionRuntimeInfo);
+
+            // for externally managed functions we don't really care about which worker the function instance is assigned to
+            // and we don't really need to stop and start the function instance because the worker its assigned to changed
+            // we just need to update the locally cached assignment info.  We only need to stop and start when there are
+            // changes to the function meta data of the instance
+            if (!runtimeFactory.externallyManaged() || !assignment.getInstance().equals(existingAssignment.getInstance())) {
+                //stop function
+                if (functionRuntimeInfo != null) {
+                    this.insertStopAction(functionRuntimeInfo);
+                }
+                // still assigned to me, need to restart
+                if (assignment.getWorkerId().equals(this.workerConfig.getWorkerId())) {
+                    //start again
+                    FunctionRuntimeInfo newFunctionRuntimeInfo = new FunctionRuntimeInfo();
+                    newFunctionRuntimeInfo.setFunctionInstance(assignment.getInstance());
+                    this.insertStartAction(newFunctionRuntimeInfo);
+                    this.setFunctionRuntimeInfo(fullyQualifiedInstanceId, newFunctionRuntimeInfo);
+                }
             }
 
             // find existing assignment

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -78,7 +78,6 @@ public class FunctionRuntimeManagerTest {
         WorkerService workerService = mock(WorkerService.class);
         doReturn(pulsarClient).when(workerService).getClient();
         doReturn(mock(PulsarAdmin.class)).when(workerService).getFunctionAdmin();
-
         // test new assignment add functions
         FunctionRuntimeManager functionRuntimeManager = spy(new FunctionRuntimeManager(
                 workerConfig,
@@ -216,8 +215,6 @@ public class FunctionRuntimeManagerTest {
         functionRuntimeManager.processAssignment(assignment2);
 
         functionRuntimeManager.deleteAssignment(org.apache.pulsar.functions.utils.Utils.getFullyQualifiedInstanceId(assignment1.getInstance()));
-
-
         verify(functionRuntimeManager, times(0)).setAssignment(any(Function.Assignment.class));
         verify(functionRuntimeManager, times(1)).deleteAssignment(any(String.class));
 


### PR DESCRIPTION

### Motivation

For externally managed functions, there is really no point in stopping and starting a function instance if there is no change to the metadata of the function but the function instance got rescheduled to other worker.

