### PR TITLE
[pom] Update mvn plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1133,7 +1133,7 @@ flexible messaging model and an intuitive client API.</description>
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>3.0.rc1</version>
+        <version>3.0</version>
         <configuration>
           <header>src/license-header.txt</header>
 
@@ -1436,7 +1436,7 @@ flexible messaging model and an intuitive client API.</description>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.7.201606060606</version>
+            <version>0.8.3</version>
             <executions>
               <execution>
                 <id>pre-unit-test</id>


### PR DESCRIPTION
### Motivation
Updates the following maven plugins:

- license-maven-plugin
- jacoco-maven-plugin

The `license-maven-plugin` in master is using a release candidate when the final version is now available.  The change to the `jacoco-maven-plugin` provides support for later versions of Java (beyond Java8) which may become important for the future.

This is a small change that doesn't impact the distribution.

### Modifications
Changed version numbers of two mvn plugins to use latest versions.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes

maven plugin dependencies only, not compile-time or runtime dependencies.

### Documentation
  - Does this pull request introduce a new feature?  no