### PR TITLE
[go] Fixed conversion of unix timestamp to golang time

### DIFF
--- a/pulsar-client-go/pulsar/c_message.go
+++ b/pulsar-client-go/pulsar/c_message.go
@@ -201,10 +201,9 @@ func latestMessageID() *messageID {
 }
 
 func timeFromUnixTimestampMillis(timestamp C.ulonglong) time.Time {
-	ts := int64(timestamp)
-	seconds := ts / int64(time.Millisecond)
-	millis := ts - seconds
-	nanos := millis * int64(time.Millisecond)
+	ts := int64(timestamp) * int64(time.Millisecond)
+	seconds := ts / int64(time.Second)
+	nanos := ts - (seconds * int64(time.Second))
 	return time.Unix(seconds, nanos)
 }
 

--- a/pulsar-client-go/pulsar/consumer_test.go
+++ b/pulsar-client-go/pulsar/consumer_test.go
@@ -85,6 +85,7 @@ func TestConsumer(t *testing.T) {
 	ctx := context.Background()
 
 	for i := 0; i < 10; i++ {
+		sendTime := time.Now()
 		if err := producer.Send(ctx, ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
@@ -92,11 +93,14 @@ func TestConsumer(t *testing.T) {
 		}
 
 		msg, err := consumer.Receive(ctx)
+		recvTime := time.Now()
 		assert.Nil(t, err)
 		assert.NotNil(t, msg)
 
 		assert.Equal(t, string(msg.Payload()), fmt.Sprintf("hello-%d", i))
 		assert.Equal(t, string(msg.Topic()), "persistent://public/default/my-topic")
+		assert.True(t, sendTime.Unix() <= msg.PublishTime().Unix())
+		assert.True(t, recvTime.Unix() >= msg.PublishTime().Unix())
 
 		consumer.Ack(msg)
 	}


### PR DESCRIPTION
### Motivation

In the consumer written in golang, when we get the publish time of the received message, it is a future than the actual one.

```sh
$ pulsar-admin persistent peek-messages -s sub1 -n 3 persistent://massakam/global/test/t1

Message ID: 5513885:114
Tenants:
{
  "publish-time" : "2019-02-22T14:21:40.871+09:00"
}
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 6d 79 2d 6d 65 73 73 61 67 65 2d 30             |my-message-0    |
+--------+-------------------------------------------------+----------------+
-------------------------------------------------------------------------

Message ID: 5513885:115
Tenants:
{
  "publish-time" : "2019-02-22T14:21:40.884+09:00"
}
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 6d 79 2d 6d 65 73 73 61 67 65 2d 31             |my-message-1    |
+--------+-------------------------------------------------+----------------+
-------------------------------------------------------------------------

Message ID: 5513885:116
Tenants:
{
  "publish-time" : "2019-02-22T14:21:40.898+09:00"
}
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 6d 79 2d 6d 65 73 73 61 67 65 2d 32             |my-message-2    |
+--------+-------------------------------------------------+----------------+

$ go run consumer.go

Received: my-message-0 (2019-03-12 12:42:42.059 +0900 JST)
Received: my-message-1 (2019-03-12 12:42:42.072 +0900 JST)
Received: my-message-2 (2019-03-12 12:42:42.086 +0900 JST)
```

### Modifications

The `timeFromUnixTimestampMillis` function in `c_message.go` was wrong, so fixed it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.