### PR TITLE
fix function termination cleanup

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionInstanceId.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionInstanceId.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils;
+
+import lombok.Data;
+
+@Data
+public class FunctionInstanceId {
+
+    private String tenant;
+    private String namespace;
+    private String name;
+    private int instanceId;
+
+    public FunctionInstanceId(String fullyQualifiedInstanceName) {
+        String[] t1 = fullyQualifiedInstanceName.split("/");
+
+        if (t1.length != 3) {
+            throw new IllegalArgumentException("Invalid format for fully qualified instance name: " + fullyQualifiedInstanceName);
+        }
+
+        this.tenant = t1[0];
+        this.namespace = t1[1];
+
+        String[] t2 = t1[2].split(":");
+
+        if (t2.length != 2) {
+            throw new IllegalArgumentException("Invalid format for fully qualified instance name: " + fullyQualifiedInstanceName);
+        }
+
+        this.name = t2[0];
+        this.instanceId = Integer.parseInt(t2[1]);
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.functions.api.Function;
@@ -391,4 +390,5 @@ public class Utils {
             return componentName;
         }
     }
+
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -390,5 +390,4 @@ public class Utils {
             return componentName;
         }
     }
-
 }


### PR DESCRIPTION
### Motivation

Currently the termination routine runs once for every function instance scheduled on a particular worker.  If there are multiple instances of a function scheduled on a single worker, the termination routine will run when terminating for each instance.

In the termination routine we cleanup subscriptions created by the function.  Ideally this only runs once when all instances of functions have stopped.  However that kind of coordination is hard to accomplish but a least on a per worker basis lets only run the termination routine on the last instance running on that worker. So that a least we are running the termination routine only once for a function on a per worker basis

