### PR TITLE
Support Kafka's ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG in PulsarKafkaConsumer.

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -86,6 +86,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     private final Set<TopicPartition> unpolledPartitions = new HashSet<>();
     private final SubscriptionInitialPosition strategy;
 
+    private List<ConsumerInterceptor<K, V>> interceptors;
+
     private volatile boolean closed = false;
 
     private final int maxRecordsInSinglePoll;
@@ -161,6 +163,9 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         } else {
             maxRecordsInSinglePoll = 1000;
         }
+
+        interceptors = (List) config.getConfiguredInstances(
+                ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, ConsumerInterceptor.class);
 
         this.properties = new Properties();
         config.originals().forEach((k, v) -> properties.put(k, v));
@@ -374,7 +379,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
                 commitAsync();
             }
 
-            return new ConsumerRecords<>(records);
+            // If no interceptor is provided, interceptors list will an empty list, original ConsumerRecords will be return.
+            return applyConsumerInterceptorsOnConsume(interceptors, new ConsumerRecords<>(records));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -438,6 +444,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     private CompletableFuture<Void> doCommitOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
+        applyConsumerInterceptorsOnCommit(interceptors, offsets);
         offsets.forEach((topicPartition, offsetAndMetadata) -> {
             org.apache.pulsar.client.api.Consumer<byte[]> consumer = consumers.get(topicPartition);
             lastCommittedOffset.put(topicPartition, offsetAndMetadata);
@@ -455,6 +462,43 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         });
 
         return offsets;
+    }
+
+    /**
+     * Apply all onConsume methods in a list of ConsumerInterceptors.
+     * Catch any exception during the process.
+     *
+     * @param interceptors     Interceptors provided.
+     * @param consumerRecords  ConsumerRecords returned by calling {@link this#poll(long)}.
+     * @return                 ConsumerRecords after applying all ConsumerInterceptor in interceptors list.
+     */
+    private ConsumerRecords applyConsumerInterceptorsOnConsume(List<ConsumerInterceptor<K, V>> interceptors, ConsumerRecords consumerRecords) {
+        ConsumerRecords processedConsumerRecords = consumerRecords;
+        for (ConsumerInterceptor interceptor : interceptors) {
+            try {
+                processedConsumerRecords = interceptor.onConsume(processedConsumerRecords);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onConsume callback.", e);
+            }
+        }
+        return processedConsumerRecords;
+    }
+
+    /**
+     * Apply all onCommit methods in a list of ConsumerInterceptors.
+     * Catch any exception during the process.
+     *
+     * @param interceptors   Interceptors provided.
+     * @param offsets        Offsets need to be commit.
+     */
+    private void applyConsumerInterceptorsOnCommit(List<ConsumerInterceptor<K, V>> interceptors, Map<TopicPartition, OffsetAndMetadata> offsets) {
+        for (ConsumerInterceptor interceptor : interceptors) {
+            try {
+                interceptor.onCommit(offsets);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onCommit callback.", e);
+            }
+        }
     }
 
     @Override

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -478,7 +478,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
             try {
                 processedConsumerRecords = interceptor.onConsume(processedConsumerRecords);
             } catch (Exception e) {
-                log.warn("Error executing interceptor onConsume callback.", e);
+                log.warn("Error executing onConsume for interceptor {}.", interceptor.getClass().getCanonicalName(), e);
             }
         }
         return processedConsumerRecords;
@@ -496,7 +496,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
             try {
                 interceptor.onCommit(offsets);
             } catch (Exception e) {
-                log.warn("Error executing interceptor onCommit callback.", e);
+                log.warn("Error executing onCommit for interceptor {}.", interceptor.getClass().getCanonicalName(), e);
             }
         }
     }

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -210,6 +210,7 @@ Properties:
 | `fetch.min.bytes`               | Ignored   |                                                       |
 | `fetch.max.bytes`               | Ignored   |                                                       |
 | `fetch.max.wait.ms`             | Ignored   |                                                       |
+| `interceptor.classes`           | Yes       |                                                       |
 | `metadata.max.age.ms`           | Ignored   |                                                       |
 | `max.partition.fetch.bytes`     | Ignored   |                                                       |
 | `send.buffer.bytes`             | Ignored   |                                                       |


### PR DESCRIPTION
**Motivatio**
Support Kafka's ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG in PulsarKafkaConsumer. close #1090

Apply onConsume in `poll()` before returning the read ConsumerRecords, apply onCommit in `doCommitOffsets()` before committing all offsets. 
All exception during applying onConsume/onCommit will be catch and log a message at the WARN level, it won't interrupt the normal `poll()` and `doCommitOffsets()` process.

Also update doc to reflect support for ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG.