### PR TITLE
[pulsar-broker][replicator] add remote cluster name in producer name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -80,7 +80,7 @@ public abstract class AbstractReplicator {
                 .enableBatching(false)
                 .sendTimeout(0, TimeUnit.SECONDS) //
                 .maxPendingMessages(producerQueueSize) //
-                .producerName(getReplicatorName(replicatorPrefix, localCluster));
+                .producerName(String.format("%s-%s", getReplicatorName(replicatorPrefix, localCluster), remoteCluster));
         STATE_UPDATER.set(this, State.Stopped);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -46,6 +46,7 @@ public abstract class AbstractReplicator {
     protected final PulsarClientImpl client;
 
     protected volatile ProducerImpl producer;
+    public static final String producerNamePadding = "####@@@@!!!!padding";
 
     protected final int producerQueueSize;
     protected final ProducerBuilder<byte[]> producerBuilder;
@@ -80,7 +81,8 @@ public abstract class AbstractReplicator {
                 .enableBatching(false)
                 .sendTimeout(0, TimeUnit.SECONDS) //
                 .maxPendingMessages(producerQueueSize) //
-                .producerName(String.format("%s-%s", getReplicatorName(replicatorPrefix, localCluster), remoteCluster));
+                .producerName(String.format("%s%s%s", getReplicatorName(replicatorPrefix, localCluster),
+                        producerNamePadding, remoteCluster));
         STATE_UPDATER.set(this, State.Stopped);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -46,7 +46,7 @@ public abstract class AbstractReplicator {
     protected final PulsarClientImpl client;
 
     protected volatile ProducerImpl producer;
-    public static final String producerNamePadding = "####@@@@!!!!padding";
+    public static final String REPL_PRODUCER_NAME_DELIMITER = "-->";
 
     protected final int producerQueueSize;
     protected final ProducerBuilder<byte[]> producerBuilder;
@@ -81,8 +81,7 @@ public abstract class AbstractReplicator {
                 .enableBatching(false)
                 .sendTimeout(0, TimeUnit.SECONDS) //
                 .maxPendingMessages(producerQueueSize) //
-                .producerName(String.format("%s%s%s", getReplicatorName(replicatorPrefix, localCluster),
-                        producerNamePadding, remoteCluster));
+                .producerName(getReplicatorName(replicatorPrefix, localCluster));
         STATE_UPDATER.set(this, State.Stopped);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.common.schema.SchemaVersion;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static org.apache.pulsar.broker.service.AbstractReplicator.producerNamePadding;
 
 /**
  * Represents a currently connected producer
@@ -107,7 +108,7 @@ public class Producer {
 
         this.isRemote = producerName
                 .startsWith(cnx.getBrokerService().pulsar().getConfiguration().getReplicatorPrefix());
-        this.remoteCluster = isRemote ? producerName.split("\\.")[2] : null;
+        this.remoteCluster = isRemote ? producerName.split("\\.")[2].split(producerNamePadding)[0] : null;
 
         this.isEncrypted = isEncrypted;
         this.schemaVersion = schemaVersion;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -50,7 +50,7 @@ import org.apache.pulsar.common.schema.SchemaVersion;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.apache.pulsar.broker.service.AbstractReplicator.producerNamePadding;
+import static org.apache.pulsar.broker.service.AbstractReplicator.REPL_PRODUCER_NAME_DELIMITER;
 
 /**
  * Represents a currently connected producer
@@ -108,7 +108,7 @@ public class Producer {
 
         this.isRemote = producerName
                 .startsWith(cnx.getBrokerService().pulsar().getConfiguration().getReplicatorPrefix());
-        this.remoteCluster = isRemote ? producerName.split("\\.")[2].split(producerNamePadding)[0] : null;
+        this.remoteCluster = isRemote ? producerName.split("\\.")[2].split(REPL_PRODUCER_NAME_DELIMITER)[0] : null;
 
         this.isEncrypted = isEncrypted;
         this.schemaVersion = schemaVersion;


### PR DESCRIPTION
### Motivation
Pulsar can have multiple replication producers and sometimes, it requires to have specific remote-cluster's producer name for debugging the issue. So, adding remote-cluster name into repl-producer name.