### PR TITLE
Only require linking with Boost program_options for CLI tools

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -207,7 +207,6 @@ include_directories(
 
 set(COMMON_LIBS
   ${COMMON_LIBS} -lpthread -lm
-  ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${Boost_REGEX_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${CURL_LIBRARY_PATH}

--- a/pulsar-client-cpp/perf/CMakeLists.txt
+++ b/pulsar-client-cpp/perf/CMakeLists.txt
@@ -31,5 +31,7 @@ set(PERF_CONSUMER_SOURCES
 add_executable(perfProducer ${PERF_PRODUCER_SOURCES})
 add_executable(perfConsumer ${PERF_CONSUMER_SOURCES})
 
-target_link_libraries(perfProducer pulsarShared ${CLIENT_LIBS})
-target_link_libraries(perfConsumer pulsarShared ${CLIENT_LIBS})
+set(TOOL_LIBS ${CLIENT_LIBS} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
+target_link_libraries(perfProducer pulsarShared ${TOOL_LIBS})
+target_link_libraries(perfConsumer pulsarShared ${TOOL_LIBS})


### PR DESCRIPTION
### Motivation

We don't need to link the pulsar client lib with Boost program-options. That's only need for C++ CLI tools.