### PR TITLE
Link to protobuf-lite library in C++ client

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -68,7 +68,7 @@ if (LINK_STATIC)
     SET(OPENSSL_USE_STATIC_LIBS TRUE)
 
     find_library(ZLIB_LIBRARY_PATH REQUIRED NAMES libz.a z)
-    find_library(PROTOBUF_LIBRARIES NAMES libprotobuf.a)
+    find_library(PROTOBUF_LIBRARIES NAMES libprotobuf-lite.a)
     find_library(CURL_LIBRARY_PATH NAMES libcurl.a curl)
     find_library(LIB_ZSTD NAMES libzstd.a)
 
@@ -96,7 +96,7 @@ else()
     if (NOT PROTOBUF_LIBRARIES)
       find_package(ProtoBuf QUIET)
       if (NOT ProtoBuf_FOUND)
-        find_library(PROTOBUF_LIBRARIES protobuf)
+        find_library(PROTOBUF_LIBRARIES protobuf-lite)
       endif (NOT ProtoBuf_FOUND)
     endif (NOT PROTOBUF_LIBRARIES)
 


### PR DESCRIPTION
### Motivation

We're currently linking the C++ client lib with the full protobuf library, even though the code is already generated to target the "lite" runtime. 

Protobuf-lite size is 500KB, compared to the 2MB of the full protobuf. This will reduce the size of the RPM/Debs and the Python wheel files.