### PR TITLE
Issue 3230:  auto update topic partitions extend for consumer and producer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -696,15 +696,13 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
             .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
             .enableBatching(false)
-            .trackPartitionUpdate(true)
-            .partitionAutoUpdatePeriod(10) // set 10 minutes, so will not auto trigger.
+            .autoUpdatePartitions(true)
             .create();
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
             .subscriptionName("my-partitioned-subscriber")
             .subscriptionType(SubscriptionType.Shared)
-            .trackPartitionUpdate(true)
-            .partitionAutoUpdatePeriod(10) // set 10 minutes, so will not auto trigger.
+            .autoUpdatePartitions(true)
             .subscribe();
 
         // 1. produce and consume 2 partitions

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import io.netty.util.Timeout;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.PartitionedProducerImpl;
 import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.common.naming.TopicName;
@@ -666,6 +668,118 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(pulsarClient.getPartitionsForTopic(nonPartitionedTopic).join(),
                 Collections.singletonList(nonPartitionedTopic));
     }
+
+
+    /**
+     * It verifies that consumer producer auto update for partitions extend.
+     *
+     * Steps:
+     * 1. create topic with 2 partitions, and producer consumer
+     * 2. update partition from 2 to 3.
+     * 3. trigger auto update in producer, after produce, consumer will only get messages from 2 partitions.
+     * 4. trigger auto update in consumer, after produce, consumer will get all messages from 3 partitions.
+     *
+     * @throws Exception
+     */
+    @Test(timeOut = 30000)
+    public void testAutoUpdatePartitionsForProducerConsumer() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
+
+        final int numPartitions = 2;
+        final String topicName = "persistent://my-property/my-ns/my-topic-" + System.currentTimeMillis();
+        final String producerMsg = "producerMsg";
+        final int totalMessages = 30;
+
+        admin.topics().createPartitionedTopic(topicName, numPartitions);
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+            .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+            .enableBatching(false)
+            .trackPartitionUpdate(true)
+            .partitionAutoUpdatePeriod(10) // set 10 minutes, so will not auto trigger.
+            .create();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
+            .subscriptionName("my-partitioned-subscriber")
+            .subscriptionType(SubscriptionType.Shared)
+            .trackPartitionUpdate(true)
+            .partitionAutoUpdatePeriod(10) // set 10 minutes, so will not auto trigger.
+            .subscribe();
+
+        // 1. produce and consume 2 partitions
+        for (int i = 0; i < totalMessages; i++) {
+            producer.send((producerMsg + " first round " + "message index: " + i).getBytes());
+        }
+        int messageSet = 0;
+        Message<byte[]> message = consumer.receive();
+        do {
+            messageSet ++;
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet, totalMessages);
+
+        // 2. update partition from 2 to 3.
+        admin.topics().updatePartitionedTopic(topicName,3);
+
+        // 3. trigger auto update in producer, after produce, consumer will get 2/3 messages.
+        log.info("trigger partitionsAutoUpdateTimerTask for producer");
+        Timeout timeout = ((PartitionedProducerImpl<byte[]>)producer).getPartitionsAutoUpdateTimeout();
+        timeout.task().run(timeout);
+        Thread.sleep(200);
+
+        for (int i = 0; i < totalMessages; i++) {
+            producer.send((producerMsg + " second round " + "message index: " + i).getBytes());
+        }
+        messageSet = 0;
+        message = consumer.receive();
+        do {
+            messageSet ++;
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet, totalMessages * 2 / 3);
+
+        // 4. trigger auto update in consumer, after produce, consumer will get all messages.
+        log.info("trigger partitionsAutoUpdateTimerTask for consumer");
+        timeout = ((MultiTopicsConsumerImpl<byte[]>)consumer).getPartitionsAutoUpdateTimeout();
+        timeout.task().run(timeout);
+        Thread.sleep(200);
+
+        // former produced messages
+        messageSet = 0;
+        message = consumer.receive();
+        do {
+            messageSet ++;
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet, totalMessages / 3);
+
+        // former produced messages
+        for (int i = 0; i < totalMessages; i++) {
+            producer.send((producerMsg + " third round " + "message index: " + i).getBytes());
+        }
+        messageSet = 0;
+        message = consumer.receive();
+        do {
+            messageSet ++;
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet, totalMessages);
+
+        pulsarClient.close();
+        admin.topics().deletePartitionedTopic(topicName);
+
+        log.info("-- Exiting {} test --", methodName);
+    }
+
 
     private class AlwaysTwoMessageRouter implements MessageRouter {
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.Lists;
+import io.netty.util.Timeout;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -669,6 +671,92 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         // verify should not time out, because of message redelivered several times.
         latch.await();
+
+        consumer.close();
+    }
+
+
+    /**
+     * Test topic partitions auto subscribe.
+     *
+     * Steps:
+     * 1. Create a consumer with 2 topics, and each topic has 2 partitions: xx-partition-0, xx-partition-1.
+     * 2. produce message to xx-partition-2, and verify consumer could not receive message.
+     * 3. update topics to have 3 partitions.
+     * 4. trigger partitionsAutoUpdate. this should be done automatically, this is to save time to manually trigger.
+     * 5. produce message to xx-partition-2 again,  and verify consumer could receive message.
+     *
+     */
+    @Test(timeOut = 30000)
+    public void testTopicAutoUpdatePartitions() throws Exception {
+        String key = "TestTopicAutoUpdatePartitions";
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final String messagePredicate = "my-message-" + key + "-";
+        final int totalMessages = 6;
+
+        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
+        List<String> topicNames = Lists.newArrayList(topicName1, topicName2);
+
+        admin.tenants().createTenant("prop", new TenantInfo());
+        admin.topics().createPartitionedTopic(topicName1, 2);
+        admin.topics().createPartitionedTopic(topicName2, 2);
+
+        // 1. Create a  consumer
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
+            .trackPartitionUpdate(true)
+            .subscribe();
+        assertTrue(consumer instanceof MultiTopicsConsumerImpl);
+
+        MultiTopicsConsumerImpl topicsConsumer = (MultiTopicsConsumerImpl) consumer;
+
+        // 2. use partition-2 producer,
+        Producer<byte[]> producer1 = pulsarClient.newProducer().topic(topicName1 + "-partition-2")
+            .enableBatching(false)
+            .create();
+        Producer<byte[]> producer2 = pulsarClient.newProducer().topic(topicName2 + "-partition-2")
+            .enableBatching(false)
+            .create();
+        for (int i = 0; i < totalMessages; i++) {
+            producer1.send((messagePredicate + "topic1-partition-2 index:" + i).getBytes());
+            producer2.send((messagePredicate + "topic2-partition-2 index:" + i).getBytes());
+            log.info("produce message to partition-2. message index: {}", i);
+        }
+        // since partition-2 not subscribed,  could not receive any message.
+        Message<byte[]> message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        assertNull(message);
+
+
+        // 3. update to 3 partitions
+        admin.topics().updatePartitionedTopic(topicName1, 3);
+        admin.topics().updatePartitionedTopic(topicName2, 3);
+
+        // 4. trigger partitionsAutoUpdate. this should be done automatically, this is to save time to manually trigger.
+        log.info("trigger partitionsAutoUpdateTimerTask");
+        Timeout timeout = topicsConsumer.getPartitionsAutoUpdateTimeout();
+        timeout.task().run(timeout);
+        Thread.sleep(200);
+
+        // 5. produce message to xx-partition-2 again,  and verify consumer could receive message.
+        for (int i = 0; i < totalMessages; i++) {
+            producer1.send((messagePredicate + "topic1-partition-2 index:" + i).getBytes());
+            producer2.send((messagePredicate + "topic2-partition-2 index:" + i).getBytes());
+            log.info("produce message to partition-2 again. messageindex: {}", i);
+        }
+        int messageSet = 0;
+        message = consumer.receive();
+        do {
+            messageSet ++;
+            consumer.acknowledge(message);
+            log.info("4 Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(200, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet, 2 * totalMessages);
 
         consumer.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -709,7 +709,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
             .receiverQueueSize(4)
-            .trackPartitionUpdate(true)
+            .autoUpdatePartitions(true)
             .subscribe();
         assertTrue(consumer instanceof MultiTopicsConsumerImpl);
 
@@ -735,7 +735,8 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.topics().updatePartitionedTopic(topicName1, 3);
         admin.topics().updatePartitionedTopic(topicName2, 3);
 
-        // 4. trigger partitionsAutoUpdate. this should be done automatically, this is to save time to manually trigger.
+        // 4. trigger partitionsAutoUpdate. this should be done automatically in 1 minutes,
+        // this is to save time to manually trigger.
         log.info("trigger partitionsAutoUpdateTimerTask");
         Timeout timeout = topicsConsumer.getPartitionsAutoUpdateTimeout();
         timeout.task().run(timeout);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -677,7 +677,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
 
     /**
-     * Test topic partitions auto subscribe.
+     * Test topic partitions auto subscribed.
      *
      * Steps:
      * 1. Create a consumer with 2 topics, and each topic has 2 partitions: xx-partition-0, xx-partition-1.
@@ -730,7 +730,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         // since partition-2 not subscribed,  could not receive any message.
         Message<byte[]> message = consumer.receive(200, TimeUnit.MILLISECONDS);
         assertNull(message);
-
 
         // 3. update to 3 partitions
         admin.topics().updatePartitionedTopic(topicName1, 3);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -368,4 +368,22 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * then the ack timeout will be set to 30000 millisecond
      */
     ConsumerBuilder<T> deadLetterPolicy(DeadLetterPolicy deadLetterPolicy);
+
+    /**
+     * If enabled, the consumer will auto subscribe for partitions increasement.
+     * This is only for partitioned consumer and multi-topics consumer.
+     *
+     * @param autoUpdate
+     *            whether to auto update partition increasement
+     */
+    ConsumerBuilder<T> trackPartitionUpdate(boolean autoUpdate);
+
+    /**
+     * Set topics auto update period when setting {@link #trackPartitionUpdate(boolean)} to true for topics consumer.
+     * The period is in minute, and default and minimum value is 1 minute.
+     *
+     * @param periodInMinutes
+     *            number of minutes between checks for topic partitions update
+     */
+    ConsumerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -371,19 +371,10 @@ public interface ConsumerBuilder<T> extends Cloneable {
 
     /**
      * If enabled, the consumer will auto subscribe for partitions increasement.
-     * This is only for partitioned consumer and multi-topics consumer.
+     * This is only for partitioned consumer.
      *
      * @param autoUpdate
      *            whether to auto update partition increasement
      */
-    ConsumerBuilder<T> trackPartitionUpdate(boolean autoUpdate);
-
-    /**
-     * Set topics auto update period when setting {@link #trackPartitionUpdate(boolean)} to true for topics consumer.
-     * The period is in minute, and default and minimum value is 1 minute.
-     *
-     * @param periodInMinutes
-     *            number of minutes between checks for topic partitions update
-     */
-    ConsumerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes);
+    ConsumerBuilder<T> autoUpdatePartitions(boolean autoUpdate);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -328,4 +328,22 @@ public interface ProducerBuilder<T> extends Cloneable {
      * @return producer builder.
      */
     ProducerBuilder<T> intercept(ProducerInterceptor<T> ... interceptors);
+
+    /**
+     * If enabled, partitioned producer will auto create new producers for new partitions.
+     * This is only for partitioned producer.
+     *
+     * @param autoUpdate
+     *            whether to auto update partition increasement
+     */
+    ProducerBuilder<T> trackPartitionUpdate(boolean autoUpdate);
+
+    /**
+     * Set topics auto update period when setting {@link #trackPartitionUpdate(boolean)} to true for partitioned producer.
+     * The period is in minute, and default and minimum value is 1 minute.
+     *
+     * @param periodInMinutes
+     *            number of minutes between checks for topic partitions update
+     */
+    ProducerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -336,14 +336,5 @@ public interface ProducerBuilder<T> extends Cloneable {
      * @param autoUpdate
      *            whether to auto update partition increasement
      */
-    ProducerBuilder<T> trackPartitionUpdate(boolean autoUpdate);
-
-    /**
-     * Set topics auto update period when setting {@link #trackPartitionUpdate(boolean)} to true for partitioned producer.
-     * The period is in minute, and default and minimum value is 1 minute.
-     *
-     * @param periodInMinutes
-     *            number of minutes between checks for topic partitions update
-     */
-    ProducerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes);
+    ProducerBuilder<T> autoUpdatePartitions(boolean autoUpdate);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -46,7 +46,6 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.util.FutureUtil;
 
 import com.google.common.collect.Lists;
@@ -295,7 +294,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> autoUpdatePartitions(boolean autoUpdate) {
-        conf.setTrackPartitionUpdate(autoUpdate);
+        conf.setAutoUpdatePartitions(autoUpdate);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -294,14 +294,8 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> trackPartitionUpdate(boolean autoUpdate) {
+    public ConsumerBuilder<T> autoUpdatePartitions(boolean autoUpdate) {
         conf.setTrackPartitionUpdate(autoUpdate);
-        return this;
-    }
-
-    @Override
-    public ConsumerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes) {
-        conf.setPartitionAutoUpdatePeriod(periodInMinutes);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -293,6 +293,18 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         return this;
     }
 
+    @Override
+    public ConsumerBuilder<T> trackPartitionUpdate(boolean autoUpdate) {
+        conf.setTrackPartitionUpdate(autoUpdate);
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes) {
+        conf.setPartitionAutoUpdatePeriod(periodInMinutes);
+        return this;
+    }
+
     public ConsumerConfigurationData<T> getConf() {
         return conf;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -121,7 +121,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         this.stats = client.getConfiguration().getStatsIntervalSeconds() > 0 ? new ConsumerStatsRecorderImpl() : null;
 
         // start track and auto subscribe partition increasement
-        if (conf.isTrackPartitionUpdate()) {
+        if (conf.isAutoUpdatePartitions()) {
             topicsPartitionChangedListener = new TopicsPartitionChangedListener();
             partitionsAutoUpdateTimeout = client.timer()
                 .newTimeout(partitionsAutoUpdateTimerTask, 1, TimeUnit.MINUTES);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -77,7 +77,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         start();
 
         // start track and auto subscribe partition increasement
-        if (conf.isTrackPartitionUpdate()) {
+        if (conf.isAutoUpdatePartitions()) {
             topicsPartitionChangedListener = new TopicsPartitionChangedListener();
             partitionsAutoUpdateTimeout = client.timer()
                 .newTimeout(partitionsAutoUpdateTimerTask, 1, TimeUnit.MINUTES);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -21,6 +21,11 @@ package org.apache.pulsar.client.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -29,12 +34,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientException.NotSupportedException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
@@ -52,7 +59,12 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     private List<ProducerImpl<T>> producers;
     private MessageRouter routerPolicy;
     private final ProducerStatsRecorderImpl stats;
-    private final TopicMetadata topicMetadata;
+    private TopicMetadata topicMetadata;
+
+    // timeout related to auto check and subscribe partition increasement
+    private volatile Timeout partitionsAutoUpdateTimeout = null;
+    TopicsPartitionChangedListener topicsPartitionChangedListener;
+    CompletableFuture<Void> partitionsAutoUpdateFuture = null;
 
     public PartitionedProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf, int numPartitions,
             CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema, ProducerInterceptors<T> interceptors) {
@@ -66,6 +78,13 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 conf.getMaxPendingMessagesAcrossPartitions() / numPartitions);
         conf.setMaxPendingMessages(maxPendingMessages);
         start();
+
+        // start track and auto subscribe partition increasement
+        if (conf.isTrackPartitionUpdate()) {
+            topicsPartitionChangedListener = new TopicsPartitionChangedListener();
+            partitionsAutoUpdateTimeout = client.timer().newTimeout(partitionsAutoUpdateTimerTask,
+                Math.min(1, conf.getPartitionAutoUpdatePeriod()), TimeUnit.MINUTES);
+        }
     }
 
     private MessageRouter getMessageRouter() {
@@ -192,6 +211,11 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         }
         setState(State.Closing);
 
+        if (partitionsAutoUpdateTimeout != null) {
+            partitionsAutoUpdateTimeout.cancel();
+            partitionsAutoUpdateTimeout = null;
+        }
+
         AtomicReference<Throwable> closeFail = new AtomicReference<Throwable>();
         AtomicInteger completed = new AtomicInteger(topicMetadata.numPartitions());
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
@@ -242,6 +266,104 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     @Override
     String getHandlerName() {
         return "partition-producer";
+    }
+
+    // This listener is triggered when topics partitions are updated.
+    private class TopicsPartitionChangedListener implements PartitionsChangedListener {
+        // Check partitions changes of passed in topics, and add new topic partitions.
+        @Override
+        public CompletableFuture<Void> onTopicsExtended(Collection<String> topicsExtended) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            if (topicsExtended.isEmpty() || !topicsExtended.contains(topic)) {
+                future.complete(null);
+                return future;
+            }
+
+            client.getLookup().getPartitionedTopicMetadata(TopicName.get(topic)).thenCompose(metadata -> {
+                int oldPartitionNumber = topicMetadata.numPartitions();
+                int currentPartitionNumber = metadata.partitions;
+
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] partitions number. old: {}, new: {}",
+                        topic, oldPartitionNumber, currentPartitionNumber);
+                }
+
+                if (oldPartitionNumber == currentPartitionNumber) {
+                    // topic partition number not changed
+                    future.complete(null);
+                    return future;
+                } else if (oldPartitionNumber < currentPartitionNumber) {
+                    List<CompletableFuture<Producer<T>>> futureList = IntStream
+                        .range(oldPartitionNumber, currentPartitionNumber)
+                        .mapToObj(
+                            partitionIndex -> {
+                                String partitionName = TopicName.get(topic).getPartition(partitionIndex).toString();
+                                ProducerImpl<T> producer =
+                                    new ProducerImpl<>(client,
+                                        partitionName, conf, new CompletableFuture<>(),
+                                        partitionIndex, schema, interceptors);
+                                producers.add(producer);
+                                return producer.producerCreatedFuture();
+                            })
+                        .collect(Collectors.toList());
+
+                    FutureUtil.waitForAll(futureList)
+                        .thenAccept(finalFuture -> {
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] success create producers for extended partitions. old: {}, new: {}",
+                                    topic, oldPartitionNumber, currentPartitionNumber);
+                            }
+                            topicMetadata = new TopicMetadataImpl(currentPartitionNumber);
+                            future.complete(null);
+                        })
+                        .exceptionally(ex -> {
+                            // error happened, remove
+                            log.warn("[{}] fail create producers for extended partitions. old: {}, new: {}",
+                                topic, oldPartitionNumber, currentPartitionNumber);
+                            List<ProducerImpl<T>> sublist = producers.subList(oldPartitionNumber, producers.size());
+                            sublist.forEach(newProducer -> newProducer.closeAsync());
+                            sublist.clear();
+                            future.completeExceptionally(ex);
+                            return null;
+                        });
+                    return null;
+                } else {
+                    log.error("[{}] not support shrink topic partitions. old: {}, new: {}",
+                        topic, oldPartitionNumber, currentPartitionNumber);
+                    future.completeExceptionally(new NotSupportedException("not support shrink topic partitions"));
+                }
+                return future;
+            });
+
+            return future;
+        }
+    }
+
+    private TimerTask partitionsAutoUpdateTimerTask = new TimerTask() {
+        @Override
+        public void run(Timeout timeout) throws Exception {
+            if (timeout.isCancelled() || getState() != State.Ready) {
+                return;
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("[{}]  run partitionsAutoUpdateTimerTask for partitioned producer: {}", topic);
+            }
+
+            // if last auto update not completed yet, do nothing.
+            if (partitionsAutoUpdateFuture == null || partitionsAutoUpdateFuture.isDone()) {
+                partitionsAutoUpdateFuture = topicsPartitionChangedListener.onTopicsExtended(ImmutableList.of(topic));
+            }
+
+            // schedule the next re-check task
+            partitionsAutoUpdateTimeout = client.timer().newTimeout(partitionsAutoUpdateTimerTask,
+                Math.min(1, conf.getPartitionAutoUpdatePeriod()), TimeUnit.MINUTES);
+        }
+    };
+
+    @VisibleForTesting
+    public Timeout getPartitionsAutoUpdateTimeout() {
+        return partitionsAutoUpdateTimeout;
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionsChangedListener.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionsChangedListener.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Listener that notified when concerned topic partitions changed.
+ */
+public interface PartitionsChangedListener {
+    /**
+     * Notified when topic partitions increased.
+     * Passed in topics that have partitions increased.
+     */
+    CompletableFuture<Void> onTopicsExtended(Collection<String> topicsExtended);
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -103,7 +103,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         });
 
         // schedule the next re-check task
-        client.timer().newTimeout(PatternMultiTopicsConsumerImpl.this,
+        recheckPatternTimeout = client.timer().newTimeout(PatternMultiTopicsConsumerImpl.this,
             Math.min(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.MINUTES);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -256,14 +256,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         return this;
     }
     @Override
-    public ProducerBuilder<T> trackPartitionUpdate(boolean autoUpdate) {
+    public ProducerBuilder<T> autoUpdatePartitions(boolean autoUpdate) {
         conf.setTrackPartitionUpdate(autoUpdate);
-        return this;
-    }
-
-    @Override
-    public ProducerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes) {
-        conf.setPartitionAutoUpdatePeriod(periodInMinutes);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -257,7 +257,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
     @Override
     public ProducerBuilder<T> autoUpdatePartitions(boolean autoUpdate) {
-        conf.setTrackPartitionUpdate(autoUpdate);
+        conf.setAutoUpdatePartitions(autoUpdate);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -255,6 +255,17 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         interceptorList.addAll(Arrays.asList(interceptors));
         return this;
     }
+    @Override
+    public ProducerBuilder<T> trackPartitionUpdate(boolean autoUpdate) {
+        conf.setTrackPartitionUpdate(autoUpdate);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilder<T> partitionAutoUpdatePeriod(int periodInMinutes) {
+        conf.setPartitionAutoUpdatePeriod(periodInMinutes);
+        return this;
+    }
 
     private void setMessageRoutingMode() throws PulsarClientException {
         if(conf.getMessageRoutingMode() == null && conf.getCustomMessageRouter() == null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -90,6 +90,10 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private DeadLetterPolicy deadLetterPolicy;
 
+    // TODO: change to false
+    private boolean trackPartitionUpdate = true;
+    private int partitionAutoUpdatePeriod = 1;
+
     @JsonIgnore
     public String getSingleTopic() {
         checkArgument(topicNames.size() == 1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -90,8 +90,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private DeadLetterPolicy deadLetterPolicy;
 
-    // TODO: change to false
-    private boolean trackPartitionUpdate = true;
+    private boolean trackPartitionUpdate = false;
     private int partitionAutoUpdatePeriod = 1;
 
     @JsonIgnore

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -90,8 +90,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private DeadLetterPolicy deadLetterPolicy;
 
-    private boolean trackPartitionUpdate = false;
-    private int partitionAutoUpdatePeriod = 1;
+    private boolean autoUpdatePartitions = true;
 
     @JsonIgnore
     public String getSingleTopic() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -73,6 +73,9 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     // Cannot use Optional<Long> since it's not serializable
     private Long initialSequenceId = null;
 
+    private boolean trackPartitionUpdate = false;
+    private int partitionAutoUpdatePeriod = 1;
+
     private SortedMap<String, String> properties = new TreeMap<>();
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -73,8 +73,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     // Cannot use Optional<Long> since it's not serializable
     private Long initialSequenceId = null;
 
-    private boolean trackPartitionUpdate = false;
-    private int partitionAutoUpdatePeriod = 1;
+    private boolean autoUpdatePartitions = true;
 
     private SortedMap<String, String> properties = new TreeMap<>();
 


### PR DESCRIPTION

Fixes #3230 
### Motivation

while update partitions for a topic: http://pulsar.apache.org/docs/en/admin-api-partitioned-topics.html#update
Already created partitioned producers and consumers can’t see newly created partitions and it requires to recreate them at application so.

This PR try to auto update topic partitions extend for consumer and producer

### Modifications

- add parameter trackPartitionUpdate to partitioned consumer and producer;
- add timer task to check partition updates; and auto update consumer/producer;
- add unit-test for this feature.

### Verifying this change

new added unit test passed.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: (  no)
  - The admin cli options: ( no)
  - Anything that affects deployment: ( no )

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
