### PR TITLE
[pulsar-broker] fix ClassCastException at ZkIsolatedBookieEnsemblePlacementPolicy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -97,7 +97,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
                 if (!clientIsolationZkCache.compareAndSet(null, zkc)) {
                     zkc.stop();
                 }
-                bkConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, this.clientIsolationZkCache);
+                bkConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, this.clientIsolationZkCache.get());
             }
         }
 


### PR DESCRIPTION
### Motivation
Fix `ClassCastException` while initializing `ZkIsolatedBookieEnsemblePlacementPolicy`

```
java.lang.ClassCastException: java.util.concurrent.atomic.AtomicReference cannot be cast to org.apache.pulsar.zookeeper.ZooKeeperCache
	at org.apache.pulsar.zookeeper.ZkIsolatedBookieEnsemblePlacementPolicy.getAndSetZkCache(ZkIsolatedBookieEnsemblePlacementPolicy.java:89) ~[classes/:?]
	at org.apache.pulsar.zookeeper.ZkIsolatedBookieEnsemblePlacementPolicy.initialize(ZkIsolatedBookieEnsemblePlacementPolicy.java:79) ~[classes/:?]
	at org.apache.pulsar.zookeeper.ZkIsolatedBookieEnsemblePlacementPolicy.initialize(ZkIsolatedBookieEnsemblePlacementPolicy.java:1) ~[classes/:?]
	at org.apache.bookkeeper.client.BookKeeper.initializeEnsemblePlacementPolicy(BookKeeper.java:562) ~[bookkeeper-server-4.9.0.jar:4.9.0]
	at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:493) ~[bookkeeper-server-4.9.0.jar:4.9.0]
	at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:368) ~[bookkeeper-server-4.9.0.jar:4.9.0]
```