### PR TITLE
[pulsar-broker] add valid-readPosition check before setting readPosition at cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1963,8 +1963,9 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     void setReadPosition(Position newReadPositionInt) {
         checkArgument(newReadPositionInt instanceof PositionImpl);
-
-        this.readPosition = (PositionImpl) newReadPositionInt;
+        if (((PositionImpl) newReadPositionInt).compareTo(this.markDeletePosition) > 0) {
+            this.readPosition = (PositionImpl) newReadPositionInt;
+        }
     }
 
     // //////////////////////////////////////////////////

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1963,7 +1963,8 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     void setReadPosition(Position newReadPositionInt) {
         checkArgument(newReadPositionInt instanceof PositionImpl);
-        if (((PositionImpl) newReadPositionInt).compareTo(this.markDeletePosition) > 0) {
+        if (this.markDeletePosition == null
+                || ((PositionImpl) newReadPositionInt).compareTo(this.markDeletePosition) > 0) {
             this.readPosition = (PositionImpl) newReadPositionInt;
         }
     }


### PR DESCRIPTION
### Motivation

Recently we saw instance where cursor's readPosition was behind markDeletePosition. So, adding check for valid-readPosition while setting up readPosition.