### PR TITLE
Multi version generic schema provider

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -184,12 +184,7 @@ public class BinaryProtoLookupService implements LookupService {
 
     @Override
     public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName) {
-        return client.getCnxPool().getConnection(serviceNameResolver.resolveHost()).thenCompose(clientCnx -> {
-            long requestId = client.newRequestId();
-            ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(), Optional.empty());
-
-            return clientCnx.sendGetSchema(request, requestId);
-        });
+        return getSchema(topicName, null);
     }
 
 
@@ -198,7 +193,7 @@ public class BinaryProtoLookupService implements LookupService {
         return client.getCnxPool().getConnection(serviceNameResolver.resolveHost()).thenCompose(clientCnx -> {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(),
-                    Optional.of(new BytesSchemaVersion(version)));
+                    Optional.ofNullable(BytesSchemaVersion.of(version)));
             return clientCnx.sendGetSchema(request, requestId);
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.L
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +188,17 @@ public class BinaryProtoLookupService implements LookupService {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(), Optional.empty());
 
+            return clientCnx.sendGetSchema(request, requestId);
+        });
+    }
+
+
+    @Override
+    public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName, byte[] version) {
+        return client.getCnxPool().getConnection(serviceNameResolver.resolveHost()).thenCompose(clientCnx -> {
+            long requestId = client.newRequestId();
+            ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(),
+                    Optional.of(new BytesSchemaVersion(version)));
             return clientCnx.sendGetSchema(request, requestId);
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -137,23 +138,7 @@ class HttpLookupService implements LookupService {
 
     @Override
     public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName) {
-        CompletableFuture<Optional<SchemaInfo>> future = new CompletableFuture<>();
-
-        String schemaName = topicName.getSchemaName();
-        String path = String.format("admin/v2/schemas/%s/schema", schemaName);
-
-        httpClient.get(path, GetSchemaResponse.class).thenAccept(response -> {
-            future.complete(Optional.of(SchemaInfoUtil.newSchemaInfo(schemaName, response)));
-        }).exceptionally(ex -> {
-            if (ex.getCause() instanceof NotFoundException) {
-                future.complete(Optional.empty());
-            } else {
-                log.warn("Failed to get schema for topic {} : {}", topicName, ex.getCause().getClass());
-                future.completeExceptionally(ex);
-            }
-            return null;
-        });
-        return future;
+        return getSchema(topicName, null);
     }
 
     @Override
@@ -161,18 +146,22 @@ class HttpLookupService implements LookupService {
         CompletableFuture<Optional<SchemaInfo>> future = new CompletableFuture<>();
 
         String schemaName = topicName.getSchemaName();
-        String path = String.format("admin/v2/schemas/%s/schema/%s",
-                schemaName,
-                new String(version, StandardCharsets.UTF_8));
-
+        String path = String.format("admin/v2/schemas/%s/schema", schemaName);
+        if (version != null) {
+            path = String.format("admin/v2/schemas/%s/schema/%s",
+                    schemaName,
+                    new String(version, StandardCharsets.UTF_8));
+        }
         httpClient.get(path, GetSchemaResponse.class).thenAccept(response -> {
             future.complete(Optional.of(SchemaInfoUtil.newSchemaInfo(schemaName, response)));
         }).exceptionally(ex -> {
             if (ex.getCause() instanceof NotFoundException) {
                 future.complete(Optional.empty());
             } else {
-                log.warn("Failed to get schema for topic {} version {} : {}",
-                        topicName, version, ex.getCause().getClass());
+                log.warn("Failed to get schema for topic {} version {}",
+                        topicName,
+                        version != null ? Base64.getEncoder().encodeToString(version) : null,
+                        ex.getCause());
                 future.completeExceptionally(ex);
             }
             return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -67,7 +67,22 @@ public interface LookupService extends AutoCloseable {
 	 */
 	public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
 
+	/**
+	 * Returns current SchemaInfo {@link SchemaInfo} for a given topic.
+	 *
+	 * @param topicName topic-name
+	 * @return SchemaInfo
+	 */
 	public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName);
+
+	/**
+	 * Returns specific version SchemaInfo {@link SchemaInfo} for a given topic.
+	 *
+	 * @param topicName topic-name
+	 * @param version schema info version
+	 * @return SchemaInfo
+	 */
+	public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName, byte[] version);
 
 	/**
 	 * Returns broker-service lookup api url.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericSchemaProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericSchemaProvider.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema.generic;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Multi version generic schema provider by guava cache.
+ */
+public class MultiVersionGenericSchemaProvider implements SchemaProvider<GenericRecord> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MultiVersionGenericSchemaProvider.class);
+
+    private final TopicName topicName;
+    private final PulsarClientImpl pulsarClient;
+
+    private final LoadingCache<byte[], GenericSchema> cache = CacheBuilder.newBuilder().maximumSize(100000)
+            .expireAfterAccess(30, TimeUnit.MINUTES).build(new CacheLoader<byte[], GenericSchema>() {
+                @Override
+                public GenericSchema load(byte[] schemaVersion) throws Exception {
+                    return loadSchema(schemaVersion);
+                }
+            });
+
+    public MultiVersionGenericSchemaProvider(TopicName topicName, PulsarClientImpl pulsarClient) {
+        this.topicName = topicName;
+        this.pulsarClient = pulsarClient;
+    }
+
+    @Override
+    public GenericSchema getSchema(byte[] schemaVersion) {
+        try {
+            if (null == schemaVersion) {
+                return null;
+            }
+            return cache.get(schemaVersion);
+        } catch (ExecutionException e) {
+            LOG.error("Can't get generic schema for topic {} schema version {}",
+                    topicName.toString(), new String(schemaVersion, StandardCharsets.UTF_8), e);
+            return null;
+        }
+    }
+
+    private GenericSchema loadSchema(byte[] schemaVersion) throws ExecutionException, InterruptedException {
+        Optional<SchemaInfo> schemaInfo = pulsarClient.getLookup()
+                .getSchema(topicName, schemaVersion).get();
+        return schemaInfo.map(GenericSchemaImpl::of).orElse(null);
+    }
+
+    public TopicName getTopic() {
+        return topicName;
+    }
+
+    public PulsarClientImpl getPulsarClient() {
+        return pulsarClient;
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericSchemaProviderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericSchemaProviderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema.generic;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.LookupService;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.SchemaTestUtils;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Unit test for {@link MultiVersionGenericSchemaProvider}.
+ */
+public class MultiVersionGenericSchemaProviderTest {
+
+    private MultiVersionGenericSchemaProvider schemaProvider;
+
+    @BeforeMethod
+    public void setup() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        when(client.getLookup()).thenReturn(mock(LookupService.class));
+        schemaProvider = new MultiVersionGenericSchemaProvider(
+                TopicName.get("persistent://public/default/my-topic"), client);
+    }
+
+    @Test
+    public void testGetSchema() {
+        CompletableFuture<Optional<SchemaInfo>> completableFuture = new CompletableFuture<>();
+        SchemaInfo schemaInfo = AvroSchema.of(SchemaTestUtils.Foo.class).getSchemaInfo();
+        completableFuture.complete(Optional.of(schemaInfo));
+        when(schemaProvider.getPulsarClient().getLookup()
+                .getSchema(
+                        any(TopicName.class),
+                        any(byte[].class)))
+                .thenReturn(completableFuture);
+        GenericSchema schema = schemaProvider.getSchema(new byte[0]);
+        assertEquals(schema.getSchemaInfo(), schemaInfo);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/schema/BytesSchemaVersion.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/schema/BytesSchemaVersion.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.schema;
+
+/**
+ * Bytes schema version
+ */
+public class BytesSchemaVersion implements SchemaVersion {
+
+    private byte[] bytes;
+
+    public BytesSchemaVersion(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/schema/BytesSchemaVersion.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/schema/BytesSchemaVersion.java
@@ -23,14 +23,18 @@ package org.apache.pulsar.common.schema;
  */
 public class BytesSchemaVersion implements SchemaVersion {
 
-    private byte[] bytes;
+    private final byte[] bytes;
 
-    public BytesSchemaVersion(byte[] bytes) {
+    private BytesSchemaVersion(byte[] bytes) {
         this.bytes = bytes;
     }
 
     @Override
     public byte[] bytes() {
         return bytes;
+    }
+
+    public static BytesSchemaVersion of(byte[] bytes) {
+        return bytes != null ? new BytesSchemaVersion(bytes) : null;
     }
 }


### PR DESCRIPTION
### Motivation

Introduce multi version generic schema provider.
The provider will be used by multi version message data deserialize on consumer side.

### Modifications

Add MultiVersionGenericSchemaProvider.
Add BytesSchemaVersion.
Add getSchema by specific schema version in lookup service.

### Verifying this change

Add MultiVersionGenericSchemaProviderTest.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (**yes** / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)
