### PR TITLE
Fixed C++ client hostname verification

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -158,6 +158,14 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
             isTlsAllowInsecureConnection_ = true;
         } else {
             ctx.set_verify_mode(boost::asio::ssl::context::verify_peer);
+
+            if (clientConfiguration.isValidateHostName()) {
+                Url service_url;
+                Url::parse(physicalAddress, service_url);
+                LOG_DEBUG("Validating hostname for " << service_url.host() << ":" << service_url.port());
+                ctx.set_verify_callback(boost::asio::ssl::rfc2818_verification(physicalAddress));
+            }
+
             std::string trustCertFilePath = clientConfiguration.getTlsTrustCertsFilePath();
             if (file_exists(trustCertFilePath)) {
                 ctx.load_verify_file(trustCertFilePath);


### PR DESCRIPTION
### Motivation

There are few issues in the changes in #2475 to enabled hostname verification in the c++ client lib. eg.: 
 * Synchronously opening a connection to the service URL to validate the hostname, while getting a connection asynchronously
 * Doing the sync tcp connect even though the connection is already cached
 * Using sslv2/sslv3  instead of tls1.2 context type
 * Segfaulting when hostname verification is set to true, but TLS is not enabled in client lib.