### PR TITLE
[Pulsar Functions] Add support for multiple sinks/sources in a single NAR file.

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,7 +42,8 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
+# PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
+PULSAR_MEM="-Xmx4g -XX:MaxDirectMemorySize=128m"
 
 # Garbage collection options
 PULSAR_GC=" -client "

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,8 +42,7 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-# PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
-PULSAR_MEM="-Xmx4g -XX:MaxDirectMemorySize=128m"
+PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
 
 # Garbage collection options
 PULSAR_GC=" -client "

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/ConnectorMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/ConnectorMap.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.io;
+
+import java.util.Map;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ConnectorMap {
+
+    private Map<String, ConnectorDefinition> connectors;
+
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/io/ConnectorDefinitionMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/io/ConnectorDefinitionMapTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.io;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public class ConnectorDefinitionMapTest {
+    
+  @Test
+  public final void readTest() {
+      String configStr = 
+        "connectors:\n" + 
+              "  hdfs:\n" + 
+              "    description: \"The HDFS connector\"\n" + 
+              "    sourceClass: \"org.apache.pulsar.io.hdfs.SoruceClassImpl\"\n" + 
+              "    sinkClass: \"org.apache.pulsar.io.hdfs.SinkClassImpl\"\n" + 
+              "  redis:\n" + 
+              "    description: \"The Redis connector\"\n" + 
+              "    sourceClass: \"org.apache.pulsar.io.redis.SoruceClassImpl\"\n" + 
+              "    sinkClass: \"org.apache.pulsar.io.redis.SinkClassImpl\"";
+      ConnectorMap map;
+      try {
+          map = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr,
+                  ConnectorMap.class);
+          assertNotNull(map);
+          assertNotNull(map.getConnectors());
+          
+          ConnectorDefinition hdfs = map.getConnectors().get("hdfs");
+          assertNotNull(hdfs);
+          assertEquals(hdfs.getSinkClass(), "org.apache.pulsar.io.hdfs.SinkClassImpl");
+          assertEquals(hdfs.getSourceClass(), "org.apache.pulsar.io.hdfs.SoruceClassImpl");
+          
+          ConnectorDefinition redis = map.getConnectors().get("redis");
+          assertNotNull(redis);
+          assertEquals(redis.getSinkClass(), "org.apache.pulsar.io.redis.SinkClassImpl");
+          assertEquals(redis.getSourceClass(), "org.apache.pulsar.io.redis.SoruceClassImpl");
+          
+      } catch (IOException e) {
+          fail(e.getMessage());
+      }
+  }
+    
+}

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -99,6 +99,10 @@
         <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+    	<groupId>commons-io</groupId>
