### PR TITLE
Use individual netty-* artifacts instead of netty-all

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -346,9 +346,23 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.15.jar
     - org.apache.commons-commons-lang3-3.4.jar
  * Netty
-    - io.netty-netty-3.10.1.Final.jar
-    - io.netty-netty-all-4.1.32.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.20.Final.jar
+    - io.netty-netty-buffer-4.1.43.Final.jar
+    - io.netty-netty-codec-4.1.43.Final.jar
+    - io.netty-netty-codec-dns-4.1.43.Final.jar
+    - io.netty-netty-codec-http-4.1.43.Final.jar
+    - io.netty-netty-codec-http2-4.1.43.Final.jar
+    - io.netty-netty-codec-socks-4.1.43.Final.jar
+    - io.netty-netty-common-4.1.43.Final.jar
+    - io.netty-netty-handler-4.1.43.Final.jar
+    - io.netty-netty-handler-proxy-4.1.43.Final.jar
+    - io.netty-netty-resolver-4.1.43.Final.jar
+    - io.netty-netty-resolver-dns-4.1.43.Final.jar
+    - io.netty-netty-transport-4.1.43.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.43.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.43.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.43.Final.jar
+    - io.netty-netty-3.10.6.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.26.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -115,22 +115,6 @@
       <outputFileNameMapping>${artifact.groupId}-${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
 
       <excludes>
-        <!-- All these dependencies are already included in netty-all -->
-        <exclude>io.netty:netty-buffer</exclude>
-        <exclude>io.netty:netty-common</exclude>
-        <exclude>io.netty:netty-codec</exclude>
-        <exclude>io.netty:netty-codec-dns</exclude>
-        <exclude>io.netty:netty-codec-http</exclude>
-        <exclude>io.netty:netty-codec-http2</exclude>
-        <exclude>io.netty:netty-codec-socks</exclude>
-        <exclude>io.netty:netty-handler</exclude>
-        <exclude>io.netty:netty-handler-proxy</exclude>
-        <exclude>io.netty:netty-resolver</exclude>
-        <exclude>io.netty:netty-resolver-dns</exclude>
-        <exclude>io.netty:netty-transport</exclude>
-        <exclude>io.netty:netty-transport-native-epoll</exclude>
-        <exclude>io.netty:netty-transport-native-unix-common</exclude>
-
         <exclude>org.apache.pulsar:pulsar-functions-runtime-all</exclude>
 
         <!-- Already included in pulsar-zookeeper instrumented jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,8 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.9.2</bookkeeper.version>
     <zookeeper.version>3.4.13</zookeeper.version>
-    <netty.version>4.1.32.Final</netty.version>
+    <netty.version>4.1.43.Final</netty.version>
+    <netty-tc-native.version>2.0.26.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jersey.version>2.27</jersey.version>
@@ -430,7 +431,43 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
         <version>${netty.version}</version>
       </dependency>
 
@@ -444,14 +481,50 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-socks</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.20.Final</version>
+        <version>${netty-tc-native.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
-        <version>3.10.1.Final</version>
+        <version>3.10.6.Final</version>
       </dependency>
 
       <dependency>
@@ -1077,30 +1150,6 @@ flexible messaging model and an intuitive client API.</description>
         <exclusion>
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-buffer</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-handler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-boringssl-static</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -65,16 +65,12 @@
                   <include>commons-*:*</include>
                   <include>org.apache.commons:*</include>
                   <include>org.asynchttpclient:*</include>
-                  <!-- netty below could be un-necessary -->
-                  <include>io.netty:netty-codec-http</include>
-                  <include>io.netty:netty-transport-native-epoll</include>
                   <include>org.reactivestreams:reactive-streams</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>
                   <include>org.javassist:javassist</include>
                   <include>com.google.*:*</include>
                   <include>com.fasterxml.jackson.*:*</include>
-                  <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
+                  <include>io.netty:*</include>
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>org.apache.bookkeeper:circe-checksum</include>
                   <include>com.yahoo.datasketches:sketches-core</include>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
+      <artifactId>netty-transport</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -63,8 +63,6 @@
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>
                   <include>org.asynchttpclient:*</include>
-                  <include>io.netty:netty-codec-http</include>
-                  <include>io.netty:netty-transport-native-epoll</include>
                   <include>org.reactivestreams:reactive-streams</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>
                   <include>org.javassist:javassist</include>
@@ -72,8 +70,7 @@
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.gson:gson</include>
                   <include>com.fasterxml.jackson.core</include>
-                  <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
+                  <include>io.netty:*</include>
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>org.apache.bookkeeper:circe-checksum</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
@@ -84,7 +81,6 @@
                   <include>com.fasterxml.jackson.*:*</include>
                   <include>io.grpc:*</include>
                   <include>com.yahoo.datasketches:*</include>
-                  <include>io.netty:*</include>
                   <include>com.squareup.*:*</include>
                   <include>com.google.*:*</include>
                   <include>commons-*:*</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -117,9 +117,7 @@
                   <include>com.fasterxml.jackson.module</include>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.fasterxml.jackson.dataformat</include>
-                  <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
-                  <include>io.netty:netty-tcnative-boringssl-static</include>
+                  <include>io.netty:*</include>
                   <include>org.eclipse.jetty:*</include>
                   <include>com.yahoo.datasketches:*</include>
                   <include>commons-*:*</include>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -45,6 +45,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -75,7 +75,17 @@
 
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-functions/localrun/pom.xml
+++ b/pulsar-functions/localrun/pom.xml
@@ -61,11 +61,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
         </dependency>

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -32,12 +32,6 @@
   <name>Pulsar Functions :: Utils</name>
 
   <dependencies>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-common</artifactId>

--- a/pulsar-functions/worker-shaded/pom.xml
+++ b/pulsar-functions/worker-shaded/pom.xml
@@ -49,34 +49,6 @@
           <groupId>org.apache.pulsar</groupId>
           <artifactId>pulsar-client-admin-shaded-for-functions</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-http</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-http2</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-handler-proxy</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-handler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-buffer</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
@@ -84,12 +56,6 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server-shaded</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -46,11 +46,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-io/netty/pom.xml
+++ b/pulsar-io/netty/pom.xml
@@ -51,8 +51,12 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
         </dependency>
 
         <dependency>

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -133,7 +133,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         return new Object[][] { { ciphers_1, protocols_1, Boolean.FALSE }, { ciphers_2, protocols_2, Boolean.FALSE },
                 { ciphers_3, protocols_3, Boolean.TRUE }, { ciphers_4, protocols_4, Boolean.TRUE },
                 { ciphers_5, protocols_5, Boolean.TRUE }, { ciphers_6, protocols_6, Boolean.FALSE },
-                { ciphers_7, protocols_7, Boolean.TRUE }, { ciphers_8, protocols_8, Boolean.FALSE } };
+                { ciphers_7, protocols_7, Boolean.FALSE }, { ciphers_8, protocols_8, Boolean.FALSE } };
     }
 
     @BeforeMethod

--- a/pulsar-spark/pom.xml
+++ b/pulsar-spark/pom.xml
@@ -84,10 +84,7 @@
               <artifactSet>
                 <includes>
                   <include>com.google.guava:guava</include>
-                  <include>io.netty:netty-codec-http</include>
-                  <include>io.netty:netty-transport-native-epoll</include>
-                  <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
+                  <include>io.netty:netty-*</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hdfs-offload-version3}</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### Motivation

All of Pulsar dependencies are using the individual dependencies instead of getting Netty-all. We should do the same to avoid doing the hacky exclusions stuff. This also reduces a bit the sizes of our shaded jars and dist file.