### PR TITLE
Use default queue size in function producer

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -111,7 +111,7 @@ class ContextImpl(pulsar.Context):
       return self.user_config[key]
     else:
       return None
-  
+
   def get_user_config_map(self):
     return self.user_config
 
@@ -146,8 +146,7 @@ class ContextImpl(pulsar.Context):
         topic_name,
         block_if_queue_full=True,
         batching_enabled=True,
-        batching_max_publish_delay_ms=1,
-        max_pending_messages=100000,
+        batching_max_publish_delay_ms=10,
         compression_type=pulsar_compression_type,
         properties=util.get_properties(util.getFullyQualifiedFunctionName(
           self.instance_config.function_details.tenant,

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -300,11 +300,10 @@ class PythonInstance(object):
         str(self.instance_config.function_details.sink.topic),
         block_if_queue_full=True,
         batching_enabled=True,
-        batching_max_publish_delay_ms=1,
+        batching_max_publish_delay_ms=10,
         # set send timeout to be infinity to prevent potential deadlock with consumer
         # that might happen when consumer is blocked due to unacked messages
         send_timeout_millis=0,
-        max_pending_messages=100000,
         properties=util.get_properties(util.getFullyQualifiedFunctionName(
                         self.instance_config.function_details.tenant,
                         self.instance_config.function_details.namespace,

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -301,6 +301,7 @@ class PythonInstance(object):
         block_if_queue_full=True,
         batching_enabled=True,
         batching_max_publish_delay_ms=10,
+        compression_type=pulsar.CompressionType.LZ4,
         # set send timeout to be infinity to prevent potential deadlock with consumer
         # that might happen when consumer is blocked due to unacked messages
         send_timeout_millis=0,


### PR DESCRIPTION
### Motivation

We should use the default queue size (1K) instead of a bigger queue size for the function producer since that will lead to use a higher amount of memory in the function instance.

At the same time, it's more efficient to use 10ms as batch interval for the function output.