### PR TITLE
If no clusters are specified, the namespace should by default use current cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1490,7 +1490,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     private void validatePolicies(NamespaceName ns, Policies policies) {
-        if (ns.isGlobal() && policies.replication_clusters.isEmpty()) {
+        if (ns.isV2() && policies.replication_clusters.isEmpty()) {
             // Default to local cluster
             policies.replication_clusters = Collections.singleton(config().getClusterName());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1490,7 +1490,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     private void validatePolicies(NamespaceName ns, Policies policies) {
-        if (policies.replication_clusters.isEmpty()) {
+        if (ns.isGlobal() && policies.replication_clusters.isEmpty()) {
             // Default to local cluster
             policies.replication_clusters = Collections.singleton(config().getClusterName());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets.SetView;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -74,9 +75,9 @@ import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
-import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -404,7 +405,7 @@ public abstract class NamespacesBase extends AdminResource {
             throw new RestException(Status.NOT_IMPLEMENTED, "Authorization is not enabled");
         }
     }
-    
+
     protected Set<String> internalGetNamespaceReplicationClusters() {
         if (!namespaceName.isGlobal()) {
             throw new RestException(Status.PRECONDITION_FAILED,
@@ -1489,6 +1490,11 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     private void validatePolicies(NamespaceName ns, Policies policies) {
+        if (policies.replication_clusters.isEmpty()) {
+            // Default to local cluster
+            policies.replication_clusters = Collections.singleton(config().getClusterName());
+        }
+
         // Validate cluster names and permissions
         policies.replication_clusters.forEach(cluster -> validateClusterForTenant(ns.getTenant(), cluster));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -902,5 +903,16 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
             Assert.fail("should have failed due to Namespace does not have any clusters configured");
         } catch (PulsarAdminException.PreconditionFailedException e) {
         }
+    }
+
+    @Test
+    public void testCreateNamespaceWithNoClusters() throws PulsarAdminException {
+        String localCluster = pulsar.getConfiguration().getClusterName();
+        String namespace = "prop-xyz/test-ns-with-no-clusters";
+        admin.namespaces().createNamespace(namespace);
+
+        // Global cluster, if there, should be omitted from the results
+        assertEquals(admin.namespaces().getNamespaceReplicationClusters(namespace),
+                Collections.singletonList(localCluster));
     }
 }


### PR DESCRIPTION
### Motivation

When creating a new namespace, by default assign it to the current cluster instead of leaving the cluster section as empty.

This will make the behavior easier and less confusing for users when creating a namespace that is not meant to use geo-replication.