### PR TITLE
[schema] revise the schema type not null

### DIFF
--- a/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -89,7 +89,7 @@ public class AvroSchema<T> implements Schema<T> {
     }
 
     private static <T> org.apache.avro.Schema createAvroSchema(Class<T> pojo) {
-        return ReflectData.AllowNull.get().getSchema(pojo);
+        return ReflectData.get().getSchema(pojo);
     }
 
     public static <T> AvroSchema<T> of(Class<T> pojo) {

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
@@ -32,10 +32,14 @@ public class SchemaTestUtils {
     @ToString
     @EqualsAndHashCode
     public static class Foo {
+        @Nullable
         private String field1;
+        @Nullable
         private String field2;
         private int field3;
+        @Nullable
         private Bar field4;
+        @Nullable
         private Color color;
     }
 
@@ -85,13 +89,12 @@ public class SchemaTestUtils {
     }
 
     public static final String SCHEMA_JSON
-            = "{\"type\":\"record\",\"name\":\"Foo\",\"namespace\":\"org.apache.pulsar.client.schema" +
-            ".SchemaTestUtils$\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"],\"default\":null}," +
-            "{\"name\":\"field2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"field3\"," +
-            "\"type\":\"int\"},{\"name\":\"field4\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Bar\"," +
-            "\"fields\":[{\"name\":\"field1\",\"type\":\"boolean\"}]}],\"default\":null},{\"name\":\"color\"," +
-            "\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Color\",\"symbols\":[\"RED\",\"BLUE\"]}]," +
-            "\"default\":null}]}";
+            = "{\"type\":\"record\",\"name\":\"Foo\",\"namespace\":\"org.apache.pulsar.client.schema.SchemaTestUtils$\"," +
+            "\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"field2\"," +
+            "\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"field3\",\"type\":\"int\"},{\"name\":\"field4\"," +
+            "\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Bar\",\"fields\":[{\"name\":\"field1\",\"type\":\"boolean\"}]}]," +
+            "\"default\":null},{\"name\":\"color\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Color\",\"symbols\":[\"RED\"," +
+            "\"BLUE\"]}],\"default\":null}]}";
 
     public static final String SCHEMA_JSON_NOTNULL
             = "{\"type\":\"record\",\"name\":\"Foo1\",\"namespace\":\"org.apache.pulsar.client.schema.SchemaTestUtils$\"" +

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.avro.reflect.Nullable;
 
 /**
  * Utils for testing avro.
@@ -31,6 +32,17 @@ public class SchemaTestUtils {
     @ToString
     @EqualsAndHashCode
     public static class Foo {
+        private String field1;
+        private String field2;
+        private int field3;
+        private Bar field4;
+        private Color color;
+    }
+
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    public static class Foo1 {
         private String field1;
         private String field2;
         private int field3;
@@ -63,9 +75,12 @@ public class SchemaTestUtils {
     @ToString
     @EqualsAndHashCode
     public static class DerivedDerivedFoo extends DerivedFoo {
+        @Nullable
         private String field7;
         private int field8;
+        @Nullable
         private DerivedFoo derivedFoo;
+        @Nullable
         private Foo foo2;
     }
 
@@ -77,6 +92,12 @@ public class SchemaTestUtils {
             "\"fields\":[{\"name\":\"field1\",\"type\":\"boolean\"}]}],\"default\":null},{\"name\":\"color\"," +
             "\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Color\",\"symbols\":[\"RED\",\"BLUE\"]}]," +
             "\"default\":null}]}";
+
+    public static final String SCHEMA_JSON_NOTNULL
+            = "{\"type\":\"record\",\"name\":\"Foo1\",\"namespace\":\"org.apache.pulsar.client.schema.SchemaTestUtils$\"" +
+            ",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"},{\"name\":\"field2\",\"type\":\"string\"},{\"name\":\"field3\"" +
+            ",\"type\":\"int\"},{\"name\":\"field4\",\"type\":{\"type\":\"record\",\"name\":\"Bar\",\"fields\":[{\"name\":\"field1\"," +
+            "\"type\":\"boolean\"}]}},{\"name\":\"color\",\"type\":{\"type\":\"enum\",\"name\":\"Color\",\"symbols\":[\"RED\",\"BLUE\"]}}]}";
 
     public static String[] FOO_FIELDS = {
             "field1",


### PR DESCRIPTION
### Motivation
make define define schema type unable null

### Modifications
make the client define schema type unable null

### Verifying this change
add unable null schema verify

### Does this pull request potentially affect one of the following parts:
_If `yes` was chosen, please highlight the changes_

* Dependencies (does it add or upgrade a dependency): (no)
* The public API: (no)
* The schema: (no)
* The default values of configurations: (no)
* The wire protocol: (no)
* The rest endpoints: (no)
* The admin cli options: (no)
* Anything that affects deployment: (no)

