### PR TITLE
Enable generation of swagger definitions for functions/sources/sinks

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -365,7 +365,7 @@
               <apiSources>
                 <apiSource>
                   <springmvc>false</springmvc>
-                  <locations>org.apache.pulsar.broker.admin</locations>
+                  <locations>org.apache.pulsar.broker.admin.v2</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v2</basePath>
                   <info>
@@ -378,6 +378,24 @@
                     </license>
                   </info>
                   <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
+                  <swaggerFileName>swaggerv2</swaggerFileName>
+                </apiSource>
+                <apiSource>
+                  <springmvc>false</springmvc>
+                  <locations>org.apache.pulsar.broker.admin.v3</locations>
+                  <schemes>http,https</schemes>
+                  <basePath>/admin/v3</basePath>
+                  <info>
+                    <title>Pulsar Admin REST API</title>
+                    <version>v3</version>
+                    <description>This provides the REST API for admin operations</description>
+                    <license>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <name>Apache 2.0</name>
+                    </license>
+                  </info>
+                  <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
+                  <swaggerFileName>swaggerv3</swaggerFileName>
                 </apiSource>
               </apiSources>
             </configuration>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -388,7 +388,7 @@
                   <info>
                     <title>Pulsar Functions REST API</title>
                     <version>v3</version>
-                    <description>This provides the REST API for admin operations</description>
+                    <description>This provides the REST API for Pulsar Functions operations</description>
                     <license>
                       <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -378,7 +378,7 @@
                     </license>
                   </info>
                   <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
-                  <swaggerFileName>swaggerv2</swaggerFileName>
+                  <swaggerFileName>swagger</swaggerFileName>
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
@@ -386,7 +386,7 @@
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
                   <info>
-                    <title>Pulsar Admin REST API</title>
+                    <title>Pulsar Functions REST API</title>
                     <version>v3</version>
                     <description>This provides the REST API for admin operations</description>
                     <license>
@@ -395,7 +395,7 @@
                     </license>
                   </info>
                   <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
-                  <swaggerFileName>swaggerv3</swaggerFileName>
+                  <swaggerFileName>swaggerfunctions</swaggerFileName>
                 </apiSource>
               </apiSources>
             </configuration>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -382,7 +382,7 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
-                  <locations>org.apache.pulsar.broker.admin.v3</locations>
+                  <locations>org.apache.pulsar.broker.admin.v3.Functions</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
                   <info>
@@ -396,6 +396,40 @@
                   </info>
                   <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
                   <swaggerFileName>swaggerfunctions</swaggerFileName>
+                </apiSource>
+                <apiSource>
+                  <springmvc>false</springmvc>
+                  <locations>org.apache.pulsar.broker.admin.v3.Source</locations>
+                  <schemes>http,https</schemes>
+                  <basePath>/admin/v3</basePath>
+                  <info>
+                    <title>Pulsar Source REST API</title>
+                    <version>v3</version>
+                    <description>This provides the REST API for Pulsar Source operations</description>
+                    <license>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <name>Apache 2.0</name>
+                    </license>
+                  </info>
+                  <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
+                  <swaggerFileName>swaggersource</swaggerFileName>
+                </apiSource>
+                <apiSource>
+                  <springmvc>false</springmvc>
+                  <locations>org.apache.pulsar.broker.admin.v3.Sink</locations>
+                  <schemes>http,https</schemes>
+                  <basePath>/admin/v3</basePath>
+                  <info>
+                    <title>Pulsar Sink REST API</title>
+                    <version>v3</version>
+                    <description>This provides the REST API for Pulsar Sink operations</description>
+                    <license>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <name>Apache 2.0</name>
+                    </license>
+                  </info>
+                  <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
+                  <swaggerFileName>swaggersink</swaggerFileName>
                 </apiSource>
               </apiSources>
             </configuration>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @Path("/functions")
