### PR TITLE
Fixed C++ batch acks tracker to evict message from sendList array

### DIFF
--- a/pulsar-client-cpp/lib/BatchAcknowledgementTracker.cc
+++ b/pulsar-client-cpp/lib/BatchAcknowledgementTracker.cc
@@ -51,9 +51,8 @@ void BatchAcknowledgementTracker::receivedMessage(const Message& message) {
         std::find(sendList_.begin(), sendList_.end(), msgID) != sendList_.end()) {
         return;
     }
-    LOG_DEBUG("Initializing the trackerMap_ with Message ID = " << msgID
-                << " -- Map size: " << trackerMap_.size()
-                << " -- List size: " << sendList_.size());
+    LOG_DEBUG("Initializing the trackerMap_ with Message ID = "
+              << msgID << " -- Map size: " << trackerMap_.size() << " -- List size: " << sendList_.size());
 
     // Since dynamic_set (this version) doesn't have all() function, initializing all bits with 1 and then
     // reseting them to 0 and using any()
@@ -70,7 +69,7 @@ void BatchAcknowledgementTracker::deleteAckedMessage(const MessageId& messageId,
     }
 
     MessageId batchMessageId =
-            MessageId(messageId.partition(), messageId.ledgerId(), messageId.entryId(), -1 /* Batch index */);
+        MessageId(messageId.partition(), messageId.ledgerId(), messageId.entryId(), -1 /* Batch index */);
 
     Lock lock(mutex_);
     if (ackType == proto::CommandAck_AckType_Cumulative) {
@@ -90,8 +89,9 @@ void BatchAcknowledgementTracker::deleteAckedMessage(const MessageId& messageId,
         // std::remove shifts all to be deleted items to the end of the vector and returns an iterator to the
         // first
         // instance of item, then we erase all elements from this iterator to the end of the list
-        sendList_.erase(std::remove_if(sendList_.begin(), sendList_.end(), SendRemoveCriteria(batchMessageId)),
-                        sendList_.end());
+        sendList_.erase(
+            std::remove_if(sendList_.begin(), sendList_.end(), SendRemoveCriteria(batchMessageId)),
+            sendList_.end());
 
         if (greatestCumulativeAckSent_ < messageId) {
             greatestCumulativeAckSent_ = messageId;

--- a/pulsar-client-cpp/lib/BatchAcknowledgementTracker.cc
+++ b/pulsar-client-cpp/lib/BatchAcknowledgementTracker.cc
@@ -51,7 +51,9 @@ void BatchAcknowledgementTracker::receivedMessage(const Message& message) {
         std::find(sendList_.begin(), sendList_.end(), msgID) != sendList_.end()) {
         return;
     }
-    LOG_DEBUG("Initializing the trackerMap_ with Message ID = " << msgID);
+    LOG_DEBUG("Initializing the trackerMap_ with Message ID = " << msgID
+                << " -- Map size: " << trackerMap_.size()
+                << " -- List size: " << sendList_.size());
 
     // Since dynamic_set (this version) doesn't have all() function, initializing all bits with 1 and then
     // reseting them to 0 and using any()
@@ -66,6 +68,9 @@ void BatchAcknowledgementTracker::deleteAckedMessage(const MessageId& messageId,
     if (messageId.batchIndex() == -1 && ackType == proto::CommandAck_AckType_Individual) {
         return;
     }
+
+    MessageId batchMessageId =
+            MessageId(messageId.partition(), messageId.ledgerId(), messageId.entryId(), -1 /* Batch index */);
 
     Lock lock(mutex_);
     if (ackType == proto::CommandAck_AckType_Cumulative) {
@@ -85,7 +90,7 @@ void BatchAcknowledgementTracker::deleteAckedMessage(const MessageId& messageId,
         // std::remove shifts all to be deleted items to the end of the vector and returns an iterator to the
         // first
         // instance of item, then we erase all elements from this iterator to the end of the list
-        sendList_.erase(std::remove_if(sendList_.begin(), sendList_.end(), SendRemoveCriteria(messageId)),
+        sendList_.erase(std::remove_if(sendList_.begin(), sendList_.end(), SendRemoveCriteria(batchMessageId)),
                         sendList_.end());
 
         if (greatestCumulativeAckSent_ < messageId) {
@@ -100,7 +105,7 @@ void BatchAcknowledgementTracker::deleteAckedMessage(const MessageId& messageId,
                             << messageId);
         }
 
-        sendList_.erase(std::remove(sendList_.begin(), sendList_.end(), messageId), sendList_.end());
+        sendList_.erase(std::remove(sendList_.begin(), sendList_.end(), batchMessageId), sendList_.end());
     }
 }
 


### PR DESCRIPTION
### Motivation

In c++ consumer, when receiving batched messages, the acknowledgment tracker is incorrectly trying remove the messageId from the last message in batch being acked from the `sendList`. In that list, the message ids being inserted are always the ones from the batch, not the individual messages.

The result of this is that the sendList keeps growing, using memory and making the linear search to skyrocket in cpu/time.

Note: this is just a quick fix to address the most pressing issue. A better fix will be to implement an equivalent of #1424.