### PR TITLE
Use less aggressive JVM memory settings in default config file

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -33,10 +33,13 @@ BOOKIE_CONF=${BOOKIE_CONF:-"$BK_HOME/conf/bookkeeper.conf"}
 # BOOKIE_LOG_DIR=
 
 # Memory size options
-BOOKIE_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"
+BOOKIE_MEM=" -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError"
 
 # Garbage collection options
-BOOKIE_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
+BOOKIE_GC=" -XX:+UseG1GC"
+
+# Example of configuration with more aggressive options to reduce the GC pause times. Works well with higher heap sizes
+# BOOKIE_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
 BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} ${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -42,10 +42,13 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_MEM=${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"}
+PULSAR_MEM=${PULSAR_MEM:-"-Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError"}
 
 # Garbage collection options
-PULSAR_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
+PULSAR_GC=" -XX:+UseG1GC"
+
+# Example of configuration with more aggressive options to reduce the GC pause times. Works well with higher heap sizes
+# PULSAR_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
 PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} ${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"


### PR DESCRIPTION
### Motivation

The default settings for JVM gc configuration that we are shipping in `pulsar_env.sh` are really calibrated on a large node size with many cores and large heap sizes. The main purpose of those settings is to have smaller gc pauses.

These are not ideal in smaller nodes deployment and actually consume more resources than needed , both in terms of cpu and memory. One such example is when running in Docker containers with quotas set and the same happens in our integration tests suite.

### Modifications 

 * Only set the basic config on JVM memory
 * ` -XX:+ExitOnOutOfMemoryError` as it's good to have that by default.