### PR TITLE
fix pulsar_message_set_replication_clusters

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/message.h
+++ b/pulsar-client-cpp/include/pulsar/c/message.h
@@ -87,7 +87,7 @@ void pulsar_message_set_sequence_id(pulsar_message_t *message, int64_t sequenceI
  *
  * @param clusters where to send this message.
  */
-void pulsar_message_set_replication_clusters(pulsar_message_t *message, const char **clusters);
+void pulsar_message_set_replication_clusters(pulsar_message_t *message, const char **clusters, size_t size);
 
 /**
  * Do not replicate this message

--- a/pulsar-client-cpp/lib/c/c_Message.cc
+++ b/pulsar-client-cpp/lib/c/c_Message.cc
@@ -48,11 +48,11 @@ void pulsar_message_set_sequence_id(pulsar_message_t *message, int64_t sequenceI
     message->builder.setSequenceId(sequenceId);
 }
 
-void pulsar_message_set_replication_clusters(pulsar_message_t *message, const char **clusters) {
-    const char *c = clusters[0];
+void pulsar_message_set_replication_clusters(pulsar_message_t *message, const char **clusters, size_t size) {
+    const char **c = clusters;
     std::vector<std::string> clustersList;
-    while (c) {
-        clustersList.push_back(c);
+    for (size_t i = 0; i < size; i++) {
+        clustersList.push_back(*c);
         ++c;
     }
 

--- a/pulsar-client-go/pulsar/c_message.go
+++ b/pulsar-client-go/pulsar/c_message.go
@@ -88,7 +88,7 @@ func buildMessage(message ProducerMessage) *C.pulsar_message_t {
 				C.setString(array, C.CString(s), C.int(i))
 			}
 
-			C.pulsar_message_set_replication_clusters(cMsg, array)
+			C.pulsar_message_set_replication_clusters(cMsg, array, size)
 		}
 	}
 


### PR DESCRIPTION
### Motivation
`pulsar_message_set_replication_clusters()` in `c_Message.cc` doesn't work.

To catch what happens, I executed [the small test code](https://gist.github.com/nkurihar/474ddba7bf2598730bb94ebbb8442117) and saw the infinite loop and finally segmentation fault:
```
c1
1

c2
2

c3
3

?
?
;?
;?
?

<

x???8
???8
??8
?8
8

.
.
.

Segmentation fault
```

### Modifications
- Fix the type of the variable `c`: it needs to be not `const char*` but `const char**`
- Add the third argument `size` to judge when to stop the loop

### Verifying this change
- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:
  - The public API: yes

This PR changes the interface of `pulsar_message_set_replication_clusters()`.
If we want to keep the back compatibility, another option is to add `NULL` to `clusters` as the last element before passing to `pulsar_message_set_replication_clusters()`, and judging when to stop the loop by null check (like `while (*c) { ... }`) in the function.
However, I think to force users to add `NULL` as the last element is error-prone, instead adding the size argument is natural.