-@Api(value = "/functions", description = "Functions admin apis", tags = "functions")
+@Api(value = "/functions", description = "Functions admin apis", tags = "functions", enabled = false)
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Functions extends AdminResource implements Supplier<WorkerService> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @Path("/functions")
-@Api(value = "/functions", description = "Functions admin apis", tags = "functions", hidden = true)
+@Api(value = "/functions", description = "Functions admin apis", tags = "functions")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Functions extends AdminResource implements Supplier<WorkerService> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @Path("/functions")
-@Api(value = "/functions", description = "Functions admin apis", tags = "functions", enabled = false)
+@Api(value = "/functions", description = "Functions admin apis", tags = "functions", hidden = true)
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Functions extends AdminResource implements Supplier<WorkerService> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Functions.java
@@ -27,7 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/functions")
-@Api(value = "/functions", description = "Functions admin apis", tags = "functions", hidden = true)
+@Api(value = "/functions", description = "Functions admin apis", tags = "functions")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Functions extends FunctionsBase {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Sink.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Sink.java
@@ -27,7 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/sink")
-@Api(value = "/sink", description = "Sink admin apis", tags = "sink", hidden = true)
+@Api(value = "/sink", description = "Sink admin apis", tags = "sink")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Sink extends SinkBase {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Source.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Source.java
@@ -27,7 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/source")
-@Api(value = "/source", description = "Source admin apis", tags = "source", hidden = true)
+@Api(value = "/source", description = "Source admin apis", tags = "source")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class Source extends SourceBase {

--- a/pulsar-client-cpp/docker/Dockerfile
+++ b/pulsar-client-cpp/docker/Dockerfile
@@ -150,6 +150,9 @@ RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.
     rm -rf /zstd-1.3.7 /zstd-1.3.7.tar.gz
 
 RUN pip install twine
+RUN pip install fastavro
+RUN pip install six
+RUN pip install enum34
 
 
 ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include

--- a/site2/tools/python-doc-gen.sh
+++ b/site2/tools/python-doc-gen.sh
@@ -29,6 +29,9 @@ find $ROOT_DIR -name CMakeFiles | xargs rm -rf
 cd $ROOT_DIR/pulsar-client-cpp
 cmake . 
 make -j8 _pulsar
+pip install enum34
+pip install six
+pip install fastavro
 
 DESTINATION=$ROOT_DIR/generated-site/api/python
 rm -fr $DESTINATION/{index.html,functions,pulsar}

--- a/site2/tools/python-doc-gen.sh
+++ b/site2/tools/python-doc-gen.sh
@@ -24,7 +24,11 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 # Make sure the Python client lib is installed
 # so that Pdoc can import the module
-pip install pulsar-client
+find $ROOT_DIR -name CMakeCache.txt | xargs rm -f
+find $ROOT_DIR -name CMakeFiles | xargs rm -rf
+cd $ROOT_DIR/pulsar-client-cpp
+cmake . 
+make -j8 _pulsar
 
 DESTINATION=$ROOT_DIR/generated-site/api/python
 rm -fr $DESTINATION/{index.html,functions,pulsar}

--- a/site2/website/pages/en/functions-rest-api.js
+++ b/site2/website/pages/en/functions-rest-api.js
@@ -1,0 +1,22 @@
+const React = require('react');
+const CompLibrary = require('../../core/CompLibrary.js');
+
+const Container = CompLibrary.Container;
+const siteConfig = require(`${process.cwd()}/siteConfig.js`);
+
+class FunctionsRestApi extends React.Component {
+  render() {
+    const swaggerUrl = `${siteConfig.baseUrl}swagger/swaggerfunctions.json`
+
+    return (
+      <div className="pageContainer">
+        <Container className="mainContainer documentContainer postContainer" >
+          <redoc spec-url={`${swaggerUrl}`} lazy-rendering="true"></redoc>
+          <script src="//cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"/>
+        </Container>
+      </div>
+    );
+  }
+}
+
+module.exports = FunctionsRestApi;

--- a/site2/website/pages/en/functions-rest-api.js
+++ b/site2/website/pages/en/functions-rest-api.js
@@ -12,7 +12,7 @@ class FunctionsRestApi extends React.Component {
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
           <redoc spec-url={`${swaggerUrl}`} lazy-rendering="true"></redoc>
-          <script src="//cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"/>
+          <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/sink-rest-api.js
+++ b/site2/website/pages/en/sink-rest-api.js
@@ -4,9 +4,9 @@ const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 
-class AdminRestApi extends React.Component {
+class SinkRestApi extends React.Component {
   render() {
-    const swaggerUrl = `${siteConfig.baseUrl}swagger/swagger.json`
+    const swaggerUrl = `${siteConfig.baseUrl}swagger/swaggersink.json`
 
     return (
       <div className="pageContainer">
@@ -19,4 +19,4 @@ class AdminRestApi extends React.Component {
   }
 }
 
-module.exports = AdminRestApi;
+module.exports = SinkRestApi;

--- a/site2/website/pages/en/source-rest-api.js
+++ b/site2/website/pages/en/source-rest-api.js
@@ -4,9 +4,9 @@ const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 
-class AdminRestApi extends React.Component {
+class SourceRestApi extends React.Component {
   render() {
-    const swaggerUrl = `${siteConfig.baseUrl}swagger/swagger.json`
+    const swaggerUrl = `${siteConfig.baseUrl}swagger/swaggersource.json`
 
     return (
       <div className="pageContainer">
@@ -19,4 +19,4 @@ class AdminRestApi extends React.Component {
   }
 }
 
-module.exports = AdminRestApi;
+module.exports = SourceRestApi;

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -25,6 +25,10 @@ const createVariableInjectionPlugin = variables => {
           return renderUrl(initializedPlugin, restApiUrl + "#", keyparts);
       } else if (keyparts[0] == 'functions') {
           return renderUrl(initializedPlugin, functionsApiUrl + "#", keyparts);
+      } else if (keyparts[0] == 'source') {
+          return renderUrl(initializedPlugin, sourceApiUrl + "#", keyparts);
+      } else if (keyparts[0] == 'sink') {
+          return renderUrl(initializedPlugin, sinkApiUrl + "#", keyparts);
       } else {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
@@ -68,6 +72,8 @@ const url = 'https://pulsar.incubator.apache.org';
 const javadocUrl = url + '/api';
 const restApiUrl = url + '/en' + "/admin-rest-api";
 const functionsApiUrl = url + '/en' + "/functions-rest-api";
+const sourceApiUrl = url + '/en' + "/source-rest-api";
+const sinkApiUrl = url + '/en' + "/sink-rest-api";
 const githubUrl = 'https://github.com/apache/incubator-pulsar';
 const baseUrl = '/';
 
@@ -99,6 +105,9 @@ const siteConfig = {
     {doc: 'client-libraries', label: 'Clients'},
     {page: 'admin-rest-api', label: 'REST API'},
     {page: 'functions-rest-api', label: 'Functions REST API'},
+    {page: 'source-rest-api', label: 'Source REST API'},
+    {page: 'sink-rest-api', label: 'Sink REST API'},
+
     {blog: true, label: 'Blog'},
     {href: '#community', label: 'Community'},
     {href: '#apache', label: 'Apache'},

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -23,6 +23,8 @@ const createVariableInjectionPlugin = variables => {
       // rest api: rest:<name>:<path>
       } else if (keyparts[0] == 'rest') {
           return renderUrl(initializedPlugin, restApiUrl + "#", keyparts);
+      } else if (keyparts[0] == 'functions') {
+          return renderUrl(initializedPlugin, functionsApiUrl + "#", keyparts);
       } else {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
@@ -65,6 +67,7 @@ const renderEndpoint = (initializedPlugin, baseUrl, keyparts) => {
 const url = 'https://pulsar.incubator.apache.org';
 const javadocUrl = url + '/api';
 const restApiUrl = url + '/en' + "/admin-rest-api";
+const functionsApiUrl = url + '/en' + "/functions-rest-api";
 const githubUrl = 'https://github.com/apache/incubator-pulsar';
 const baseUrl = '/';
 
@@ -95,6 +98,7 @@ const siteConfig = {
     {page: 'download', label: 'Download'},
     {doc: 'client-libraries', label: 'Clients'},
     {page: 'admin-rest-api', label: 'REST API'},
+    {page: 'functions-rest-api', label: 'Functions REST API'},
     {blog: true, label: 'Blog'},
     {href: '#community', label: 'Community'},
     {href: '#apache', label: 'Apache'},

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -103,11 +103,7 @@ const siteConfig = {
     {doc: 'standalone', label: 'Docs'},
     {page: 'download', label: 'Download'},
     {doc: 'client-libraries', label: 'Clients'},
-    {page: 'admin-rest-api', label: 'REST API'},
-    {page: 'functions-rest-api', label: 'Functions REST API'},
-    {page: 'source-rest-api', label: 'Source REST API'},
-    {page: 'sink-rest-api', label: 'Sink REST API'},
-
+    {href: '#restapis', label: 'REST APIs'},
     {blog: true, label: 'Blog'},
     {href: '#community', label: 'Community'},
     {href: '#apache', label: 'Apache'},

--- a/site2/website/static/css/custom.css
+++ b/site2/website/static/css/custom.css
@@ -63,6 +63,7 @@
 /* for drop down menus */
 #community-dropdown.hide,
 #apache-dropdown.hide,
+#restapis-dropdown.hide,
 #languages-dropdown.hide {
   display: none;
 }
@@ -70,12 +71,14 @@
 
 #community-dropdown.visible,
 #apache-dropdown.visible,
+#restapis-dropdown.visible,
 #languages-dropdown.visible {
   display: flex;
 }
 
 #community-dropdown,
 #apache-dropdown,
+#restapis-dropdown,
 #languages-dropdown {
   pointer-events: none;
   position: absolute;
@@ -84,6 +87,7 @@
 
 #community-dropdown-items,
 #apache-dropdown-items,
+#restapis-dropdown-items,
 #languages-dropdown-items {
   background-color: white;
   display: flex;

--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -64,6 +64,35 @@ window.addEventListener('load', function() {
     }
   });
 
+  // setup rest api menu items in nav bar
+  const restapis = document.querySelector("a[href='#restapis']").parentNode;
+  const restapisMenu =
+    '<li>' +
+    '<a id="restapis-menu" href="#">REST APIs <span style="font-size: 0.75em">&nbsp;▼</span></a>' +
+    '<div id="restapis-dropdown" class="hide">' +
+      '<ul id="restapis-dropdown-items">' +
+        '<li><a href="/admin-rest-api">Admin REST API </a></li>' +
+        '<li><a href="/functions-rest-api">Functions </a></li>' +
+        '<li><a href="/source-rest-api">Sources </a></li>' +
+        '<li><a href="/sink-rest-api">Sinks </a></li>' +
+      '</ul>' +
+    '</div>' +
+    '</li>';
+
+  restapis.innerHTML = restapisMenu;
+
+  const restapisMenuItem = document.getElementById("restapis-menu");
+  const restapisDropDown = document.getElementById("restapis-dropdown");
+  restapisMenuItem.addEventListener("click", function(event) {
+    event.preventDefault();
+
+    if (restapisDropDown.className == 'hide') {
+      restapisDropDown.className = 'visible';
+    } else {
+      restapisDropDown.className = 'hide';
+    }
+  });
+
 
   function button(label, ariaLabel, icon, className) {
     const btn = document.createElement('button');

--- a/site2/website/static/swagger/swagger.json
+++ b/site2/website/static/swagger/swagger.json
@@ -281,7 +281,7 @@
     "/broker-stats/topics" : {
       "get" : {
         "tags" : [ "broker-stats" ],
-        "summary" : "Get all the topic stats by namespace",
+        "summary" : "Get all the topic stats by namesapce",
         "description" : "",
         "operationId" : "getTopics2",
         "produces" : [ "application/json" ],
@@ -314,29 +314,6 @@
                 "type" : "object"
               }
             }
-          }
-        }
-      }
-    },
-    "/brokers/configuration/runtime" : {
-      "get" : {
-        "tags" : [ "brokers" ],
-        "summary" : "Get all runtime configurations. This operation requires Pulsar super-user privileges.",
-        "description" : "",
-        "operationId" : "getRuntimeConfiguration",
-        "produces" : [ "application/json" ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "object",
-              "additionalProperties" : {
-                "type" : "object"
-              }
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
           }
         }
       }
@@ -394,26 +371,6 @@
           },
           "412" : {
             "description" : "Configuration can't be updated dynamically"
-          }
-        }
-      }
-    },
-    "/brokers/health" : {
-      "get" : {
-        "tags" : [ "brokers" ],
-        "summary" : "Run a healthcheck against the broker",
-        "description" : "",
-        "operationId" : "healthcheck",
-        "produces" : [ "application/json" ],
-        "responses" : {
-          "200" : {
-            "description" : "Everything is OK"
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Cluster doesn't exist"
           }
         }
       }
@@ -1050,6 +1007,243 @@
         }
       }
     },
+    "/namespaces/{property}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{property}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{property}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
     "/namespaces/{tenant}" : {
       "get" : {
         "tags" : [ "namespaces" ],
@@ -1511,75 +1705,6 @@
         }
       }
     },
-    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
-        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
-        "operationId" : "getCompactionThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
-        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
-        "operationId" : "setCompactionThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "compactionThreshold value is not valid"
-          }
-        }
-      }
-    },
     "/namespaces/{tenant}/{namespace}/deduplication" : {
       "post" : {
         "tags" : [ "namespaces" ],
@@ -1973,174 +2098,6 @@
         }
       }
     },
