### PR TITLE
[pulsar-broker]Fix: Topic loaded by multiple brokers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -941,7 +941,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         });
     }
 
-    void checkTopicNsOwnership(final String topic) throws RuntimeException {
+    public void checkTopicNsOwnership(final String topic) throws RuntimeException {
         TopicName topicName = TopicName.get(topic);
         boolean ownedByThisInstance;
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -226,6 +226,8 @@ public class NonPersistentTopic implements Topic {
 
         lock.readLock().lock();
         try {
+            brokerService.checkTopicNsOwnership(getName());
+            
             if (isFenced) {
                 log.warn("[{}] Attempting to add producer to a fenced topic", topic);
                 throw new TopicFencedException("Topic is temporarily unavailable");
@@ -310,6 +312,13 @@ public class NonPersistentTopic implements Topic {
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
+        
+        try {
+            brokerService.checkTopicNsOwnership(getName());
+        } catch (Exception e) {
+            future.completeExceptionally(e);
+            return future;
+        }
 
         if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

Right now, while unloading bundle, broker tries to unload all the topics parallel by fencing all the topics. However, if topic unloading fails then broker makes topic available again and makes `fence=false` because of that in race-condition, topic allows to add producer and starts replicator even if that broker is not suppose to own it because bundle will not be owned by this broker anymore. So, broker should always check bundle state/ownership before adding producer/consumer to the topic.
Below log shows that example. 


```
05:51:44.995 [pulsar-web-29-27] INFO  org.apache.pulsar.broker.namespace.OwnedBundle - Disabling ownership: sample/global/ns1/0x80000000_0xffffffff
:
05:51:47.358 [ForkJoinPool.commonPool-worker-16] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://sample/global/ns1/splitbrain-topic] Attempting to add producer to a fenced topic
:
05:51:47.381 [pulsar-io-21-23] ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://sample/global/ns1/splitbrain-topic] Error closing topic
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException: Producer was not registered on the connection
        :
        at org.apache.pulsar.common.util.FutureUtil.lambda$waitForAll$3(FutureUtil.java:51) ~[pulsar-common-2.2.jar:2.2]
:
:
05:51:47.382 [pulsar-io-21-23] WARN  org.apache.pulsar.broker.service.AbstractReplicator - [persistent://sample/global/ns1/splitbrain-topic][us-west1 -> us-west2] Exception: 'org.apache.pulsar.client.api.PulsarClientException: Producer was not registered on the connection' occured while trying to close the producer. retrying again in 0.1 s
:
05:51:47.468 [pulsar-io-21-48] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.0.0.1:36730][persistent://sample/global/ns1/splitbrain-topic] Creating producer. producerId=7276
05:51:47.469 [ForkJoinPool.commonPool-worker-19] INFO  org.apache.pulsar.broker.service.AbstractReplicator - [persistent://sample/global/ns1/splitbrain-topic][us-west1 -> us-west3] Starting replicator
:
:
05:51:47.680 [pulsar-web-29-27] ERROR org.apache.pulsar.broker.namespace.OwnedBundle - Failed to close topics under namespace sample/global/ns1/0x80000000_0xffffffff
java.util.concurrent.ExecutionException: org.apache.pulsar.client.api.PulsarClientException: Producer was not registered on the connection
        at org.apache.pulsar.broker.namespace.OwnedBundle.handleUnloadRequest(OwnedBundle.java:125) [pulsar-broker-2.2.jar:2.2]
:
05:51:47.685 [pulsar-web-29-27] INFO  org.apache.pulsar.broker.namespace.OwnedBundle - Unloading sample/global/ns1/0x80000000_0xffffffff namespace-bundle with 0 topics completed in 2690.0 ms
```

### Modification
- it fixes issues where topic is loaded by multiple broker 
- it also fixes very known replicator issue where incorrect replicator connected to remote colo