### PR TITLE
Expand add env functionality to add variables if not present

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -34,7 +34,7 @@ if len(sys.argv) < 2:
 # Always apply env config to env scripts as well
 conf_files = ['conf/pulsar_env.sh', 'conf/bkenv.sh'] + sys.argv[1:]
 
-PF_ENV_PREFIX = 'INS_'
+PF_ENV_PREFIX = 'PULSAR_'
 
 
 for conf_filename in conf_files:

--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -34,6 +34,9 @@ if len(sys.argv) < 2:
 # Always apply env config to env scripts as well
 conf_files = ['conf/pulsar_env.sh', 'conf/bkenv.sh'] + sys.argv[1:]
 
+PF_ENV_PREFIX = 'INS_'
+
+
 for conf_filename in conf_files:
     lines = []  # List of config file lines
     keys = {} # Map a key to its line number in the file
@@ -55,6 +58,17 @@ for conf_filename in conf_files:
             print('[%s] Applying config %s = %s' % (conf_filename, k, v))
             idx = keys[k]
             lines[idx] = '%s=%s\n' % (k, v)
+
+
+    # Add new keys from Env
+    for k in sorted(os.environ.keys()):
+        v = os.environ[k]
+        if not k.startswith(PF_ENV_PREFIX):
+            continue
+        k = k[len(PF_ENV_PREFIX):]
+        if k not in keys:
+            print('[%s] Adding config %s = %s' % (conf_filename, k, v))
+            lines.append('%s=%s\n' % (k, v))
 
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')


### PR DESCRIPTION
### Motivation
currently apply-config-from-env does not provide a way to inject new variables in the config during testing phase. This makes testing different scenarios very cumbersome. This pr adds this capability
### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
