### PR TITLE
Use `INSERTPULSARKEY_` for appending new keys

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -34,7 +34,7 @@ if len(sys.argv) < 2:
 # Always apply env config to env scripts as well
 conf_files = ['conf/pulsar_env.sh', 'conf/bkenv.sh'] + sys.argv[1:]
 
-PF_ENV_PREFIX = 'PULSAR_'
+PF_ENV_PREFIX = 'INSERTPULSARKEY_'
 
 
 for conf_filename in conf_files:


### PR DESCRIPTION

### Motivation
Motivation

Currently integration tests are broken due to #3827

PULSAR_ is used almost everywhere in our scripts. If we are using
PULSAR_ for appending new keys, then we are potentially appending
a wrong key into the config file.

Currently this happens on presto. We are appending PULSAR_ROOT_LOGGER
into presto's config file and cause presto fail to load the config.

Modifications

Use INSERTPULSARKEY_ instead of PULSAR_

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
