### PR TITLE
Build docker images from directories instead of tgz files

### DIFF
--- a/distribution/offloaders/src/assemble/offloaders.xml
+++ b/distribution/offloaders/src/assemble/offloaders.xml
@@ -24,6 +24,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>bin</id>
   <formats>
+    <format>dir</format>
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -24,6 +24,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>bin</id>
   <formats>
+    <format>dir</format>
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -20,9 +20,7 @@
 FROM apachepulsar/pulsar:latest
 
 ARG PULSAR_IO_DIR
-ARG PULSAR_OFFLOADER_TARBALL
+ARG PULSAR_OFFLOADER_DIR
 
 ADD ${PULSAR_IO_DIR} /pulsar/connectors
-
-ADD ${PULSAR_OFFLOADER_TARBALL} /
-RUN mv /apache-pulsar-offloaders-*/offloaders /pulsar/offloaders
+ADD ${PULSAR_OFFLOADER_DIR}/offloaders /pulsar/offloaders

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -81,22 +81,20 @@
                   </resources>
                 </configuration>
               </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
               <execution>
-                <id>copy-offloader-tarball</id>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
+                <id>copy-offloader-archives</id>
                 <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
                 <configuration>
-                  <outputDirectory>${project.build.directory}/</outputDirectory>
-                  <includeArtifactIds>pulsar-offloader-distribution</includeArtifactIds>
-                  <excludeTransitive>true</excludeTransitive>
+                  <outputDirectory>${basedir}/target/apache-pulsar-offloaders-${project.version}-bin</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/../../distribution/offloaders/target/apache-pulsar-offloaders-${project.version}-bin/apache-pulsar-offloaders-${project.version}</directory>
+                      <filtering>false</filtering>
+                    </resource>
+                  </resources>
                 </configuration>
               </execution>
             </executions>
@@ -130,7 +128,7 @@
               <tag>${project.version}</tag>
               <buildArgs>
                 <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
-                <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
+                <PULSAR_OFFLOADER_DIR>target/apache-pulsar-offloaders-${project.version}-bin</PULSAR_OFFLOADER_DIR>
               </buildArgs>
             </configuration>
           </plugin>

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -24,10 +24,8 @@ RUN echo "deb http://ftp.de.debian.org/debian testing main" >> /etc/apt/sources.
 # Install some utilities
 RUN apt-get update && apt-get install -y netcat dnsutils python-kazoo python-yaml python-pip python3.7 python3-pip
 
-ARG PULSAR_TARBALL
-
-ADD ${PULSAR_TARBALL} /
-RUN mv /apache-pulsar-* /pulsar
+ARG PULSAR_DIR
+ADD ${PULSAR_DIR} /pulsar
 
 COPY scripts/apply-config-from-env.py /pulsar/bin
 COPY scripts/gen-yml-from-env.py /pulsar/bin

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -26,7 +26,6 @@
     <version>2.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.pulsar</groupId>
   <artifactId>pulsar-docker-image</artifactId>
   <name>Apache Pulsar :: Docker Images :: Pulsar Latest Version</name>
   <packaging>pom</packaging>
@@ -155,24 +154,28 @@
               <pullNewerImage>false</pullNewerImage>
               <tag>${project.version}</tag>
               <buildArgs>
-                <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
+                <PULSAR_DIR>target/apache-pulsar-${project.version}-bin</PULSAR_DIR>
               </buildArgs>
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.1.0</version>
             <executions>
               <execution>
-                <id>copy-tarball</id>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
+                <id>copy-server-dir</id>
                 <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
                 <configuration>
-                  <outputDirectory>${project.build.directory}/</outputDirectory>
-                  <includeArtifactIds>pulsar-server-distribution</includeArtifactIds>
-                  <excludeTransitive>true</excludeTransitive>
+                  <outputDirectory>${basedir}/target/apache-pulsar-${project.version}-bin</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/../../distribution/server/target/apache-pulsar-${project.version}-bin/apache-pulsar-${project.version}</directory>
+                      <filtering>false</filtering>
+                    </resource>
+                  </resources>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
### Motivation

Similar to what done in #3601, use directories to build the Docker images, that will avoid the docker images to have twice the size of our archives. 

The double size was due to adding the tgz, unpacking it and then moving the `/apache-pulsar-2.3.0` into `/pulsar`.