### PR TITLE
fix Jenkins pulsar-website-build error 571

### DIFF
--- a/site2/website/versioned_docs/version-2.3.0/io-cdc-canal.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc-canal.md
@@ -1,5 +1,5 @@
 ---
-id: io-cdc-canal
+id: version-2.3.0-io-cdc-canal
 title: CDC Canal Connector
 sidebar_label: CDC Canal Connector
 original_id: io-cdc-canal

--- a/site2/website/versioned_docs/version-2.3.0/io-cdc-canal.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc-canal.md
@@ -2,6 +2,7 @@
 id: io-cdc-canal
 title: CDC Canal Connector
 sidebar_label: CDC Canal Connector
+original_id: io-cdc-canal
 ---
 
 ### Source Configuration Options

--- a/site2/website/versioned_docs/version-2.3.0/io-cdc-debezium.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc-debezium.md
@@ -2,6 +2,7 @@
 id: io-cdc-debezium
 title: CDC Debezium Connector
 sidebar_label: CDC Debezium Connector
+original_id: io-cdc-debezium
 ---
 
 ### Source Configuration Options

--- a/site2/website/versioned_docs/version-2.3.0/io-cdc-debezium.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc-debezium.md
@@ -1,5 +1,5 @@
 ---
-id: io-cdc-debezium
+id: version-2.3.0-io-cdc-debezium
 title: CDC Debezium Connector
 sidebar_label: CDC Debezium Connector
 original_id: io-cdc-debezium

--- a/site2/website/versioned_docs/version-2.3.0/io-cdc.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc.md
@@ -1,5 +1,5 @@
 ---
-id: io-cdc
+id: version-2.3.0-io-cdc
 title: CDC Connector
 sidebar_label: CDC Connector
 original_id: io-cdc

--- a/site2/website/versioned_docs/version-2.3.0/io-cdc.md
+++ b/site2/website/versioned_docs/version-2.3.0/io-cdc.md
@@ -2,6 +2,7 @@
 id: io-cdc
 title: CDC Connector
 sidebar_label: CDC Connector
+original_id: io-cdc
 ---
 
 ## Source


### PR DESCRIPTION
### Motivation
Jenkins pulsar-website-build error 571， error info:
```java
Error: No 'original_id' field found in /pulsar/site2/website/versioned_docs/version-2.3.0/io-cdc-canal.md. Perhaps you forgot to add it when importing prior versions of your docs?
    at /pulsar/site2/website/node_modules/docusaurus/lib/server/versionFallback.js:64:11
    at Array.forEach (<anonymous>)
    at Object.forEach (/pulsar/site2/website/node_modules/docusaurus/lib/server/versionFallback.js:52:7)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Module._compile (/pulsar/site2/website/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Object.newLoader [as .js] (/pulsar/site2/website/node_modules/pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
error Command failed with exit code 1.
```

### Modifications

io-cdc doc add original_id content.
