### PR TITLE
[issue 3838] [schema] : Allow incompatible schemas to co-exist on a topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AlwaysSchemaValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AlwaysSchemaValidator.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.schema;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaValidator;
+
+/**
+ * A schema validator that always reports as compatible.
+ */
+class AlwaysSchemaValidator implements SchemaValidator {
+    static AlwaysSchemaValidator INSTANCE = new AlwaysSchemaValidator();
+
+    @Override
+    public void validate(Schema toValidate, Iterable<Schema> existing) {
+        return;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -58,6 +58,8 @@ abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityC
                 return createLatestOrAllValidator(validatorBuilder.canBeReadStrategy(), onlyLatestValidator);
             case FULL:
                 return createLatestOrAllValidator(validatorBuilder.mutualReadStrategy(), onlyLatestValidator);
+            case ALWAYS_COMPATIBLE:
+                return AlwaysSchemaValidator.INSTANCE;
             default:
                 return NeverSchemaValidator.INSTANCE;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
@@ -27,6 +27,11 @@ public enum SchemaCompatibilityStrategy {
     ALWAYS_INCOMPATIBLE,
 
     /**
+     * Always compatible
+     */
+    ALWAYS_COMPATIBLE,
+
+    /**
      * Messages written by a new schema can be read by an old schema
      */
     BACKWARD,
@@ -52,6 +57,8 @@ public enum SchemaCompatibilityStrategy {
             return FORWARD;
         case Full:
             return FULL;
+        case AlwaysCompatible:
+            return ALWAYS_COMPATIBLE;
         case AutoUpdateDisabled:
         default:
             return ALWAYS_INCOMPATIBLE;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1004,6 +1004,8 @@ public class CmdNamespaces extends CmdBase {
                 strategy = SchemaAutoUpdateCompatibilityStrategy.Backward;
             } else if (strategyStr.equals("FORWARD")) {
                 strategy = SchemaAutoUpdateCompatibilityStrategy.Forward;
+            } else if (strategyStr.equals("NONE")) {
+                strategy = SchemaAutoUpdateCompatibilityStrategy.AlwaysCompatible;
             } else {
                 throw new PulsarAdminException("Either --compatibility or --disabled must be specified");
             }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SchemaAutoUpdateCompatibilityStrategy.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SchemaAutoUpdateCompatibilityStrategy.java
@@ -45,5 +45,11 @@ public enum SchemaAutoUpdateCompatibilityStrategy {
     /**
      * Backward and Forward.
      */
-    Full
+    Full,
+
+    /**
+     * Always Compatible - The new schema will not be checked for compatibility against
+     * old schemas. In other words, new schemas will always be marked assumed compatible.
+     */
+    AlwaysCompatible
 }

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1320,7 +1320,7 @@ $ pulsar-admin namespaces set-schema-autoupdate-strategy tenant/namespace option
 Options
 |Flag|Description|Default|
 |----|---|---|
-|`-c`, `--compatibility`|Compatibility level required for new schemas created via a Producer. Possible values (Full, Backward, Forward).||
+|`-c`, `--compatibility`|Compatibility level required for new schemas created via a Producer. Possible values (Full, Backward, Forward, None).||
 |`-d`, `--disabled`|Disable automatic schema updates.|false|
 
 


### PR DESCRIPTION
## Problem:

Fixes #3838 : The set-schema-autoupdate-strategy policy currently allows disabling schema update (--disabled) and one of --compatibility(FULL, BACKWARD, FORWARD). There is no way to currently allow multiple schemas for a topic.

## Solution:
It would be useful to allow --compatibility so the schemas can be added without checking with the previous schemas. This allows for extra flexibility for instance having multiple objects on a topic, supports use cases like a simple event bus etc.

### Modifications

This change added tests and can be verified as follows:

  - *Added test cases under SchemaUpdateStrategyTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: (yes)
  - The schema: (yes)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (yes)
  - The admin cli options: (yes)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs added)
