### PR TITLE
[docs] Clarify apt install instructions

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -39,7 +39,7 @@ $ rpm -ivh apache-pulsar-client*.rpm
 To install a DEB package, download the DEB packages and install them using the following command:
 
 ```bash
-$ apt-install apache-pulsar-client*.deb
+$ apt install ./apache-pulsar-client*.deb
 ```
 
 ### Build


### PR DESCRIPTION
### Motivation

`apt-install` doesn't need a hyphen - removing that

`apt install` needs a `./`  - without it, with just a single filename, the following errors can occur:
```
root@2e72da3b2a16:~# apt install apache-pulsar-client*.deb
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package apache-pulsar-client.deb
E: Couldn't find any package by glob 'apache-pulsar-client.deb'
E: Couldn't find any package by regex 'apache-pulsar-client.deb'
```

### Modifications

Change docs

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No

### Documentation

N/A