### PR TITLE
[Issue 3590] [broker] Support to get broker server runtime configuration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -154,7 +154,7 @@ public class BrokersBase extends AdminResource {
     @Path("/configuration/runtime")
     @ApiOperation(value = "Get all runtime configurations. This operation requires Pulsar super-user privileges.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public List<String> getRuntimeConfiguration() {
+    public Map<String, String> getRuntimeConfiguration() {
         validateSuperUserAccess();
         return pulsar().getBrokerService().getRuntimeConfiguration();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -152,8 +152,10 @@ public class BrokersBase extends AdminResource {
 
     @GET
     @Path("/configuration/runtime")
-    @ApiOperation(value = "Get all runtime configurations")
+    @ApiOperation(value = "Get all runtime configurations. This operation requires Pulsar super-user privileges.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public List<String> getRuntimeConfiguration() {
+        validateSuperUserAccess();
         return pulsar().getBrokerService().getRuntimeConfiguration();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -150,6 +150,13 @@ public class BrokersBase extends AdminResource {
         return BrokerService.getDynamicConfiguration();
     }
 
+    @GET
+    @Path("/configuration/runtime")
+    @ApiOperation(value = "Get all runtime configurations")
+    public List<String> getRuntimeConfiguration() {
+        return pulsar().getBrokerService().getRuntimeConfiguration();
+    }
+
     /**
      * if {@link ServiceConfiguration}-field is allowed to be modified dynamically, update configuration-map into zk, so
      * all other brokers get the watch and can see the change and take appropriate action on the change.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -62,7 +62,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -1337,12 +1336,13 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return dynamicConfigurationMap.keys();
     }
 
-    public List<String> getRuntimeConfiguration() {
+    public Map<String, String> getRuntimeConfiguration() {
+        Map<String, String> configMap = Maps.newHashMap();
         ConcurrentOpenHashMap<String, Object> runtimeConfigurationMap = getRuntimeConfigurationMap();
-        return runtimeConfigurationMap.keys().stream()
-            .sorted()
-            .map(key -> key + "=" + runtimeConfigurationMap.get(key))
-            .collect(Collectors.toList());
+        runtimeConfigurationMap.forEach((key, value) -> {
+            configMap.put(key, String.valueOf(value));
+        });
+        return configMap;
     }
 
     public static boolean isDynamicConfiguration(String key) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1340,6 +1340,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public List<String> getRuntimeConfiguration() {
         ConcurrentOpenHashMap<String, Object> runtimeConfigurationMap = getRuntimeConfigurationMap();
         return runtimeConfigurationMap.keys().stream()
+            .sorted()
             .map(key -> key + "=" + runtimeConfigurationMap.get(key))
             .collect(Collectors.toList());
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -92,6 +92,14 @@ public interface Brokers {
     List<String> getDynamicConfigurationNames() throws PulsarAdminException;
 
     /**
+     * Get list of runtime configuration values
+     *
+     * @return
+     * @throws PulsarAdminException
+     */
+    List<String> getRuntimeConfigurations() throws PulsarAdminException;
+
+    /**
      * Get values of all overridden dynamic-configs
      * 
      * @return

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -92,12 +92,12 @@ public interface Brokers {
     List<String> getDynamicConfigurationNames() throws PulsarAdminException;
 
     /**
-     * Get list of runtime configuration values
+     * Get values of runtime configuration
      *
      * @return
      * @throws PulsarAdminException
      */
-    List<String> getRuntimeConfigurations() throws PulsarAdminException;
+    Map<String, String> getRuntimeConfigurations() throws PulsarAdminException;
 
     /**
      * Get values of all overridden dynamic-configs

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -93,6 +93,16 @@ public class BrokersImpl extends BaseResource implements Brokers {
     }
 
     @Override
+    public List<String> getRuntimeConfigurations() throws PulsarAdminException {
+        try {
+            return request(adminBrokers.path("/configuration").path("runtime")).get(new GenericType<List<String>>() {
+            });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
     public InternalConfigurationData getInternalConfigurationData() throws PulsarAdminException {
         try {
             return request(adminBrokers.path("/internal-configuration")).get(InternalConfigurationData.class);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -93,9 +93,9 @@ public class BrokersImpl extends BaseResource implements Brokers {
     }
 
     @Override
-    public List<String> getRuntimeConfigurations() throws PulsarAdminException {
+    public Map<String, String> getRuntimeConfigurations() throws PulsarAdminException {
         try {
-            return request(adminBrokers.path("/configuration").path("runtime")).get(new GenericType<List<String>>() {
+            return request(adminBrokers.path("/configuration").path("runtime")).get(new GenericType<Map<String, String>>() {
             });
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -72,6 +72,9 @@ public class PulsarAdminToolTest {
         brokers.run(split("list use"));
         verify(mockBrokers).getActiveBrokers("use");
 
+        brokers.run(split("namespaces use --url http://my-service.url:8080"));
+        verify(mockBrokers).getOwnedNamespaces("use", "http://my-service.url:8080");
+
         brokers.run(split("get-all-dynamic-config"));
         verify(mockBrokers).getAllDynamicConfigurations();
 
@@ -83,6 +86,12 @@ public class PulsarAdminToolTest {
 
         brokers.run(split("get-internal-config"));
         verify(mockBrokers).getInternalConfigurationData();
+
+        brokers.run(split("get-runtime-config"));
+        verify(mockBrokers).getRuntimeConfigurations();
+
+        brokers.run(split("healthcheck"));
+        verify(mockBrokers).healthcheck();
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -83,7 +83,7 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get list of runtime configuration values")
+    @Parameters(commandDescription = "Get runtime configuration values")
     private class GetRuntimeConfigCmd extends CliCommand {
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -83,6 +83,15 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Get list of runtime configuration values")
+    private class GetRuntimeConfigCmd extends CliCommand {
+
+        @Override
+        void run() throws Exception {
+            print(admin.brokers().getRuntimeConfigurations());
+        }
+    }
+
     @Parameters(commandDescription = "Get internal configuration information")
     private class GetInternalConfigurationCmd extends CliCommand {
 
@@ -112,6 +121,7 @@ public class CmdBrokers extends CmdBase {
         jcommander.addCommand("list-dynamic-config", new GetUpdatableConfigCmd());
         jcommander.addCommand("get-all-dynamic-config", new GetAllConfigurationsCmd());
         jcommander.addCommand("get-internal-config", new GetInternalConfigurationCmd());
+        jcommander.addCommand("get-runtime-config", new GetRuntimeConfigCmd());
         jcommander.addCommand("healthcheck", new HealthcheckCmd());
     }
 }

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -184,7 +184,7 @@ $ pulsar-admin brokers get-internal-config
 ```
 
 ### `get-runtime-config`
-Get list of runtime configuration values
+Get runtime configuration values
 
 Usage
 ```bash

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -119,6 +119,7 @@ Subcommands
 * `list-dynamic-config`
 * `get-all-dynamic-config`
 * `get-internal-config`
+* `get-runtime-config`
 * `healthcheck`
 
 ### `list`
@@ -180,6 +181,14 @@ Get internal configuration information
 Usage
 ```bash
 $ pulsar-admin brokers get-internal-config
+```
+
+### `get-runtime-config`
+Get list of runtime configuration values
+
+Usage
+```bash
+$ pulsar-admin brokers get-runtime-config
 ```
 
 ### `healthcheck`


### PR DESCRIPTION
### Motivation

Fixes #3590

### Modifications

Add a `GetRuntimeConfigCmd` in command `pulsar-admin brokers`.

### Documentation

```
$ bin/pulsar-admin brokers get-runtime-config
{
  "loadBalancerSheddingGracePeriodMinutes" : "30",
  "backlogQuotaCheckIntervalInSeconds" : "61",
  "loadBalancerNamespaceBundleMaxBandwidthMbytes" : "100",
  "bookkeeperClientTimeoutInSeconds" : "31",
  "exposeTopicLevelMetricsInPrometheus" : "true",
  "tlsTrustCertsFilePath" : "",
  "tlsCertificateFilePath" : "",
  "subscribeRatePeriodPerConsumerInSecond" : "30",
  "replicatorPrefix" : "pulsar.repl",
  "autoSkipNonRecoverableData" : "false",
   ... 
}
```