### PR TITLE
[distribution] remove pulsar-io-debezium nar package

### DIFF
--- a/distribution/io/src/assemble/io.xml
+++ b/distribution/io/src/assemble/io.xml
@@ -63,7 +63,6 @@
     <file><source>${basedir}/../../pulsar-io/data-generator/target/pulsar-io-data-generator-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/canal/target/pulsar-io-canal-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/netty/target/pulsar-io-netty-${project.version}.nar</source></file>
-    <file><source>${basedir}/../../pulsar-io/debezium/target/pulsar-io-debezium-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/mongo/target/pulsar-io-mongo-${project.version}.nar</source></file>
   </files>
 </assembly>

--- a/pulsar-io/debezium/pom.xml
+++ b/pulsar-io/debezium/pom.xml
@@ -101,14 +101,4 @@
 
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.nifi</groupId>
-        <artifactId>nifi-nar-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
-
 </project>

--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -54,6 +54,12 @@ module.exports = [
         link: null
     },
     {
+        name: 'kafka-connect-adaptor',
+        longName: 'Apache Kafka Connect Adaptor',
+        type: 'Source, Sink',
+        link: 'http://kafka.apache.org/'
+    },
+    {
         name: 'kafka',
         longName: 'Apache Kafka',
         type: 'Source, Sink',


### PR DESCRIPTION
Fixes #3651 

### Motivation

`pulsar-io-debezium` is a normal module but not a connector package.
it was added as a connector package by mistake at #3601. This would
cause failing to load connectors during broker starts up.

### Modifications

- remove nar plugin from `pulsar-io-debezium`
- remove `pulsar-io-debezium` from distribution
- add `pulsar-io-kafka-connect-adaptor` in the website

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
