### PR TITLE
For integration tests, copy function logs out of container on shutdown for debugging purposes

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/WorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/WorkerContainer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.tests.integration.containers;
 
+import org.apache.pulsar.tests.integration.utils.DockerUtils;
+
 /**
  * A pulsar container that runs functions worker.
  */
@@ -34,5 +36,17 @@ public class WorkerContainer extends PulsarContainer<WorkerContainer> {
             -1,
             BROKER_HTTP_PORT,
             "/admin/v2/worker/cluster");
+    }
+
+    @Override
+    protected void beforeStop() {
+        super.beforeStop();
+        if (null != containerId) {
+            DockerUtils.dumpContainerDirToTargetCompressed(
+                    getDockerClient(),
+                    containerId,
+                    "/pulsar/logs/functions"
+            );
+        }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/utils/DockerUtils.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/utils/DockerUtils.java
@@ -24,6 +24,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
@@ -140,7 +141,9 @@ public class DockerUtils {
                 read = dockerStream.read(block, 0, READ_BLOCK_SIZE);
             }
         } catch (RuntimeException|IOException e) {
-            LOG.error("Error reading dir from container {}", containerName, e);
+            if (!(e instanceof NotFoundException)) {
+                LOG.error("Error reading dir from container {}", containerName, e);
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

The integrations tests for functions, retrieve and store the worker logs but not the function instance logs.  Function instances are useful for debugging failed tests as well 

### Modifications

Copy function instances logs out of containers as well.
