### PR TITLE
[tiered-storage] fix jcloud-shaded version to build in IDEA

### DIFF
--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>jclouds-shaded</artifactId>
-      <version>${project.version}</version>
+      <version>${pulsar.jclouds.shaded.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.gson</groupId>

--- a/tiered-storage/pom.xml
+++ b/tiered-storage/pom.xml
@@ -32,6 +32,11 @@
   <artifactId>tiered-storage-parent</artifactId>
   <name>Apache Pulsar :: Tiered Storage :: Parent</name>
 
+  <properties>
+    <!-- pin the jclouds-shaded version to make the pulsar build friendly to intellij -->
+    <pulsar.jclouds.shaded.version>2.3.0</pulsar.jclouds.shaded.version>
+  </properties>
+
   <modules>
     <module>jcloud</module>
   </modules>


### PR DESCRIPTION
### Motivation

pin the jclouds-shaded version to make the pulsar build friendly to intellij

### Modifications

jclouds-shaded version fix to 2.3.0

### Verifying this change

- [✔️ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
