### PR TITLE
[pulsar-broker] Add support of default ttl for namespace

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -82,6 +82,9 @@ backlogQuotaDefaultLimitGB=10
 # 'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
 backlogQuotaDefaultRetentionPolicy=producer_request_hold
 
+# Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
+ttlDurationDefaultInSeconds=0
+
 # Enable the deletion of inactive topics
 brokerDeleteInactiveTopicsEnabled=true
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -66,6 +66,9 @@ backlogQuotaCheckIntervalInSeconds=60
 # Default per-topic backlog quota limit
 backlogQuotaDefaultLimitGB=10
 
+# Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
+ttlDurationDefaultInSeconds=0
+
 # Enable the deletion of inactive topics
 brokerDeleteInactiveTopicsEnabled=true
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -220,7 +220,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + "'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog"
     )
     private BacklogQuota.RetentionPolicy backlogQuotaDefaultRetentionPolicy = BacklogQuota.RetentionPolicy.producer_request_hold;
-
+    @FieldContext(
+            category = CATEGORY_POLICIES,
+            doc = "Default ttl for namespaces if ttl is not already configured at namespace policies. "
+                    + "(disable default-ttl with value 0)"
+        )
+    private int ttlDurationDefaultInSeconds = 0;
+    
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Enable the deletion of inactive topics"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1007,9 +1007,12 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             policies = brokerService.pulsar().getConfigurationCache().policiesCache()
                     .get(AdminResource.path(POLICIES, name.getNamespace()))
                     .orElseThrow(() -> new KeeperException.NoNodeException());
-            if (policies.message_ttl_in_seconds != 0) {
-                subscriptions.forEach((subName, sub) -> sub.expireMessages(policies.message_ttl_in_seconds));
-                replicators.forEach((region, replicator) -> ((PersistentReplicator)replicator).expireMessages(policies.message_ttl_in_seconds));
+            int defaultTTL = brokerService.pulsar().getConfiguration().getTtlDurationDefaultInSeconds();
+            int message_ttl_in_seconds = (policies.message_ttl_in_seconds <= 0 && defaultTTL > 0) ? defaultTTL
+                    : policies.message_ttl_in_seconds;
+            if (message_ttl_in_seconds != 0) {
+                subscriptions.forEach((subName, sub) -> sub.expireMessages(message_ttl_in_seconds));
+                replicators.forEach((region, replicator) -> ((PersistentReplicator)replicator).expireMessages(message_ttl_in_seconds));
             }
         } catch (Exception e) {
             if (log.isDebugEnabled()) {

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -316,6 +316,7 @@ The [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool can be used
 |backlogQuotaCheckEnabled|  Enable the backlog quota check, which enforces a specified action when the quota is reached.  |true|
 |backlogQuotaCheckIntervalInSeconds|  How often to check for topics that have reached the backlog quota.  |60|
 |backlogQuotaDefaultLimitGB|  The default per-topic backlog quota limit.  |10|
+|ttlDurationDefaultInSeconds|  Default ttl for namespaces if ttl is not already configured at namespace policies.  |0|
 |brokerDeleteInactiveTopicsEnabled| Enable the deletion of inactive topics. |true|
 |brokerDeleteInactiveTopicsFrequencySeconds|  How often to check for inactive topics, in seconds. |60|
 |messageExpiryCheckIntervalInMinutes| How often to proactively check and purged expired messages. |5|


### PR DESCRIPTION
### Motivation

We need default ttl for the namespace when pulsar cluster has lower data-storage capacity at bookie and client is trying to retain more data in the system. In such cases, bookie disk gets 100% full which require manual process to bring them up. So, we want broker to apply default ttl if ttl is not configured as part of namespace policies.
set `ttlDurationDefaultInSeconds=0` to disable this feature.