### PR TITLE
fix: ack timeout in  pulsar cpp client when subscribing to regex topic

### DIFF
--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -450,7 +450,7 @@ void MultiTopicsConsumerImpl::messageReceived(Consumer consumer, const Message& 
         }
         messages_.push(msg);
         if (messageListener_) {
-                unAckedMessageTrackerPtr_->add(msg.getMessageId());
+            unAckedMessageTrackerPtr_->add(msg.getMessageId());
             listenerExecutor_->postWork(
                 std::bind(&MultiTopicsConsumerImpl::internalListener, shared_from_this(), consumer));
         }

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -39,7 +39,6 @@ MultiTopicsConsumerImpl::MultiTopicsConsumerImpl(ClientImplPtr client, const std
       lookupServicePtr_(lookupServicePtr),
       numberTopicPartitions_(std::make_shared<std::atomic<int>>(0)),
       topics_(topics) {
-
     std::stringstream consumerStrStream;
     consumerStrStream << "[Muti Topics Consumer: "
                       << "TopicName - " << topic_ << " - Subscription - " << subscriptionName << "]";

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -39,6 +39,7 @@ MultiTopicsConsumerImpl::MultiTopicsConsumerImpl(ClientImplPtr client, const std
       lookupServicePtr_(lookupServicePtr),
       numberTopicPartitions_(std::make_shared<std::atomic<int>>(0)),
       topics_(topics) {
+
     std::stringstream consumerStrStream;
     consumerStrStream << "[Muti Topics Consumer: "
                       << "TopicName - " << topic_ << " - Subscription - " << subscriptionName << "]";
@@ -450,6 +451,7 @@ void MultiTopicsConsumerImpl::messageReceived(Consumer consumer, const Message& 
         }
         messages_.push(msg);
         if (messageListener_) {
+                unAckedMessageTrackerPtr_->add(msg.getMessageId());
             listenerExecutor_->postWork(
                 std::bind(&MultiTopicsConsumerImpl::internalListener, shared_from_this(), consumer));
         }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2963,7 +2963,8 @@ TEST(BasicEndToEndTest, testRegexTopicsWithMessageListener) {
 
     Producer producer;
     ProducerConfiguration producerConf;
-    Result result = client.createProducer("persistent://public/default/testRegexTopicsWithMessageListenerTopic-1", producerConf, producer);
+    Result result = client.createProducer(
+        "persistent://public/default/testRegexTopicsWithMessageListenerTopic-1", producerConf, producer);
     ASSERT_EQ(ResultOk, result);
 
     Consumer consumer;
@@ -2978,7 +2979,7 @@ TEST(BasicEndToEndTest, testRegexTopicsWithMessageListener) {
 
     producer.flush();
     long timeWaited = 0;
-    while(true) {
+    while (true) {
         // maximum wait time
         ASSERT_LE(timeWaited, unAckedMessagesTimeoutMs * 3);
         if (regexTestMessagesReceived >= 10 * 2) {

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -35,8 +35,9 @@
 #include <lib/PatternMultiTopicsConsumerImpl.h>
 #include "lib/Future.h"
 #include "lib/Utils.h"
-#include <unistd.h>
 #include <functional>
+#include <thread>
+#include <chrono>
 
 DECLARE_LOG_OBJECT()
 
@@ -2979,11 +2980,11 @@ TEST(BasicEndToEndTest, testRegexTopicsWithMessageListener) {
     long timeWaited = 0;
     while(true) {
         // maximum wait time
-        ASSERT_LE(timeWaited, unAckedMessagesTimeoutMs * 1000 * 3);
+        ASSERT_LE(timeWaited, unAckedMessagesTimeoutMs * 3);
         if (regexTestMessagesReceived >= 10 * 2) {
             break;
         }
-        usleep(500000);
-        timeWaited += 500000;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        timeWaited += 500;
     }
 }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2953,12 +2953,11 @@ TEST(BasicEndToEndTest, testRegexTopicsWithMessageListener) {
     Client client(lookupUrl);
     long unAckedMessagesTimeoutMs = 10000;
     std::string subsName = "testRegexTopicsWithMessageListener-sub";
-    std::string pattern =
-        "persistent://public/default/testRegexTopicsWithMessageListenerTopic-.*";
+    std::string pattern = "persistent://public/default/testRegexTopicsWithMessageListenerTopic-.*";
     ConsumerConfiguration consumerConf;
     consumerConf.setConsumerType(ConsumerShared);
     consumerConf.setMessageListener(
-            std::bind(regexMessageListenerFunction, std::placeholders::_1, std::placeholders::_2));
+        std::bind(regexMessageListenerFunction, std::placeholders::_1, std::placeholders::_2));
     consumerConf.setUnAckedMessagesTimeoutMs(unAckedMessagesTimeoutMs);
 
     Producer producer;

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -35,7 +35,7 @@
 #include <lib/PatternMultiTopicsConsumerImpl.h>
 #include "lib/Future.h"
 #include "lib/Utils.h"
-
+#include <unistd.h>
 #include <functional>
 
 DECLARE_LOG_OBJECT()
@@ -2939,4 +2939,51 @@ TEST(BasicEndToEndTest, testPreventDupConsumersAllowSameSubForDifferentTopics) {
 
     // consumer C should be a different instance from A and B and should be with open state.
     ASSERT_EQ(ResultOk, consumerC.close());
+}
+
+static long regexTestMessagesReceived = 0;
+
+static void regexMessageListenerFunction(Consumer consumer, const Message &msg) {
+    regexTestMessagesReceived++;
+}
+
+TEST(BasicEndToEndTest, testRegexTopicsWithMessageListener) {
+    ClientConfiguration config;
+    Client client(lookupUrl);
+    long unAckedMessagesTimeoutMs = 10000;
+    std::string subsName = "testRegexTopicsWithMessageListener-sub";
+    std::string pattern =
+        "persistent://public/default/testRegexTopicsWithMessageListenerTopic-.*";
+    ConsumerConfiguration consumerConf;
+    consumerConf.setConsumerType(ConsumerShared);
+    consumerConf.setMessageListener(
+            std::bind(regexMessageListenerFunction, std::placeholders::_1, std::placeholders::_2));
+    consumerConf.setUnAckedMessagesTimeoutMs(unAckedMessagesTimeoutMs);
+
+    Producer producer;
+    ProducerConfiguration producerConf;
+    Result result = client.createProducer("persistent://public/default/testRegexTopicsWithMessageListenerTopic-1", producerConf, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    Consumer consumer;
+    result = client.subscribeWithRegex(pattern, subsName, consumerConf, consumer);
+    ASSERT_EQ(ResultOk, result);
+    ASSERT_EQ(consumer.getSubscriptionName(), subsName);
+
+    for (int i = 0; i < 10; i++) {
+        Message msg = MessageBuilder().setContent("test-" + std::to_string(i)).build();
+        producer.sendAsync(msg, nullptr);
+    }
+
+    producer.flush();
+    long timeWaited = 0;
+    while(true) {
+        // maximum wait time
+        ASSERT_LE(timeWaited, unAckedMessagesTimeoutMs * 1000 * 3);
+        if (regexTestMessagesReceived >= 10 * 2) {
+            break;
+        }
+        usleep(500000);
+        timeWaited += 500000;
+    }
 }


### PR DESCRIPTION
### Motivation

When subscribing to a regex in cpp/python client and using a message listener, ack timeout does work and unacked messages are not delivered.

This is because the unack message tracker is not call in one place