### PR TITLE
[Issue 3806] Fix NPE while call PartitionedProducerImpl.getStats()

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -63,16 +63,16 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     private static final DecimalFormat THROUGHPUT_FORMAT = new DecimalFormat("0.00");
 
     public ConsumerStatsRecorderImpl() {
-        numMsgsReceived = null;
-        numBytesReceived = null;
-        numReceiveFailed = null;
-        numAcksSent = null;
-        numAcksFailed = null;
-        totalMsgsReceived = null;
-        totalBytesReceived = null;
-        totalReceiveFailed = null;
-        totalAcksSent = null;
-        totalAcksFailed = null;
+        numMsgsReceived = new LongAdder();
+        numBytesReceived = new LongAdder();
+        numReceiveFailed = new LongAdder();
+        numAcksSent = new LongAdder();
+        numAcksFailed = new LongAdder();
+        totalMsgsReceived = new LongAdder();
+        totalBytesReceived = new LongAdder();
+        totalReceiveFailed = new LongAdder();
+        totalAcksSent = new LongAdder();
+        totalAcksFailed = new LongAdder();
     }
 
     public ConsumerStatsRecorderImpl(PulsarClientImpl pulsarClient, ConsumerConfigurationData<?> conf,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -64,15 +64,15 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
     private static final double[] PERCENTILES = { 0.5, 0.75, 0.95, 0.99, 0.999, 1.0 };
 
     public ProducerStatsRecorderImpl() {
-        numMsgsSent = null;
-        numBytesSent = null;
-        numSendFailed = null;
-        numAcksReceived = null;
-        totalMsgsSent = null;
-        totalBytesSent = null;
-        totalSendFailed = null;
-        totalAcksReceived = null;
-        ds = null;
+        numMsgsSent = new LongAdder();
+        numBytesSent = new LongAdder();
+        numSendFailed = new LongAdder();
+        numAcksReceived = new LongAdder();
+        totalMsgsSent = new LongAdder();
+        totalBytesSent = new LongAdder();
+        totalSendFailed = new LongAdder();
+        totalAcksReceived = new LongAdder();
+        ds = DoublesSketch.builder().build(256);
     }
 
     public ProducerStatsRecorderImpl(PulsarClientImpl pulsarClient, ProducerConfigurationData conf,

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import com.google.common.collect.Sets;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.util.netty.EventLoopUtil;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit Tests of {@link MultiTopicsConsumerImpl}.
+ */
+public class MultiTopicsConsumerImplTest {
+
+    @Test
+    public void testGetStats() throws Exception {
+        String topicName = "test-stats";
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        conf.setStatsIntervalSeconds(100);
+
+        ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), threadFactory);
+        ExecutorService listenerExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
+
+        PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
+
+        ConsumerConfigurationData consumerConfData = new ConsumerConfigurationData();
+        consumerConfData.setTopicNames(Sets.newHashSet(topicName));
+
+        assertEquals(Long.parseLong("100"), clientImpl.getConfiguration().getStatsIntervalSeconds());
+
+        MultiTopicsConsumerImpl impl = new MultiTopicsConsumerImpl(
+            clientImpl, consumerConfData,
+            listenerExecutor, null, null, null);
+
+        impl.getStats();
+    }
+
+}


### PR DESCRIPTION
### Motivation

Fixes #3806

### Modifications

Initialize `LongAdder` variables by `LongAdder` Object.