### PR TITLE
Fixed Reader.HasNext() in Go client

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -1040,8 +1040,7 @@ void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback
         return;
     }
 
-    getLastMessageIdAsync([this, lastDequed, callback](Result result,
-                                                       MessageId messageId) {
+    getLastMessageIdAsync([this, lastDequed, callback](Result result, MessageId messageId) {
         if (result == ResultOk) {
             if (messageId > lastDequed && messageId.entryId() != -1) {
                 callback(ResultOk, true);

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -503,6 +503,7 @@ void ConsumerImpl::internalListener() {
     unAckedMessageTrackerPtr_->add(msg.getMessageId());
     try {
         consumerStatsBasePtr_->receivedMessage(msg, ResultOk);
+        lastDequedMessage_ = Optional<MessageId>::of(msg.getMessageId());
         messageListener_(Consumer(shared_from_this()), msg);
     } catch (const std::exception& e) {
         LOG_ERROR(getName() << "Exception thrown from listener" << e.what());
@@ -1039,8 +1040,8 @@ void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback
         return;
     }
 
-    BrokerGetLastMessageIdCallback callback1 = [this, lastDequed, callback](Result result,
-                                                                            MessageId messageId) {
+    getLastMessageIdAsync([this, lastDequed, callback](Result result,
+                                                       MessageId messageId) {
         if (result == ResultOk) {
             if (messageId > lastDequed && messageId.entryId() != -1) {
                 callback(ResultOk, true);
@@ -1050,9 +1051,7 @@ void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback
         } else {
             callback(result, false);
         }
-    };
-
-    getLastMessageIdAsync(callback1);
+    });
 }
 
 void ConsumerImpl::brokerGetLastMessageIdListener(Result res, MessageId messageId,

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -177,12 +177,12 @@ class ConsumerImpl : public ConsumerImplBase,
     void brokerGetLastMessageIdListener(Result res, MessageId messageId,
                                         BrokerGetLastMessageIdCallback callback);
 
-    MessageId lastMessageIdDequed() {
-        return lastDequedMessage_.is_present() ? lastDequedMessage_.value() : MessageId();
+    const MessageId& lastMessageIdDequed() {
+        return lastDequedMessage_.is_present() ? lastDequedMessage_.value() : MessageId::earliest();
     }
 
-    MessageId lastMessageIdInBroker() {
-        return lastMessageInBroker_.is_present() ? lastMessageInBroker_.value() : MessageId();
+    const MessageId& lastMessageIdInBroker() {
+        return lastMessageInBroker_.is_present() ? lastMessageInBroker_.value() : MessageId::earliest();
     }
 
     friend class PulsarFriend;

--- a/pulsar-client-cpp/lib/Reader.cc
+++ b/pulsar-client-cpp/lib/Reader.cc
@@ -77,13 +77,9 @@ void Reader::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {
 }
 
 Result Reader::hasMessageAvailable(bool& hasMessageAvailable) {
-    if (!impl_) {
-        return ResultConsumerNotInitialized;
-    }
-
     Promise<Result, bool> promise;
 
-    impl_->hasMessageAvailableAsync(WaitForCallbackValue<bool>(promise));
+    hasMessageAvailableAsync(WaitForCallbackValue<bool>(promise));
     return promise.getFuture().get(hasMessageAvailable);
 }
 

--- a/pulsar-client-go/pulsar/reader_test.go
+++ b/pulsar-client-go/pulsar/reader_test.go
@@ -225,10 +225,7 @@ func TestReaderHasNext(t *testing.T) {
 	ctx := context.Background()
 
 	client, err := NewClient(ClientOptions{
-		URL:                     "pulsar://localhost:6650",
-		//Logger: func(level logutil.LoggerLevel, file string, line int, message string) {
-		//	// no-op to reduce noise in the log messages for this test.
-		//},
+		URL: "pulsar://localhost:6650",
 	})
 	assert.Nil(t, err)
 	defer client.Close()


### PR DESCRIPTION
### Motivation

In Go client, the `Reader.HasNext()` is currently broken because it returns "true" when there are no more messages to read. 

The issue is in the C++ `Consumer::hasMessageAvailable()`, combined with the use of message listener. The `lastDequedMessage` is being updated only after the listener is triggered, therefore an app checking `hasMessageAvailable()` from the listener thread will always be 1 message behind.

Since Go client wrapper, uses the listener internally, it is affected by this problem and it looks like a race condition with the `lastDequedMessage` being updated in a background thread.