### PR TITLE
Use minimal number of threads in BK instance used for tests

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -363,6 +363,12 @@ public class LocalBookkeeperEnsemble {
         conf.setProperty("journalMaxGroupWaitMSec", 0L);
         conf.setAllowLoopback(true);
         conf.setGcWaitTime(60000);
+        conf.setNumAddWorkerThreads(0);
+        conf.setNumReadWorkerThreads(0);
+        conf.setNumHighPriorityWorkerThreads(0);
+        conf.setNumJournalCallbackThreads(0);
+        conf.setServerNumIOThreads(1);
+        conf.setNumLongPollWorkerThreads(1);
 
         runZookeeper(1000);
         initializeZookeper();


### PR DESCRIPTION
### Motivation

There are several tests that are using the LocalBookkeeperEnsemble to spin up "real" bookies. We should use a small amount of threads rather than the default.