-    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
-        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
-        "operationId" : "getOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
-        "description" : "A negative value disables the deletion completely.",
-        "operationId" : "setOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "offloadDeletionLagMs value is not valid"
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
-        "description" : "",
-        "operationId" : "clearOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          }
-        }
-      }
-    },
-    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
-        "description" : "A negative value disables automatic offloading",
-        "operationId" : "getOffloadThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
-        "description" : "A negative value disables automatic offloading",
-        "operationId" : "setOffloadThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "offloadThreshold value is not valid"
-          }
-        }
-      }
-    },
     "/namespaces/{tenant}/{namespace}/permissions" : {
       "get" : {
         "tags" : [ "namespaces" ],
@@ -2220,9 +2177,6 @@
           },
           "409" : {
             "description" : "Concurrent modification"
-          },
-          "501" : {
-            "description" : "Authorization is not enabled"
           }
         }
       },
@@ -2472,134 +2426,6 @@
         }
       }
     },
-    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
-        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
-        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "string",
-              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
-        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
-        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          }
-        }
-      }
-    },
-    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Get subscribe-rate configured for the namespace",
-        "description" : "",
-        "operationId" : "getSubscribeRate",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "$ref" : "#/definitions/SubscribeRate"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace does not exist"
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
-        "description" : "",
-        "operationId" : "setSubscribeRate",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          }
-        }
-      }
-    },
     "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
       "post" : {
         "tags" : [ "namespaces" ],
@@ -2709,13 +2535,6 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "required" : false,
-          "type" : "string",
-          "default" : "PERSISTENT",
-          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
         } ],
         "responses" : {
           "200" : {
@@ -3184,49 +3003,6 @@
       }
     },
     "/non-persistent/{tenant}/{namespace}/{topic}" : {
-      "put" : {
-        "tags" : [ "non-persistent topic" ],
-        "summary" : "Create a non-partitioned topic.",
-        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
-        "operationId" : "createNonPartitionedTopic",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "topic",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "409" : {
-            "description" : "Partitioned topic already exist"
-          },
-          "412" : {
-            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
-          },
-          "503" : {
-            "description" : "Failed to validate global cluster configuration"
-          }
-        }
-      },
       "delete" : {
         "tags" : [ "non-persistent topic" ],
         "summary" : "Delete a topic.",
@@ -3533,54 +3309,6 @@
         }
       }
     },
