### PR TITLE
[Issue #3810][pulsar-broker] Implement configurable token auth claim

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -340,6 +340,9 @@ tokenSecretKey=
 # tokenPublicKey=file:///my/public.key
 tokenPublicKey=
 
+# The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
+tokenAuthClaim=
+
 ### --- BookKeeper Client --- ###
 
 # Authentication plugin to use when connecting to bookies

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -183,6 +183,8 @@ tokenSecretKey=
 # tokenPublicKey=file:///my/public.key
 tokenPublicKey=
 
+# The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
+tokenAuthClaim=
 
 ### --- Deprecated config variables --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -223,6 +223,9 @@ athenzDomainNames=
 # When this parameter is not empty, unauthenticated users perform as anonymousUserRole
 anonymousUserRole=
 
+# The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
+tokenAuthClaim=
+
 ### --- BookKeeper Client --- ###
 
 # Authentication plugin to use when connecting to bookies

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -144,6 +144,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |tlsCiphers|Specify the tls cipher the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256```||
 |tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
 |tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenAuthClaim| Specify which of the token's claims will be used as the authentication "principal" or "role". The default "sub" claim will be used if this is left blank ||
 |maxUnackedMessagesPerConsumer| Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending messages to consumer once, this limit reaches until consumer starts acknowledging messages back. Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction  |50000|
 |maxUnackedMessagesPerSubscription| Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher can dispatch messages without any restriction  |200000|
 |subscriptionRedeliveryTrackerEnabled| Enable subscription message redelivery tracker |true|
@@ -448,6 +449,7 @@ The [Pulsar proxy](concepts-architecture-overview.md#pulsar-proxy) can be config
 |tlsCiphers|Specify the tls cipher the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256```||
 |tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
 |tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenAuthClaim| Specify the token claim that will be used as the authentication "principal" or "role". The "subject" field will be used if this is left blank ||
 
 ## ZooKeeper
 


### PR DESCRIPTION
Resolves #3810 

Please let me know if I've missed anything!

### Motivation

This change allows more configuration of the AuthenticationTokenProvider, so that the user can specify which "claim" that is attached to the token should be used as the "role". Before, it was hard-coded in to use the token's subject claim ("sub").

### Modifications

Added a field to the AuthenticationTokenProvider which controls which claim is returned from `parseToken`, and a method that sets that field based on the .conf file. Added some documentation and a test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added unit test to `AuthenticationTokenProviderTest` which sets the configuration and verifies that it picks up the right value*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? 
       - yes
  - If yes, how is the feature documented?
       - Addition to `reference-configuration.md`
