### PR TITLE
[pulsar-broker] redelivery tracker use open hashmap

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -33,7 +33,7 @@ public class InMemoryRedeliveryTracker implements RedeliveryTracker {
     public int incrementAndGetRedeliveryCount(Position position) {
         PositionImpl positionImpl = (PositionImpl) position;
         LongPair count = trackerCache.get(positionImpl.getLedgerId(), positionImpl.getEntryId());
-        int newCount = (int) (count != null ? count.first + 1 : 0);
+        int newCount = (int) (count != null ? count.first + 1 : 1);
         trackerCache.put(positionImpl.getLedgerId(), positionImpl.getEntryId(), newCount, 0L);
         return newCount;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -18,30 +18,37 @@
  */
 package org.apache.pulsar.broker.service;
 
-import org.apache.bookkeeper.mledger.Position;
-
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
+import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 
 public class InMemoryRedeliveryTracker implements RedeliveryTracker {
 
-    private ConcurrentHashMap<Position, AtomicInteger> trackerCache = new ConcurrentHashMap<>(16);
+    private ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap(256, 1);
 
     @Override
     public int incrementAndGetRedeliveryCount(Position position) {
-        trackerCache.putIfAbsent(position, new AtomicInteger(0));
-        return trackerCache.get(position).incrementAndGet();
+        PositionImpl positionImpl = (PositionImpl) position;
+        LongPair count = trackerCache.get(positionImpl.getLedgerId(), positionImpl.getEntryId());
+        int newCount = (int) (count != null ? count.first + 1 : 0);
+        trackerCache.put(positionImpl.getLedgerId(), positionImpl.getEntryId(), newCount, 0L);
+        return newCount;
     }
 
     @Override
     public int getRedeliveryCount(Position position) {
-        return trackerCache.getOrDefault(position, new AtomicInteger(0)).get();
+        PositionImpl positionImpl = (PositionImpl) position;
+        LongPair count = trackerCache.get(positionImpl.getLedgerId(), positionImpl.getEntryId());
+        return (int) (count!=null ? count.first : 0);
     }
 
     @Override
     public void remove(Position position) {
-        trackerCache.remove(position);
+        PositionImpl positionImpl = (PositionImpl) position;
+        trackerCache.remove(positionImpl.getLedgerId(), positionImpl.getEntryId());
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.broker.service;
 
-import org.apache.bookkeeper.mledger.Position;
-
 import java.util.List;
+
+import org.apache.bookkeeper.mledger.Position;
 
 public interface RedeliveryTracker {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTrackerDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTrackerDisabled.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.broker.service;
 
-import org.apache.bookkeeper.mledger.Position;
-
 import java.util.List;
+
+import org.apache.bookkeeper.mledger.Position;
 
 public class RedeliveryTrackerDisabled implements RedeliveryTracker {
 


### PR DESCRIPTION
### Motivation
as per #3584, In order to improve GC: use open hashmap for message-redelivery-tracker.