### PR TITLE
allow function state storage url to configurable in standalone deployment

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -282,9 +282,9 @@ public class PulsarStandalone implements AutoCloseable {
                     : PulsarService.webAddress(localhost, config.getWebServicePort().get());
             workerConfig.setPulsarServiceUrl(pulsarServiceUrl);
             workerConfig.setPulsarWebServiceUrl(webServiceUrl);
-            if (!this.isNoStreamStorage()) {
+            if (this.isNoStreamStorage()) {
                 // only set the state storage service url when state is enabled.
-                workerConfig.setStateStorageServiceUrl("bk://127.0.0.1:" + this.getStreamStoragePort());
+                workerConfig.setStateStorageServiceUrl(null);
             }
             String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                 config.getAdvertisedAddress());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -285,7 +285,10 @@ public class PulsarStandalone implements AutoCloseable {
             if (this.isNoStreamStorage()) {
                 // only set the state storage service url when state is enabled.
                 workerConfig.setStateStorageServiceUrl(null);
+            } else if (workerConfig.getStateStorageServiceUrl() == null) {
+                workerConfig.setStateStorageServiceUrl("bk://127.0.0.1:" + this.getStreamStoragePort());
             }
+            
             String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                 config.getAdvertisedAddress());
             workerConfig.setWorkerHostname(hostname);


### PR DESCRIPTION
### Motivation

Currently, the logic for setting storateStateServiceUrl in the worker is not correct and not configurable.