-    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
-      "get" : {
-        "tags" : [ "non-persistent topic" ],
-        "summary" : "Return the last commit message id of topic",
-        "description" : "",
-        "operationId" : "getLastMessageId",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "topic",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "$ref" : "#/definitions/MessageId"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Topic does not exist"
-          },
-          "405" : {
-            "description" : "Operation not allowed on persistent topic"
-          }
-        }
-      }
-    },
     "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
       "get" : {
         "tags" : [ "non-persistent topic" ],
@@ -3713,9 +3441,6 @@
           },
           "404" : {
             "description" : "Topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -3789,9 +3514,6 @@
           },
           "409" : {
             "description" : "Partitioned topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -3829,12 +3551,6 @@
           },
           "409" : {
             "description" : "Partitioned topic already exists"
-          },
-          "412" : {
-            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
-          },
-          "503" : {
-            "description" : "Failed to validate global cluster configuration"
           }
         }
       },
@@ -3878,9 +3594,6 @@
           },
           "404" : {
             "description" : "Partitioned topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -4040,7 +3753,7 @@
           "200" : {
             "description" : "successful operation",
             "schema" : {
-              "$ref" : "#/definitions/NonPersistentTopicStats"
+              "$ref" : "#/definitions/TopicStats"
             }
           },
           "403" : {
@@ -4650,49 +4363,6 @@
       }
     },
     "/persistent/{tenant}/{namespace}/{topic}" : {
-      "put" : {
-        "tags" : [ "persistent topic" ],
-        "summary" : "Create a non-partitioned topic.",
-        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
-        "operationId" : "createNonPartitionedTopic",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "topic",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "409" : {
-            "description" : "Partitioned topic already exist"
-          },
-          "412" : {
-            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
-          },
-          "503" : {
-            "description" : "Failed to validate global cluster configuration"
-          }
-        }
-      },
       "delete" : {
         "tags" : [ "persistent topic" ],
         "summary" : "Delete a topic.",
@@ -4999,54 +4669,6 @@
         }
       }
     },
