### PR TITLE
Replaces boost::regex with std::regex

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ else()
     endif (USE_LOG4CXX)
 endif (LINK_STATIC)
 
-find_package(Boost REQUIRED COMPONENTS program_options filesystem regex system)
+find_package(Boost REQUIRED COMPONENTS program_options filesystem system)
 
 if (BUILD_PYTHON_WRAPPER)
     find_package(PythonLibs REQUIRED)
@@ -209,12 +209,7 @@ set(COMMON_LIBS
   ${COMMON_LIBS} -lpthread -lm
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_REGEX_LIBRARY}
-  ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
-  ${Boost_CHRONO_LIBRARY}
-  ${Boost_DATE_TIME_LIBRARY}
-  ${Boost_ATOMIC_LIBRARY}
   ${CURL_LIBRARY_PATH}
   ${OPENSSL_LIBRARIES}
   ${ZLIB_LIBRARY_PATH}

--- a/pulsar-client-cpp/lib/NamedEntity.cc
+++ b/pulsar-client-cpp/lib/NamedEntity.cc
@@ -18,8 +18,9 @@
  */
 #include "NamedEntity.h"
 
-const boost::regex NamedEntity::pattern = boost::regex("^[-=:.\\w]*$");
+#include <regex>
 
 bool NamedEntity::checkName(const std::string& name) {
-    return boost::regex_match(name, pattern) ? true : false;
+    static const std::regex pattern = std::regex("^[-=:.\\w]*$");
+    return std::regex_match(name, pattern) ? true : false;
 }

--- a/pulsar-client-cpp/lib/NamedEntity.h
+++ b/pulsar-client-cpp/lib/NamedEntity.h
@@ -19,12 +19,9 @@
 #ifndef _PULSAR_NAMED_ENTITY_HEADER_
 #define _PULSAR_NAMED_ENTITY_HEADER_
 
-#include <boost/regex.hpp>
+#include <string>
 
 class NamedEntity {
-   private:
-    static const boost::regex pattern;
-
    public:
     static bool checkName(const std::string& name);
 };

--- a/pulsar-client-cpp/lib/Url.cc
+++ b/pulsar-client-cpp/lib/Url.cc
@@ -18,8 +18,10 @@
  */
 #include "Url.h"
 
-#include <boost/regex.hpp>
+#include <regex>
 #include <iostream>
+#include <map>
+#include <sstream>
 
 namespace pulsar {
 
@@ -39,14 +41,14 @@ static const std::map<std::string, int>& defaultPortsMap() {
 
 bool Url::parse(const std::string& urlStr, Url& url) {
     std::vector<std::string> values;
-    static const boost::regex expression(
+    static const std::regex expression(
         //       proto                 host               port
         "^(\?:([^:/\?#]+)://)\?(\\w+[^/\?#:]*)(\?::(\\d+))\?"
         //       path                  file       parameters
         "(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)\?(\\\?(.*))\?");
 
-    boost::cmatch groups;
-    if (!boost::regex_match(urlStr.c_str(), groups, expression)) {
+    std::cmatch groups;
+    if (!std::regex_match(urlStr.c_str(), groups, expression)) {
         // Invalid url
         return false;
     }

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -352,14 +352,16 @@ PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     PrivateKeyUri uriSt;
     // scheme mediatype[;base64] path file
     static const std::regex expression(
-        "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
+        R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?(\/[^?#]+)?)");
+
     std::cmatch groups;
     if (std::regex_match(uri, groups, expression)) {
         uriSt.scheme = groups.str(1);
         uriSt.mediaTypeAndEncodingType = groups.str(2);
-        uriSt.data = groups.str(4);
-        uriSt.path = groups.str(3) + groups.str(4);
+        uriSt.data = groups.str(3);
+        uriSt.path = groups.str(4);
     }
+
     return uriSt;
 }
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -33,7 +33,7 @@
 #include <json/value.h>
 #include <json/reader.h>
 
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/xpressive/xpressive.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -351,10 +351,10 @@ const std::string ZTSClient::getHeader() const { return roleHeader_; }
 PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     PrivateKeyUri uriSt;
     // scheme mediatype[;base64] path file
-    static const boost::regex expression(
+    static const std::regex expression(
         "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
-    boost::cmatch groups;
-    if (boost::regex_match(uri, groups, expression)) {
+    std::cmatch groups;
+    if (std::regex_match(uri, groups, expression)) {
         uriSt.scheme = groups.str(1);
         uriSt.mediaTypeAndEncodingType = groups.str(2);
         uriSt.data = groups.str(4);

--- a/pulsar-client-cpp/tests/ZTSClientTest.cc
+++ b/pulsar-client-cpp/tests/ZTSClientTest.cc
@@ -39,7 +39,7 @@ TEST(ZTSClientTest, testZTSClient) {
     {
         PrivateKeyUri uri = ZTSClientWrapper::parseUri("file:///path/to/private.key");
         ASSERT_EQ("file", uri.scheme);
-        ASSERT_EQ("///path/to/private.key", uri.path);
+        ASSERT_EQ("/path/to/private.key", uri.path);
     }
 
     {


### PR DESCRIPTION
### Motivation

Convert from `boost::regex` to C++11 `std::regex` and remove linking against boost regex library.