### PR TITLE
fix: RuntimeInfo doesn't get set when transferring ownership of function from another worker to this worker

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.functions.runtime;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -85,7 +86,8 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
  * The service abstraction is used for getting functionstatus.
  */
 @Slf4j
-class KubernetesRuntime implements Runtime {
+@VisibleForTesting
+public class KubernetesRuntime implements Runtime {
 
     private static final String ENV_SHARD_ID = "SHARD_ID";
     private static final int maxJobNameSize = 55;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -125,7 +125,6 @@ public class KubernetesRuntime implements Runtime {
     private final String originalCodeFileName;
     private final String pulsarAdminUrl;
     private final SecretsProviderConfigurator secretsProviderConfigurator;
-    private boolean running;
 
 
     KubernetesRuntime(AppsV1Api appsClient,
@@ -195,7 +194,6 @@ public class KubernetesRuntime implements Runtime {
             pythonDependencyRepository,
             pythonExtraDependencyRepository,
                 METRICS_PORT);
-        running = false;
         doChecks(instanceConfig.getFunctionDetails());
     }
 
@@ -214,7 +212,6 @@ public class KubernetesRuntime implements Runtime {
                     instanceConfig.getFunctionDetails().getName(), e);
             deleteService();
         }
-        running = true;
         if (channel == null && stub == null) {
             channel = new ManagedChannel[instanceConfig.getFunctionDetails().getParallelism()];
             stub = new InstanceControlGrpc.InstanceControlFutureStub[instanceConfig.getFunctionDetails().getParallelism()];
@@ -237,10 +234,9 @@ public class KubernetesRuntime implements Runtime {
 
     @Override
     public void stop() throws Exception {
-        if (running) {
-            deleteStatefulSet();
-            deleteService();
-        }
+        deleteStatefulSet();
+        deleteService();
+
         if (channel != null) {
             for (ManagedChannel cn : channel) {
                 cn.shutdown();
@@ -248,7 +244,6 @@ public class KubernetesRuntime implements Runtime {
         }
         channel = null;
         stub = null;
-        running = false;
     }
 
     @Override
@@ -337,7 +332,8 @@ public class KubernetesRuntime implements Runtime {
 
     @Override
     public boolean isAlive() {
-        return running;
+        // No point for kubernetes just return dummy value
+        return true;
     }
 
     private void submitService() throws Exception {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -47,6 +47,7 @@ public class RuntimeSpawner implements AutoCloseable {
 
     @Getter
     private final InstanceConfig instanceConfig;
+    @Getter
     private final RuntimeFactory runtimeFactory;
     private final String codeFile;
     private final String originalCodeFileName;
@@ -69,6 +70,12 @@ public class RuntimeSpawner implements AutoCloseable {
         this.originalCodeFileName = originalCodeFileName;
         this.numRestarts = 0;
         this.instanceLivenessCheckFreqMs = instanceLivenessCheckFreqMs;
+        try {
+            this.runtime = runtimeFactory.createContainer(this.instanceConfig, codeFile, originalCodeFileName,
+                    instanceLivenessCheckFreqMs / 1000);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void start() throws Exception {
@@ -76,8 +83,6 @@ public class RuntimeSpawner implements AutoCloseable {
         log.info("{}/{}/{}-{} RuntimeSpawner starting function", details.getTenant(), details.getNamespace(),
                 details.getName(), this.instanceConfig.getInstanceId());
 
-        runtime = runtimeFactory.createContainer(this.instanceConfig, codeFile, originalCodeFileName,
-                instanceLivenessCheckFreqMs / 1000);
         runtime.start();
 
         // monitor function runtime to make sure it is running.  If not, restart the function runtime

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -150,7 +150,7 @@ public class RuntimeSpawner implements AutoCloseable {
             try {
                 runtime.stop();
             } catch (Exception e) {
-                // Ignore
+                log.warn("Failed to stop function runtime: {}", e, e);
             }
             runtime = null;
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -87,6 +87,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
     private FunctionAssignmentTailer functionAssignmentTailer;
 
+    @Setter
     private FunctionActioner functionActioner;
 
     @Getter
@@ -104,6 +105,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
     boolean isInitializePhase = false;
 
     private final FunctionMetaDataManager functionMetaDataManager;
+
 
     public FunctionRuntimeManager(WorkerConfig workerConfig, WorkerService workerService, Namespace dlogNamespace,
                                   MembershipManager membershipManager, ConnectorsManager connectorsManager,
@@ -641,6 +643,11 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     if (assignment.getWorkerId().equals(this.workerConfig.getWorkerId())) {
                         FunctionRuntimeInfo newFunctionRuntimeInfo = new FunctionRuntimeInfo();
                         newFunctionRuntimeInfo.setFunctionInstance(assignment.getInstance());
+                        RuntimeSpawner runtimeSpawner = functionActioner.getRuntimeSpawner(
+                                assignment.getInstance(),
+                                assignment.getInstance().getFunctionMetaData().getPackageLocation().getPackagePath());
+                        newFunctionRuntimeInfo.setRuntimeSpawner(runtimeSpawner);
+
                         this.setFunctionRuntimeInfo(fullyQualifiedInstanceId, newFunctionRuntimeInfo);
                     } else {
                         deleteFunctionRuntimeInfo(fullyQualifiedInstanceId);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -425,6 +425,99 @@ public class FunctionRuntimeManagerTest {
     }
 
     @Test
+    public void testReassignment() throws Exception {
+        WorkerConfig workerConfig = new WorkerConfig();
+        workerConfig.setWorkerId("worker-1");
+        workerConfig.setThreadContainerFactory(new WorkerConfig.ThreadContainerFactory().setThreadGroupName("test"));
+        workerConfig.setPulsarServiceUrl("pulsar://localhost:6650");
+        workerConfig.setStateStorageServiceUrl("foo");
+
+        PulsarClient pulsarClient = mock(PulsarClient.class);
+        ReaderBuilder readerBuilder = mock(ReaderBuilder.class);
+        doReturn(readerBuilder).when(pulsarClient).newReader();
+        doReturn(readerBuilder).when(readerBuilder).topic(anyString());
+        doReturn(readerBuilder).when(readerBuilder).startMessageId(any());
+        doReturn(readerBuilder).when(readerBuilder).readCompacted(anyBoolean());
+        doReturn(mock(Reader.class)).when(readerBuilder).create();
+        WorkerService workerService = mock(WorkerService.class);
+        doReturn(pulsarClient).when(workerService).getClient();
+        doReturn(mock(PulsarAdmin.class)).when(workerService).getFunctionAdmin();
+
+        // test new assignment update functions
+        FunctionRuntimeManager functionRuntimeManager = spy(new FunctionRuntimeManager(
+                workerConfig,
+                workerService,
+                mock(Namespace.class),
+                mock(MembershipManager.class),
+                mock(ConnectorsManager.class),
+                mock(FunctionMetaDataManager.class)));
+
+        Function.FunctionMetaData function1 = Function.FunctionMetaData.newBuilder().setFunctionDetails(
+                Function.FunctionDetails.newBuilder()
+                        .setTenant("test-tenant").setNamespace("test-namespace").setName("func-1")).build();
+
+
+        Function.Assignment assignment1 = Function.Assignment.newBuilder()
+                .setWorkerId("worker-1")
+                .setInstance(Function.Instance.newBuilder()
+                        .setFunctionMetaData(function1).setInstanceId(0).build())
+                .build();
+
+        /** Test transfer from me to other worker **/
+
+        // add existing assignments
+        functionRuntimeManager.setAssignment(assignment1);
+        reset(functionRuntimeManager);
+
+        // new assignment with different worker
+        Function.Assignment assignment2 = Function.Assignment.newBuilder()
+                .setWorkerId("worker-2")
+                .setInstance(Function.Instance.newBuilder()
+                        .setFunctionMetaData(function1).setInstanceId(0).build())
+                .build();
+
+        FunctionRuntimeInfo functionRuntimeInfo = new FunctionRuntimeInfo().setFunctionInstance(
+                Function.Instance.newBuilder().setFunctionMetaData(function1).setInstanceId(0)
+                        .build());
+        functionRuntimeManager.functionRuntimeInfoMap.put(
+                "test-tenant/test-namespace/func-1:0", functionRuntimeInfo);
+
+        functionRuntimeManager.processAssignment(assignment2);
+
+        verify(functionRuntimeManager, times(0)).insertStartAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(0)).insertTerminateAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(1)).insertStopAction(any(FunctionRuntimeInfo.class));
+
+        Assert.assertEquals(functionRuntimeManager.workerIdToAssignments
+                .get("worker-2").get("test-tenant/test-namespace/func-1:0"), assignment2);
+        Assert.assertEquals(functionRuntimeManager.functionRuntimeInfoMap.size(), 0);
+        Assert.assertEquals(functionRuntimeManager.functionRuntimeInfoMap.get("test-tenant/test-namespace/func-1:0"), null);
+
+        /** Test transfer from other worker to me **/
+        reset(functionRuntimeManager);
+
+        Function.Assignment assignment3 = Function.Assignment.newBuilder()
+                .setWorkerId("worker-1")
+                .setInstance(Function.Instance.newBuilder()
+                        .setFunctionMetaData(function1).setInstanceId(0).build())
+                .build();
+
+        functionRuntimeManager.processAssignment(assignment3);
+
+        verify(functionRuntimeManager, times(1)).insertStartAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(0)).insertTerminateAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(0)).insertStopAction(any(FunctionRuntimeInfo.class));
+
+        Assert.assertEquals(functionRuntimeManager.workerIdToAssignments
+                .get("worker-1").get("test-tenant/test-namespace/func-1:0"), assignment3);
+        Assert.assertEquals(functionRuntimeManager.workerIdToAssignments
+                .get("worker-2"), null);
+
+        Assert.assertEquals(functionRuntimeManager.functionRuntimeInfoMap.size(), 1);
+        Assert.assertEquals(functionRuntimeManager.functionRuntimeInfoMap.get("test-tenant/test-namespace/func-1:0"), functionRuntimeInfo);
+    }
+
+    @Test
     public void testRuntimeManagerInitialize() throws Exception {
         WorkerConfig workerConfig = new WorkerConfig();
         workerConfig.setWorkerId("worker-1");
@@ -602,7 +695,7 @@ public class FunctionRuntimeManagerTest {
         functionRuntimeManager.processAssignment(assignment2);
 
         // make sure nothing is called
-        verify(functionRuntimeManager, times(0)).insertStopAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(0)).insertStartAction(any(FunctionRuntimeInfo.class));
         verify(functionRuntimeManager, times(0)).insertTerminateAction(any(FunctionRuntimeInfo.class));
         verify(functionRuntimeManager, times(0)).insertStopAction(any(FunctionRuntimeInfo.class));
 
@@ -621,7 +714,7 @@ public class FunctionRuntimeManagerTest {
         functionRuntimeManager.processAssignment(assignment3);
 
         // make sure nothing is called
-        verify(functionRuntimeManager, times(0)).insertStopAction(any(FunctionRuntimeInfo.class));
+        verify(functionRuntimeManager, times(0)).insertStartAction(any(FunctionRuntimeInfo.class));
         verify(functionRuntimeManager, times(0)).insertTerminateAction(any(FunctionRuntimeInfo.class));
         verify(functionRuntimeManager, times(0)).insertStopAction(any(FunctionRuntimeInfo.class));
 


### PR DESCRIPTION
### Motivation

For externally managed runtimes in functions, when the assignment of a function gets transferred from another worker to this worker, the runtime info of the function doesn't get set causing the function to not be able to be deleted afterwards


### Modifications

Fix the issue as well as add unit tests to test for this situation.

Also add some print statements to make sure runtime infos and assignments for a worker is in sync

