### PR TITLE
[schema] use UTF_8 for storing schema information

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
@@ -57,7 +59,7 @@ public class AvroSchema<T> implements Schema<T> {
         this.schemaInfo.setName("");
         this.schemaInfo.setProperties(properties);
         this.schemaInfo.setType(SchemaType.AVRO);
-        this.schemaInfo.setSchema(this.schema.toString().getBytes());
+        this.schemaInfo.setSchema(this.schema.toString().getBytes(UTF_8));
 
         this.byteArrayOutputStream = new ByteArrayOutputStream();
         this.encoder = EncoderFactory.get().binaryEncoder(this.byteArrayOutputStream, this.encoder);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -63,7 +65,7 @@ public class JSONSchema<T> implements Schema<T>{
         this.schemaInfo.setName("");
         this.schemaInfo.setProperties(properties);
         this.schemaInfo.setType(SchemaType.JSON);
-        this.schemaInfo.setSchema(this.schema.toString().getBytes());
+        this.schemaInfo.setSchema(this.schema.toString().getBytes(UTF_8));
         this.objectMapper = JSON_MAPPER.get();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Descriptors;
@@ -72,7 +74,7 @@ public class ProtobufSchema<T extends com.google.protobuf.GeneratedMessageV3> im
             this.schemaInfo.setType(SchemaType.PROTOBUF);
             ProtobufDatumReader datumReader = new ProtobufDatumReader(pojo);
             org.apache.avro.Schema schema = datumReader.getSchema();
-            this.schemaInfo.setSchema(schema.toString().getBytes());
+            this.schemaInfo.setSchema(schema.toString().getBytes(UTF_8));
 
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new IllegalArgumentException(e);


### PR DESCRIPTION
### Motivation

Currently we don't specify charset. It will be causing troubles when client
and broker are using different system charsets.

### Modifications

Use UTF_8 for the schema information for AVRO/PROTOBUF/JSON

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

