### PR TITLE
fix: Exception thrown in get list connectors 

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1037,9 +1037,7 @@ public abstract class ComponentImpl {
 
     public List<ConnectorDefinition> getListOfConnectors() {
         if (!isWorkerServiceAvailable()) {
-            throw new WebApplicationException(
-                    Response.status(Status.SERVICE_UNAVAILABLE).type(MediaType.APPLICATION_JSON)
-                            .entity(new ErrorData("Function worker service is not avaialable")).build());
+            throwUnavailableException();
         }
 
         return this.worker().getConnectorsManager().getConnectors();


### PR DESCRIPTION
### Motivation

When worker service is not available, the inputs to the WebApplicationException is not correct and throwns another exception i.e.

```
Caused by: java.lang.IllegalArgumentException: Illegal base64 character 5f
	at java.util.Base64$Decoder.decode0(Base64.java:714) ~[?:1.8.0_181]
	at java.util.Base64$Decoder.decode(Base64.java:526) ~[?:1.8.0_181]
	at java.util.Base64$Decoder.decode(Base64.java:549) ~[?:1.8.0_181]
	at org.apache.pulsar.functions.worker.rest.api.ComponentImpl.triggerFunction(ComponentImpl.java:1041) ~[org.apache.pulsar-pulsar-functions-worker-2.3.0-streamlio-5.jar:2.3.0-streamlio-5]
	at org.apache.pulsar.broker.admin.impl.FunctionsBase.triggerFunction(FunctionsBase.java:256) 
```