### PR TITLE
Fixed getting message properties map in Python client

### DIFF
--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -140,6 +140,31 @@ class PulsarTest(TestCase):
         consumer.unsubscribe()
         client.close()
 
+    def test_message_properties(self):
+        client = Client(self.serviceUrl)
+        topic = 'my-python-test-message-properties'
+        consumer = client.subscribe(topic=topic,
+                                    subscription_name='my-subscription',
+                                    schema=pulsar.schema.StringSchema())
+        producer = client.create_producer(topic=topic,
+                                          schema=StringSchema())
+        producer.send('hello',
+                      properties={
+                          'a': '1',
+                          'b': '2'
+                      })
+
+        msg = consumer.receive()
+        self.assertTrue(msg)
+        self.assertEqual(msg.value(), 'hello')
+        self.assertEqual(msg.properties(), {
+                          'a': '1',
+                          'b': '2'
+                      })
+
+        consumer.unsubscribe()
+        client.close()
+
     def test_tls_auth(self):
         certs_dir = '/pulsar/pulsar-broker/src/test/resources/authentication/tls/'
         if not os.path.exists(certs_dir):

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -66,6 +66,14 @@ boost::python::object Message_data(const Message& msg) {
     return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
 }
 
+boost::python::object Message_properties(const Message& msg) {
+    boost::python::dict pyProperties;
+    for (const auto& item : msg.getProperties()) {
+        pyProperties[item.first] = item.second;
+    }
+    return pyProperties;
+}
+
 std::string Topic_name_str(const Message& msg) {
     std::stringstream ss;
     ss << msg.getTopicName();
@@ -115,7 +123,7 @@ void export_message() {
             ;
 
     class_<Message>("Message")
-            .def("properties", &Message::getProperties, return_value_policy<copy_const_reference>())
+            .def("properties", &Message_properties)
             .def("data", &Message_data)
             .def("length", &Message::getLength)
             .def("partition_key", &Message::getPartitionKey, return_value_policy<copy_const_reference>())


### PR DESCRIPTION
### Motivation

Fixes #3524. Message properties were not usable in Python client. Convert into a property dict from C++ wrapper.
