### PR TITLE
[pulsar-broker-test] add timeout to function test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -168,7 +168,7 @@ public class PulsarWorkerAssignmentTest {
         return new WorkerService(workerConfig);
     }
 
-    @Test
+    @Test(timeOut = 20000)
     public void testFunctionAssignments() throws Exception {
 
         final String namespacePortion = "assignment-test";
@@ -218,7 +218,7 @@ public class PulsarWorkerAssignmentTest {
         assertEquals(admin.topics().getStats(sinkTopic).subscriptions.values().iterator().next().consumers.size(), 1);
     }
 
-    @Test(timeOut=20000)
+    @Test(timeOut = 20000)
     public void testFunctionAssignmentsWithRestart() throws Exception {
 
         final String namespacePortion = "assignment-test";


### PR DESCRIPTION
### Motivation
Recently [ci-job](https://builds.apache.org/job/pulsar_precommit_java8/6714/console) is getting stuck due to one of the `PulsarWorkerAssignmentTest.java` test. so, adding timeout to the test.