### PR TITLE
copy logs from presto server container on teardown in integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.tests.integration.containers;
 
+import org.apache.pulsar.tests.integration.utils.DockerUtils;
+
 /**
  * A pulsar container that runs the presto worker
  */
@@ -35,5 +37,17 @@ public class PrestoWorkerContainer extends PulsarContainer<PrestoWorkerContainer
                 -1,
                 PRESTO_HTTP_PORT,
                 "/v1/node");
+    }
+
+    @Override
+    protected void beforeStop() {
+        super.beforeStop();
+        if (null != containerId) {
+            DockerUtils.dumpContainerDirToTargetCompressed(
+                    getDockerClient(),
+                    containerId,
+                    "/pulsar/lib/presto/var/log"
+            );
+        }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -42,6 +42,25 @@ public class TestBasicPresto extends PulsarTestSuite {
     @BeforeClass
     public void setupPresto() throws Exception {
         pulsarCluster.startPrestoWorker();
+    }
+
+    @AfterClass
+    public void teardownPresto() {
+        log.info("tearing down...");
+        pulsarCluster.stopPrestoWorker();
+    }
+
+    @Test
+    public void testSimpleSQLQueryBatched() throws Exception {
+        testSimpleSQLQuery(true);
+    }
+
+    @Test
+    public void testSimpleSQLQueryNonBatched() throws Exception {
+        testSimpleSQLQuery(false);
+    }
+    
+    public void testSimpleSQLQuery(boolean isBatched) throws Exception {
 
         // wait until presto worker started
         ContainerExecResult result;
@@ -59,24 +78,6 @@ public class TestBasicPresto extends PulsarTestSuite {
                 }
             }
         } while (true);
-    }
-
-    @AfterClass
-    public void teardownPresto() {
-        pulsarCluster.stopPrestoWorker();;
-    }
-
-    @Test
-    public void testSimpleSQLQueryBatched() throws Exception {
-        testSimpleSQLQuery(true);
-    }
-
-    @Test
-    public void testSimpleSQLQueryNonBatched() throws Exception {
-        testSimpleSQLQuery(false);
-    }
-    
-    public void testSimpleSQLQuery(boolean isBatched) throws Exception {
 
         @Cleanup
         PulsarClient pulsarClient = PulsarClient.builder()
@@ -96,7 +97,7 @@ public class TestBasicPresto extends PulsarTestSuite {
             producer.send(stock);
         }
 
-        ContainerExecResult result = execQuery("show schemas in pulsar;");
+        result = execQuery("show schemas in pulsar;");
         assertThat(result.getExitCode()).isEqualTo(0);
         assertThat(result.getStdout()).contains("public/default");
 


### PR DESCRIPTION
### Motivation

For integrations tests for Pulsar SQL, we do not copy the presto server logs out of the container on teardown of the cluster.  The presto server logs should be copy out of the container for ease of debugging if the test failed
