### PR TITLE
Pulsar-IO: Add Kinesis Source

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AbstractKinesisConnector.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AbstractKinesisConnector.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractKinesisConnector {
+    
+    public static final String ACCESS_KEY_NAME = "accessKey";
+    public static final String SECRET_KEY_NAME = "secretKey";
+
+    protected AWSCredentialsProvider createCredentialProvider(String awsCredentialPluginName,
+            String awsCredentialPluginParam) {
+        if (isNotBlank(awsCredentialPluginName)) {
+            return createCredentialProviderWithPlugin(awsCredentialPluginName, awsCredentialPluginParam);
+        } else {
+            return defaultCredentialProvider(awsCredentialPluginParam);
+        }
+    }
+
+    /**
+     * Creates a instance of credential provider which can return {@link AWSCredentials} or {@link BasicAWSCredentials}
+     * based on IAM user/roles.
+     *
+     * @param pluginFQClassName
+     * @param param
+     * @return
+     * @throws IllegalArgumentException
+     */
+    public static AWSCredentialsProvider createCredentialProviderWithPlugin(String pluginFQClassName, String param)
+            throws IllegalArgumentException {
+        try {
+            Class<?> clazz = Class.forName(pluginFQClassName);
+            Constructor<?> ctor = clazz.getConstructor();
+            final AwsCredentialProviderPlugin plugin = (AwsCredentialProviderPlugin) ctor.newInstance(new Object[] {});
+            plugin.init(param);
+            return plugin.getCredentialProvider();
+        } catch (Exception e) {
+            log.error("Failed to initialize AwsCredentialProviderPlugin {}", pluginFQClassName, e);
+            throw new IllegalArgumentException(
+                    String.format("invalid authplugin name %s , failed to init %s", pluginFQClassName, e.getMessage()));
+        }
+    }
+    
+    /**
+     * It creates a default credential provider which takes accessKey and secretKey form configuration and creates
+     * {@link AWSCredentials}
+     *
+     * @param awsCredentialPluginParam
+     * @return
+     */
+    protected AWSCredentialsProvider defaultCredentialProvider(String awsCredentialPluginParam) {
+        Map<String, String> credentialMap = new Gson().fromJson(awsCredentialPluginParam,
+                new TypeToken<Map<String, String>>() {
+                }.getType());
+        String accessKey = credentialMap.get(ACCESS_KEY_NAME);
+        String secretKey = credentialMap.get(SECRET_KEY_NAME);
+        checkArgument(isNotBlank(accessKey) && isNotBlank(secretKey),
+                String.format(
+                        "Default %s and %s must be present into json-map if AwsCredentialProviderPlugin not provided",
+                        ACCESS_KEY_NAME, SECRET_KEY_NAME));
+        return defaultCredentialProvider(accessKey, secretKey);
+    }
+    
+    private AWSCredentialsProvider defaultCredentialProvider(String accessKey, String secretKey) {
+        return new AWSCredentialsProvider() {
+            @Override
+            public AWSCredentials getCredentials() {
+                return new AWSCredentials() {
+                    @Override
+                    public String getAWSAccessKeyId() {
+                        return accessKey;
+                    }
+
+                    @Override
+                    public String getAWSSecretKey() {
+                        return secretKey;
+                    }
+                };
+            }
+            @Override
+            public void refresh() {
+                // no-op
+            }
+        };
+    }
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.io.Serializable;
+
+import org.apache.pulsar.io.core.annotations.FieldDoc;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+public abstract class BaseKinesisConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "Kinesis end-point url. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
+    )
+    private String awsEndpoint;
+    
+    @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "Appropriate aws region. E.g. us-west-1, us-west-2"
+    )
+    private String awsRegion;
+    
+    @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "Kinesis stream name"
+    )
+    private String awsKinesisStreamName;
+    
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "Fully-Qualified class name of implementation of AwsCredentialProviderPlugin."
+            + " It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Sink."
+            + " If it is empty then KinesisSink will create a default AWSCredentialsProvider which accepts json-map"
+            + " of credentials in `awsCredentialPluginParam`")
+    private String awsCredentialPluginName;
+    
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "json-parameters to initialize `AwsCredentialsProviderPlugin`")
+    private String awsCredentialPluginParam;
+    
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecord.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecord.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.pulsar.functions.api.Record;
+import org.inferred.freebuilder.shaded.org.apache.commons.lang3.StringUtils;
+
+public class KinesisRecord implements Record<byte[]> {
+    
+    public static final String ARRIVAL_TIMESTAMP = "";
+    public static final String ENCRYPTION_TYPE = "";
+    public static final String PARTITION_KEY = "";
+    public static final String SEQUENCE_NUMBER = "";
+
+    private static final CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
+    private final Optional<String> key;
+    private final byte[] value;
+    private final HashMap<String, String> userProperties = new HashMap<String, String> ();
+    
+    public KinesisRecord(com.amazonaws.services.kinesis.model.Record record) {
+        this.key = Optional.of(record.getPartitionKey() + "-" + record.getSequenceNumber());
+        setProperty(ARRIVAL_TIMESTAMP, record.getApproximateArrivalTimestamp().toString());
+        setProperty(ENCRYPTION_TYPE, record.getEncryptionType());
+        setProperty(PARTITION_KEY, record.getPartitionKey());
+        setProperty(SEQUENCE_NUMBER, record.getSequenceNumber());
+        
+        if (StringUtils.isBlank(record.getEncryptionType())) {
+            String s = null;
+            try {
+                s = decoder.decode(record.getData()).toString();
+            } catch (CharacterCodingException e) {
+               // Ignore 
+            }
+            this.value = (s != null) ? s.getBytes() : null;
+        } else {
+            // Who knows?
+            this.value = null;
+        }
+    }
+    
+    @Override
+    public Optional<String> getKey() {
+        return key;
+    }
+
+    @Override
+    public byte[] getValue() {
+        return value;
+    }
+
+    public Map<String, String> getProperties() {
+        return userProperties;
+    }
+
+    public void setProperty(String key, String value) {
+        userProperties.put(key, value);
+    }
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.amazonaws.services.kinesis.clientlibrary.exceptions.InvalidStateException;
+import com.amazonaws.services.kinesis.clientlibrary.exceptions.KinesisClientLibDependencyException;
+import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException;
+import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
+import com.amazonaws.services.kinesis.model.Record;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class KinesisRecordProcessor implements IRecordProcessor {
+    
+    private final int numRetries;
+    private final long checkpointInterval;
+    private final long backoffTime;
+    
+    private final LinkedBlockingQueue<KinesisRecord> queue;
+    private long nextCheckpointTimeInMillis;
+    private String kinesisShardId;
+    
+    public KinesisRecordProcessor(LinkedBlockingQueue<KinesisRecord> queue, KinesisSourceConfig config) {
+        this.queue = queue;
+        this.backoffTime = config.getBackoffTime();
+        this.checkpointInterval = config.getCheckpointInterval();
+        this.numRetries = config.getNumRetries();
+    }
+
+    @Override
+    public void initialize(String shardId) {
+        kinesisShardId = shardId;
+    }
+
+    @Override
+    public void processRecords(List<Record> records, IRecordProcessorCheckpointer checkpointer) {
+        log.info("Processing " + records.size() + " records from " + kinesisShardId);
+        
+        for (Record record : records) {
+           try {
+               queue.put(new KinesisRecord(record));
+           } catch (InterruptedException e) {
+               log.error("unable to create KinesisRecord ", e);
+           }
+        }
+
+       // Checkpoint once every checkpoint interval.
+        if (System.currentTimeMillis() > nextCheckpointTimeInMillis) {
+            checkpoint(checkpointer);
+            nextCheckpointTimeInMillis = System.currentTimeMillis() + checkpointInterval;
+        }
+    }
+
+    @Override
+    public void shutdown(IRecordProcessorCheckpointer checkpointer, ShutdownReason reason) {
+        log.info("Shutting down record processor for shard: " + kinesisShardId);
+        if (reason == ShutdownReason.TERMINATE) {
+            checkpoint(checkpointer);
+        }
+    }
+    
+    private void checkpoint(IRecordProcessorCheckpointer checkpointer) {
+        log.info("Checkpointing shard " + kinesisShardId);
+        
+        for (int i = 0; i < numRetries; i++) {
+
+            try {
+                checkpointer.checkpoint();
+            } catch (KinesisClientLibDependencyException | InvalidStateException | ThrottlingException
+                    | ShutdownException e1) {
+                break;
+            }
+
+            try {
+                Thread.sleep(backoffTime);
+            } catch (InterruptedException e) {
+                
+            }
+        }
+    }
+
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
+
+public class KinesisRecordProcessorFactory implements IRecordProcessorFactory {
+
+    private final LinkedBlockingQueue<KinesisRecord> queue;
+    private final KinesisSourceConfig config;
+    
+    public KinesisRecordProcessorFactory(LinkedBlockingQueue<KinesisRecord> queue, 
+            KinesisSourceConfig kinesisSourceConfig) {
+        this.queue = queue;
+        this.config = kinesisSourceConfig;
+    }
+
+    @Override
+    public IRecordProcessor createProcessor() {
+        return new KinesisRecordProcessor(queue, config);
+    }
+
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory;
     help = "A sink connector that copies messages from Pulsar to Kinesis",
     configClass = KinesisSinkConfig.class
 )
-public class KinesisSink implements Sink<byte[]> {
+public class KinesisSink extends AbstractKinesisConnector implements Sink<byte[]> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisSink.class);
 
@@ -104,9 +104,6 @@ public class KinesisSink implements Sink<byte[]> {
     private volatile int previousPublishFailed = FALSE;
     private static final AtomicIntegerFieldUpdater<KinesisSink> IS_PUBLISH_FAILED =
             AtomicIntegerFieldUpdater.newUpdater(KinesisSink.class, "previousPublishFailed");
-
-    public static final String ACCESS_KEY_NAME = "accessKey";
-    public static final String SECRET_KEY_NAME = "secretKey";
 
     public static final String METRICS_TOTAL_INCOMING = "_kinesis_total_incoming_";
     public static final String METRICS_TOTAL_INCOMING_BYTES = "_kinesis_total_incoming_bytes_";
@@ -157,7 +154,6 @@ public class KinesisSink implements Sink<byte[]> {
         checkArgument(isNotBlank(kinesisSinkConfig.getAwsKinesisStreamName()), "empty kinesis-stream name");
         checkArgument(isNotBlank(kinesisSinkConfig.getAwsEndpoint()), "empty aws-end-point");
         checkArgument(isNotBlank(kinesisSinkConfig.getAwsRegion()), "empty aws region name");
-        checkArgument(isNotBlank(kinesisSinkConfig.getAwsKinesisStreamName()), "empty kinesis stream name");
         checkArgument(isNotBlank(kinesisSinkConfig.getAwsCredentialPluginParam()), "empty aws-credential param");
 
         KinesisProducerConfiguration kinesisConfig = new KinesisProducerConfiguration();
@@ -175,15 +171,6 @@ public class KinesisSink implements Sink<byte[]> {
         IS_PUBLISH_FAILED.set(this, FALSE);
 
         LOG.info("Kinesis sink started. {}", (ReflectionToStringBuilder.toString(kinesisConfig, ToStringStyle.SHORT_PREFIX_STYLE)));
-    }
-
-    protected AWSCredentialsProvider createCredentialProvider(String awsCredentialPluginName,
-            String awsCredentialPluginParam) {
-        if (isNotBlank(awsCredentialPluginName)) {
-            return createCredentialProviderWithPlugin(awsCredentialPluginName, awsCredentialPluginParam);
-        } else {
-            return defaultCredentialProvider(awsCredentialPluginParam);
-        }
     }
 
     private static final class ProducerSendCallback implements FutureCallback<UserRecordResult> {
@@ -247,73 +234,6 @@ public class KinesisSink implements Sink<byte[]> {
             }
             recycle();
         }
-    }
-
-    /**
-     * Creates a instance of credential provider which can return {@link AWSCredentials} or {@link BasicAWSCredentials}
-     * based on IAM user/roles.
-     *
-     * @param pluginFQClassName
-     * @param param
-     * @return
-     * @throws IllegalArgumentException
-     */
-    public static AWSCredentialsProvider createCredentialProviderWithPlugin(String pluginFQClassName, String param)
-            throws IllegalArgumentException {
-        try {
-            Class<?> clazz = Class.forName(pluginFQClassName);
-            Constructor<?> ctor = clazz.getConstructor();
-            final AwsCredentialProviderPlugin plugin = (AwsCredentialProviderPlugin) ctor.newInstance(new Object[] {});
-            plugin.init(param);
-            return plugin.getCredentialProvider();
-        } catch (Exception e) {
-            LOG.error("Failed to initialize AwsCredentialProviderPlugin {}", pluginFQClassName, e);
-            throw new IllegalArgumentException(
-                    String.format("invalid authplugin name %s , failed to init %s", pluginFQClassName, e.getMessage()));
-        }
-    }
-
-    /**
-     * It creates a default credential provider which takes accessKey and secretKey form configuration and creates
-     * {@link AWSCredentials}
-     *
-     * @param awsCredentialPluginParam
-     * @return
-     */
-    protected AWSCredentialsProvider defaultCredentialProvider(String awsCredentialPluginParam) {
-        Map<String, String> credentialMap = new Gson().fromJson(awsCredentialPluginParam,
-                new TypeToken<Map<String, String>>() {
-                }.getType());
-        String accessKey = credentialMap.get(ACCESS_KEY_NAME);
-        String secretKey = credentialMap.get(SECRET_KEY_NAME);
-        checkArgument(isNotBlank(accessKey) && isNotBlank(secretKey),
-                String.format(
-                        "Default %s and %s must be present into json-map if AwsCredentialProviderPlugin not provided",
-                        ACCESS_KEY_NAME, SECRET_KEY_NAME));
-        return defaultCredentialProvider(accessKey, secretKey);
-    }
-
-    private AWSCredentialsProvider defaultCredentialProvider(String accessKey, String secretKey) {
-        return new AWSCredentialsProvider() {
-            @Override
-            public AWSCredentials getCredentials() {
-                return new AWSCredentials() {
-                    @Override
-                    public String getAWSAccessKeyId() {
-                        return accessKey;
-                    }
-
-                    @Override
-                    public String getAWSSecretKey() {
-                        return secretKey;
-                    }
-                };
-            }
-            @Override
-            public void refresh() {
-                // no-op
-            }
-        };
     }
 
     public static ByteBuffer createKinesisMessage(MessageFormat msgFormat, Record<byte[]> record) {

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -22,7 +22,6 @@ package org.apache.pulsar.io.kinesis;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import lombok.*;
-import lombok.experimental.Accessors;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,46 +30,11 @@ import java.util.Map;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
-@Setter
-@Getter
-@EqualsAndHashCode
-@ToString
-@Accessors(chain = true)
-public class KinesisSinkConfig implements Serializable {
+@EqualsAndHashCode(callSuper=true)
+public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
-    @FieldDoc(
-        required = true,
-        defaultValue = "",
-        help = "Kinesis end-point url. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
-    )
-    private String awsEndpoint;
-    @FieldDoc(
-        required = true,
-        defaultValue = "",
-        help = "Appropriate aws region. E.g. us-west-1, us-west-2"
-    )
-    private String awsRegion;
-    @FieldDoc(
-        required = true,
-        defaultValue = "",
-        help = "Kinesis stream name"
-    )
-    private String awsKinesisStreamName;
-    @FieldDoc(
-        required = false,
-        defaultValue = "",
-        help = "Fully-Qualified class name of implementation of AwsCredentialProviderPlugin."
-            + " It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Sink."
-            + " If it is empty then KinesisSink will create a default AWSCredentialsProvider which accepts json-map"
-            + " of credentials in `awsCredentialPluginParam`")
-    private String awsCredentialPluginName;
-    @FieldDoc(
-        required = false,
-        defaultValue = "",
-        help = "json-parameters to initialize `AwsCredentialsProviderPlugin`")
-    private String awsCredentialPluginParam;
+    
     @FieldDoc(
         required = true,
         defaultValue = "ONLY_RAW_PAYLOAD",
@@ -93,6 +57,7 @@ public class KinesisSinkConfig implements Serializable {
             + "  #   properties and encryptionCtx, and publishes flatbuffer payload into the configured kinesis stream."
     )
     private MessageFormat messageFormat = MessageFormat.ONLY_RAW_PAYLOAD; // default : ONLY_RAW_PAYLOAD
+    
     @FieldDoc(
         required = false,
         defaultValue = "false",
@@ -109,10 +74,6 @@ public class KinesisSinkConfig implements Serializable {
         return mapper.readValue(new ObjectMapper().writeValueAsString(map), KinesisSinkConfig.class);
     }
     
-    /**
-     * Message format in which kinesis-sink converts pulsar-message and publishes to kinesis stream.
-     *
-     */
     public static enum MessageFormat {
         /**
          * Kinesis sink directly publishes pulsar-payload as a message into the kinesis-stream
@@ -135,4 +96,5 @@ public class KinesisSinkConfig implements Serializable {
          */
         FULL_MESSAGE_IN_FB;
     }
+    
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSource.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSource.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.Source;
+import org.apache.pulsar.io.core.SourceContext;
+import org.apache.pulsar.io.core.annotations.Connector;
+import org.apache.pulsar.io.core.annotations.IOType;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker;
+
+/**
+ * 
+ * @see KinesisClientLibConfiguration 
+ */
+@Connector(
+        name = "kinesis",
+        type = IOType.SOURCE,
+        help = "A source connector that copies messages from Kinesis to Pulsar",
+        configClass = KinesisSourceConfig.class
+    )
+public class KinesisSource extends AbstractKinesisConnector implements Source<byte[]> {
+
+    private LinkedBlockingQueue<KinesisRecord> queue;
+    private KinesisSourceConfig kinesisSourceConfig;
+    private KinesisClientLibConfiguration kinesisClientLibConfig;
+    private IRecordProcessorFactory recordProcessorFactory;
+    private String workerId;
+    private Worker worker;
+
+    @Override
+    public void close() throws Exception {
+        worker.shutdown();
+    }
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+        this.kinesisSourceConfig = KinesisSourceConfig.load(config);
+        
+        checkArgument(isNotBlank(kinesisSourceConfig.getAwsKinesisStreamName()), "empty kinesis-stream name");
+        checkArgument(isNotBlank(kinesisSourceConfig.getAwsEndpoint()), "empty aws-end-point");
+        checkArgument(isNotBlank(kinesisSourceConfig.getAwsRegion()), "empty aws region name");
+        checkArgument(isNotBlank(kinesisSourceConfig.getAwsCredentialPluginParam()), "empty aws-credential param");
+        
+        if (kinesisSourceConfig.getInitialPositionInStream() == InitialPositionInStream.AT_TIMESTAMP) {
+            checkArgument((kinesisSourceConfig.getStartAtTime() != null),"Timestamp must be specified");
+        }
+        
+        queue = new LinkedBlockingQueue<KinesisRecord> (kinesisSourceConfig.getReceiveQueueSize());
+        workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID();
+        
+        AWSCredentialsProvider credentialsProvider = createCredentialProvider(
+                kinesisSourceConfig.getAwsCredentialPluginName(), 
+                kinesisSourceConfig.getAwsCredentialPluginParam());
+        
+        kinesisClientLibConfig = 
+                new KinesisClientLibConfiguration(kinesisSourceConfig.getApplicationName(),
+                        kinesisSourceConfig.getAwsKinesisStreamName(),
+                        credentialsProvider,
+                        workerId)
+                .withRegionName(kinesisSourceConfig.getAwsRegion())
+                .withInitialPositionInStream(kinesisSourceConfig.getInitialPositionInStream());
+        
+        if (kinesisSourceConfig.getInitialPositionInStream() == InitialPositionInStream.AT_TIMESTAMP) {
+           kinesisClientLibConfig.withTimestampAtInitialPositionInStream(kinesisSourceConfig.getStartAtTime());
+        }
+        
+        recordProcessorFactory = new KinesisRecordProcessorFactory(queue, kinesisSourceConfig);
+        
+        worker = new Worker(recordProcessorFactory, kinesisClientLibConfig);
+        worker.run();
+    }
+
+    @Override
+    public KinesisRecord read() throws Exception {
+        return queue.take();
+    }
+
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.pulsar.io.core.annotations.FieldDoc;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper=true)
+public class KinesisSourceConfig extends BaseKinesisConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @FieldDoc(
+       required = false,
+       defaultValue = "LATEST",
+       help = "Used to specify the position in the stream where the connector should start from.\n" 
+               + "  #\n"
+               + "  # The available options are: \n"
+               + "  #\n"
+               + "  # - AT_TIMESTAMP \n"
+               + "  #\n"
+               + "  #   Start from the record at or after the specified timestamp. \n"
+               + "  #\n"
+               + "  # - LATEST \n"
+               + "  #\n"
+               + "  #   Start after the most recent data record (fetch new data). \n"
+               + "  #\n"
+               + "  # - TRIM_HORIZON \n"
+               + "  #\n"
+               + "  #   Start from the oldest available data record. \n"
+    )
+    private InitialPositionInStream initialPositionInStream = InitialPositionInStream.LATEST;
+    
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "If the initalPositionInStream is set to 'AT_TIMESTAMP', then this "
+                + " property specifies the point in time to start consumption."
+    )
+    private Date startAtTime;
+    
+    @FieldDoc(
+      required = false,
+      defaultValue = "Apache Pulsar IO Connector",
+      help = "Name of the Amazon Kinesis application. By default the application name is included "
+              + "in the user agent string used to make AWS requests. This can assist with troubleshooting "
+              + "(e.g. distinguish requests made by separate connectors instances)."
+    )
+    private String applicationName = "Apache Pulsar IO Connector";
+    
+    @FieldDoc(
+       required = false,
+       defaultValue = "60000",
+       help = "The frequency of the Kinesis stream checkpointing (in milliseconds)"
+    )
+    private long checkpointInterval = 60000L;
+
+    @FieldDoc(
+       required = false,
+       defaultValue = "3000",
+       help = "The amount of time to delay between requests when the connector encounters a Throttling"
+               + "exception from AWS Kinesis (in milliseconds)"
+    )
+    private long backoffTime = 3000L;
+    
+    @FieldDoc(
+       required = false,
+       defaultValue = "3",
+       help = "The number of re-attempts to make when the connector encounters an "
+               + "exception while trying to set a checkpoint"
+    )    
+    private int numRetries;
+    
+    @FieldDoc(
+        required = false,
+        defaultValue = "1000",
+        help = "The maximum number of AWS Records that can be buffered inside the connector. "
+                + "Once this is reached, the connector will not consume any more messages from "
+                + "Kinesis until some of the messages in the queue have been successfully consumed."
+    )  
+    private int receiveQueueSize = 1000;
+    
+    public static KinesisSourceConfig load(String yamlFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        return mapper.readValue(new File(yamlFile), KinesisSourceConfig.class);
+    }
+    
+    public static KinesisSourceConfig load(Map<String, Object> map) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(new ObjectMapper().writeValueAsString(map), KinesisSourceConfig.class);
+    }
+}

--- a/pulsar-io/kinesis/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/kinesis/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -18,5 +18,6 @@
 #
 
 name: kinesis
-description: Kinesis sink connector
+description: Kinesis connectors
 sinkClass: org.apache.pulsar.io.kinesis.KinesisSink
+sourceClass: org.apache.pulsar.io.kinesis.KinesisSource

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTests.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTests.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pulsar.io.kinesis.KinesisSinkConfig.MessageFormat;
+import org.testng.annotations.Test;
+
+public class KinesisSinkConfigTests {
+
+    @Test
+    public final void loadFromYamlFileTest() throws IOException {
+        File yamlFile = getFile("sinkConfig.yaml");
+        KinesisSinkConfig config = KinesisSinkConfig.load(yamlFile.getAbsolutePath());
+        
+        assertNotNull(config);
+        assertEquals(config.getAwsEndpoint(), "https://some.endpoint.aws");
+        assertEquals(config.getAwsRegion(), "us-east-1");
+        assertEquals(config.getAwsKinesisStreamName(), "my-stream");
+        assertEquals(config.getAwsCredentialPluginParam(),
+                "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        assertEquals(config.getMessageFormat(), MessageFormat.ONLY_RAW_PAYLOAD);
+        assertEquals(true, config.isRetainOrdering());
+    }
+    
+    @Test
+    public final void loadFromMapTest() throws IOException {
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("awsEndpoint", "https://some.endpoint.aws");
+        map.put("awsRegion", "us-east-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        
+        KinesisSinkConfig config = KinesisSinkConfig.load(map);
+        
+        assertNotNull(config);
+        assertEquals(config.getAwsEndpoint(), "https://some.endpoint.aws");
+        assertEquals(config.getAwsRegion(), "us-east-1");
+        assertEquals(config.getAwsKinesisStreamName(), "my-stream");
+        assertEquals(config.getAwsCredentialPluginParam(),
+                "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+    }
+    
+    private File getFile(String name) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return new File(classLoader.getResource(name).getFile());
+    }
+}

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
+
+public class KinesisSourceConfigTests {
+
+    private static final Date DAY;
+    
+    static {
+        Calendar then = Calendar.getInstance();
+        then.set(Calendar.YEAR, 2019);
+        then.set(Calendar.MONTH, Calendar.MARCH);
+        then.set(Calendar.DAY_OF_MONTH, 5);
+        then.set(Calendar.HOUR_OF_DAY, 4);
+        then.set(Calendar.MINUTE, 0);
+        then.set(Calendar.SECOND, 0);
+        DAY = then.getTime();
+    }
+
+    @Test
+    public final void loadFromYamlFileTest() throws IOException {
+        File yamlFile = getFile("sourceConfig.yaml");
+        KinesisSourceConfig config = KinesisSourceConfig.load(yamlFile.getAbsolutePath());
+        assertNotNull(config);
+        assertEquals(config.getAwsEndpoint(), "https://some.endpoint.aws");
+        assertEquals(config.getAwsRegion(), "us-east-1");
+        assertEquals(config.getAwsKinesisStreamName(), "my-stream");
+        assertEquals(config.getAwsCredentialPluginParam(),
+                "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        assertEquals(config.getApplicationName(), "My test application");
+        assertEquals(config.getCheckpointInterval(), 30000);
+        assertEquals(config.getBackoffTime(), 4000);
+        assertEquals(config.getNumRetries(), 3);
+        assertEquals(config.getReceiveQueueSize(), 2000);
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
+        assertEquals(config.getStartAtTime().toString(), "Tue Mar 05 04:00:00 PST 2019");
+    }
+    
+    @Test
+    public final void loadFromMapTest() throws IOException {
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("awsEndpoint", "https://some.endpoint.aws");
+        map.put("awsRegion", "us-east-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        map.put("checkpointInterval", "30000");
+        map.put("backoffTime", "4000");
+        map.put("numRetries", "3");
+        map.put("receiveQueueSize", 2000);
+        map.put("applicationName", "My test application");
+        map.put("initialPositionInStream", InitialPositionInStream.TRIM_HORIZON);
+        map.put("startAtTime", DAY);
+        
+        KinesisSourceConfig config = KinesisSourceConfig.load(map);
+        
+        assertNotNull(config);
+        assertEquals(config.getAwsEndpoint(), "https://some.endpoint.aws");
+        assertEquals(config.getAwsRegion(), "us-east-1");
+        assertEquals(config.getAwsKinesisStreamName(), "my-stream");
+        assertEquals(config.getAwsCredentialPluginParam(),
+                "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        assertEquals(config.getApplicationName(), "My test application");
+        assertEquals(config.getCheckpointInterval(), 30000);
+        assertEquals(config.getBackoffTime(), 4000);
+        assertEquals(config.getNumRetries(), 3);
+        assertEquals(config.getReceiveQueueSize(), 2000);
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
+        assertEquals(config.getStartAtTime().toString(), "Tue Mar 05 04:00:00 PST 2019");
+    }
+    
+    @Test(expectedExceptions = IllegalArgumentException.class, 
+            expectedExceptionsMessageRegExp = "empty aws-credential param")
+    public final void missingCredentialsTest() throws Exception {
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("awsEndpoint", "https://some.endpoint.aws");
+        map.put("awsRegion", "us-east-1");
+        map.put("awsKinesisStreamName", "my-stream");
+     
+        KinesisSource source = new KinesisSource();
+        source.open(map, null);
+    }
+    
+    @Test(expectedExceptions = IllegalArgumentException.class, 
+            expectedExceptionsMessageRegExp = "Timestamp must be specified")
+    public final void missingStartTimeTest() throws Exception {
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("awsEndpoint", "https://some.endpoint.aws");
+        map.put("awsRegion", "us-east-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", 
+                "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        map.put("initialPositionInStream", InitialPositionInStream.AT_TIMESTAMP);
+     
+        KinesisSource source = new KinesisSource();
+        source.open(map, null);
+    }
+    
+    private File getFile(String name) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return new File(classLoader.getResource(name).getFile());
+    }
+}

--- a/pulsar-io/kinesis/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/kinesis/src/test/resources/sinkConfig.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{
+  "awsEndpoint" : "https://some.endpoint.aws",
+  "awsRegion": "us-east-1",
+  "awsKinesisStreamName": "my-stream",
+  "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
+  "messageFormat": "ONLY_RAW_PAYLOAD",
+  "retainOrdering": "true"
+}

--- a/pulsar-io/kinesis/src/test/resources/sourceConfig.yaml
+++ b/pulsar-io/kinesis/src/test/resources/sourceConfig.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{
+  "awsEndpoint" : "https://some.endpoint.aws",
+  "awsRegion": "us-east-1",
+  "awsKinesisStreamName": "my-stream",
+  "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
+  "applicationName": "My test application",
+  "checkpointInterval": "30000",
+  "backoffTime":"4000",
+  "numRetries":"3",
+  "receiveQueueSize": 2000,
+  "initialPositionInStream": "TRIM_HORIZON",
+  "startAtTime": "2019-03-05T12:00:00.000"
+}


### PR DESCRIPTION
### Motivation

Added an AWS Kinesis Source connector to the existing Kinesis module.

### Modifications

- Added an AWS Kinesis Source connector and associated configuration class
- Added test class for AWS Kinesis Source connector
- Refactored Configuration hierarchy to promote code reused between the Sink and Source configurations.
- Added test cases to confirm the above refactoring did NOT break anything in the Sink

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change added tests and can be verified as follows:

- Added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API: NO
  - The schema: NO
  - The default values of configurations: NO
  - The wire protocol: NO
  - The rest endpoints: NO
  - The admin cli options: NO
  - Anything that affects deployment: NO

### Documentation

  - Does this pull request introduce a new feature? YES
  - If yes, how is the feature documented?  YES, I updated the docs