-    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
-      "get" : {
-        "tags" : [ "persistent topic" ],
-        "summary" : "Return the last commit message id of topic",
-        "description" : "",
-        "operationId" : "getLastMessageId",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "topic",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "$ref" : "#/definitions/MessageId"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Topic does not exist"
-          },
-          "405" : {
-            "description" : "Operation not allowed on persistent topic"
-          }
-        }
-      }
-    },
     "/persistent/{tenant}/{namespace}/{topic}/offload" : {
       "get" : {
         "tags" : [ "persistent topic" ],
@@ -5179,9 +4801,6 @@
           },
           "404" : {
             "description" : "Topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -5224,12 +4843,6 @@
           },
           "403" : {
             "description" : "Don't have admin permission"
-          },
-          "409" : {
-            "description" : "Partitioned topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -5261,9 +4874,6 @@
           },
           "409" : {
             "description" : "Partitioned topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -5301,12 +4911,6 @@
           },
           "409" : {
             "description" : "Partitioned topic already exist"
-          },
-          "412" : {
-            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
-          },
-          "503" : {
-            "description" : "Failed to validate global cluster configuration"
           }
         }
       },
@@ -5350,9 +4954,6 @@
           },
           "404" : {
             "description" : "Partitioned topic does not exist"
-          },
-          "412" : {
-            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -6221,12 +5822,6 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -6285,12 +5880,6 @@
           "x-examples" : {
             "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
           }
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -6337,12 +5926,6 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -6396,12 +5979,6 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
-        }, {
-          "name" : "authoritative",
-          "in" : "query",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -6628,16 +6205,6 @@
                 "type" : "string",
                 "enum" : [ "produce", "consume" ]
               }
