### PR TITLE
Pulsar standalone does not read zk port form conf/standalone.conf

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -71,8 +71,27 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         }
 
         // Set ZK server's host to localhost
-        config.setZookeeperServers(zkServers + ":" + this.getZkPort());
-        config.setConfigurationStoreServers(zkServers + ":" + this.getZkPort());
+        // Priority: args > conf > default
+        boolean fg = false;
+        for( String st : args )
+        {
+            if ( st.equals("--zookeeper-port") ) {
+                fg = true;
+                config.setZookeeperServers(zkServers + ":" + this.getZkPort());
+                break;
+            }
+        }
+        if ( fg == false ) {
+            if (config.getZookeeperServers() != null) {
+                this.setZkPort(Integer.parseInt(config.getZookeeperServers().split(":")[1]));
+            }
+            config.setZookeeperServers(zkServers + ":" + this.getZkPort());
+        }
+
+        if ( config.getConfigurationStoreServers() == null ) {
+            config.setConfigurationStoreServers(zkServers + ":" + this.getZkPort());
+        }
+
         config.setRunningStandalone(true);
 
         Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -73,7 +73,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
 
         // Set ZK server's host to localhost
         // Priority: args > conf > default
-        if ( argsContains(args,"--zookeeper-port") ) {
+        if (argsContains(args,"--zookeeper-port")) {
             config.setZookeeperServers(zkServers + ":" + this.getZkPort());
         } else {
             if (config.getZookeeperServers() != null) {
@@ -82,7 +82,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             config.setZookeeperServers(zkServers + ":" + this.getZkPort());
         }
 
-        if ( config.getConfigurationStoreServers() == null ) {
+        if (config.getConfigurationStoreServers() == null) {
             config.setConfigurationStoreServers(zkServers + ":" + this.getZkPort());
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -21,6 +21,7 @@ package org.apache.pulsar;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.FileInputStream;
+import java.util.Arrays;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
@@ -72,15 +73,9 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
 
         // Set ZK server's host to localhost
         // Priority: args > conf > default
-        boolean fg = true;
-        for( String st : args ) {
-            if ( st.equals("--zookeeper-port") ) {
-                fg = false;
-                config.setZookeeperServers(zkServers + ":" + this.getZkPort());
-                break;
-            }
-        }
-        if ( fg ) {
+        if ( argsContains(args,"--zookeeper-port") ) {
+            config.setZookeeperServers(zkServers + ":" + this.getZkPort());
+        } else {
             if (config.getZookeeperServers() != null) {
                 this.setZkPort(Integer.parseInt(config.getZookeeperServers().split(":")[1]));
             }
@@ -112,6 +107,10 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
                 }
             }
         });
+    }
+
+    private static boolean argsContains(String[] args, String arg) {
+        return Arrays.asList(args).contains(arg);
     }
 
     public static void main(String args[]) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -72,16 +72,15 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
 
         // Set ZK server's host to localhost
         // Priority: args > conf > default
-        boolean fg = false;
-        for( String st : args )
-        {
+        boolean fg = true;
+        for( String st : args ) {
             if ( st.equals("--zookeeper-port") ) {
-                fg = true;
+                fg = false;
                 config.setZookeeperServers(zkServers + ":" + this.getZkPort());
                 break;
             }
         }
-        if ( fg == false ) {
+        if ( fg ) {
             if (config.getZookeeperServers() != null) {
                 this.setZkPort(Integer.parseInt(config.getZookeeperServers().split(":")[1]));
             }


### PR DESCRIPTION
### Motivation
Fixes #3788

### Modifications
Add codes make it read zk port from standalone.conf. And it follow the Priority: args > conf > default
