### PR TITLE
Use `PULSAR_PREFIX_` for appending new keys

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -34,8 +34,7 @@ if len(sys.argv) < 2:
 # Always apply env config to env scripts as well
 conf_files = ['conf/pulsar_env.sh', 'conf/bkenv.sh'] + sys.argv[1:]
 
-PF_ENV_PREFIX = 'PULSAR_'
-
+PF_ENV_PREFIX = 'PULSAR_PREFIX_'
 
 for conf_filename in conf_files:
     lines = []  # List of config file lines

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -97,6 +97,7 @@ public class PulsarCluster {
                     .withNetworkAliases(PrestoWorkerContainer.NAME)
                     .withEnv("clusterName", clusterName)
                     .withEnv("zkServers", ZKContainer.NAME)
+                    .withEnv("zookeeperServers", ZKContainer.NAME + ":" + ZKContainer.ZK_PORT)
                     .withEnv("pulsar.zookeeper-uri", ZKContainer.NAME + ":" + ZKContainer.ZK_PORT)
                     .withEnv("pulsar.broker-service-url", "http://pulsar-broker-0:8080");
         } else {
@@ -314,6 +315,7 @@ public class PulsarCluster {
                     .withNetworkAliases(PrestoWorkerContainer.NAME)
                     .withEnv("clusterName", clusterName)
                     .withEnv("zkServers", ZKContainer.NAME)
+                    .withEnv("zookeeperServers", ZKContainer.NAME + ":" + ZKContainer.ZK_PORT)
                     .withEnv("pulsar.zookeeper-uri", ZKContainer.NAME + ":" + ZKContainer.ZK_PORT)
                     .withEnv("pulsar.broker-service-url", "http://pulsar-broker-0:8080");
         }

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -30,4 +30,5 @@ docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest
 docker pull cassandra:3
 docker pull confluentinc/cp-kafka:4.0.0
+docker pull debezium/example-mysql:0.8
 docker pull mysql:5.7.22


### PR DESCRIPTION
*Motivation*

Currently integration tests are broken due to #3827

`PULSAR_` is used almost everywhere in our scripts. If we are using
`PULSAR_` for appending new keys, then we are potentially appending
a wrong key into the config file.

Currently this happens on presto. We are appending `PULSAR_ROOT_LOGGER`
into presto's config file and cause presto fail to load the config.

*Modifications*

Use `PULSAR_PREFIX_` instead of `PULSAR_`
