### PR TITLE
When linking statically a the Python wrapper on Macos, also include libicu

### DIFF
--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -53,6 +53,15 @@ set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
 if (APPLE)
     set(PYTHON_WRAPPER_LIBS ${PYTHON_LIBRARIES} ${PYTHON_WRAPPER_LIBS}
                          ${Boost_PYTHON27-MT_LIBRARY_RELEASE} ${Boost_PYTHON37-MT_LIBRARY_RELEASE})
+
+    if (LINK_STATIC)
+        # When linking statically on MacOS, include also libicu since it's now required by boost::regex
+        find_library(ICU_DATA REQUIRED NAMES libicudata.a PATHS /usr/local/opt/icu4c/lib)
+        find_library(ICU_I18N REQUIRED NAMES libicui18n.a PATHS /usr/local/opt/icu4c/lib)
+        find_library(ICU_UUC REQUIRED NAMES libicuuc.a PATHS /usr/local/opt/icu4c/lib)
+
+        set(ICU_LIBS ${ICU_DATA} ${ICU_I18N} ${ICU_UUC})
+    endif ()
 endif()
 
 message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")
@@ -62,7 +71,7 @@ if (NOT PYTHON_WRAPPER_LIBS)
 endif ()
 
 if (APPLE)
-    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS})
+    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS} ${ICU_LIBS})
 else ()
     set (CMAKE_SHARED_LINKER_FLAGS " -static-libgcc  -static-libstdc++")
     target_link_libraries(_pulsar pulsarStatic ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS})


### PR DESCRIPTION
### Motivation

On boost 1.68 that it's shipped by brew on MacOS the dependencies have changed for boost regex to now include libicu. When statically linking the `_pulsar.so` Python plugin, we need to ensure `libicu` is included. (this works fine when doing regular non-static link, since linking with boost_regex will automatically pull the other shared libs).