### PR TITLE
Issue #3803: Make ManagedLedger read batch size configurable

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -186,6 +186,17 @@ dispatchThrottlingRatePerSubscribeInByte=0
 # backlog.
 dispatchThrottlingOnNonBacklogConsumerEnabled=true
 
+# Max number of entries to read from bookkeeper. By default it is 100 entries.
+dispatcherMaxReadBatchSize=100
+
+# Min number of entries to read from bookkeeper. By default it is 1 entries.
+# When there is an error occurred on reading entries from bookkeeper, the broker
+# will backoff the batch size to this minimum number."
+dispatcherMinReadBatchSize=1
+
+# Max number of entries to dispatch for a shared subscription. By default it is 20 entries.
+dispatcherMaxRoundRobinBatchSize=20
+
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=50000
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -377,6 +377,31 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " published messages and don't have backlog. This enables dispatch-throttling for "
             + " non-backlog consumers as well.")
     private boolean dispatchThrottlingOnNonBacklogConsumerEnabled = false;
+
+    // <-- dispatcher read settings -->
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_SERVER,
+        doc = "Max number of entries to read from bookkeeper. By default it is 100 entries."
+    )
+    private int dispatcherMaxReadBatchSize = 100;
+
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_SERVER,
+        doc = "Min number of entries to read from bookkeeper. By default it is 1 entries."
+            + "When there is an error occurred on reading entries from bookkeeper, the broker"
+            + " will backoff the batch size to this minimum number."
+    )
+    private int dispatcherMinReadBatchSize = 1;
+
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_SERVER,
+        doc = "Max number of entries to dispatch for a shared subscription. By default it is 20 entries."
+    )
+    private int dispatcherMaxRoundRobinBatchSize = 20;
+
     @FieldContext(
         dynamic = true,
         category = CATEGORY_SERVER,


### PR DESCRIPTION
*Motivation*

Fixes #3803

Hardcoding is a very bad practice. It means we have no way to alter system behavior
when production issues occur.

*Modifications*

introduce a few read batch related settings to make them configurable

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API: NO
  - The schema: NO
  - The default values of configurations: NO
  - The wire protocol: NO
  - The rest endpoints: NO
  - The admin cli options: NO
  - Anything that affects deployment: NO

### Documentation

  - Does this pull request introduce a new feature? NO
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
     * it is self-documented in configuration file
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