+    	<artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Reflections.java
@@ -64,7 +64,7 @@ public class Reflections {
         try {
             theCls = Class.forName(userClassName, true, classLoader);
         } catch (ClassNotFoundException cnfe) {
-            throw new RuntimeException("User class must be in class path", cnfe);
+            throw new RuntimeException(String.format("User class %s must be in class path", userClassName), cnfe);
         }
         if (!xface.isAssignableFrom(theCls)) {
             throw new RuntimeException(userClassName + " not " + xface.getName());
@@ -105,7 +105,7 @@ public class Reflections {
         try {
             theCls = Class.forName(userClassName, true, classLoader);
         } catch (ClassNotFoundException cnfe) {
-            throw new RuntimeException("User class must be in class path", cnfe);
+            throw new RuntimeException(String.format("User class %s must be in class path", userClassName), cnfe);
         }
         Object result;
         try {
@@ -139,7 +139,7 @@ public class Reflections {
         try {
             theCls = Class.forName(userClassName, true, classLoader);
         } catch (ClassNotFoundException cnfe) {
-            throw new RuntimeException("User class must be in class path", cnfe);
+            throw new RuntimeException(String.format("User class %s must be in class path", userClassName), cnfe);
         }
         Object result;
         try {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -299,7 +299,7 @@ public class SinkConfigUtils {
         if (!isEmpty(sinkConfig.getClassName())) {
             sinkClassName = sinkConfig.getClassName();
             try {
-            	String ext = null;
+                String ext = null;
             	if (!isEmpty(functionPkgUrl)) {
             		File file = Utils.extractFileFromPkg(functionPkgUrl);
             		ext = FilenameUtils.getExtension(file.getName());
@@ -314,7 +314,6 @@ public class SinkConfigUtils {
             	} else {
                    classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
             	}
-            	
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid Sink Jar");
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -24,6 +24,8 @@ import com.google.gson.reflect.TypeToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -297,7 +299,22 @@ public class SinkConfigUtils {
         if (!isEmpty(sinkConfig.getClassName())) {
             sinkClassName = sinkConfig.getClassName();
             try {
-                classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	String ext = null;
+            	if (!isEmpty(functionPkgUrl)) {
+            		File file = Utils.extractFileFromPkg(functionPkgUrl);
+            		ext = FilenameUtils.getExtension(file.getName());
+            	} else if (archivePath != null) {
+            		ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
+            	} else if (uploadedInputStreamAsFile != null) {
+            		ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
+            	}
+            	
+            	if ("nar".equalsIgnoreCase(ext)) {
+            	   classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	} else {
+                   classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	}
+            	
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid Sink Jar");
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -300,20 +300,20 @@ public class SinkConfigUtils {
             sinkClassName = sinkConfig.getClassName();
             try {
                 String ext = null;
-            	if (!isEmpty(functionPkgUrl)) {
-            		File file = Utils.extractFileFromPkg(functionPkgUrl);
-            		ext = FilenameUtils.getExtension(file.getName());
-            	} else if (archivePath != null) {
-            		ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
-            	} else if (uploadedInputStreamAsFile != null) {
-            		ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
-            	}
-            	
-            	if ("nar".equalsIgnoreCase(ext)) {
-            	   classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
-            	} else {
-                   classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
-            	}
+                if (!isEmpty(functionPkgUrl)) {
+                    File file = Utils.extractFileFromPkg(functionPkgUrl);
+                    ext = FilenameUtils.getExtension(file.getName());
+                } else if (archivePath != null) {
+                    ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
+                } else if (uploadedInputStreamAsFile != null) {
+                    ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
+                }
+
+                if ("nar".equalsIgnoreCase(ext)) {
+                    classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+                } else {
+                    classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+                }
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid Sink Jar");
             }
@@ -325,7 +325,7 @@ public class SinkConfigUtils {
                 throw new IllegalArgumentException("Sink Package is not provided");
             }
             try {
-                sinkClassName = ConnectorUtils.getIOSinkClass(classLoader);
+                sinkClassName = ConnectorUtils.getIOSinkClass(sinkConfig.getName(), classLoader);
             } catch (IOException e1) {
                 throw new IllegalArgumentException("Failed to extract sink class from archive", e1);
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -24,6 +24,8 @@ import com.google.gson.reflect.TypeToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.io.SourceConfig;
@@ -210,7 +212,21 @@ public class SourceConfigUtils {
         if (!isEmpty(sourceConfig.getClassName())) {
             sourceClassName = sourceConfig.getClassName();
             try {
-                classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	String ext = null;
+            	if (!isEmpty(functionPkgUrl)) {
+            		File file = Utils.extractFileFromPkg(functionPkgUrl);
+            		ext = FilenameUtils.getExtension(file.getName());
+            	} else if (archivePath != null) {
+            		ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
+            	} else if (uploadedInputStreamAsFile != null) {
+            		ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
+            	}
+
+            	if ("nar".equalsIgnoreCase(ext)) {
+            		classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	} else {
+            		classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+            	}
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid Source Jar");
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -212,21 +212,21 @@ public class SourceConfigUtils {
         if (!isEmpty(sourceConfig.getClassName())) {
             sourceClassName = sourceConfig.getClassName();
             try {
-            	String ext = null;
-            	if (!isEmpty(functionPkgUrl)) {
-            		File file = Utils.extractFileFromPkg(functionPkgUrl);
-            		ext = FilenameUtils.getExtension(file.getName());
-            	} else if (archivePath != null) {
-            		ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
-            	} else if (uploadedInputStreamAsFile != null) {
-            		ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
-            	}
+                String ext = null;
+                if (!isEmpty(functionPkgUrl)) {
+                    File file = Utils.extractFileFromPkg(functionPkgUrl);
+                    ext = FilenameUtils.getExtension(file.getName());
+                } else if (archivePath != null) {
+                    ext = FilenameUtils.getExtension(archivePath.getFileName().toString());
+                } else if (uploadedInputStreamAsFile != null) {
+                    ext = FilenameUtils.getExtension(uploadedInputStreamAsFile.getName());
+                }
 
-            	if ("nar".equalsIgnoreCase(ext)) {
-            		classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
-            	} else {
-            		classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
-            	}
+                if ("nar".equalsIgnoreCase(ext)) {
+                    classLoader = Utils.extractNarClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+                } else {
+                    classLoader = Utils.extractClassLoader(archivePath, functionPkgUrl, uploadedInputStreamAsFile);
+                }
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid Source Jar");
             }
@@ -238,7 +238,7 @@ public class SourceConfigUtils {
                 throw new IllegalArgumentException("Source Package is not provided");
             }
             try {
-                sourceClassName = ConnectorUtils.getIOSourceClass((NarClassLoader) classLoader);
+                sourceClassName = ConnectorUtils.getIOSourceClass(sourceConfig.getName(), (NarClassLoader) classLoader);
             } catch (IOException e1) {
                 throw new IllegalArgumentException("Failed to extract source class from archive", e1);
             }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -135,7 +135,7 @@ public class Utils {
             try {
                 theCls = Class.forName(userClassName, true, classLoader);
             } catch (ClassNotFoundException e) {
-                throw new RuntimeException("User class must be in class path", cnfe);
+                throw new RuntimeException(String.format("User class %s must be in class path", userClassName), cnfe);
             }
         }
         Object result;
@@ -144,13 +144,13 @@ public class Utils {
             meth.setAccessible(true);
             result = meth.newInstance();
         } catch (InstantiationException ie) {
-            throw new RuntimeException("User class must be concrete", ie);
+            throw new RuntimeException(String.format("User class must be concrete", userClassName), ie);
         } catch (NoSuchMethodException e) {
-            throw new RuntimeException("User class doesn't have such method", e);
+            throw new RuntimeException(String.format("User class doesn't have such method", userClassName), e);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("User class must have a no-arg constructor", e);
+            throw new RuntimeException(String.format("User class must have a no-arg constructor", userClassName), e);
         } catch (InvocationTargetException e) {
-            throw new RuntimeException("User class constructor throws exception", e);
+            throw new RuntimeException(String.format("User class constructor throws exception", userClassName), e);
         }
         return result;
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -25,12 +25,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.io.ConnectorDefinition;
+import org.apache.pulsar.common.io.ConnectorMap;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.functions.utils.Exceptions;
@@ -46,11 +50,14 @@ public class ConnectorUtils {
     /**
      * Extract the Pulsar IO Source class from a connector archive.
      */
-    public static String getIOSourceClass(NarClassLoader ncl) throws IOException {
-        String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
-
-        ConnectorDefinition conf = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr,
-                ConnectorDefinition.class);
+    public static String getIOSourceClass(String connectorName, NarClassLoader ncl) throws IOException {
+        
+        ConnectorDefinition conf = getConnectorDefinition(connectorName, ncl);
+        
+        if (conf == null) {
+            throw new IOException(String.format("Couldn't find '%s' connector.", connectorName));
+        }
+        
         if (StringUtils.isEmpty(conf.getSourceClass())) {
             throw new IOException(
                     String.format("The '%s' connector does not provide a source implementation", conf.getName()));
@@ -73,12 +80,14 @@ public class ConnectorUtils {
     /**
      * Extract the Pulsar IO Sink class from a connector archive.
      */
-    public static String getIOSinkClass(ClassLoader classLoader) throws IOException {
+    public static String getIOSinkClass(String connectorName, ClassLoader classLoader) throws IOException {
         NarClassLoader ncl = (NarClassLoader) classLoader;
-        String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
-
-        ConnectorDefinition conf = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr,
-                ConnectorDefinition.class);
+        ConnectorDefinition conf = getConnectorDefinition(connectorName, ncl);
+        
+        if (conf == null) {
+            throw new IOException(String.format("Couldn't find '%s' connector.", connectorName));
+        }
+        
         if (StringUtils.isEmpty(conf.getSinkClass())) {
             throw new IOException(
                     String.format("The '%s' connector does not provide a sink implementation", conf.getName()));
@@ -97,13 +106,39 @@ public class ConnectorUtils {
 
         return conf.getSinkClass();
     }
-
-    public static ConnectorDefinition getConnectorDefinition(String narPath) throws IOException {
+    
+    /**
+     * Parses out all of the Connector definitions from the specified NAR file.
+     * Supports both versions of the pulsar-io.yaml file.
+     * 
+     */
+    public static ConnectorMap getConnectors(String narPath) throws IOException {
         try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(narPath), Collections.emptySet())) {
             String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
 
-            return ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorDefinition.class);
+            ConnectorMap map = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorMap.class);
+            
+            if (map == null) {
+                map = new ConnectorMap();
+                map.setConnectors(new HashMap<String, ConnectorDefinition>());
+                ConnectorDefinition def = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorDefinition.class);
+                if (def != null) {
+                    map.getConnectors().put(def.getName(), def);
+                }
+            }
+            
+            return map;
         }
+    }
+
+    /**
+     * Returns the Connector definition associated with the given name (if it exists) from the specified NAR file.
+     * Supports both versions of the pulsar-io.yaml file.
+     * 
+     */
+    public static ConnectorDefinition getConnectorDefinition(String connectorName, String narPath) throws IOException {
+        return getConnectorDefinition(connectorName, 
+                NarClassLoader.getFromArchive(new File(narPath), Collections.emptySet()));
     }
 
     public static Connectors searchForConnectors(String connectorsDirectory) throws IOException {
@@ -120,20 +155,22 @@ public class ConnectorUtils {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, "*.nar")) {
             for (Path archive : stream) {
                 try {
-                    ConnectorDefinition cntDef = ConnectorUtils.getConnectorDefinition(archive.toString());
-                    log.info("Found connector {} from {}", cntDef, archive);
+                    // This call supports both versions of the pulsar-io.yaml 
+                    ConnectorMap map = ConnectorUtils.getConnectors(archive.toString());
+                    connectors.connectors.addAll(map.getConnectors().values());
+                    
+                    for (ConnectorDefinition cntDef: map.getConnectors().values()) {
+                        if (!StringUtils.isEmpty(cntDef.getSourceClass())) {
+                            connectors.sources.put(cntDef.getName(), archive);
+                        }
 
-                    if (!StringUtils.isEmpty(cntDef.getSourceClass())) {
-                        connectors.sources.put(cntDef.getName(), archive);
+                        if (!StringUtils.isEmpty(cntDef.getSinkClass())) {
+                            connectors.sinks.put(cntDef.getName(), archive);
+                        }
                     }
 
-                    if (!StringUtils.isEmpty(cntDef.getSinkClass())) {
-                        connectors.sinks.put(cntDef.getName(), archive);
-                    }
-
-                    connectors.connectors.add(cntDef);
                 } catch (Throwable t) {
-                    log.warn("Failed to load connector from {}", archive, t);
+                    log.warn("Failed to load connectors from {}", archive, t);
                 }
             }
         }
@@ -142,5 +179,33 @@ public class ConnectorUtils {
                 (c1, c2) -> String.CASE_INSENSITIVE_ORDER.compare(c1.getName(), c2.getName()));
 
         return connectors;
+    }
+
+    /**
+     * Added to provide backward compatibility for the old pulsar-io.yaml format.
+     * We first try the newer format, and if that fails, we try the older format.
+     * 
+     */
+    private static ConnectorDefinition getConnectorDefinition(String connectorName, NarClassLoader ncl) throws IOException {
+        
+        ConnectorDefinition conDef = null;
+        
+        try {
+            String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
+            ConnectorMap map = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorMap.class);
+            
+            if (map != null && map.getConnectors() != null) {
+                conDef = map.getConnectors().get(connectorName);
+            } 
+            
+            if (conDef == null) {
+                conDef = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorDefinition.class);
+            }
+            
+        } catch (Throwable t) {
+            Exceptions.rethrowIOException(t);
+        } finally {
+            return conDef; 
+        }
     }
 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/io/ConnectorUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/io/ConnectorUtilsTest.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils.io;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+import org.apache.pulsar.common.io.ConnectorDefinition;
+import org.apache.pulsar.common.io.ConnectorMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ConnectorUtilsTest {
+    
+    private static final String NEW_FORMAT_NAR_FILE_NAME = "pulsar-io-cassandra-new-format.nar";
+    private static final String OLD_FORMAT_NAR_FILE_NAME = "pulsar-io-twitter-old-format.nar";
+    
+    private String NEW_FORMAT_FILE_PATH;
+    private String OLD_FORMAT_FILE_PATH;
+    
+    @BeforeMethod
+    public void setup() {
+        URL file = Thread.currentThread().getContextClassLoader().getResource(NEW_FORMAT_NAR_FILE_NAME);
+        if (file == null)  {
+            throw new RuntimeException("Failed to file required test archive: " + NEW_FORMAT_NAR_FILE_NAME);
+        }
+        NEW_FORMAT_FILE_PATH = file.getFile();
+        OLD_FORMAT_FILE_PATH = Thread.currentThread().getContextClassLoader().getResource(OLD_FORMAT_NAR_FILE_NAME).getFile();
+    }
+
+    /**
+     * Validate that we can handle older versions of the pulsar-io.yaml
+     * @throws IOException 
+     */
+    @Test
+    public final void getConnectorsBackwardCompatTest() throws IOException {
+        ConnectorMap map = ConnectorUtils.getConnectors(OLD_FORMAT_FILE_PATH);
+        assertNotNull(map);
+        assertNotNull(map.getConnectors());
+        assertTrue(map.getConnectors().containsKey("twitter"));
+        
+        ConnectorDefinition def = map.getConnectors().get("twitter");
+        assertNotNull(def);
+        assertEquals(def.getName(), "twitter");
+        assertEquals(def.getDescription(), "Ingest data from Twitter firehose");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.twitter.TwitterFireHose");
+    }
+    
+    /**
+     * Validate that we can parse the new pulsar-io.yaml format.
+     */
+    @Test
+    public final void getConnectorsNewFormatTest() throws IOException {
+        ConnectorMap map = ConnectorUtils.getConnectors(NEW_FORMAT_FILE_PATH);
+        assertNotNull(map);
+        assertNotNull(map.getConnectors());
+        assertTrue(map.getConnectors().containsKey("cassandra"));
+        
+        ConnectorDefinition def = map.getConnectors().get("cassandra");
+        assertNotNull(def);
+        assertEquals(def.getName(), "cassandra");
+        assertEquals(def.getDescription(), "Writes data into Cassandra");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.cassandra.CassandraStringSink");
+    }
+    
+    /**
+     * Validate that we can handle both versions simultaneously by loading in two
+     * NAR file with different formats and confirming that connectors from both were loaded
+     *
+     */
+    @Test
+    public final void getConnectorsBothFormatTests() throws IOException {
+        String narPath = NEW_FORMAT_FILE_PATH.
+                substring(0,NEW_FORMAT_FILE_PATH.lastIndexOf(File.separator));
+                
+        Connectors connectors = ConnectorUtils.searchForConnectors(narPath);
+        assertNotNull(connectors);
+        assertNotNull(connectors.getConnectors());
+        assertFalse(connectors.getConnectors().isEmpty());
+        assertEquals(connectors.getConnectors().size(), 2);
+        
+        ConnectorDefinition def = connectors.getConnectors().get(0);
+        assertNotNull(def);
+        assertEquals(def.getName(), "cassandra");
+        assertEquals(def.getDescription(), "Writes data into Cassandra");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.cassandra.CassandraStringSink");
+        
+        def = connectors.getConnectors().get(1);
+        assertNotNull(def);
+        assertEquals(def.getName(), "twitter");
+        assertEquals(def.getDescription(), "Ingest data from Twitter firehose");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.twitter.TwitterFireHose");
+    }
+    
+    /**
+     * Validate that we can get a specific connector by name
+     * @throws IOException 
+     */
+    @Test
+    public final void getConnectorDefinitionTest() throws IOException {
+        ConnectorDefinition def = ConnectorUtils.getConnectorDefinition("twitter", OLD_FORMAT_FILE_PATH);
+        assertNotNull(def);
+        assertEquals(def.getName(), "twitter");
+        assertEquals(def.getDescription(), "Ingest data from Twitter firehose");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.twitter.TwitterFireHose");
+        
+        def = ConnectorUtils.getConnectorDefinition("cassandra", NEW_FORMAT_FILE_PATH);
+        assertNotNull(def);
+        assertEquals(def.getName(), "cassandra");
+        assertEquals(def.getDescription(), "Writes data into Cassandra");
+        assertEquals(def.getSourceClass(), null);
+        assertEquals(def.getSinkClass(), "org.apache.pulsar.io.cassandra.CassandraStringSink");
+    }
+}

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -359,7 +359,10 @@ public class FunctionActioner implements AutoCloseable {
             SourceSpec sourceSpec = functionDetails.getSource();
             if (!StringUtils.isEmpty(sourceSpec.getBuiltin())) {
                 File archive = connectorsManager.getSourceArchive(sourceSpec.getBuiltin()).toFile();
-                String sourceClass = ConnectorUtils.getConnectorDefinition(archive.toString()).getSourceClass();
+                /* Used to pull in the archive and assume that there is only one source/sink. 
+                 * now we use the className provided in the Source Specification
+                 */
+                String sourceClass = sourceSpec.getClassName(); 
                 SourceSpec.Builder builder = SourceSpec.newBuilder(functionDetails.getSource());
                 builder.setClassName(sourceClass);
                 functionDetails.setSource(builder);
@@ -373,7 +376,10 @@ public class FunctionActioner implements AutoCloseable {
             SinkSpec sinkSpec = functionDetails.getSink();
             if (!StringUtils.isEmpty(sinkSpec.getBuiltin())) {
                 File archive = connectorsManager.getSinkArchive(sinkSpec.getBuiltin()).toFile();
-                String sinkClass = ConnectorUtils.getConnectorDefinition(archive.toString()).getSinkClass();
+                /* Used to pull in the archive and assume that there is only one source/sink. 
+                 * now we use the className provided in the Source Specification
+                 */
+                String sinkClass = sinkSpec.getClassName(); 
                 SinkSpec.Builder builder = SinkSpec.newBuilder(functionDetails.getSink());
                 builder.setClassName(sinkClass);
                 functionDetails.setSink(builder);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -337,7 +337,7 @@ public class FunctionApiV2ResourceTest {
         }
     }
 
-    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class must be in class path")
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class UnknownClass must be in class path")
     public void testRegisterFunctionWrongClassName() {
         try {
             testRegisterFunctionMissingArguments(

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -334,7 +334,7 @@ public class FunctionApiV3ResourceTest {
         }
     }
 
-    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class must be in class path")
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class UnknownClass must be in class path")
     public void testRegisterFunctionWrongClassName() {
         try {
             testRegisterFunctionMissingArguments(

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -63,6 +63,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -891,7 +892,7 @@ public class SinkApiV3ResourceTest {
     }
 
     @Test
-    public void testUpdateSinkWithUrl() throws IOException {
+    public void testUpdateSinkWithUrl() throws IOException, URISyntaxException {
         Configurator.setRootLevel(Level.DEBUG);
 
         String filePackageUrl = "file://" + JAR_FILE_PATH;
@@ -912,6 +913,11 @@ public class SinkApiV3ResourceTest {
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
         org.apache.pulsar.functions.utils.Utils.getSinkType(anyString(), any(NarClassLoader.class));
+        
+        File mockedFile = mock(File.class);
+        when(mockedFile.getName()).thenReturn(JAR_FILE_NAME);
+        doReturn(mockedFile ).when(org.apache.pulsar.functions.utils.Utils.class);
+        org.apache.pulsar.functions.utils.Utils.extractFileFromPkg(anyString());
 
         doReturn(mock(NarClassLoader.class)).when(org.apache.pulsar.functions.utils.Utils.class);
         org.apache.pulsar.functions.utils.Utils.extractNarClassLoader(any(Path.class), anyString(), any(File.class));

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -109,7 +109,7 @@ public class SinkApiV3ResourceTest {
     private static final String subscriptionName = "test-subscription";
     private static final String className = CassandraStringSink.class.getName();
     private static final int parallelism = 1;
-    private static final String JAR_FILE_NAME = "pulsar-io-cassandra.nar";
+    private static final String JAR_FILE_NAME = "pulsar-io-cassandra-2.3.0-SNAPSHOT.nar";
     private static final String INVALID_JAR_FILE_NAME = "pulsar-io-twitter.nar";
     private String JAR_FILE_PATH;
     private String INVALID_JAR_FILE_PATH;
@@ -743,7 +743,7 @@ public class SinkApiV3ResourceTest {
             String expectedError) throws IOException {
         mockStatic(ConnectorUtils.class);
         doReturn(CassandraStringSink.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSinkClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSinkClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
@@ -813,7 +813,7 @@ public class SinkApiV3ResourceTest {
 
         mockStatic(ConnectorUtils.class);
         doReturn(CassandraStringSink.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSinkClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSinkClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
@@ -908,7 +908,7 @@ public class SinkApiV3ResourceTest {
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
         mockStatic(ConnectorUtils.class);
         doReturn(CassandraStringSink.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSinkClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSinkClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -66,6 +66,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.LinkedList;
@@ -915,7 +916,7 @@ public class SourceApiV3ResourceTest {
     }
 
     @Test
-    public void testUpdateSourceWithUrl() throws IOException {
+    public void testUpdateSourceWithUrl() throws IOException, URISyntaxException {
         Configurator.setRootLevel(Level.DEBUG);
 
         String filePackageUrl = "file://" + JAR_FILE_PATH;
@@ -936,6 +937,11 @@ public class SourceApiV3ResourceTest {
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
         org.apache.pulsar.functions.utils.Utils.getSourceType(anyString(), any(NarClassLoader.class));
+        
+        File mockedFile = mock(File.class);
+        when(mockedFile.getName()).thenReturn(JAR_FILE_NAME);
+        doReturn(mockedFile ).when(org.apache.pulsar.functions.utils.Utils.class);
+        org.apache.pulsar.functions.utils.Utils.extractFileFromPkg(anyString());
 
         doReturn(mock(NarClassLoader.class)).when(org.apache.pulsar.functions.utils.Utils.class);
         org.apache.pulsar.functions.utils.Utils.extractNarClassLoader(any(Path.class), anyString(), any(File.class));

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -106,7 +106,7 @@ public class SourceApiV3ResourceTest {
     private static final String className = TwitterFireHose.class.getName();
     private static final int parallelism = 1;
     private static final String JAR_FILE_NAME = "pulsar-io-twitter.nar";
-    private static final String INVALID_JAR_FILE_NAME = "pulsar-io-cassandra.nar";
+    private static final String INVALID_JAR_FILE_NAME = "pulsar-io-cassandra-2.3.0-SNAPSHOT.nar";
     private String JAR_FILE_PATH;
     private String INVALID_JAR_FILE_PATH;
 
@@ -772,7 +772,7 @@ public class SourceApiV3ResourceTest {
 
         mockStatic(ConnectorUtils.class);
         doReturn(TwitterFireHose.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSourceClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSourceClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
@@ -842,7 +842,7 @@ public class SourceApiV3ResourceTest {
 
         mockStatic(ConnectorUtils.class);
         doReturn(TwitterFireHose.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSourceClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSourceClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);
@@ -932,7 +932,7 @@ public class SourceApiV3ResourceTest {
 
         mockStatic(ConnectorUtils.class);
         doReturn(TwitterFireHose.class.getName()).when(ConnectorUtils.class);
-        ConnectorUtils.getIOSourceClass(any(NarClassLoader.class));
+        ConnectorUtils.getIOSourceClass(anyString(), any(NarClassLoader.class));
 
         mockStatic(org.apache.pulsar.functions.utils.Utils.class);
         doReturn(String.class).when(org.apache.pulsar.functions.utils.Utils.class);


### PR DESCRIPTION
### Contribution Checklist

Address https://github.com/apache/pulsar/issues/3576


### Motivation

Added logic to use the proper class loader when a Source or Sink is created from the command line and an "archive" and "className" are provided. Prior to this change, it was always assumed the the archive file specified was a standard "JAR" file. 

Now, we check the file extension of the archive and choose the appropriate class loader based on that. This allows user to submit Pulsar connectors that are bundled inside a NAR file

Also added support for multiple sink/source definitions in NAR files, while also being 100% fully-backward complaint. Added test classes to validate that

### Modifications

Modified both the 
pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java

classes to check the file extension of the archive, and use the correct class loader

Modified the org.apache.pulsar.functions.utils.io.ConnectorUtils class to read both the old and new pulsar-io.yaml formats as shown below. Therefore this is NOT a breaking change

`name: file`
`description: Reads data from local filesystem`
`sourceClass: org.apache.pulsar.io.file.FileSource`

and 

`connectors:`
`                hdfs:`
`                 description: The HDFS connector `
`                  sourceClass: org.apache.pulsar.io.hdfs.SoruceClassImpl`
`                  sinkClass: org.apache.pulsar.io.hdfs.SinkClassImpl `
`                redis:`
`                  description: The Redis connector`
`                  sourceClass: org.apache.pulsar.io.redis.SoruceClassImpl `
`                  sinkClass: org.apache.pulsar.io.redis.SinkClassImpl`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as

- org.apache.pulsar.functions.worker.rest.api.v3.SinkApiV3ResourceTest
- org.apache.pulsar.functions.worker.rest.api.v3.SourceApiV3ResourceTest

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: No
  - The schema: No
  - The default values of configurations: No
  - The wire protocol: No
  - The rest endpoints: No (Fixes existing broken usage of archive/className params)
  - The admin cli options: No (Fixes existing broken usage of archive/className params)
  - Anything that affects deployment: No

### Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? It's already documented