### PR TITLE
In functions log topic appender, don't set producer name

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.instance;
 
 import org.apache.logging.log4j.core.*;
+import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -88,13 +89,14 @@ public class LogAppender implements Appender {
     public void start() {
         this.state = State.STARTING;
         try {
-            ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+            producer = pulsarClient.newProducer()
                     .topic(logTopic)
-                    .producerName(fqn)
                     .blockIfQueueFull(false)
                     .enableBatching(true)
-                    .batchingMaxPublishDelay(10, TimeUnit.MILLISECONDS);
-            producer = producerBuilder.create();
+                    .compressionType(CompressionType.LZ4)
+                    .batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS)
+                    .property("function", fqn)
+                    .create();
         } catch (Exception e) {
             throw new RuntimeException("Error starting LogTopic Producer", e);
         }


### PR DESCRIPTION
### Motivation

When enabling log topic in functions, we shouldn't set the producer name, otherwise multiple function instances will fail to produce on the log topic.

At the same time: 
 * Increase batch time to have more batching (since the latency hit will not be important here)
 * Enabled LZ4 compression, since it's always good for logs.