### PR TITLE
Ignore namespace in schema validation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
@@ -22,17 +22,20 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
 import org.apache.avro.SchemaValidatorBuilder;
+import org.apache.avro.reflect.AvroIgnore;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
 
 
 import java.util.Arrays;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class AvroSchemaCompatibilityCheck implements SchemaCompatibilityCheck {
-    private final static Logger log = LoggerFactory.getLogger(AvroSchemaCompatibilityCheck.class);
 
     @Override
     public SchemaType getSchemaType() {
@@ -41,10 +44,8 @@ public class AvroSchemaCompatibilityCheck implements SchemaCompatibilityCheck {
 
     @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
-        Schema.Parser fromParser = new Schema.Parser();
-        Schema fromSchema = fromParser.parse(new String(from.getData()));
-        Schema.Parser toParser = new Schema.Parser();
-        Schema toSchema =  toParser.parse(new String(to.getData()));
+        Schema fromSchema = AvroSchemaParser.parseSchema(from.getData());
+        Schema toSchema =  AvroSchemaParser.parseSchema(to.getData());
 
         SchemaValidator schemaValidator = createSchemaValidator(strategy, true);
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaParser.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaParser.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.schema;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+
+import org.apache.avro.Schema;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+@UtilityClass
+public class AvroSchemaParser {
+
+    private static final String NAMESPACE_MARKER = "NS";
+
+    static Schema parseSchema(byte[] serializedSchema) {
+        Schema.Parser parser = new Schema.Parser();
+        String schemaDef = removeNamespace(serializedSchema);
+        return parser.parse(schemaDef);
+    }
+
+    /**
+     * Remove the namespace attributes from the Avro schema definition.
+     */
+    @SneakyThrows
+    static String removeNamespace(byte[] serializedSchema) {
+        Map<String, Object> schemaDef = ObjectMapperFactory.getThreadLocal().readValue(serializedSchema,
+                new TypeReference<TreeMap<String, Object>>() {
+                });
+        removeNamespace(schemaDef);
+        return ObjectMapperFactory.getThreadLocal().writeValueAsString(schemaDef);
+    }
+
+    /**
+     * Recursively remove the namespace from schema definition
+     */
+    @SuppressWarnings("unchecked")
+    private static void removeNamespace(Map<String, Object> schemaDef) {
+        if ("record".equals(schemaDef.get("type"))) {
+            schemaDef.put("namespace", NAMESPACE_MARKER);
+            Object fieldsObj = schemaDef.get("fields");
+            if (fieldsObj instanceof List) {
+                List<Map<String, Object>> fields = (List<Map<String, Object>>) fieldsObj;
+                fields.forEach(field -> removeNamespace(field));
+            }
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BaseAvroSchemaCompatibilityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BaseAvroSchemaCompatibilityTest.java
@@ -32,6 +32,11 @@ public abstract class BaseAvroSchemaCompatibilityTest {
                     ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
     private static final SchemaData schemaData1 = getSchemaData(schemaJson1);
 
+    private static final String schemaJson1_differentNamespace =
+            "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema.XYZ" +
+                    ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
+    private static final SchemaData schemaData1_differentNamespace = getSchemaData(schemaJson1_differentNamespace);
+
     private static final String schemaJson2 =
             "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
                     ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
@@ -155,7 +160,16 @@ public abstract class BaseAvroSchemaCompatibilityTest {
         Assert.assertFalse(schemaCompatibilityCheck.isCompatible(schemaData3, schemaData1,
                                                                  SchemaCompatibilityStrategy.FULL),
                 "adding a field without default is not fully compatible");
+    }
 
+    /**
+     * Make sure the new schema is compatible even if the namespace specified is different
+     */
+    @Test
+    public void testIgnoringNamespace() {
+        SchemaCompatibilityCheck schemaCompatibilityCheck = getSchemaCheck();
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(schemaData1, schemaData1_differentNamespace,
+                SchemaCompatibilityStrategy.FULL),  "using different namespace is fully compatible");
     }
 
     private static SchemaData getSchemaData(String schemaJson) {


### PR DESCRIPTION
### Motivation

Right now we use Avro schema definition to validate the compatibility of schemas for Avro, JSON and Protobuf. 

When the schema is extracted from a POJO with Avro tools, the "namespace" is set to the schema. The "namespace" is actually the Java package name for the pojo.

When declaring schemas in Python, the Java package name is of little relevance, and we should just ignore it when validating the schema, since in our case, the topic is already providing a sort of namespacing.