### PR TITLE
Fix license exclude for local license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1138,6 +1138,13 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/*.crt</exclude>
             <exclude>**/*.key</exclude>
             <exclude>**/*.csr</exclude>
+            <exclude>**/*.log</exclude>
+            <exclude>**/*.patch</exclude>
+            <exclude>**/*.avsc</exclude>
+            <exclude>**/*.versionsBackup</exclude>
+            <exclude>**/*.pyc</exclude>
+            <exclude>**/*.graffle</exclude>
+            <exclude>**/*.hgrm</exclude>
             <exclude>src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java</exclude>
             <exclude>src/main/java/org/apache/pulsar/broker/service/schema/proto/SchemaRegistryFormat.java</exclude>
             <exclude>src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java</exclude>
@@ -1150,11 +1157,9 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/ByteBufCodedInputStream.java</exclude>
             <exclude>**/ByteBufCodedOutputStream.java</exclude>
             <exclude>bin/proto/*</exclude>
-            <exclude>**/*.patch</exclude>
             <exclude>conf/schema_example.conf</exclude>
             <exclude>data/**</exclude>
             <exclude>logs/**</exclude>
-            <exclude>**/*.versionsBackup</exclude>
             <exclude>**/circe/**</exclude>
             <exclude>pulsar-broker/src/test/resources/authentication/basic/.htpasswd</exclude>
             <exclude>pulsar-client-cpp/lib/checksum/int_types.h</exclude>
@@ -1163,14 +1168,10 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>pulsar-client-cpp/lib/checksum/crc32c_sse42.h</exclude>
             <exclude>pulsar-client-cpp/lib/checksum/crc32c_sw.cc</exclude>
             <exclude>pulsar-client-cpp/lib/lz4/lz4.*</exclude>
-            <exclude>pulsar-client-cpp/.idea/*</exclude>
             <exclude>pulsar-client-cpp/lib/PulsarApi.pb.*</exclude>
             <exclude>pulsar-client-cpp/CMakeFiles/**</exclude>
             <exclude>pulsar-client-cpp/**/Makefile</exclude>
             <exclude>pulsar-client-cpp/**/cmake_install.cmake</exclude>
-            <exclude>**/*.pyc</exclude>
-            <exclude>**/*.graffle</exclude>
-            <exclude>**/*.hgrm</exclude>
             <exclude>**/CMakeFiles/**</exclude>
             <exclude>**/django/stats/migrations/*.py</exclude>
             <exclude>site/vendor/**</exclude>
@@ -1189,7 +1190,8 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>site2/**</exclude>
             <exclude>generated-site/**</exclude>
             <exclude>.github/*.md</exclude>
-            <exclude>**/.idea/*</exclude>
+            <exclude>**/.idea/**</exclude>
+            <exclude>**/generated/**</exclude>
             <exclude>**/zk-3.5-test-data/*</exclude>
           </excludes>
           <mapping>


### PR DESCRIPTION
### Motivation

when run `mvn clean license:check` for pulsar, some check is not passed. This change try to fix the issue.

### Modifications

- add exclude rule for auto generated files, 
- exclude type `.avsc`, put types of file together,
- fix `**/.idea/**`

### Verifying this change
 ` mvn clean license:check`  runs success.
