### PR TITLE
Define the maven phase for generating protobuf code

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>org.apache.bookkeeper.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
-      <version>${bookkeeper.version}</version>
     </dependency>
 
     <dependency>
@@ -133,6 +132,7 @@
         </configuration>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
             <goals>
               <goal>compile</goal>
             </goals>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -313,6 +313,7 @@
         </configuration>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
             <goals>
               <goal>compile</goal>
               <goal>test-compile</goal>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -160,6 +160,7 @@
         </configuration>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
             <goals>
               <goal>test-compile</goal>
             </goals>

--- a/pulsar-functions/proto/pom.xml
+++ b/pulsar-functions/proto/pom.xml
@@ -78,6 +78,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>compile</goal>
                             <goal>compile-custom</goal>


### PR DESCRIPTION
### Motivation

We're not setting the correct phase for maven when using the plugin that generates protobuf sources. This is the source of issues with IDEs failing to perform that step, or `mvn install` failing when running multiple times.