### PR TITLE
Use python xml to parse pom for version instead of xmllint

### DIFF
--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 file(GLOB PULSAR_SOURCES *.cc lz4/*.c checksum/*.cc stats/*.cc c/*.cc auth/*.cc auth/athenz/*.cc)
 
-execute_process(COMMAND cat ../pom.xml COMMAND xmllint --format - COMMAND sed "s/xmlns=\".*\"//g" COMMAND xmllint --stream --pattern /project/version --debug - COMMAND grep -A 2 "matches pattern" COMMAND grep text COMMAND sed "s/.* [0-9] //g" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PV)
+execute_process(COMMAND ../src/get-project-version.py OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PV)
 set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -D_PULSAR_VERSION_=\\\"${PV}\\\"")
 
 # Protobuf generation is only supported natively starting from CMake 3.8

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -24,7 +24,7 @@ cd /pulsar
 SRC_ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $SRC_ROOT_DIR/pulsar-client-cpp/pkg/deb
 
-POM_VERSION=`cat ../../../pom.xml | xmllint --format - | sed "s/xmlns=\".*\"//g" | xmllint --stream --pattern /project/version --debug - |  grep -A 2 "matches pattern" |  grep text |  sed "s/.* [0-9] //g"`
+POM_VERSION=`$SRC_ROOT_DIR/src/get-project-version.py`
 # Sanitize VERSION by removing `SNAPSHOT` if any since it's not legal in DEB
 VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
 

--- a/pulsar-client-cpp/pkg/rpm/build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/build-rpm.sh
@@ -24,7 +24,7 @@ cd /pulsar
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp/pkg/rpm
 
-POM_VERSION=`cat ../../../pom.xml | xmllint --format - | sed "s/xmlns=\".*\"//g" | xmllint --stream --pattern /project/version --debug - |  grep -A 2 "matches pattern" |  grep text |  sed "s/.* [0-9] //g"`
+POM_VERSION=`$ROOT_DIR/src/get-project-version.py`
 
 # Sanitize VERSION by removing `-incubating` since it's not legal in RPM
 VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`

--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -24,20 +24,19 @@ import sys
 
 from distutils.command import build_ext
 
+import xml.etree.ElementTree as ET
+from os.path import dirname, realpath, join
 
 def get_version():
     # Get the pulsar version from pom.xml
-    command = '''cat ../../pom.xml | xmllint --format - | \\
-        sed "s/xmlns=\\".*\\"//g" | xmllint --stream --pattern /project/version --debug - | \\
-        grep -A 2 "matches pattern" | grep text | sed "s/.* [0-9] //g"'''
-    process = subprocess.Popen(['bash', '-c', command], stdout=subprocess.PIPE)
-    output, error = process.communicate()
-    if error:
-        raise 'Failed to get version: ' + error
+    TOP_LEVEL_PATH = dirname(dirname(dirname(realpath(__file__))))
+    POM_PATH = join(TOP_LEVEL_PATH, 'pom.xml')
+    root = ET.XML(open(POM_PATH).read())
+    version = root.find('{http://maven.apache.org/POM/4.0.0}version').text.strip()
 
     # Strip the '-incubating' suffix, since it prevents the packages
     # from being uploaded into PyPI
-    return output.strip().decode('utf-8', 'strict').split('-')[0]
+    return version.split('-')[0]
 
 
 VERSION = get_version()

--- a/src/get-project-version.py
+++ b/src/get-project-version.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -18,11 +18,12 @@
 # under the License.
 #
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+import xml.etree.ElementTree as ET
+from os.path import dirname, realpath, join
 
-pushd $ROOT_DIR > /dev/null
+# Derive the POM path from the current script location
+TOP_LEVEL_PATH = dirname(dirname(realpath(__file__)))
+POM_PATH = join(TOP_LEVEL_PATH, 'pom.xml')
 
-# Get the project version from the Maven pom.xml
-src/get-project-version.py
-
-popd > /dev/null
+root = ET.XML(open(POM_PATH).read())
+print(root.find('{http://maven.apache.org/POM/4.0.0}version').text)

--- a/src/stage-release.sh
+++ b/src/stage-release.sh
@@ -27,9 +27,9 @@ fi
 
 DEST_PATH=$1
 
-pushd $(dirname "$0")/..
+pushd $(dirname "$0")
 PULSAR_PATH=$(git rev-parse --show-toplevel)
-VERSION=`cat pom.xml | xmllint --format - | sed "s/xmlns=\".*\"//g" | xmllint --stream --pattern /project/version --debug - |  grep -A 2 "matches pattern" |  grep text |  sed "s/.* [0-9] //g"`
+VERSION=`./get-project-version.py`
 popd
 
 cp $PULSAR_PATH/distribution/server/target/apache-pulsar-$VERSION-src.tar.gz $DEST_PATH


### PR DESCRIPTION
### Motivation

In certain cases, `xmllint` is not installed on a host and will make compile C++ or Python (or building Docker images) to fail. 

Simplified the hacky code to get the version from `pom.xml` by parsing the xml in Python instead of using a collection of bash tools.