### PR TITLE
Support Kafka's ConsumerConfig.MAX_POLL_RECORDS_CONFIG to config max number of message will return in a single poll

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -88,6 +88,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
     private volatile boolean closed = false;
 
+    private final int maxRecordsInSinglePoll;
+
     private final Properties properties;
 
     private static class QueueItem {
@@ -152,6 +154,13 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         log.info("Offset reset strategy has been assigned value {}", strategy);
 
         String serviceUrl = config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG).get(0);
+
+        // If MAX_POLL_RECORDS_CONFIG is provided then use the config, else use default value.
+        if(config.values().containsKey(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)){
+            maxRecordsInSinglePoll = config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
+        } else {
+            maxRecordsInSinglePoll = 1000;
+        }
 
         this.properties = new Properties();
         config.originals().forEach((k, v) -> properties.put(k, v));
@@ -304,8 +313,6 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         });
     }
 
-    private static final int MAX_RECORDS_IN_SINGLE_POLL = 1000;
-
     @SuppressWarnings("unchecked")
     @Override
     public ConsumerRecords<K, V> poll(long timeoutMillis) {
@@ -354,7 +361,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
                 lastReceivedOffset.put(tp, offset);
                 unpolledPartitions.remove(tp);
 
-                if (++numberOfRecords >= MAX_RECORDS_IN_SINGLE_POLL) {
+                if (++numberOfRecords >= maxRecordsInSinglePoll) {
                     break;
                 }
 

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -198,7 +198,7 @@ Properties:
 | Config property                 | Supported | Notes                                                 |
 |:--------------------------------|:----------|:------------------------------------------------------|
 | `group.id`                      | Yes       | Maps to a Pulsar subscription name                    |
-| `max.poll.records`              | Ignored   |                                                       |
+| `max.poll.records`              | Yes       |                                                       |
 | `max.poll.interval.ms`          | Ignored   | Messages are "pushed" from broker                     |
 | `session.timeout.ms`            | Ignored   |                                                       |
 | `heartbeat.interval.ms`         | Ignored   |                                                       |
@@ -206,7 +206,7 @@ Properties:
 | `enable.auto.commit`            | Yes       |                                                       |
 | `auto.commit.interval.ms`       | Ignored   | With auto-commit, acks are sent immediately to broker |
 | `partition.assignment.strategy` | Ignored   |                                                       |
-| `auto.offset.reset`             | Ignored   |                                                       |
+| `auto.offset.reset`             | Yes       | Only support earliest and latest.                     |
 | `fetch.min.bytes`               | Ignored   |                                                       |
 | `fetch.max.bytes`               | Ignored   |                                                       |
 | `fetch.max.wait.ms`             | Ignored   |                                                       |


### PR DESCRIPTION
Motivation
Support Kafka's ConsumerConfig.MAX_POLL_RECORDS_CONFIG to config max number of message will return in a single poll. #1090
Also update doc to reflect that we already supporting earlist and latest strategy for ConsumerConfig.AUTO_OFFSET_RESET_CONFIG.

Kafka config parser has check to make sure 'max.poll.records' value is greater than 1 and will throw exception if config < 1, so I didn't add extra check.