-            }
-          }
-        },
-        "subscription_auth_roles" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "type" : "array",
-            "uniqueItems" : true,
-            "items" : {
-              "type" : "string"
             }
           }
         }
@@ -6895,7 +6462,7 @@
         },
         "type" : {
           "type" : "string",
-          "enum" : [ "NONE", "BOOLEAN", "STRING", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "BYTES", "JSON", "PROTOBUF", "AVRO", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH", "KEY_VALUE" ]
+          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO" ]
         },
         "timestamp" : {
           "type" : "integer",
@@ -6922,9 +6489,6 @@
           "type" : "string"
         },
         "ledgersRootPath" : {
-          "type" : "string"
-        },
-        "stateStorageServiceUrl" : {
           "type" : "string"
         }
       }
@@ -7099,13 +6663,13 @@
         "cpu" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
-        "memory" : {
-          "$ref" : "#/definitions/ResourceUsage"
-        },
         "directMemory" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
         "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
         "bandwidthOut" : {
@@ -7123,14 +6687,14 @@
           "type" : "number",
           "format" : "double"
         },
-        "underLoaded" : {
-          "type" : "boolean"
-        },
         "overLoaded" : {
           "type" : "boolean"
         },
         "loadReportType" : {
           "type" : "string"
+        },
+        "underLoaded" : {
+          "type" : "boolean"
         }
       }
     },
@@ -7293,13 +6857,13 @@
         "address" : {
           "type" : "string"
         },
-        "producerName" : {
-          "type" : "string"
-        },
         "connectedSince" : {
           "type" : "string"
         },
         "clientVersion" : {
+          "type" : "string"
+        },
+        "producerName" : {
           "type" : "string"
         }
       }
@@ -7733,12 +7297,6 @@
             "$ref" : "#/definitions/DispatchRate"
           }
         },
-        "clusterSubscribeRate" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "$ref" : "#/definitions/SubscribeRate"
-          }
-        },
         "persistence" : {
           "$ref" : "#/definitions/PersistencePolicies"
         },
@@ -7795,10 +7353,6 @@
         "offload_deletion_lag_ms" : {
           "type" : "integer",
           "format" : "int64"
-        },
-        "schema_auto_update_compatibility_strategy" : {
-          "type" : "string",
-          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
         }
       }
     },
@@ -8007,13 +7561,13 @@
         "address" : {
           "type" : "string"
         },
-        "producerName" : {
-          "type" : "string"
-        },
         "connectedSince" : {
           "type" : "string"
         },
         "clientVersion" : {
+          "type" : "string"
+        },
+        "producerName" : {
           "type" : "string"
         }
       }
@@ -8148,19 +7702,6 @@
     },
     "SchemaVersion" : {
       "type" : "object"
-    },
-    "SubscribeRate" : {
-      "type" : "object",
-      "properties" : {
-        "subscribeThrottlingRatePerConsumer" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
-        "ratePeriodInSecond" : {
-          "type" : "integer",
-          "format" : "int32"
-        }
-      }
     },
     "SubscriptionStats" : {
       "type" : "object",

--- a/site2/website/static/swagger/swagger.json
+++ b/site2/website/static/swagger/swagger.json
@@ -281,7 +281,7 @@
     "/broker-stats/topics" : {
       "get" : {
         "tags" : [ "broker-stats" ],
-        "summary" : "Get all the topic stats by namesapce",
+        "summary" : "Get all the topic stats by namespace",
         "description" : "",
         "operationId" : "getTopics2",
         "produces" : [ "application/json" ],
@@ -314,6 +314,29 @@
                 "type" : "object"
               }
             }
+          }
+        }
+      }
+    },
+    "/brokers/configuration/runtime" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all runtime configurations. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "getRuntimeConfiguration",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
           }
         }
       }
