### PR TITLE
Added perf producer/consumers for Go client lib

### DIFF
--- a/pulsar-client-go/go.mod
+++ b/pulsar-client-go/go.mod
@@ -2,7 +2,11 @@ module github.com/apache/pulsar/pulsar-client-go
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6
+	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/sirupsen/logrus v1.3.0
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/pulsar-client-go/go.sum
+++ b/pulsar-client-go/go.sum
@@ -1,5 +1,9 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6 h1:KXlsf+qt/X5ttPGEjR0tPH1xaWWoKBEg9Q1THAj2h3I=
+github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6/go.mod h1:6YNgTHLutezwnBvyneBbwvB8C82y3dcoOj5EQJIdGXA=
+github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
+github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,6 +13,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
+github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pulsar-client-go/pulsar-perf-go/.gitignore
+++ b/pulsar-client-go/pulsar-perf-go/.gitignore
@@ -1,0 +1,1 @@
+pulsar-perf-go

--- a/pulsar-client-go/pulsar-perf-go/perf-consumer.go
+++ b/pulsar-client-go/pulsar-perf-go/perf-consumer.go
@@ -1,0 +1,116 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/apache/pulsar/pulsar-client-go/pulsar"
+	"github.com/spf13/cobra"
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+type ConsumeArgs struct {
+	Topic             string
+	SubscriptionName  string
+	ReceiverQueueSize int
+}
+
+var consumeArgs ConsumeArgs
+
+var cmdConsume = &cobra.Command{
+	Use:   "consume <topic>",
+	Short: "Consume from topic",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		consumeArgs.Topic = args[0]
+		consume()
+	},
+}
+
+func initConsumer() {
+	cmdConsume.Flags().StringVarP(&consumeArgs.SubscriptionName, "subscription", "s", "sub", "Subscription name")
+	cmdConsume.Flags().IntVarP(&consumeArgs.ReceiverQueueSize, "receiver-queue-size", "r", 1000, "Receiver queue size")
+}
+
+func consume() {
+	b, _ := json.MarshalIndent(clientArgs, "", "  ")
+	fmt.Println("Client config: ", string(b))
+	b, _ = json.MarshalIndent(consumeArgs, "", "  ")
+	fmt.Println("Consumer config: ", string(b))
+
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL:                    clientArgs.ServiceUrl,
+		IOThreads:              clientArgs.IoThreads,
+		StatsIntervalInSeconds: 0,
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer client.Close()
+
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:            consumeArgs.Topic,
+		SubscriptionName: consumeArgs.SubscriptionName,
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer consumer.Close()
+
+	ctx := context.Background()
+
+	var msgReceived int64 = 0
+	var bytesReceived int64 = 0
+
+	go func() {
+		for {
+			msg, _ := consumer.Receive(ctx)
+
+			atomic.AddInt64(&msgReceived, 1)
+			atomic.AddInt64(&bytesReceived, int64(len(msg.Payload())))
+
+			consumer.Ack(msg)
+		}
+	}()
+
+	// Print stats of the consume rate
+	tick := time.NewTicker(10 * time.Second)
+
+	for {
+		select {
+		case <-tick.C:
+			currentMsgReceived := atomic.SwapInt64(&msgReceived, 0)
+			currentBytesReceived := atomic.SwapInt64(&bytesReceived, 0)
+			msgRate := float64(currentMsgReceived) / float64(10)
+			bytesRate := float64(currentBytesReceived) / float64(10)
+
+			log.Printf(`Stats - Consume rate: %6.1f msg/s - %6.1f Mbps`,
+				msgRate, bytesRate*8/1024/1024)
+		}
+	}
+}

