### PR TITLE
Revert "Replaces boost::regex with std::regex (#3512)"

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ else()
     endif (USE_LOG4CXX)
 endif (LINK_STATIC)
 
-find_package(Boost REQUIRED COMPONENTS program_options filesystem system)
+find_package(Boost REQUIRED COMPONENTS program_options filesystem regex system)
 
 if (BUILD_PYTHON_WRAPPER)
     find_package(PythonLibs REQUIRED)
@@ -209,6 +209,7 @@ set(COMMON_LIBS
   ${COMMON_LIBS} -lpthread -lm
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_REGEX_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${CURL_LIBRARY_PATH}
   ${OPENSSL_LIBRARIES}

--- a/pulsar-client-cpp/lib/NamedEntity.cc
+++ b/pulsar-client-cpp/lib/NamedEntity.cc
@@ -18,9 +18,8 @@
  */
 #include "NamedEntity.h"
 
-#include <regex>
+const boost::regex NamedEntity::pattern = boost::regex("^[-=:.\\w]*$");
 
 bool NamedEntity::checkName(const std::string& name) {
-    static const std::regex pattern = std::regex("^[-=:.\\w]*$");
-    return std::regex_match(name, pattern) ? true : false;
+    return boost::regex_match(name, pattern) ? true : false;
 }

--- a/pulsar-client-cpp/lib/NamedEntity.h
+++ b/pulsar-client-cpp/lib/NamedEntity.h
@@ -19,9 +19,12 @@
 #ifndef _PULSAR_NAMED_ENTITY_HEADER_
 #define _PULSAR_NAMED_ENTITY_HEADER_
 
-#include <string>
+#include <boost/regex.hpp>
 
 class NamedEntity {
+   private:
+    static const boost::regex pattern;
+
    public:
     static bool checkName(const std::string& name);
 };

--- a/pulsar-client-cpp/lib/Url.cc
+++ b/pulsar-client-cpp/lib/Url.cc
@@ -18,10 +18,8 @@
  */
 #include "Url.h"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <iostream>
-#include <map>
-#include <sstream>
 
 namespace pulsar {
 
@@ -41,14 +39,14 @@ static const std::map<std::string, int>& defaultPortsMap() {
 
 bool Url::parse(const std::string& urlStr, Url& url) {
     std::vector<std::string> values;
-    static const std::regex expression(
+    static const boost::regex expression(
         //       proto                 host               port
         "^(\?:([^:/\?#]+)://)\?(\\w+[^/\?#:]*)(\?::(\\d+))\?"
         //       path                  file       parameters
         "(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)\?(\\\?(.*))\?");
 
-    std::cmatch groups;
-    if (!std::regex_match(urlStr.c_str(), groups, expression)) {
+    boost::cmatch groups;
+    if (!boost::regex_match(urlStr.c_str(), groups, expression)) {
         // Invalid url
         return false;
     }

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -33,7 +33,7 @@
 #include <json/value.h>
 #include <json/reader.h>
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <boost/xpressive/xpressive.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -351,17 +351,15 @@ const std::string ZTSClient::getHeader() const { return roleHeader_; }
 PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     PrivateKeyUri uriSt;
     // scheme mediatype[;base64] path file
-    static const std::regex expression(
-        R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?(\/[^?#]+)?)");
-
-    std::cmatch groups;
-    if (std::regex_match(uri, groups, expression)) {
+    static const boost::regex expression(
+        "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
+    boost::cmatch groups;
+    if (boost::regex_match(uri, groups, expression)) {
         uriSt.scheme = groups.str(1);
         uriSt.mediaTypeAndEncodingType = groups.str(2);
-        uriSt.data = groups.str(3);
-        uriSt.path = groups.str(4);
+        uriSt.data = groups.str(4);
+        uriSt.path = groups.str(3) + groups.str(4);
     }
-
     return uriSt;
 }
 }  // namespace pulsar

--- a/pulsar-client-cpp/tests/ZTSClientTest.cc
+++ b/pulsar-client-cpp/tests/ZTSClientTest.cc
@@ -39,7 +39,7 @@ TEST(ZTSClientTest, testZTSClient) {
     {
         PrivateKeyUri uri = ZTSClientWrapper::parseUri("file:///path/to/private.key");
         ASSERT_EQ("file", uri.scheme);
-        ASSERT_EQ("/path/to/private.key", uri.path);
+        ASSERT_EQ("///path/to/private.key", uri.path);
     }
 
     {


### PR DESCRIPTION
### Motivation

Reverting 8fcc7ca5e5d3615b60a082699bb100907044cf79.

That reason is that std::regex are completely unusable on GCC 4.8.2 (even though the code compiles fine....) which is the version used in the Manylinux1 Docker images that are used to build the Python wheel files.

This is the reason why the integration tests are failing with Python functions errors.