### PR TITLE
[3928][tiered-storage] Include java-xmlbuilder in tiered-storage-jcloud NAR

### DIFF
--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.jamesmurty.utils</groupId>
+      <artifactId>java-xmlbuilder</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>managed-ledger-original</artifactId>
       <version>${project.version}</version>
@@ -84,12 +89,6 @@
     <!-- we excluded the transitive dependencies above to make it work for standalone.
          however it will cause test failures. bring following dependencies back for testing.
          all these should be gone once we introduce NAR package for offloaders. -->
-    <dependency>
-      <groupId>com.jamesmurty.utils</groupId>
-      <artifactId>java-xmlbuilder</artifactId>
-      <version>1.1</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>net.iharder</groupId>
       <artifactId>base64</artifactId>


### PR DESCRIPTION
In the POM file for tiered-storage-jcloud, the dependency on
com.jamesmurty.utils/java-xmlbuilder was marked with test scope, but in
fact this dependency is needed during normal use. This commit changes
the POM file so that the java-xmlbuilder dependency is packaged in the
NAR file.

Fixes #3928.

### Verifying this change

I am not sure how to test this change. I don't know the implications of changing this dependency. Maybe the java-xmlbuilder dependency was marked as "test" for a specific reason, and my change will break something else.

The NAR file builds when I run `mvn package`. When I deployed it to a test cluster running pulsar 2.3.0, I did not see the errors that were reported in #3928.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: don't know

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
