### PR TITLE
Add minimum amount of resources to run setting for functions

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -111,6 +111,14 @@ processContainerFactory:
 #  # if it is not an absolute path, it is relative to `pulsarRootDir`
 #  extraFunctionDependenciesDir:
 
+## A set of the minimum amount of resources functions must request.
+## Support for this depends on function runtime.
+## Only kubernetes runtime currently supports this.
+# functionInstanceMinResources:
+#   cpu: 1
+#   ram: 1073741824
+#   disk: 10737418240
+
 ############################################
 # security settings for worker service
 ############################################

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
@@ -285,10 +285,10 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             if (minCpu != null) {
                 if (functionDetails.getResources() == null) {
                     throw new IllegalArgumentException(
-                            String.format("Per instance CPU requested is not specified. Must specify CPU requested for function to be at least %d", minCpu));
+                            String.format("Per instance CPU requested is not specified. Must specify CPU requested for function to be at least %s", minCpu));
                 } else if (functionDetails.getResources().getCpu() < minCpu) {
                     throw new IllegalArgumentException(
-                            String.format("Per instance CPU requested, %d, for function is less than the minimum required, %d",
+                            String.format("Per instance CPU requested, %s, for function is less than the minimum required, %s",
                                     functionDetails.getResources().getCpu(), minCpu));
                 }
             }
@@ -296,10 +296,10 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             if (minRam != null) {
                 if (functionDetails.getResources() == null) {
                     throw new IllegalArgumentException(
-                            String.format("Per instance RAM requested is not specified. Must specify RAM requested for function to be at least %d", minRam));
+                            String.format("Per instance RAM requested is not specified. Must specify RAM requested for function to be at least %s", minRam));
                 } else if (functionDetails.getResources().getRam() < minRam) {
                     throw new IllegalArgumentException(
-                            String.format("Per instance CPU requested, %d, for function is less than the minimum required, %d",
+                            String.format("Per instance RAM requested, %s, for function is less than the minimum required, %s",
                                     functionDetails.getResources().getRam(), minRam));
                 }
             }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
@@ -22,7 +22,6 @@ package org.apache.pulsar.functions.runtime;
 import io.kubernetes.client.apis.AppsV1Api;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.models.V1PodSpec;
-import lombok.ToString;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.functions.proto.Function;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -155,7 +155,7 @@ public class KubernetesRuntimeTest {
             null,
             null,
             null,
-            new TestSecretProviderConfigurator()));
+                null, new TestSecretProviderConfigurator()));
         doNothing().when(factory).setupClient();
         return factory;
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -165,6 +165,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     workerConfig.getKubernetesContainerFactory().getExpectedMetricsCollectionInterval() == null ? -1 : workerConfig.getKubernetesContainerFactory().getExpectedMetricsCollectionInterval(),
                     workerConfig.getKubernetesContainerFactory().getChangeConfigMap(),
                     workerConfig.getKubernetesContainerFactory().getChangeConfigMapNamespace(),
+                    workerConfig.getFunctionInstanceMinResources(),
                     secretsProviderConfigurator);
         } else {
             throw new RuntimeException("Either Thread, Process or Kubernetes Container Factory need to be set");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -36,7 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
-import org.apache.pulsar.common.stats.JvmG1GCMetricsLogger;
+import org.apache.pulsar.common.functions.Resources;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -432,6 +432,11 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             + " to the init method of the secretproviderconfigurator"
     )
     private Map<String, String> secretsProviderConfiguratorConfig;
+    @FieldContext(
+            category = CATEGORY_FUNC_RUNTIME_MNG,
+            doc = "A set of the minimum amount of resources functions must request.  Support for this depends on function runtime."
+    )
+    private Resources functionInstanceMinResources;
 
     public String getFunctionMetadataTopic() {
         return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionMetadataTopicName);


### PR DESCRIPTION

### Motivation

Some runtime might require a minimum about of resources to run a function instance.  Currently functions don't support the check to determine if the resources requested is greater the the minimum required. 

### Modification

Add a worker config to set the minimum amount of resource a function must request