### PR TITLE
Fixed typo on the site build command line args

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -44,4 +44,4 @@ CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 
 DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -e CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID} -e CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY} -v $ROOT_DIR:/pulsar $IMAGE"
 
-$DOCKER_CMD bash -l -c '/pulsar/site/tools/generate-api-docs.sh && cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && rm -rf /pulsar/generated-site/content && mkdir -p /pulsar/generated-site/content && cp -R ./build/pulsar/* /pulsar/generated-site/content'
+$DOCKER_CMD bash -l -c '/pulsar/site2/tools/generate-api-docs.sh && cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && rm -rf /pulsar/generated-site/content && mkdir -p /pulsar/generated-site/content && cp -R ./build/pulsar/* /pulsar/generated-site/content'


### PR DESCRIPTION
### Motivation

I have a fixed missing from what I was testing locally.. that the new tool for website build is in `site2` directory rather than `site/`