--- a/pulsar-client-go/pulsar-perf-go/perf-producer.go
+++ b/pulsar-client-go/pulsar-perf-go/perf-producer.go
@@ -1,0 +1,151 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/apache/pulsar/pulsar-client-go/pulsar"
+	"github.com/bmizerany/perks/quantile"
+	"github.com/spf13/cobra"
+	"github.com/beefsack/go-rate"
+	"log"
+	"time"
+)
+
+type ProduceArgs struct {
+	Topic             string
+	Rate              int
+	Batching          bool
+	MessageSize       int
+	ProducerQueueSize int
+}
+
+var produceArgs ProduceArgs
+
+var cmdProduce = &cobra.Command{
+	Use:   "produce ",
+	Short: "Produce on a topic and measure performance",
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		produceArgs.Topic = args[0]
+		produce()
+	},
+}
+
+func initProducer() {
+	cmdProduce.Flags().IntVarP(&produceArgs.Rate, "rate", "r", 100, "Publish rate. Set to 0 to go unthrottled")
+	cmdProduce.Flags().BoolVarP(&produceArgs.Batching, "batching", "b", true, "Enable batching")
+	cmdProduce.Flags().IntVarP(&produceArgs.MessageSize, "size", "s", 1024, "Message size")
+	cmdProduce.Flags().IntVarP(&produceArgs.ProducerQueueSize, "queue-size", "q", 1000, "Produce queue size")
+}
+
+func produce() {
+	b, _ := json.MarshalIndent(clientArgs, "", "  ")
+	fmt.Println("Client config: ", string(b))
+	b, _ = json.MarshalIndent(produceArgs, "", "  ")
+	fmt.Println("Producer config: ", string(b))
+
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL:                    clientArgs.ServiceUrl,
+		IOThreads:              clientArgs.IoThreads,
+		StatsIntervalInSeconds: 0,
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer client.Close()
+
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic:                   produceArgs.Topic,
+		MaxPendingMessages:      produceArgs.ProducerQueueSize,
+		Batching:                produceArgs.Batching,
+		BatchingMaxPublishDelay: 1 * time.Millisecond,
+		SendTimeout:             0,
+		BlockIfQueueFull:        true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer producer.Close()
+
+	ctx := context.Background()
+
+	payload := make([]byte, produceArgs.MessageSize)
+
+	ch := make(chan float64)
+
+	go func() {
+		var rateLimiter *rate.RateLimiter = nil
+		if produceArgs.Rate > 0 {
+			rateLimiter = rate.New(produceArgs.Rate, time.Second)
+		}
+
+		for {
+			if rateLimiter != nil {
+				rateLimiter.Wait()
+			}
+
+			start := time.Now()
+
+			producer.SendAsync(ctx, pulsar.ProducerMessage{
+				Payload: payload,
+			}, func(message pulsar.ProducerMessage, e error) {
+				if e != nil {
+					log.Fatal("Failed to publish", e)
+				}
+
+				latency := time.Since(start).Seconds()
+				ch <- latency
+			})
+		}
+	}()
+
+	// Print stats of the publish rate and latencies
+	tick := time.NewTicker(10 * time.Second)
+	q := quantile.NewTargeted(0.90, 0.95, 0.99, 0.999, 1.0)
+	messagesPublished := 0
+
+	for {
+		select {
+		case <-tick.C:
+			messageRate := float64(messagesPublished) / float64(10)
+			log.Printf(`Stats - Publish rate: %6.1f msg/s - %6.1f Mbps - Latency ms: 50%% %5.1f - 95%% %5.1f - 99%% %5.1f - 99.9%% %5.1f - max %6.1f`,
+				messageRate,
+				messageRate*float64(produceArgs.MessageSize)/1024/1024*8,
+				q.Query(0.5)*1000,
+				q.Query(0.95)*1000,
+				q.Query(0.99)*1000,
+				q.Query(0.999)*1000,
+				q.Query(1.0)*1000,
+			)
+
+			q.Reset()
+			messagesPublished = 0
+		case latency := <-ch:
+			messagesPublished += 1
+			q.Insert(latency)
+		}
+	}
+}

--- a/pulsar-client-go/pulsar-perf-go/pulsar-perf-go.go
+++ b/pulsar-client-go/pulsar-perf-go/pulsar-perf-go.go
@@ -1,0 +1,48 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type ClientArgs struct {
+	ServiceUrl      string
+	IoThreads       int
+	ListenerThreads int
+}
+
+var clientArgs ClientArgs
+
+func main() {
+	initProducer()
+	initConsumer()
+
+	var rootCmd = &cobra.Command{Use: "pulsar-perf-go"}
+	rootCmd.Flags().StringVarP(&clientArgs.ServiceUrl, "service-url", "u",
+		"pulsar://localhost:6650", "The Pulsar service URL")
+	rootCmd.Flags().IntVar(&clientArgs.IoThreads, "io-threads",
+		1, "The number of IO threads in client")
+	rootCmd.Flags().IntVar(&clientArgs.ListenerThreads, "listener-threads",
+		1, "The number of listener threads in client")
+	rootCmd.AddCommand(cmdProduce, cmdConsume)
+
+	rootCmd.Execute()
+}


### PR DESCRIPTION
### Motivation

Add perf CLI tools for the Go client library. This works in similar way as the Java and C++ based perf tools and allows to test the performance of the Go client library on produce and consume operations.