### PR TITLE
[pulsar-client] Fix pulsar-cpp crash on lookup timeout

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1106,11 +1106,11 @@ void ClientConnection::newLookup(const SharedBuffer& cmd, const uint64_t request
         return;
     }
     LookupRequestData requestData;
+    requestData.promise = promise;
     requestData.timer = executor_->createDeadlineTimer();
     requestData.timer->expires_from_now(operationsTimeout_);
     requestData.timer->async_wait(std::bind(&ClientConnection::handleLookupTimeout, shared_from_this(),
                                             std::placeholders::_1, requestData));
-    requestData.promise = promise;
 
     pendingLookupRequests_.insert(std::make_pair(requestId, requestData));
     numOfPendingLookupRequest_++;


### PR DESCRIPTION
### Motivation
cpp-client crashes when lookup operation timeout because it finds lookup-promise null.

```
Thread 1 (Thread 0x2b5cb0736700 (LWP 17356)):
#0  0x00002b5c865ec90f in pulsar::Promise<pulsar::Result, std::shared_ptr<pulsar::LookupDataResult> >::setFailed (this=0x0, result=pulsar::ResultTimeout)
```

### Modification
Setting up lookup-promise to lookupData before passing to function which will avoid cpp-client crash.