### PR TITLE
Fix command name in ns-isolation-policy help

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -224,7 +224,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
     }
 
     public CmdNamespaceIsolationPolicy(PulsarAdmin admin) {
-        super("clusters", admin);
+        super("ns-isolation-policy", admin);
         jcommander.addCommand("set", new SetPolicy());
         jcommander.addCommand("get", new GetPolicy());
         jcommander.addCommand("list", new GetAllPolicies());


### PR DESCRIPTION
### Motivation

`"pulsar-admin clusters"` is in help of `ns-isolation-policy`.

```
$ ./bin/pulsar-admin ns-isolation-policy
Usage: pulsar-admin clusters [options] [command] [command options]
  Commands:
    set      Create/Update a namespace isolation policy for a cluster. This operation requires Pulsar super-user privileges
      Usage: set [options] cluster-name policy-name

...........

```