### PR TITLE
By default use `journalFormatVersionToWrite=5` for Bookie journal

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -74,8 +74,8 @@ bookieDeathWatchInterval=1000
 # When entryLogPerLedgerEnabled is enabled, checkpoint doesn't happens
 # when a new active entrylog is created / previous one is rolled over.
 # Instead SyncThread checkpoints periodically with 'flushInterval' delay
-# (in milliseconds) in between executions. Checkpoint flushes both ledger 
-# entryLogs and ledger index pages to disk. 
+# (in milliseconds) in between executions. Checkpoint flushes both ledger
+# entryLogs and ledger index pages to disk.
 # Flushing entrylog and index files will introduce much random disk I/O.
 # If separating journal dir and ledger dirs each on different devices,
 # flushing would not affect performance. But if putting journal dir
@@ -379,6 +379,16 @@ auditorPeriodicCheckInterval=604800
 # to gain performance according your requirements.
 openFileLimit=0
 
+# The fileinfo format version to write.
+#  Available formats are 0-1:
+#   0: Initial version
+#   1: persisting explicitLac is introduced
+# By default, it is `1`.
+# If you'd like to disable persisting ExplicitLac, you can set this config to 0 and
+# also journalFormatVersionToWrite should be set to < 6. If there is mismatch then the
+# serverconfig is considered invalid.
+fileInfoFormatVersionToWrite=0
+
 # Size of a index page in ledger cache, in bytes
 # A larger index page can improve performance writing page to disk,
 # which is efficent when you have small number of ledgers and these
@@ -440,9 +450,9 @@ readBufferSizeBytes=4096
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
 writeBufferSizeBytes=65536
 
-# Specifies if entryLog per ledger is enabled/disabled. If it is enabled, then there would be a 
-# active entrylog for each ledger. It would be ideal to enable this feature if the underlying 
-# storage device has multiple DiskPartitions or SSD and if in a given moment, entries of fewer 
+# Specifies if entryLog per ledger is enabled/disabled. If it is enabled, then there would be a
+# active entrylog for each ledger. It would be ideal to enable this feature if the underlying
+# storage device has multiple DiskPartitions or SSD and if in a given moment, entries of fewer
 # number of active ledgers are written to a bookie.
 # entryLogPerLedgerEnabled=false
 

--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -273,16 +273,19 @@ serverTcpNoDelay=true
 #############################################################################
 
 # The journal format version to write.
-# Available formats are 1-5:
+# Available formats are 1-6:
 # 1: no header
 # 2: a header section was added
 # 3: ledger key was introduced
 # 4: fencing key was introduced
 # 5: expanding header to 512 and padding writes to align sector size configured by `journalAlignmentSize`
-# By default, it is `4`. If you'd like to enable `padding-writes` feature, you can set journal version to `5`.
+# 6: persisting explicitLac is introduced
+# By default, it is `6`.
+# If you'd like to disable persisting ExplicitLac, you can set this config to < `6` and also
+# fileInfoFormatVersionToWrite should be set to 0. If there is mismatch then the serverconfig is considered invalid.
 # You can disable `padding-writes` by setting journal version back to `4`. This feature is available in 4.5.0
 # and onward versions.
-# journalFormatVersionToWrite=4
+journalFormatVersionToWrite=5
 
 # Max file size of journal file, in mega bytes
 # A new journal file will be created when the old one reaches the file size limitation


### PR DESCRIPTION
### Motivation

In BookKeeper 4.9.0 the default value for `journalFormatVersionToWrite` has been bumped to `6`. While version 6 is supported in BK 4.8, in Pulsar we have jumped from 4.7.2 (in Pulsar 2.2) to 4.9.0 (in Pulsar 2.3). 

That means that, with default configuration the rollback of bookies from 2.3 to 2.2 is failing.

We need to ensure that it's always possible to rollback the entire Pulsar distribution to the previous minor version.

For that, fixing explicitely the bookie journal version in the `bookkeeper.conf` that we ship.

