### PR TITLE
Support graceful shutdown Kubernetes

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -46,10 +46,7 @@ import org.apache.pulsar.functions.utils.Reflections;
 import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.TimerTask;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -201,8 +201,7 @@ public class JavaInstanceMain implements AutoCloseable {
             public void run() {
                 // Use stderr here since the logger may have been reset by its JVM shutdown hook.
                 try {
-                    server.shutdown();
-                    runtimeSpawner.close();
+                    close();
                 } catch (Exception ex) {
                     System.err.println(ex);
                 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -39,16 +39,12 @@ import org.apache.pulsar.functions.proto.InstanceControlGrpc;
 import org.apache.pulsar.functions.secretsproviderconfigurator.SecretsProviderConfigurator;
 import org.apache.pulsar.functions.utils.Utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -108,7 +104,7 @@ class ProcessRuntime implements Runtime {
                 break;
         }
         this.extraDependenciesDir = extraDependenciesDir;
-        this.processArgs = RuntimeUtils.composeArgs(
+        this.processArgs = RuntimeUtils.composeCmd(
             instanceConfig,
             instanceFile,
             // DONT SET extra dependencies here (for python runtime),

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -271,14 +271,14 @@ public class KubernetesRuntimeTest {
         if (null != depsDir) {
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir;
             classpath = classpath + ":" + depsDir + "/*";
-            totalArgs = 34;
-            portArg = 25;
-            metricsPortArg = 27;
+            totalArgs = 35;
+            portArg = 26;
+            metricsPortArg = 28;
         } else {
             extraDepsEnv = "";
-            portArg = 24;
-            metricsPortArg = 26;
-            totalArgs = 33;
+            portArg = 25;
+            metricsPortArg = 27;
+            totalArgs = 34;
         }
         if (secretsAttached) {
             totalArgs += 4;
@@ -287,7 +287,7 @@ public class KubernetesRuntimeTest {
         assertEquals(args.size(), totalArgs,
             "Actual args : " + StringUtils.join(args, " "));
 
-        String expectedArgs = "java -cp " + classpath
+        String expectedArgs = "exec java -cp " + classpath
                 + " -Dpulsar.functions.java.instance.jar=" + javaInstanceJarFile
                 + extraDepsEnv
                 + " -Dlog4j.configurationFile=kubernetes_instance_log4j2.yml "
@@ -352,16 +352,16 @@ public class KubernetesRuntimeTest {
         int configArg;
         int metricsPortArg;
         if (null == extraDepsDir) {
-            totalArgs = 36;
-            portArg = 29;
-            configArg = 9;
-            pythonPath = "";
-            metricsPortArg = 31;
-        } else {
-            totalArgs = 39;
+            totalArgs = 37;
             portArg = 30;
             configArg = 10;
+            pythonPath = "";
             metricsPortArg = 32;
+        } else {
+            totalArgs = 40;
+            portArg = 31;
+            configArg = 11;
+            metricsPortArg = 33;
             pythonPath = "PYTHONPATH=${PYTHONPATH}:" + extraDepsDir + " ";
         }
         if (secretsAttached) {
@@ -370,7 +370,7 @@ public class KubernetesRuntimeTest {
 
         assertEquals(args.size(), totalArgs,
             "Actual args : " + StringUtils.join(args, " "));
-        String expectedArgs = pythonPath + "python " + pythonInstanceFile
+        String expectedArgs = pythonPath + "exec python " + pythonInstanceFile
                 + " --py " + pulsarRootDir + "/" + userJarFile
                 + " --logging_directory " + logDirectory
                 + " --logging_file " + config.getFunctionDetails().getName()


### PR DESCRIPTION
### Motivation

Currently, the function process is forked from the bash process that launches it.  When a function terminates, kubernetes send s SIGTERM signal to the pod and the bash process but the signal is not propagated to the function process. Use "exec" to launch the function as the same process as bash so that the SIGTERM signal gets send to the function instance.