### PR TITLE
[tests] Allow configure integration test suite file using system property

### DIFF
--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -32,6 +32,10 @@
   <packaging>jar</packaging>
   <name>Apache Pulsar :: Tests :: Integration</name>
 
+  <properties>
+    <integrationTestSuiteFile>pulsar.xml</integrationTestSuiteFile>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.testng</groupId>
@@ -187,7 +191,7 @@
               </argLine>
               <skipTests>false</skipTests>
               <suiteXmlFiles>
-                <file>src/test/resources/pulsar.xml</file>
+                <file>src/test/resources/${integrationTestSuiteFile}</file>
               </suiteXmlFiles>
               <forkCount>1</forkCount>
             </configuration>

--- a/tests/integration/src/test/resources/pulsar-cli-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-cli-suite.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
-        <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
-        </classes>
-    </test>
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
+    <suite-files>
+        <suite-file path="./pulsar-cli.xml" />
+    </suite-files>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -19,10 +19,12 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
+<suite name="Pulsar CLI Integration Tests" verbose="2" annotations="JDK">
+    <test name="pulsar-cli-test-suite" preserve-order="true" >
         <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
+            <class name="org.apache.pulsar.tests.integration.cli.CLITest" />
+            <class name="org.apache.pulsar.tests.integration.cli.HealthcheckTest" />
+            <class name="org.apache.pulsar.tests.integration.compaction.TestCompaction" />
         </classes>
     </test>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-process-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-process-suite.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
-        <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
-        </classes>
-    </test>
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
+    <suite-files>
+        <suite-file path="./pulsar-process.xml" />
+    </suite-files>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-sql-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-sql-suite.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
-        <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
-        </classes>
-    </test>
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
+    <suite-files>
+        <suite-file path="./pulsar-sql.xml" />
+    </suite-files>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-sql.xml
+++ b/tests/integration/src/test/resources/pulsar-sql.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
+<suite name="Pulsar SQL Integration Tests" verbose="2" annotations="JDK">
+    <test name="pulsar-sql-test-suite" preserve-order="true" >
         <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
+            <class name="org.apache.pulsar.tests.integration.presto.TestBasicPresto" />
         </classes>
     </test>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-thread-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-thread-suite.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
-        <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
-        </classes>
-    </test>
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
+    <suite-files>
+        <suite-file path="./pulsar-thread.xml" />
+    </suite-files>
 </suite>

--- a/tests/integration/src/test/resources/pulsar.xml
+++ b/tests/integration/src/test/resources/pulsar.xml
@@ -23,7 +23,9 @@
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
     <suite-files>
+        <suite-file path="./pulsar-cli.xml" />
         <suite-file path="./pulsar-process.xml" />
+        <suite-file path="./pulsar-sql.xml" />
         <suite-file path="./pulsar-thread.xml" />
         <suite-file path="./tiered-storage.xml" />
     </suite-files>

--- a/tests/integration/src/test/resources/tiered-storage-suite.xml
+++ b/tests/integration/src/test/resources/tiered-storage-suite.xml
@@ -19,10 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
-    <test name="pulsar-function-process-test-suite" preserve-order="true" >
-        <classes>
-            <class name="org.apache.pulsar.tests.integration.functions.PulsarFunctionsProcessTest" />
-        </classes>
-    </test>
+<!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
+           see {@link https://github.com/cbeust/testng/issues/508} -->
+<suite name="Pulsar Test Suite" parallel="instances" thread-count="1">
+    <suite-files>
+        <suite-file path="./tiered-storage.xml" />
+    </suite-files>
 </suite>


### PR DESCRIPTION
### Motivation

Sometimes users would like to only execute a set of test suite in command line.

### Modifications

Make the suite file name configurable in the pom file.
So people can run a specific test suite using
```
mvn -pl tests/integration -DredirectTestOutputToFile=false -DintegrationTestSuiteFile=pulsar-thread-suite.xml clean test -PintegrationTests
```

Also categorize the tests info a few test suites. This would allow us break down
the integration test job into multiple smaller test jobs.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