@@ -371,6 +394,26 @@
           },
           "412" : {
             "description" : "Configuration can't be updated dynamically"
+          }
+        }
+      }
+    },
+    "/brokers/health" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Run a healthcheck against the broker",
+        "description" : "",
+        "operationId" : "healthcheck",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Everything is OK"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
           }
         }
       }
@@ -1007,243 +1050,6 @@
         }
       }
     },
-    "/namespaces/{property}/{namespace}/compactionThreshold" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
-        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
-        "operationId" : "getCompactionThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
-        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
-        "operationId" : "setCompactionThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "compactionThreshold value is not valid"
-          }
-        }
-      }
-    },
-    "/namespaces/{property}/{namespace}/offloadDeletionLagMs" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
-        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
-        "operationId" : "getOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
-        "description" : "A negative value disables the deletion completely.",
-        "operationId" : "setOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "offloadDeletionLagMs value is not valid"
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
-        "description" : "",
-        "operationId" : "clearOffloadDeletionLag",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          }
-        }
-      }
-    },
-    "/namespaces/{property}/{namespace}/offloadThreshold" : {
-      "get" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
-        "description" : "A negative value disables automatic offloading",
-        "operationId" : "getOffloadThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "namespaces" ],
-        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
-        "description" : "A negative value disables automatic offloading",
-        "operationId" : "setOffloadThreshold",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "property",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "namespace",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "403" : {
-            "description" : "Don't have admin permission"
-          },
-          "404" : {
-            "description" : "Namespace doesn't exist"
-          },
-          "409" : {
-            "description" : "Concurrent modification"
-          },
-          "412" : {
-            "description" : "offloadThreshold value is not valid"
-          }
-        }
-      }
-    },
     "/namespaces/{tenant}" : {
       "get" : {
         "tags" : [ "namespaces" ],
@@ -1705,6 +1511,75 @@
         }
       }
     },
+    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
     "/namespaces/{tenant}/{namespace}/deduplication" : {
       "post" : {
         "tags" : [ "namespaces" ],
@@ -2098,6 +1973,174 @@
         }
       }
     },
+    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
     "/namespaces/{tenant}/{namespace}/permissions" : {
       "get" : {
         "tags" : [ "namespaces" ],
@@ -2177,6 +2220,9 @@
           },
           "409" : {
             "description" : "Concurrent modification"
+          },
+          "501" : {
+            "description" : "Authorization is not enabled"
           }
         }
       },
@@ -2426,6 +2472,134 @@
         }
       }
     },
+    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get subscribe-rate configured for the namespace",
+        "description" : "",
+        "operationId" : "getSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SubscribeRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
     "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
       "post" : {
         "tags" : [ "namespaces" ],
@@ -2535,6 +2709,13 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "PERSISTENT",
+          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
         } ],
         "responses" : {
           "200" : {
@@ -3003,6 +3184,49 @@
       }
     },
     "/non-persistent/{tenant}/{namespace}/{topic}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a non-partitioned topic.",
+        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
+        "operationId" : "createNonPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
       "delete" : {
         "tags" : [ "non-persistent topic" ],
         "summary" : "Delete a topic.",
@@ -3309,6 +3533,54 @@
         }
       }
     },
+    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
     "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
       "get" : {
         "tags" : [ "non-persistent topic" ],
@@ -3441,6 +3713,9 @@
           },
           "404" : {
             "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -3514,6 +3789,9 @@
           },
           "409" : {
             "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -3551,6 +3829,12 @@
           },
           "409" : {
             "description" : "Partitioned topic already exists"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
           }
         }
       },
@@ -3594,6 +3878,9 @@
           },
           "404" : {
             "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -3753,7 +4040,7 @@
           "200" : {
             "description" : "successful operation",
             "schema" : {
-              "$ref" : "#/definitions/TopicStats"
+              "$ref" : "#/definitions/NonPersistentTopicStats"
             }
           },
           "403" : {
@@ -4363,6 +4650,49 @@
       }
     },
     "/persistent/{tenant}/{namespace}/{topic}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a non-partitioned topic.",
+        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
+        "operationId" : "createNonPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
       "delete" : {
         "tags" : [ "persistent topic" ],
         "summary" : "Delete a topic.",
@@ -4669,6 +4999,54 @@
         }
       }
     },
