### PR TITLE
Fixed deadlock by triggering asyncCreateFullPathOptimistic() callback…

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
@@ -222,8 +222,10 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
     @Test(timeOut = 20000)
     public void createOptimisticBaseNotExist() throws Exception {
         CompletableFuture<Void> promise = new CompletableFuture<>();
-        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
-                zkc, "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+
+        MetaStoreImplZookeeper store = new MetaStoreImplZookeeper(zkc, executor);
+        store.asyncCreateFullPathOptimistic(
+                "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
                 (rc, path, ctx, name) -> {
                     if (rc != KeeperException.Code.OK.intValue()) {
                         promise.completeExceptionally(KeeperException.create(rc));
@@ -241,10 +243,11 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
 
     @Test(timeOut = 20000)
     public void createOptimisticBaseExists() throws Exception {
+        MetaStoreImplZookeeper store = new MetaStoreImplZookeeper(zkc, executor);
         zkc.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         CompletableFuture<Void> promise = new CompletableFuture<>();
-        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
-                zkc, "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+        store.asyncCreateFullPathOptimistic(
+                "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
                 (rc, path, ctx, name) -> {
                     if (rc != KeeperException.Code.OK.intValue()) {
                         promise.completeExceptionally(KeeperException.create(rc));
@@ -255,8 +258,8 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
         promise.get();
 
         CompletableFuture<Void> promise2 = new CompletableFuture<>();
-        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
-                zkc, "/foo", "blah", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+        store.asyncCreateFullPathOptimistic(
+                "/foo", "blah", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
                 (rc, path, ctx, name) -> {
                     if (rc != KeeperException.Code.OK.intValue()) {
                         promise2.completeExceptionally(KeeperException.create(rc));


### PR DESCRIPTION
### Motivation

As outlined in #3566 , there's a deadlock that is triggered by doing a ZK blocking call (when fetching the rack-aware information) from a ZK event callback thread (after creating a z-node).

Most of the callbacks issued by `MetaStoreImplZooKeeper` are being issued from a background thread (eg. different from ZK event thread), the only one was not is `asyncCreateFullPathOptimistic()` introduced in 2.2. 

Fixes #3566