### PR TITLE
Fixed CMake lookup of boost Python for Py 3.4, 3.5 and 3.6

### DIFF
--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -46,7 +46,9 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
-                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY})
+                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY}
+			${Boost_PYTHON34_LIBRARY} ${Boost_PYTHON35_LIBRARY}
+			${Boost_PYTHON36_LIBRARY})
 
 if (APPLE)
     set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS}


### PR DESCRIPTION
### Motivation

Building Python wheels is failing in the updated Docker image for Python 3.4, 3.5 and 3.6. Fixing it here by explicitly including the library defined variables.