### PR TITLE
[pulsar-broker] zk-isolation placement policy should make sure isolation group bookies must not be excluded

### DIFF
--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
@@ -299,4 +299,58 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
 
         isolationPolicy.newEnsemble(4, 4, 4, Collections.emptyMap(), new HashSet<>());
     }
+    
+    /**
+     * validates overlapped bookies between default-groups and isolated-groups.
+     * 
+     * <pre>
+     * a. default-group has all 5 bookies.
+     * b. 3 of the default-group bookies have been added to isolated-group without being removed from default-group.
+     * c. isolated-policy-placement should be identify those 3 overlapped bookies and exclude them from blacklisted bookies.
+     * </pre>
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOverlappedBookies() throws Exception {
+        Map<String, Map<String, BookieInfo>> bookieMapping = new HashMap<>();
+        Map<String, BookieInfo> defaultBookieGroup = new HashMap<>();
+        final String isolatedGroup = "isolatedGroup";
+
+        defaultBookieGroup.put(BOOKIE1, new BookieInfo("rack0", null));
+        defaultBookieGroup.put(BOOKIE2, new BookieInfo("rack1", null));
+        defaultBookieGroup.put(BOOKIE3, new BookieInfo("rack1", null));
+        defaultBookieGroup.put(BOOKIE4, new BookieInfo("rack1", null));
+        defaultBookieGroup.put(BOOKIE5, new BookieInfo("rack1", null));
+
+        Map<String, BookieInfo> isolatedBookieGroup = new HashMap<>();
+        isolatedBookieGroup.put(BOOKIE1, new BookieInfo("rack1", null));
+        isolatedBookieGroup.put(BOOKIE2, new BookieInfo("rack0", null));
+        isolatedBookieGroup.put(BOOKIE4, new BookieInfo("rack0", null));
+
+        bookieMapping.put("default", defaultBookieGroup);
+        bookieMapping.put(isolatedGroup, isolatedBookieGroup);
+
+        ZkUtils.createFullPathOptimistic(localZkc, ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH,
+                jsonMapper.writeValueAsBytes(bookieMapping), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        Thread.sleep(100);
+
+        ZkIsolatedBookieEnsemblePlacementPolicy isolationPolicy = new ZkIsolatedBookieEnsemblePlacementPolicy();
+        ClientConfiguration bkClientConf = new ClientConfiguration();
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, 30) {
+        });
+        bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
+        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
+                NullStatsLogger.INSTANCE);
+        isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
+
+        List<BookieSocketAddress> ensemble = isolationPolicy
+                .newEnsemble(3, 3, 2, Collections.emptyMap(), new HashSet<>()).getResult();
+        assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE1)));
+        assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE2)));
+        assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE4)));
+
+        localZkc.delete(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, -1);
+    }
 }


### PR DESCRIPTION
### Motivation
Right now, bookie-isolation-placement policy is not able to identify overlapped bookies which exist into given isolated group and in existing default group. Because of that user always has to update other default-groups when user creates new isolation group.
eg:
there could be a default-group present with rack-aware bookie info and this group contains all available bookies. However, if user wants to create isolated group with few bookies present into default-group then first user has to remove bookies from default-group and then have to create new isolated group else default-group bookies will be excluded.

### Modification

To fix this issue, Placement-policy should be able to identify overlapped bookies from default-group and isolated-group and then remove those overlapped bookies from the excluded bookie list so, bk-client can select overlapped bookies from isolated group.
