### PR TITLE
[pulsar-broker] provide option to disable redelivery-tracker to reduce in memory positionImpl footprint and gc improvement

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -95,6 +95,10 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
+# Disable subscription message redelivery tracker to 
+# reduce in-memory message-id footprints (default is false)
+subscriptionRedeliveryTrackerDisable=false
+
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -95,9 +95,8 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
-# Disable subscription message redelivery tracker to 
-# reduce in-memory message-id footprints (default is false)
-subscriptionRedeliveryTrackerDisable=false
+# Enable subscription message redelivery tracker to send redelivery count to consumer (default is enabled)
+subscriptionRedeliveryTrackerEnabled=true
 
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -76,6 +76,10 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
+# Disable subscription message redelivery tracker to 
+# reduce in-memory message-id footprints (default is false)
+subscriptionRedeliveryTrackerDisable=false
+
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -76,9 +76,8 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
-# Disable subscription message redelivery tracker to 
-# reduce in-memory message-id footprints (default is false)
-subscriptionRedeliveryTrackerDisable=false
+# Enable subscription message redelivery tracker to send redelivery count to consumer (default is enabled)
+subscriptionRedeliveryTrackerEnabled=true
 
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -237,6 +237,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private long subscriptionExpirationTimeMinutes = 0;
     @FieldContext(
+            category = CATEGORY_POLICIES,
+            dynamic = true,
+            doc = "Disable subscription message redelivery tracker to reduce in-memory "
+                    + "message-id footprints (default is false)"
+        )
+    private boolean subscriptionRedeliveryTrackerDisable = false;
+    @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired subscription"
     )

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -239,10 +239,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_POLICIES,
             dynamic = true,
-            doc = "Disable subscription message redelivery tracker to reduce in-memory "
-                    + "message-id footprints (default is false)"
+            doc = "Enable subscription message redelivery tracker to send redelivery "
+                    + "count to consumer (default is enabled)"
         )
-    private boolean subscriptionRedeliveryTrackerDisable = false;
+    private boolean subscriptionRedeliveryTrackerEnabled = true;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired subscription"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Consumer.SendMessageInfo;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
+import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.InMemoryRedeliveryTracker;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
@@ -97,15 +98,17 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
     }
 
     public PersistentDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor) {
+        this.serviceConfig = topic.getBrokerService().pulsar().getConfiguration();
         this.cursor = cursor;
         this.name = topic.getName() + " / " + Codec.decode(cursor.getName());
         this.topic = topic;
         this.messagesToReplay = new ConcurrentLongPairSet(512, 2);
-        this.redeliveryTracker = new InMemoryRedeliveryTracker();
+        this.redeliveryTracker = this.serviceConfig.isSubscriptionRedeliveryTrackerDisable()
+                ? RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED
+                : new InMemoryRedeliveryTracker();
         this.readBatchSize = MaxReadBatchSize;
         this.maxUnackedMessages = topic.getBrokerService().pulsar().getConfiguration()
                 .getMaxUnackedMessagesPerSubscription();
-        this.serviceConfig = topic.getBrokerService().pulsar().getConfiguration();
         this.initializeDispatchRateLimiterIfNeeded(Optional.empty());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -103,9 +103,9 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
         this.name = topic.getName() + " / " + Codec.decode(cursor.getName());
         this.topic = topic;
         this.messagesToReplay = new ConcurrentLongPairSet(512, 2);
-        this.redeliveryTracker = this.serviceConfig.isSubscriptionRedeliveryTrackerDisable()
-                ? RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED
-                : new InMemoryRedeliveryTracker();
+        this.redeliveryTracker = this.serviceConfig.isSubscriptionRedeliveryTrackerEnabled()
+                ? new InMemoryRedeliveryTracker()
+                : RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED;
         this.readBatchSize = MaxReadBatchSize;
         this.maxUnackedMessages = topic.getBrokerService().pulsar().getConfiguration()
                 .getMaxUnackedMessagesPerSubscription();

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -146,6 +146,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |maxUnackedMessagesPerConsumer| Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending messages to consumer once, this limit reaches until consumer starts acknowledging messages back. Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction  |50000|
 |maxUnackedMessagesPerSubscription| Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher can dispatch messages without any restriction  |200000|
+|subscriptionRedeliveryTrackerDisable| Disable subscription message redelivery tracker |false|
 |maxConcurrentLookupRequest|  Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic |50000|
 |maxConcurrentTopicLoadRequest| Max number of concurrent topic loading request broker allows to control number of zk-operations |5000|
 |authenticationEnabled| Enable authentication |false|

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -146,7 +146,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |maxUnackedMessagesPerConsumer| Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending messages to consumer once, this limit reaches until consumer starts acknowledging messages back. Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction  |50000|
 |maxUnackedMessagesPerSubscription| Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher can dispatch messages without any restriction  |200000|
-|subscriptionRedeliveryTrackerDisable| Disable subscription message redelivery tracker |false|
+|subscriptionRedeliveryTrackerEnabled| Enable subscription message redelivery tracker |true|
 |maxConcurrentLookupRequest|  Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic |50000|
 |maxConcurrentTopicLoadRequest| Max number of concurrent topic loading request broker allows to control number of zk-operations |5000|
 |authenticationEnabled| Enable authentication |false|


### PR DESCRIPTION
### Motivation

Right now, broker captures every redelivered message-id for each subscription in memory even though client doesn't need dead-letter-topic feature. Because of that, sometimes clients who has high redelivery-message rate builds large number of objects and it can go up to 6M `positionImpl` objects into memory and it can take up to 200MB of heap-size which cause very high gc pause in broker and makes broker unstable. 
So, broker should have a way to limit and disable to store and track these objects.

### Modification
Option to disable redelivery-tracker.

### Note
I will create a separate PR which can allow admin to add policy to enable this feature for white-listed namespace and not for all the the topics. and it will also have some limitation in terms of keeping number of message-ids.
