### PR TITLE
[pulsar-broker] vip-status checker for tls-only mode broker

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -216,6 +216,9 @@ clientLibraryVersionCheckEnabled=false
 # to service discovery health checks
 statusFilePath=
 
+# Dedicated status-check service port if broker is not listening on non-tls port
+#statusCheckServicePort=
+
 # If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to
 # use only brokers running the latest software version (to minimize impact to bundles)
 preferLaterVersions=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -154,6 +154,9 @@ clientLibraryVersionCheckEnabled=false
 # to service discovery health checks
 statusFilePath=/usr/local/apache/htdocs
 
+# Dedicated status-check service port if broker is not listening on non-tls port
+#statusCheckServicePort=
+
 # Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
 # messages to consumer once, this limit reaches until consumer starts acknowledging messages back
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -449,6 +449,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Path for the file used to determine the rotation status for the broker"
             + " when responding to service discovery health checks")
     private String statusFilePath;
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Dedicated status-check service port if broker is not listening on non-tls port"
+        )
+    private Optional<Integer> statusCheckServicePort;
+
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/VipStatusCheckerFilter.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/VipStatusCheckerFilter.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Servlet filter that only allows requests for vip url.
+ */
+public class VipStatusCheckerFilter implements Filter {
+    private static final Logger LOG = LoggerFactory.getLogger(VipStatusCheckerFilter.class);
+
+    private final String statusPath;
+    private final int statusPort;
+
+    public VipStatusCheckerFilter(String vipPath, int port) {
+        this.statusPath = vipPath;
+        this.statusPort = port;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest httpRequest = ((HttpServletRequest) request);
+            String path = httpRequest.getPathInfo();
+            int port = httpRequest.getServerPort();
+            // only status-health check url call is allowed to call on this port
+            if (statusPort == port && !statusPath.equalsIgnoreCase(path)) {
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("{} is not allowed on port {}", httpRequest.getRequestURL(), statusPort);
+                }
+                httpResponse.sendError(HttpServletResponse.SC_NOT_FOUND, "Request url not found");
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void init(FilterConfig arg) throws ServletException {
+        // No init necessary.
+    }
+
+    @Override
+    public void destroy() {
+        // No state to clean up.
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/VipStatus.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/VipStatus.java
@@ -31,9 +31,10 @@ import javax.ws.rs.core.Response.Status;
 /**
  * Web resource used by the VIP service to check to availability of the service instance.
  */
-@Path("/status.html")
+@Path(VipStatus.VIP_STATUS_PATH)
 public class VipStatus {
 
+    public static final String VIP_STATUS_PATH = "/status.html";
     public static final String ATTRIBUTE_STATUS_FILE_PATH = "statusFilePath";
     public static final String ATTRIBUTE_IS_READY_PROBE = "isReadyProbe";
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -1152,7 +1152,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         return future.get();
     }
 
-    private AsyncHttpClient getHttpClient(String version) {
+    public static AsyncHttpClient getHttpClient(String version) {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setFollowRedirect(true);
         confBuilder.setUserAgent(version);


### PR DESCRIPTION
### Motivation

When user starts broker in tls-mode only then load-balancer/VIP-status checker fails to call vip-status url successfully without passing the tls certs to broker. So, broker needs to listen on a non-tls port that can only serve status-check url.

### Modification
Provide a way for broker to listen on non-tls port that can only serve status-check url.
- if tls is enabled then user can set `statusCheckServicePort` non-tls port which can only serve status-check url.