### PR TITLE
Support Kafka's ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG.

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
@@ -119,7 +119,7 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
         String serviceUrl = producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG).get(0);
         try {
             // Support Kafka's ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG in ms.
-            // If passed in value is greater than Integer.MAX_VALUE in second will throw ArithmeticException.
+            // If passed in value is greater than Integer.MAX_VALUE in second will throw IllegalArgumentException.
             int keepAliveInterval = Math.toIntExact(keepAliveIntervalMs / 1000);
             client = PulsarClientKafkaConfig.getClientBuilder(properties).serviceUrl(serviceUrl).keepAliveInterval(keepAliveInterval, TimeUnit.SECONDS).build();
         } catch (ArithmeticException e) {
@@ -146,7 +146,7 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
 
         pulsarProducerBuilder.messageRouter(new KafkaMessageRouter(lingerMs));
 
-        int sendTimeoutMillis = Integer.parseInt(properties.getProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "60000"));
+        int sendTimeoutMillis = Integer.parseInt(properties.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000"));
         pulsarProducerBuilder.sendTimeout(sendTimeoutMillis, TimeUnit.MILLISECONDS);
 
         boolean blockOnBufferFull = Boolean

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -152,7 +152,7 @@ Properties:
 | `request.timeout.ms`                    | Ignored   |                                                                               |
 | `retries`                               | Ignored   | Pulsar client retries with exponential backoff until the send timeout expires |
 | `send.buffer.bytes`                     | Ignored   |                                                                               |
-| `timeout.ms`                            | Ignored   |                                                                               |
+| `timeout.ms`                            | Yes       |                                                                               |
 | `value.serializer`                      | Yes       |                                                                               |
 
 


### PR DESCRIPTION
**Motivatio** 
Support Kafka's ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG  #1090 

Previously `ProducerBuilder.sendTimeout` was set by parsing Kafka's `ProducerConfig.MAX_BLOCK_MS_CONFIG`.
According to Kafka's [document](https://kafka.apache.org/20/documentation.html) it's for   

> Controlling how long KafkaProducer.send() and KafkaProducer.partitionsFor() will block either because the buffer is full or metadata unavailable.

But `ProducerBuilder.sendTimeout`  is for  

> If a message is not acknowledged by the server before the sendTimeout expires, an error will be reported.

And Kafka's `ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG`, according to the document is for:
> Controlling the maximum amount of time the client will wait for the response of a request.

Which I think would be better fit purpose of Pulsar's `ProducerBuilder.sendTimeout`. 