### PR TITLE
fix a couple race conditions in function worker

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -138,7 +138,7 @@ public class RuntimeSpawner implements AutoCloseable {
     public void close() {
         // cancel liveness checker before stopping runtime.
         if (processLivenessCheckTimer != null) {
-            processLivenessCheckTimer.cancel(false);
+            processLivenessCheckTimer.cancel(true);
             processLivenessCheckTimer = null;
         }
         if (null != runtime) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -832,9 +832,11 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
     @Override
     public void close() throws Exception {
-        stopAllOwnedFunctions();
         this.functionActioner.close();
         this.functionAssignmentTailer.close();
+
+        stopAllOwnedFunctions();
+
         if (runtimeFactory != null) {
             runtimeFactory.close();
         }


### PR DESCRIPTION
### Motivation

The two potential race conditions:

1. RuntimeSpawner - make sure to interrupt the processLivenessCheckTimer so that we that the processLivenessCheckTimer doesn't potentially restart a functions during the shutdown of the functions

2. FunctionRuntimeManager - stop all the functions instances owned by this worker only after we close functionactioner and functionAssignmentTailer, to prevent worker from potentially starting functions during a worker shutdown


