### PR TITLE
Fix: package windowing code with function instance

### DIFF
--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -78,6 +78,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-functions-windowing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <exclusions>


### PR DESCRIPTION
### Motivation

Recently the windowing code got moved to its on module:

https://github.com/apache/pulsar/pull/3583

this caused the windowing code to not be packaged in the java-instance.jar that contains all functions related code.

Functions expects all dependencies to be in java-instance.jar including the windowing code.  

Moving the windowing code to its module caused the windowing classes to not be packaged into java-instance.jar and causes a class not found exception with trying to run a window function

