### PR TITLE
CPP Client - changing min cmake to 3.4 and adding flag for ccache

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -17,9 +17,15 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4) 
 project (pulsar-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
+    MESSAGE(STATUS "Using CCache")
+endif(CCACHE_PROGRAM)
 
 option(BUILD_TESTS "Build tests" ON)
 MESSAGE(STATUS "BUILD_TESTS:  " ${BUILD_TESTS})


### PR DESCRIPTION
### Motivation
Currently, we use add_custom_command -> BYPRODUCTS in `lib/CMakeLists.txt`, a feature that was introduced in 3.2 but we bumped up the cmake minimum version.

CCache to speed up builds, adding support to use ccache to build pulsar client cpp library. `CMAKE_CXX_COMPILER_LAUNCHER` flag introduced in 3.4

### Modifications
- Bumped cmake_minimum_required to 3.4
- Added flag `CMAKE_CXX_COMPILER_LAUNCHER`

### Verifying this change
If CPP Client library Build is successful then the change is verified.