### PR TITLE
Fixed RAT check to exclude Avro generated files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1237,6 +1237,13 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>src/main/java/org/apache/pulsar/broker/service/schema/proto/SchemaRegistryFormat.java</exclude>
             <exclude>bin/proto/MLDataFormats_pb2.py</exclude>
 
+            <!-- These files are generated automatically by the Avro compiler
+                 and are included in source tree for convenience -->
+            <exclude>**/avro/generated/*.java</exclude>
+
+            <!-- Avro schema definitions - JSON format -->
+            <exclude>**/*.avsc</exclude>
+
             <!-- pulasr-io-connector kinesis : auto generated files from flatbuffer schema -->
             <exclude>src/main/java/org/apache/pulsar/io/kinesis/fbs/CompressionType.java</exclude>
             <exclude>src/main/java/org/apache/pulsar/io/kinesis/fbs/EncryptionCtx.java</exclude>

--- a/pulsar-io/mongo/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/mongo/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 name: mongo
 description: Writes data into MongoDB
 sinkClass: org.apache.pulsar.io.mongodb.MongoSink


### PR DESCRIPTION
### Motivation

Fixes the Apache RAT check to exclude the auto-generated files from Avro compiler and Avro JSON schema definitions.