+    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
     "/persistent/{tenant}/{namespace}/{topic}/offload" : {
       "get" : {
         "tags" : [ "persistent topic" ],
@@ -4801,6 +5179,9 @@
           },
           "404" : {
             "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -4843,6 +5224,12 @@
           },
           "403" : {
             "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -4874,6 +5261,9 @@
           },
           "409" : {
             "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       },
@@ -4911,6 +5301,12 @@
           },
           "409" : {
             "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
           }
         }
       },
@@ -4954,6 +5350,9 @@
           },
           "404" : {
             "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
           }
         }
       }
@@ -5822,6 +6221,12 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -5880,6 +6285,12 @@
           "x-examples" : {
             "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
           }
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -5926,6 +6337,12 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -5979,6 +6396,12 @@
           "in" : "path",
           "required" : true,
           "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -6205,6 +6628,16 @@
                 "type" : "string",
                 "enum" : [ "produce", "consume" ]
               }
+            }
+          }
+        },
+        "subscription_auth_roles" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
             }
           }
         }
@@ -6462,7 +6895,7 @@
         },
         "type" : {
           "type" : "string",
-          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO" ]
+          "enum" : [ "NONE", "BOOLEAN", "STRING", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "BYTES", "JSON", "PROTOBUF", "AVRO", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH", "KEY_VALUE" ]
         },
         "timestamp" : {
           "type" : "integer",
@@ -6489,6 +6922,9 @@
           "type" : "string"
         },
         "ledgersRootPath" : {
+          "type" : "string"
+        },
+        "stateStorageServiceUrl" : {
           "type" : "string"
         }
       }
@@ -6663,13 +7099,13 @@
         "cpu" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
         "directMemory" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
         "bandwidthIn" : {
-          "$ref" : "#/definitions/ResourceUsage"
-        },
-        "memory" : {
           "$ref" : "#/definitions/ResourceUsage"
         },
         "bandwidthOut" : {
@@ -6687,14 +7123,14 @@
           "type" : "number",
           "format" : "double"
         },
+        "underLoaded" : {
+          "type" : "boolean"
+        },
         "overLoaded" : {
           "type" : "boolean"
         },
         "loadReportType" : {
           "type" : "string"
-        },
-        "underLoaded" : {
-          "type" : "boolean"
         }
       }
     },
@@ -6857,13 +7293,13 @@
         "address" : {
           "type" : "string"
         },
+        "producerName" : {
+          "type" : "string"
+        },
         "connectedSince" : {
           "type" : "string"
         },
         "clientVersion" : {
-          "type" : "string"
-        },
-        "producerName" : {
           "type" : "string"
         }
       }
@@ -7297,6 +7733,12 @@
             "$ref" : "#/definitions/DispatchRate"
           }
         },
+        "clusterSubscribeRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscribeRate"
+          }
+        },
         "persistence" : {
           "$ref" : "#/definitions/PersistencePolicies"
         },
@@ -7353,6 +7795,10 @@
         "offload_deletion_lag_ms" : {
           "type" : "integer",
           "format" : "int64"
+        },
+        "schema_auto_update_compatibility_strategy" : {
+          "type" : "string",
+          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
         }
       }
     },
@@ -7561,13 +8007,13 @@
         "address" : {
           "type" : "string"
         },
+        "producerName" : {
+          "type" : "string"
+        },
         "connectedSince" : {
           "type" : "string"
         },
         "clientVersion" : {
-          "type" : "string"
-        },
-        "producerName" : {
           "type" : "string"
         }
       }
@@ -7702,6 +8148,19 @@
     },
     "SchemaVersion" : {
       "type" : "object"
+    },
+    "SubscribeRate" : {
+      "type" : "object",
+      "properties" : {
+        "subscribeThrottlingRatePerConsumer" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
     },
     "SubscriptionStats" : {
       "type" : "object",

--- a/src/gen-swagger.sh
+++ b/src/gen-swagger.sh
@@ -26,6 +26,6 @@ echo "Generating swagger json file ..."
 mvn -am -pl pulsar-broker install -DskipTests -Pswagger
 echo "Swagger json file is generated."
 
-cp pulsar-broker/target/docs/swagger.json site2/website/static/swagger/
+cp pulsar-broker/target/docs/swagger*.json site2/website/static/swagger/
 echo "Copied swagger json file."
 


### PR DESCRIPTION
### Motivation
Currently Functions/Sources/Sinks don't have their swagger definitions generated. This pr enables their generation
### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
