### PR TITLE
Fixed reading from file with newlines

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
@@ -77,7 +77,7 @@ public class AuthenticationToken implements Authentication, EncodedAuthenticatio
             URI filePath = URI.create(encodedAuthParamString);
             this.tokenSupplier = () -> {
                 try {
-                    return new String(Files.readAllBytes(Paths.get(filePath)), Charsets.UTF_8);
+                    return new String(Files.readAllBytes(Paths.get(filePath)), Charsets.UTF_8).trim();
                 } catch (IOException e) {
                     throw new RuntimeException("Failed to read token from file", e);
                 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -90,6 +90,34 @@ public class AuthenticationTokenTest {
         authToken.close();
     }
 
+    /**
+     * File can have spaces and newlines before or after the token. We should be able to read
+     * the token correctly anyway.
+     */
+    @Test
+    public void testAuthTokenConfigFromFileWithNewline() throws Exception {
+        File tokenFile = File.createTempFile("pular-test-token", ".key");
+        tokenFile.deleteOnExit();
+        FileUtils.write(tokenFile, "  my-test-token-string  \r\n", Charsets.UTF_8);
+
+        AuthenticationToken authToken = new AuthenticationToken();
+        authToken.configure("file://" + tokenFile);
+        assertEquals(authToken.getAuthMethodName(), "token");
+
+        AuthenticationDataProvider authData = authToken.getAuthData();
+        assertTrue(authData.hasDataFromCommand());
+        assertEquals(authData.getCommandData(), "my-test-token-string");
+
+        // Ensure if the file content changes, the token will get refreshed as well
+        FileUtils.write(tokenFile, "other-token", Charsets.UTF_8);
+
+        AuthenticationDataProvider authData2 = authToken.getAuthData();
+        assertTrue(authData2.hasDataFromCommand());
+        assertEquals(authData2.getCommandData(), "other-token");
+
+        authToken.close();
+    }
+
     @Test
     public void testAuthTokenConfigNoPrefix() throws Exception {
         AuthenticationToken authToken = new AuthenticationToken();


### PR DESCRIPTION
### Motivation

By default token is saved to file with a new line at the end. We should be stripping all
the whitespaces and newlines from the token when reading from file.