### PR TITLE
Expose Get/SetSubscriptionDispatchRate subcommands in CmdNamespaces

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.admin.Bookies;
 import org.apache.pulsar.client.admin.BrokerStats;
@@ -47,11 +48,13 @@ import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
@@ -400,6 +403,49 @@ public class PulsarAdminToolTest {
 
         namespaces.run(split("set-max-consumers-per-subscription myprop/clust/ns1 -c 3"));
         verify(mockNamespaces).setMaxConsumersPerSubscription("myprop/clust/ns1", 3);
+
+        mockNamespaces = mock(Namespaces.class);
+        when(admin.namespaces()).thenReturn(mockNamespaces);
+        namespaces = new CmdNamespaces(admin);
+
+        namespaces.run(split("set-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
+        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", new DispatchRate(-1, -1, 2));
+
+        namespaces.run(split("get-dispatch-rate myprop/clust/ns1"));
+        verify(mockNamespaces).getDispatchRate("myprop/clust/ns1");
+
+        namespaces.run(split("set-subscribe-rate myprop/clust/ns1 -sr 2 -st 60"));
+        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", new SubscribeRate(2, 60));
+
+        namespaces.run(split("get-subscribe-rate myprop/clust/ns1"));
+        verify(mockNamespaces).getSubscribeRate("myprop/clust/ns1");
+
+        namespaces.run(split("set-subscription-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
+        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", new DispatchRate(-1, -1, 2));
+
+        namespaces.run(split("get-subscription-dispatch-rate myprop/clust/ns1"));
+        verify(mockNamespaces).getSubscriptionDispatchRate("myprop/clust/ns1");
+
+        namespaces.run(split("get-compaction-threshold myprop/clust/ns1"));
+        verify(mockNamespaces).getCompactionThreshold("myprop/clust/ns1");
+
+        namespaces.run(split("set-compaction-threshold myprop/clust/ns1 -t 1G"));
+        verify(mockNamespaces).setCompactionThreshold("myprop/clust/ns1", 1024 * 1024 * 1024);
+
+        namespaces.run(split("get-offload-threshold myprop/clust/ns1"));
+        verify(mockNamespaces).getOffloadThreshold("myprop/clust/ns1");
+
+        namespaces.run(split("set-offload-threshold myprop/clust/ns1 -s 1G"));
+        verify(mockNamespaces).setOffloadThreshold("myprop/clust/ns1", 1024 * 1024 * 1024);
+
+        namespaces.run(split("get-offload-deletion-lag myprop/clust/ns1"));
+        verify(mockNamespaces).getOffloadDeleteLagMs("myprop/clust/ns1");
+
+        namespaces.run(split("set-offload-deletion-lag myprop/clust/ns1 -l 1d"));
+        verify(mockNamespaces).setOffloadDeleteLag("myprop/clust/ns1", 24 * 60 * 60, TimeUnit.SECONDS);
+
+        namespaces.run(split("clear-offload-deletion-lag myprop/clust/ns1"));
+        verify(mockNamespaces).clearOffloadDeleteLag("myprop/clust/ns1");
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -544,7 +544,7 @@ public class CmdNamespaces extends CmdBase {
 
 
     @Parameters(commandDescription = "Set subscription message-dispatch-rate for all subscription of the namespace")
-    private class SetSuscriptionDispatchRate extends CliCommand {
+    private class SetSubscriptionDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace\n", required = true)
         private java.util.List<String> params;
 
@@ -1061,6 +1061,9 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("set-subscribe-rate", new SetSubscribeRate());
         jcommander.addCommand("get-subscribe-rate", new GetSubscribeRate());
+
+        jcommander.addCommand("set-subscription-dispatch-rate", new SetSubscriptionDispatchRate());
+        jcommander.addCommand("get-subscription-dispatch-rate", new GetSubscriptionDispatchRate());
 
         jcommander.addCommand("clear-backlog", new ClearBacklog());
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -692,6 +692,8 @@ Subcommands
 * `get-dispatch-rate`
 * `set-subscribe-rate`
 * `get-subscribe-rate`
+* `set-subscription-dispatch-rate`
+* `get-subscription-dispatch-rate`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1081,6 +1083,29 @@ Get configured subscribe-rate per consumer for all topics of the namespace
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscribe-rate tenant/namespace
+```
+
+### `set-subscription-dispatch-rate`
+Set subscription message-dispatch-rate for all subscription of the namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-dispatch-rate tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-bd`, `--byte-dispatch-rate`|The byte dispatch rate (default -1 will be overwrite if not passed)|-1|
+|`-dt`, `--dispatch-rate-period`|The dispatch rate period in second type (default 1 second will be overwrite if not passed)|1|
+|`-md`, `--sub-msg-dispatch-rate`|The message dispatch rate (default -1 will be overwrite if not passed)|-1|
+
+### `get-subscription-dispatch-rate`
+Get subscription configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `clear-backlog`


### PR DESCRIPTION
### Motivation

Add the omissive subcommands in `namespaces` CLI.

### Modifications

Add `Get/SetSubscriptionDispatchRate` subcommands and its usage.