### PR TITLE
Upgrade AsyncHTTP client to 2.7.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -392,8 +392,8 @@ The Apache Software License, Version 2.0
     - org.apache.bookkeeper.stats-codahale-metrics-provider-4.7.3.jar
  * LZ4 -- org.lz4-lz4-java-1.5.0.jar
  * AsyncHttpClient
-    - org.asynchttpclient-async-http-client-2.1.0-alpha26.jar
-    - org.asynchttpclient-async-http-client-netty-utils-2.1.0-alpha26.jar
+    - org.asynchttpclient-async-http-client-2.7.0.jar
+    - org.asynchttpclient-async-http-client-netty-utils-2.7.0.jar
  * Jetty
     - org.eclipse.jetty-jetty-client-9.4.12.v20180830.jar
     - org.eclipse.jetty-jetty-continuation-9.4.12.v20180830.jar

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
-        <version>2.1.0-alpha26</version>
+        <version>2.7.0</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
### Motivation

We're still using a quite old alpha version of Async HTTP client lib. Move to latest stable version.