### PR TITLE
[Issue 3851] [pulsar-broker] Support to start broker use the port initialized in cluster metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -49,8 +49,13 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
+import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
+import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
+import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -110,6 +115,23 @@ public class PulsarBrokerStarter {
         return Arrays.asList(args).contains(arg);
     }
 
+    private static ClusterData retrieveClusterData(ServiceConfiguration config) throws Exception {
+        String configurationStoreServers = config.getConfigurationStoreServers();
+        Long zkSessionTimeoutMillis = config.getZooKeeperSessionTimeoutMillis();
+        String clusterName = config.getClusterName();
+        ZooKeeperClientFactory zkfactory = new ZookeeperClientFactoryImpl();
+        ZooKeeper configStoreZk = zkfactory.create(
+            configurationStoreServers, ZooKeeperClientFactory.SessionType.ReadWrite, zkSessionTimeoutMillis.intValue()).get();
+        byte[] metadata = configStoreZk.getData("/admin/clusters/" + clusterName, false, null);
+        ClusterData clusterData = ObjectMapperFactory.getThreadLocal().readValue(metadata, ClusterData.class);
+        return clusterData;
+    }
+
+    private static int retrievePort(String url) {
+        String[] uris = url.split(":");
+        return Integer.parseInt(uris[uris.length-1]);
+    }
+
     private static class BrokerStarter {
         private final ServiceConfiguration brokerConfig;
         private final PulsarService pulsarService;
@@ -119,7 +141,7 @@ public class PulsarBrokerStarter {
         private final ServerConfiguration bookieConfig;
         private final WorkerService functionsWorkerService;
 
-        BrokerStarter(String[] args) throws Exception{
+        BrokerStarter(String[] args) throws Exception {
             StarterArguments starterArguments = new StarterArguments();
             JCommander jcommander = new JCommander(starterArguments);
             jcommander.setProgramName("PulsarBrokerStarter");
@@ -138,6 +160,15 @@ public class PulsarBrokerStarter {
             } else {
                 brokerConfig = loadConfig(starterArguments.brokerConfigFile);
             }
+
+            // get the cluster metadata initialized in zookeeper
+            ClusterData clusterData = retrieveClusterData(brokerConfig);
+
+            // override the port of service urls in brokerConfig (i.e. config priority: initialized in zookeeper > broker.conf)
+            brokerConfig.setBrokerServicePort(retrievePort(clusterData.getBrokerServiceUrl()));
+            brokerConfig.setBrokerServicePortTls(retrievePort(clusterData.getBrokerServiceUrlTls()));
+            brokerConfig.setWebServicePort(retrievePort(clusterData.getServiceUrl()));
+            brokerConfig.setWebServicePortTls(retrievePort(clusterData.getServiceUrlTls()));
 
             // init functions worker
             if (starterArguments.runFunctionsWorker || brokerConfig.isFunctionsWorkerEnabled()) {

--- a/site2/docs/deploy-bare-metal-multi-cluster.md
+++ b/site2/docs/deploy-bare-metal-multi-cluster.md
@@ -280,7 +280,7 @@ Brokers can be configured using the [`conf/broker.conf`](reference-configuration
 
 The most important element of broker configuration is ensuring that each broker is aware of its local ZooKeeper quorum as well as the configuration store quorum. Make sure that you set the [`zookeeperServers`](reference-configuration.md#broker-zookeeperServers) parameter to reflect the local quorum and the [`configurationStoreServers`](reference-configuration.md#broker-configurationStoreServers) parameter to reflect the configuration store quorum (although you'll need to specify only those ZooKeeper servers located in the same cluster).
 
-You also need to specify the name of the [cluster](reference-terminology.md#cluster) to which the broker belongs using the [`clusterName`](reference-configuration.md#broker-clusterName) parameter.
+You also need to specify the name of the [cluster](reference-terminology.md#cluster) to which the broker belongs using the [`clusterName`](reference-configuration.md#broker-clusterName) parameter. In addition, you need to match the broker and web service ports provided when initializing the cluster's metadata (especially when using a different port from default).
 
 Here's an example configuration:
 
@@ -292,6 +292,18 @@ zookeeperServers=zk1.us-west.example.com:2181,zk2.us-west.example.com:2181,zk3.u
 configurationStoreServers=zk1.us-west.example.com:2184,zk2.us-west.example.com:2184,zk3.us-west.example.com:2184
 
 clusterName=us-west
+
+# Broker data port
+brokerServicePort=6650
+
+# Broker data port for TLS
+brokerServicePortTls=6651
+
+# Port to use to server HTTP request
+webServicePort=8080
+
+# Port to use to server HTTPS request
+webServicePortTls=8443
 ```
 
 ### Broker hardware

--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -312,17 +312,26 @@ Pulsar brokers are the last thing you need to deploy in your Pulsar cluster. Bro
 
 ### Configuring Brokers
 
-The most important element of broker configuration is ensuring that that each broker is aware of the ZooKeeper cluster that you've deployed. Make sure that the [`zookeeperServers`](reference-configuration.md#broker-zookeeperServers) and [`configurationStoreServers`](reference-configuration.md#broker-configurationStoreServers) parameters. In this case, since we only have 1 cluster and no configuration store setup, the `configurationStoreServers` will point to the same `zookeeperServers`.
+The most important element of broker configuration is ensuring that each broker is aware of the ZooKeeper cluster that you've deployed. Make sure that the [`zookeeperServers`](reference-configuration.md#broker-zookeeperServers) and [`configurationStoreServers`](reference-configuration.md#broker-configurationStoreServers) parameters. In this case, since we only have 1 cluster and no configuration store setup, the `configurationStoreServers` will point to the same `zookeeperServers`.
 
 ```properties
 zookeeperServers=zk1.us-west.example.com:2181,zk2.us-west.example.com:2181,zk3.us-west.example.com:2181
 configurationStoreServers=zk1.us-west.example.com:2181,zk2.us-west.example.com:2181,zk3.us-west.example.com:2181
 ```
 
-You also need to specify the cluster name (matching the name that you provided when [initializing the cluster's metadata](#initializing-cluster-metadata):
+You also need to specify the cluster name (matching the name that you provided when [initializing the cluster's metadata](#initializing-cluster-metadata)):
 
 ```properties
 clusterName=pulsar-cluster-1
+```
+
+In addition, you need to match the broker and web service ports provided when initializing the cluster's metadata (especially when using a different port from default):
+
+```properties
+brokerServicePort=6650
+brokerServicePortTls=6651
+webServicePort=8080
+webServicePortTls=8443
 ```
 
 > If you deploy Pulsar in a one-node cluster, you should update the replication settings in `conf/broker.conf` to `1`


### PR DESCRIPTION
### Motivation

Fixes #3851

### Modifications

Override the port of service urls in brokerConfig by the config initialized in cluster metadata.