### PR TITLE
Replaced boost::array with std::array

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -20,7 +20,6 @@
 
 #include "PulsarApi.pb.h"
 
-#include <boost/array.hpp>
 #include <iostream>
 #include <algorithm>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/pulsar-client-cpp/lib/SharedBuffer.h
+++ b/pulsar-client-cpp/lib/SharedBuffer.h
@@ -19,9 +19,9 @@
 #ifndef LIB_SHARED_BUFFER_H_
 #define LIB_SHARED_BUFFER_H_
 
-#include <boost/array.hpp>
 #include <boost/asio.hpp>
 
+#include <array>
 #include <vector>
 
 namespace pulsar {
@@ -223,8 +223,8 @@ class CompositeSharedBuffer {
     const boost::asio::const_buffer* end() const { return begin() + Size; }
 
    private:
-    boost::array<SharedBuffer, Size> sharedBuffers_;
-    boost::array<boost::asio::const_buffer, Size> asioBuffers_;
+    std::array<SharedBuffer, Size> sharedBuffers_;
+    std::array<boost::asio::const_buffer, Size> asioBuffers_;
 };
 
 typedef CompositeSharedBuffer<2> PairSharedBuffer;

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
@@ -21,10 +21,12 @@
 
 #include <lib/LogUtils.h>
 
+#include <array>
+
 namespace pulsar {
 DECLARE_LOG_OBJECT();
 
-static const boost::array<double, 4> probs = {0.5, 0.9, 0.99, 0.999};
+static const std::array<double, 4> probs = {0.5, 0.9, 0.99, 0.999};
 
 std::string ProducerStatsImpl::latencyToString(const LatencyAccumulator& obj) {
     boost::accumulators::detail::extractor_result<

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -33,7 +33,6 @@
 #include <boost/accumulators/statistics.hpp>
 #include <boost/accumulators/framework/accumulator_set.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
-#include <boost/array.hpp>
 
 #include <boost/date_time/local_time/local_time.hpp>
 #include <memory>


### PR DESCRIPTION
### Motivation

Replace `boost::array` with regular C++11 `std::array`