### PR TITLE
Allow to automatically assign TCP ports when starting a broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -161,15 +161,6 @@ public class PulsarBrokerStarter {
                     workerConfig = WorkerConfig.load(starterArguments.fnWorkerConfigFile);
                 }
                 // worker talks to local broker
-                boolean useTls = workerConfig.isUseTls();
-                String pulsarServiceUrl = useTls
-                        ? PulsarService.brokerUrlTls(brokerConfig)
-                        : PulsarService.brokerUrl(brokerConfig);
-                String webServiceUrl = useTls
-                        ? PulsarService.webAddressTls(brokerConfig)
-                        : PulsarService.webAddress(brokerConfig);
-                workerConfig.setPulsarServiceUrl(pulsarServiceUrl);
-                workerConfig.setPulsarWebServiceUrl(webServiceUrl);
                 String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                     brokerConfig.getAdvertisedAddress());
                 workerConfig.setWorkerHostname(hostname);
@@ -188,7 +179,6 @@ public class PulsarBrokerStarter {
                 workerConfig.setZooKeeperSessionTimeoutMillis(brokerConfig.getZooKeeperSessionTimeoutMillis());
                 workerConfig.setZooKeeperOperationTimeoutSeconds(brokerConfig.getZooKeeperOperationTimeoutSeconds());
 
-                workerConfig.setUseTls(useTls);
                 workerConfig.setTlsHostnameVerificationEnable(false);
 
                 workerConfig.setTlsAllowInsecureConnection(brokerConfig.isTlsAllowInsecureConnection());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -272,15 +272,6 @@ public class PulsarStandalone implements AutoCloseable {
                 workerConfig = WorkerConfig.load(this.getFnWorkerConfigFile());
             }
             // worker talks to local broker
-            boolean useTls = workerConfig.isUseTls();
-            String pulsarServiceUrl = useTls
-                    ? PulsarService.brokerUrlTls(config)
-                    : PulsarService.brokerUrl(config);
-            String webServiceUrl = useTls
-                    ? PulsarService.webAddressTls(config)
-                    : PulsarService.webAddress(config);
-            workerConfig.setPulsarServiceUrl(pulsarServiceUrl);
-            workerConfig.setPulsarWebServiceUrl(webServiceUrl);
             if (this.isNoStreamStorage()) {
                 // only set the state storage service url when state is enabled.
                 workerConfig.setStateStorageServiceUrl(null);
@@ -306,7 +297,6 @@ public class PulsarStandalone implements AutoCloseable {
             workerConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
             workerConfig.setZooKeeperOperationTimeoutSeconds(config.getZooKeeperOperationTimeoutSeconds());
 
-            workerConfig.setUseTls(useTls);
             workerConfig.setTlsHostnameVerificationEnable(false);
 
             workerConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1091,4 +1091,20 @@ public class PulsarService implements AutoCloseable {
             LOG.info("Function worker service started");
         }
     }
+
+    public Optional<Integer> getListenPortHTTP() {
+        return webService.getListenPortHTTP();
+    }
+
+    public Optional<Integer> getListenPortHTTPS() {
+        return webService.getListenPortHTTPS();
+    }
+
+    public Optional<Integer> getListenPort() {
+        return brokerService.getListenPort();
+    }
+
+    public Optional<Integer> getListenPortTls() {
+        return brokerService.getListenPortTls();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1100,11 +1100,11 @@ public class PulsarService implements AutoCloseable {
         return webService.getListenPortHTTPS();
     }
 
-    public Optional<Integer> getListenPort() {
+    public Optional<Integer> getBrokerListenPort() {
         return brokerService.getListenPort();
     }
 
-    public Optional<Integer> getListenPortTls() {
+    public Optional<Integer> getBrokerListenPortTls() {
         return brokerService.getListenPortTls();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -42,6 +42,7 @@ import org.apache.zookeeper.ZooKeeper;
 
 public class NoopLoadManager implements LoadManager {
 
+    private PulsarService pulsar;
     private String lookupServiceAddress;
     private ResourceUnit localResourceUnit;
     private ZooKeeper zkClient;
@@ -54,6 +55,11 @@ public class NoopLoadManager implements LoadManager {
 
     @Override
     public void initialize(PulsarService pulsar) {
+        this.pulsar = pulsar;
+    }
+
+    @Override
+    public void start() throws PulsarServerException {
         lookupServiceAddress = pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getWebServicePort().get();
         localResourceUnit = new SimpleResourceUnit(String.format("http://%s", lookupServiceAddress),
                 new PulsarResourceDescription());
@@ -62,10 +68,6 @@ public class NoopLoadManager implements LoadManager {
         localData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(), pulsar.getWebServiceAddressTls(),
                 pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
         localData.setProtocols(pulsar.getProtocolDataToAdvertise());
-    }
-
-    @Override
-    public void start() throws PulsarServerException {
         String brokerZnodePath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;
 
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -265,22 +265,6 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         defaultStats.msgRateIn = DEFAULT_MESSAGE_RATE;
         defaultStats.msgRateOut = DEFAULT_MESSAGE_RATE;
 
-        Map<String, String> protocolData = pulsar.getProtocolDataToAdvertise();
-
-        lastData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(), pulsar.getWebServiceAddressTls(),
-                pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
-        lastData.setProtocols(protocolData);
-        localData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(), pulsar.getWebServiceAddressTls(),
-                pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
-        lastData.setProtocols(protocolData);
-        localData.setBrokerVersionString(pulsar.getBrokerVersion());
-        // configure broker-topic mode
-        lastData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
-        lastData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
-        localData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
-        localData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
-
-
         placementStrategy = ModularLoadManagerStrategy.create(conf);
         policies = new SimpleResourceAllocationPolicies(pulsar);
         zkClient = pulsar.getZkClient();
@@ -790,6 +774,23 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     @Override
     public void start() throws PulsarServerException {
         try {
+            // At this point, the ports will be updated with the real port number that the server was assigned
+            Map<String, String> protocolData = pulsar.getProtocolDataToAdvertise();
+
+            lastData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                    pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+            lastData.setProtocols(protocolData);
+            localData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                    pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+            lastData.setProtocols(protocolData);
+            localData.setBrokerVersionString(pulsar.getBrokerVersion());
+            // configure broker-topic mode
+            lastData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
+            lastData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
+            localData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
+            localData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
+
+
             // Register the brokers in zk list
             createZPathIfNotExists(zkClient, LoadManager.LOADBALANCE_BROKERS_ROOT);
 
@@ -974,7 +975,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             log.warn("Failed to get domain-list for cluster {}", e.getMessage());
         }
     }
-    
+
     @Override
     public LocalBrokerData getBrokerLocalData(String broker) {
         String key = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, broker);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -371,7 +371,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new PulsarChannelInitializer(pulsar, true));
             try {
-                tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort.get())).sync();
                 listenChannelTls = tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort.get())).sync()
                         .channel();
                 log.info("Started Pulsar Broker TLS service on {} - TLS provider: {}", listenChannelTls.localAddress(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -372,17 +372,13 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             tlsBootstrap.childHandler(new PulsarChannelInitializer(pulsar, true));
             try {
                 tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort.get())).sync();
-                Channel channel = tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort.get())).sync()
+                listenChannelTls = tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort.get())).sync()
                         .channel();
-                log.info("Started Pulsar Broker TLS service on {} - TLS provider: {}", channel.localAddress(),
+                log.info("Started Pulsar Broker TLS service on {} - TLS provider: {}", listenChannelTls.localAddress(),
                         SslContext.defaultServerProvider());
-                if (tlsPort.get() == 0) {
-                    // Set the config with the real port that the service is bound on
-                    serviceConfig.setBrokerServicePortTls(Optional.of(((InetSocketAddress) channel.localAddress()).getPort()));
-                }
             } catch (Exception e) {
                 throw new IOException(String.format("Failed to start Pulsar Broker TLS service on %s:%d",
-                        pulsar.getBindAddress(), port.get()), e);
+                        pulsar.getBindAddress(), tlsPort.get()), e);
             }
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -72,6 +72,9 @@ public class WebService implements AutoCloseable {
     private final List<Handler> handlers;
     private final WebExecutorThreadPool webServiceExecutor;
 
+    private final ServerConnector httpConnector;
+    private final ServerConnector httpsConnector;
+
     public WebService(PulsarService pulsar) throws PulsarServerException {
         this.handlers = Lists.newArrayList();
         this.pulsar = pulsar;
@@ -83,10 +86,12 @@ public class WebService implements AutoCloseable {
 
         Optional<Integer> port = pulsar.getConfiguration().getWebServicePort();
         if (port.isPresent()) {
-            ServerConnector connector = new PulsarServerConnector(server, 1, 1);
-            connector.setPort(port.get());
-            connector.setHost(pulsar.getBindAddress());
-            connectors.add(connector);
+            httpConnector = new PulsarServerConnector(server, 1, 1);
+            httpConnector.setPort(port.get());
+            httpConnector.setHost(pulsar.getBindAddress());
+            connectors.add(httpConnector);
+        } else {
+            httpConnector = null;
         }
 
         Optional<Integer> tlsPort = pulsar.getConfiguration().getWebServicePortTls();
@@ -99,13 +104,15 @@ public class WebService implements AutoCloseable {
                         pulsar.getConfiguration().getTlsKeyFilePath(),
                         pulsar.getConfiguration().isTlsRequireTrustedClientCertOnConnect(), true,
                         pulsar.getConfiguration().getTlsCertRefreshCheckDurationSec());
-                ServerConnector tlsConnector = new PulsarServerConnector(server, 1, 1, sslCtxFactory);
-                tlsConnector.setPort(tlsPort.get());
-                tlsConnector.setHost(pulsar.getBindAddress());
-                connectors.add(tlsConnector);
+                httpsConnector = new PulsarServerConnector(server, 1, 1, sslCtxFactory);
+                httpsConnector.setPort(tlsPort.get());
+                httpsConnector.setHost(pulsar.getBindAddress());
+                connectors.add(httpsConnector);
             } catch (Exception e) {
                 throw new PulsarServerException(e);
             }
+        } else {
+            httpsConnector = null;
         }
 
         // Limit number of concurrent HTTP connections to avoid getting out of file descriptors
@@ -187,7 +194,20 @@ public class WebService implements AutoCloseable {
 
             server.start();
 
-            log.info("Web Service started at {}", pulsar.getSafeWebServiceAddress());
+            if (httpConnector != null) {
+                log.info("HTTP Service started at http://{}:{}", httpConnector.getHost(), httpConnector.getLocalPort());
+                pulsar.getConfiguration().setWebServicePort(Optional.of(httpConnector.getLocalPort()));
+            } else {
+                log.info("HTTP Service disabled");
+            }
+
+            if (httpsConnector != null) {
+                log.info("HTTPS Service started at https://{}:{}", httpsConnector.getHost(),
+                        httpsConnector.getLocalPort());
+                pulsar.getConfiguration().setWebServicePortTls(Optional.of(httpsConnector.getLocalPort()));
+            } else {
+                log.info("HTTPS Service disabled");
+            }
         } catch (Exception e) {
             throw new PulsarServerException(e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -224,5 +224,21 @@ public class WebService implements AutoCloseable {
         }
     }
 
+    public Optional<Integer> getListenPortHTTP() {
+        if (httpConnector != null) {
+            return Optional.of(httpConnector.getLocalPort());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<Integer> getListenPortHTTPS() {
+        if (httpsConnector != null) {
+            return Optional.of(httpsConnector.getLocalPort());
+        } else {
+            return Optional.empty();
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(WebService.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -86,17 +86,20 @@ public class CompactorTool {
             clientBuilder.authentication(brokerConfig.getBrokerClientAuthenticationPlugin(),
                     brokerConfig.getBrokerClientAuthenticationParameters());
         }
-        
+
 
         if (brokerConfig.getBrokerServicePortTls().isPresent()) {
-            clientBuilder.serviceUrl(PulsarService.brokerUrlTls(brokerConfig))
-            .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
-            .tlsTrustCertsFilePath(brokerConfig.getTlsCertificateFilePath());
+            clientBuilder
+                    .serviceUrl(PulsarService.brokerUrlTls(PulsarService.advertisedAddress(brokerConfig),
+                            brokerConfig.getBrokerServicePortTls().get()))
+                    .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
+                    .tlsTrustCertsFilePath(brokerConfig.getTlsCertificateFilePath());
 
         } else {
-            clientBuilder.serviceUrl(PulsarService.brokerUrl(brokerConfig));
+            clientBuilder.serviceUrl(PulsarService.brokerUrl(PulsarService.advertisedAddress(brokerConfig),
+                    brokerConfig.getBrokerServicePort().get()));
         }
-        
+
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("compaction-%d").setDaemon(true).build());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -97,7 +97,6 @@ public class OwnershipCacheTest {
         doReturn(Optional.ofNullable(new Integer(port))).when(config).getBrokerServicePort();
         doReturn(Optional.ofNullable(null)).when(config).getWebServicePort();
         doReturn(brokerService).when(pulsar).getBrokerService();
-        doReturn(webAddress(config)).when(pulsar).getSafeWebServiceAddress();
         doReturn(selfBrokerUrl).when(pulsar).getSafeBrokerServiceUrl();
     }
 

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.AdaptiveRecvByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -31,6 +32,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 import lombok.Getter;
 
@@ -55,8 +57,8 @@ import org.slf4j.LoggerFactory;
 public class DiscoveryService implements Closeable {
 
     private final ServiceConfig config;
-    private final String serviceUrl;
-    private final String serviceUrlTls;
+    private String serviceUrl;
+    private String serviceUrlTls;
     private ConfigurationCacheService configurationCacheService;
     private AuthenticationService authenticationService;
     private AuthorizationService authorizationService;
@@ -69,11 +71,12 @@ public class DiscoveryService implements Closeable {
     private final DefaultThreadFactory workersThreadFactory = new DefaultThreadFactory("pulsar-discovery-io");
     private final int numThreads = Runtime.getRuntime().availableProcessors();
 
+    private Channel channelListen;
+    private Channel channelListenTls;
+
     public DiscoveryService(ServiceConfig serviceConfig) {
         checkNotNull(serviceConfig);
         this.config = serviceConfig;
-        this.serviceUrl = serviceUrl();
-        this.serviceUrlTls = serviceUrlTls();
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(1, acceptorThreadFactory);
         this.workerGroup = EventLoopUtil.newEventLoopGroup(numThreads, workersThreadFactory);
     }
@@ -116,17 +119,19 @@ public class DiscoveryService implements Closeable {
 
         if (config.getServicePort().isPresent()) {
             // Bind and start to accept incoming connections.
-            bootstrap.bind(config.getServicePort().get()).sync();
-            LOG.info("Started Pulsar Discovery service on port {}", config.getServicePort());
+            channelListen = bootstrap.bind(config.getServicePort().get()).sync().channel();
+            LOG.info("Started Pulsar Discovery service on {}", channelListen.localAddress());
         }
 
         if (config.getServicePortTls().isPresent()) {
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new ServiceChannelInitializer(this, config, true));
-            tlsBootstrap.bind(config.getServicePortTls().get()).sync();
-            LOG.info("Started Pulsar Discovery TLS service on port {}", config.getServicePortTls().get());
+            channelListenTls = tlsBootstrap.bind(config.getServicePortTls().get()).sync().channel();
+            LOG.info("Started Pulsar Discovery TLS service on port {}", channelListenTls.localAddress());
         }
 
+        this.serviceUrl = serviceUrl();
+        this.serviceUrlTls = serviceUrlTls();
     }
 
     public ZooKeeperClientFactory getZooKeeperClientFactory() {
@@ -168,7 +173,8 @@ public class DiscoveryService implements Closeable {
 
     public String serviceUrl() {
         if (config.getServicePort().isPresent()) {
-            return new StringBuilder("pulsar://").append(host()).append(":").append(config.getServicePort().get())
+            return new StringBuilder("pulsar://").append(host()).append(":")
+                    .append(((InetSocketAddress) channelListen.localAddress()).getPort())
                     .toString();
         } else {
             return null;
@@ -178,7 +184,8 @@ public class DiscoveryService implements Closeable {
     public String serviceUrlTls() {
         if (config.getServicePortTls().isPresent()) {
             return new StringBuilder("pulsar+ssl://").append(host()).append(":")
-                    .append(config.getServicePortTls().get()).toString();
+                    .append(((InetSocketAddress) channelListenTls.localAddress()).getPort())
+                    .toString();
         } else {
             return null;
         }

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.discovery.service.server;
 
+import com.google.common.collect.Lists;
+
 import java.net.URI;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import javax.servlet.Servlet;
@@ -43,8 +45,6 @@ import org.eclipse.jetty.util.thread.ExecutorThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Lists;
-
 /**
  * Manages web-service startup/stop on jetty server.
  *
@@ -54,6 +54,9 @@ public class ServerManager {
     private final ExecutorThreadPool webServiceExecutor;
     private final List<Handler> handlers = Lists.newArrayList();
 
+    private final ServerConnector connector;
+    private final ServerConnector connectorTls;
+
     public ServerManager(ServiceConfig config) {
         this.webServiceExecutor = new ExecutorThreadPool();
         this.webServiceExecutor.setName("pulsar-external-web");
@@ -62,9 +65,11 @@ public class ServerManager {
         List<ServerConnector> connectors = Lists.newArrayList();
 
         if (config.getWebServicePort().isPresent()) {
-            ServerConnector connector = new ServerConnector(server, 1, 1);
+            connector = new ServerConnector(server, 1, 1);
             connector.setPort(config.getWebServicePort().get());
             connectors.add(connector);
+        } else {
+            connector = null;
         }
 
         if (config.getWebServicePortTls().isPresent()) {
@@ -73,16 +78,18 @@ public class ServerManager {
                         config.isTlsAllowInsecureConnection(),
                         config.getTlsTrustCertsFilePath(),
                         config.getTlsCertificateFilePath(),
-                        config.getTlsKeyFilePath(), 
+                        config.getTlsKeyFilePath(),
                         config.getTlsRequireTrustedClientCertOnConnect(),
                         true,
                         config.getTlsCertRefreshCheckDurationSec());
-                ServerConnector tlsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
-                tlsConnector.setPort(config.getWebServicePortTls().get());
-                connectors.add(tlsConnector);
+                connectorTls = new ServerConnector(server, 1, 1, sslCtxFactory);
+                connectorTls.setPort(config.getWebServicePortTls().get());
+                connectors.add(connectorTls);
             } catch (Exception e) {
                 throw new RestException(e);
-            }            
+            }
+        } else {
+            connectorTls = null;
         }
 
         // Limit number of concurrent HTTP connections to avoid getting out of file descriptors
@@ -131,10 +138,26 @@ public class ServerManager {
         webServiceExecutor.stop();
         log.info("Server stopped successfully");
     }
-    
+
 	public boolean isStarted() {
 		return server.isStarted();
 	}
+
+	public Optional<Integer> getListenPortHTTP() {
+	    if (connector != null) {
+	        return Optional.of(connector.getLocalPort());
+	    } else {
+	        return Optional.empty();
+	    }
+	}
+
+	public Optional<Integer> getListenPortHTTPS() {
+        if (connectorTls != null) {
+            return Optional.of(connectorTls.getLocalPort());
+        } else {
+            return Optional.empty();
+        }
+    }
 
     private static final Logger log = LoggerFactory.getLogger(ServerManager.class);
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -192,7 +193,7 @@ public class Worker {
             if (null != this.server) {
                 this.server.stop();
             }
-            workerService.stop();    
+            workerService.stop();
         } catch(Exception e) {
             log.warn("Failed to gracefully stop worker service ", e);
         }
@@ -204,8 +205,14 @@ public class Worker {
                 log.warn("Failed to close global zk cache ", e);
             }
         }
+    }
 
 
-        
+    public Optional<Integer> getListenPortHTTP() {
+        return this.server.getListenPortHTTP();
+    }
+
+    public Optional<Integer> getListenPortHTTPS() {
+        return this.server.getListenPortHTTPS();
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import javax.servlet.DispatcherType;
@@ -63,6 +64,9 @@ public class WorkerServer {
     private final WebExecutorThreadPool webServerExecutor;
     private Server server;
 
+    private ServerConnector httpConnector;
+    private ServerConnector httpsConnector;
+
     private static String getErrorMessage(Server server, int port, Exception ex) {
         if (ex instanceof BindException) {
             final URI uri = server.getURI();
@@ -88,9 +92,9 @@ public class WorkerServer {
         server = new Server(webServerExecutor);
 
         List<ServerConnector> connectors = new ArrayList<>();
-        ServerConnector connector = new ServerConnector(server, 1, 1);
-        connector.setPort(this.workerConfig.getWorkerPort());
-        connectors.add(connector);
+        httpConnector = new ServerConnector(server, 1, 1);
+        httpConnector.setPort(this.workerConfig.getWorkerPort());
+        connectors.add(httpConnector);
 
         List<Handler> handlers = new ArrayList<>(4);
         handlers.add(
@@ -124,9 +128,9 @@ public class WorkerServer {
                         this.workerConfig.isTlsRequireTrustedClientCertOnConnect(),
                         true,
                         this.workerConfig.getTlsCertRefreshCheckDurationSec());
-                ServerConnector tlsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
-                tlsConnector.setPort(this.workerConfig.getWorkerPortTls());
-                connectors.add(tlsConnector);
+                httpsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
+                httpsConnector.setPort(this.workerConfig.getWorkerPortTls());
+                connectors.add(httpsConnector);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -176,4 +180,19 @@ public class WorkerServer {
         }
     }
 
+    public Optional<Integer> getListenPortHTTP() {
+        if (httpConnector != null) {
+            return Optional.of(httpConnector.getLocalPort());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<Integer> getListenPortHTTPS() {
+        if (httpsConnector != null) {
+            return Optional.of(httpsConnector.getLocalPort());
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -148,7 +148,7 @@ public class ProxyService implements Closeable {
         if (proxyConfig.getServicePortTls().isPresent()) {
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, true));
-            Channel listenChannelTls = tlsBootstrap.bind(proxyConfig.getServicePortTls().get()).sync().channel();
+            listenChannelTls = tlsBootstrap.bind(proxyConfig.getServicePortTls().get()).sync().channel();
             LOG.info("Started Pulsar TLS Proxy on {}", listenChannelTls.localAddress());
         }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -23,6 +23,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.AdaptiveRecvByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -32,7 +33,9 @@ import io.prometheus.client.Gauge;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,8 +56,8 @@ import org.slf4j.LoggerFactory;
 public class ProxyService implements Closeable {
 
     private final ProxyConfiguration proxyConfig;
-    private final String serviceUrl;
-    private final String serviceUrlTls;
+    private String serviceUrl;
+    private String serviceUrlTls;
     private ConfigurationCacheService configurationCacheService;
     private final AuthenticationService authenticationService;
     private AuthorizationService authorizationService;
@@ -62,6 +65,9 @@ public class ProxyService implements Closeable {
 
     private final EventLoopGroup acceptorGroup;
     private final EventLoopGroup workerGroup;
+
+    private Channel listenChannel;
+    private Channel listenChannelTls;
 
     private final DefaultThreadFactory acceptorThreadFactory = new DefaultThreadFactory("pulsar-proxy-acceptor");
     private final DefaultThreadFactory workersThreadFactory = new DefaultThreadFactory("pulsar-proxy-io");
@@ -100,24 +106,6 @@ public class ProxyService implements Closeable {
         this.lookupRequestSemaphore = new AtomicReference<Semaphore>(
                 new Semaphore(proxyConfig.getMaxConcurrentLookupRequests(), false));
 
-        String hostname;
-        try {
-            hostname = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
-        if (proxyConfig.getServicePort().isPresent()) {
-            this.serviceUrl = String.format("pulsar://%s:%d/", hostname, proxyConfig.getServicePort().get());
-        } else {
-            this.serviceUrl = null;
-        }
-
-        if (proxyConfig.getServicePortTls().isPresent()) {
-            this.serviceUrlTls = String.format("pulsar://%s:%d/", hostname, proxyConfig.getServicePortTls().get());
-        } else {
-            this.serviceUrlTls = null;
-        }
-
         if (proxyConfig.getproxyLogLevel().isPresent()) {
             ProxyService.proxyLogLevel = Integer.valueOf(proxyConfig.getproxyLogLevel().get());
         } else {
@@ -150,19 +138,37 @@ public class ProxyService implements Closeable {
         // Bind and start to accept incoming connections.
         if (proxyConfig.getServicePort().isPresent()) {
             try {
-                bootstrap.bind(proxyConfig.getServicePort().get()).sync();
-                LOG.info("Started Pulsar Proxy at {}", serviceUrl);
+                listenChannel = bootstrap.bind(proxyConfig.getServicePort().get()).sync().channel();
+                LOG.info("Started Pulsar Proxy at {}", listenChannel.localAddress());
             } catch (Exception e) {
                 throw new IOException("Failed to bind Pulsar Proxy on port " + proxyConfig.getServicePort().get(), e);
             }
         }
-        LOG.info("Started Pulsar Proxy at {}", serviceUrl);
 
         if (proxyConfig.getServicePortTls().isPresent()) {
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, true));
-            tlsBootstrap.bind(proxyConfig.getServicePortTls().get()).sync();
-            LOG.info("Started Pulsar TLS Proxy on port {}", proxyConfig.getServicePortTls().get());
+            Channel listenChannelTls = tlsBootstrap.bind(proxyConfig.getServicePortTls().get()).sync().channel();
+            LOG.info("Started Pulsar TLS Proxy on {}", listenChannelTls.localAddress());
+        }
+
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (proxyConfig.getServicePort().isPresent()) {
+            this.serviceUrl = String.format("pulsar://%s:%d/", hostname, getListenPort().get());
+        } else {
+            this.serviceUrl = null;
+        }
+
+        if (proxyConfig.getServicePortTls().isPresent()) {
+            this.serviceUrlTls = String.format("pulsar+ssl://%s:%d/", hostname, getListenPortTls().get());
+        } else {
+            this.serviceUrlTls = null;
         }
     }
 
@@ -182,6 +188,15 @@ public class ProxyService implements Closeable {
         if (discoveryProvider != null) {
             discoveryProvider.close();
         }
+
+        if (listenChannel != null) {
+            listenChannel.close();
+        }
+
+        if (listenChannelTls != null) {
+            listenChannelTls.close();
+        }
+
         acceptorGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
     }
@@ -220,6 +235,22 @@ public class ProxyService implements Closeable {
 
     public EventLoopGroup getWorkerGroup() {
         return workerGroup;
+    }
+
+    public Optional<Integer> getListenPort() {
+        if (listenChannel != null) {
+            return Optional.of(((InetSocketAddress) listenChannel.localAddress()).getPort());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<Integer> getListenPortTls() {
+        if (listenChannelTls != null) {
+            return Optional.of(((InetSocketAddress) listenChannelTls.localAddress()).getPort());
+        } else {
+            return Optional.empty();
+        }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(ProxyService.class);


### PR DESCRIPTION
### Motivation

Allow to configure the broker listen ports with 0 for (broker, broker+tls, http, https) in order to have ports automatically assigned by the OS. 

This will be primarily used in tests to avoid port conflicts.