### PR TITLE
Use testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe to avoid interference with other tests running in parallel

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -342,10 +342,11 @@ void ClientImpl::subscribeAsync(const std::string& topic, const std::string& con
             return;
         } else if (conf.getConsumerType() == ConsumerShared) {
             ConsumersList consumers(consumers_);
-            for (ConsumersList::iterator it = consumers.begin(); it != consumers.end(); ++it) {
-                ConsumerImplBasePtr consumer = it->lock();
+            for (auto& weakPtr : consumers) {
+                ConsumerImplBasePtr consumer = weakPtr.lock();
                 if (consumer && consumer->getSubscriptionName() == consumerName && !consumer->isClosed()) {
                     lock.unlock();
+                    LOG_INFO("Reusing existing consumer instance for " << topic << " -- " << consumerName);
                     callback(ResultOk, Consumer(consumer));
                     return;
                 }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2782,7 +2782,7 @@ TEST(BasicEndToEndTest, testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe) {
     ClientConfiguration config;
     Client client(lookupUrl);
     std::string subsName = "my-only-sub";
-    std::string topicName = "persistent://public/default/test-prevent-dup-consumers";
+    std::string topicName = "persistent://public/default/testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe";
     ConsumerConfiguration consumerConf;
     consumerConf.setConsumerType(ConsumerShared);
 

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2782,7 +2782,8 @@ TEST(BasicEndToEndTest, testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe) {
     ClientConfiguration config;
     Client client(lookupUrl);
     std::string subsName = "my-only-sub";
-    std::string topicName = "persistent://public/default/testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe";
+    std::string topicName =
+        "persistent://public/default/testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe";
     ConsumerConfiguration consumerConf;
     consumerConf.setConsumerType(ConsumerShared);
 


### PR DESCRIPTION
### Motivation

As reported in #3481, the `testDupConsumersOnSharedModeNotThrowsExcOnUnsubscribe` is failing intermmittently. 

The problem is due to fact that C++ tests are being executed in parallel and that this test was using the same topic / subscription name as another test. When these 2 tests ran at the same time, the test would fail.

### Modifications

 * Use unique name for test topic
 * Added info message when we're returning the shared consumer instance.

Fixes #3481 