### PR TITLE
Upgrade third party libraries with security vulnerabilities

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -314,14 +314,14 @@ The Apache Software License, Version 2.0
  * Jackson
      - org.codehaus.jackson-jackson-core-asl-1.9.13.jar
      - org.codehaus.jackson-jackson-mapper-asl-1.9.13.jar
-     - com.fasterxml.jackson.core-jackson-annotations-2.9.7.jar
-     - com.fasterxml.jackson.core-jackson-core-2.9.7.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.9.7.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.7.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.7.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.7.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.7.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.7.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.9.8.jar
+     - com.fasterxml.jackson.core-jackson-core-2.9.8.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.9.8.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.8.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.8.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.8.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.8.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.8.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
  * Gson -- com.google.code.gson-gson-2.8.2.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -335,15 +335,12 @@ The Apache Software License, Version 2.0
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
  * Apache Commons
-    - commons-beanutils-commons-beanutils-1.7.0.jar
-    - commons-beanutils-commons-beanutils-core-1.8.0.jar
     - commons-cli-commons-cli-1.2.jar
     - commons-codec-commons-codec-1.10.jar
     - commons-collections-commons-collections-3.2.2.jar
-    - commons-configuration-commons-configuration-1.6.jar
-    - commons-digester-commons-digester-1.8.jar
+    - commons-configuration-commons-configuration-1.10.jar
     - commons-io-commons-io-2.5.jar
-    - commons-lang-commons-lang-2.4.jar
+    - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.1.jar
     - org.apache.commons-commons-compress-1.15.jar

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>1.6</version>
+        <version>1.10</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -40,6 +40,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -35,7 +35,7 @@
         <jackson.version>2.8.11</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.1</jackson.databind.version>
+        <jackson.databind.version>2.8.11.3</jackson.databind.version>
     </properties>
 
     <modules>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -209,7 +209,7 @@ The Apache Software License, Version 2.0
 
   * Jackson
     - jackson-annotations-2.8.11.jar
-    - jackson-databind-2.8.11.1.jar
+    - jackson-databind-2.8.11.3.jar
     - jackson-dataformat-smile-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -229,7 +229,6 @@ The Apache Software License, Version 2.0
     - guice-multibindings-4.2.0.jar
  * Apache Commons
     - commons-math3-3.6.1.jar
-    - commons-beanutils-core-1.8.0.jar
     - commons-beanutils-core-1.8.3.jar
     - commons-compress-1.15.jar
     - commons-lang3-3.3.2.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -45,7 +45,7 @@
         <jackson.version>2.8.11</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.1</jackson.databind.version>
+        <jackson.databind.version>2.8.11.3</jackson.databind.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Motivation

The Pulsar distribution includes some third-party libraries with security vulnerabilities.

- jackson-databind-2.9.7
  - https://nvd.nist.gov/vuln/detail/CVE-2018-19360
  - https://nvd.nist.gov/vuln/detail/CVE-2018-19361
  - https://nvd.nist.gov/vuln/detail/CVE-2018-19362
- commons-beanutils-1.7.0, commons-beanutils-core-1.8.0
  - https://nvd.nist.gov/vuln/detail/CVE-2014-0114

### Modifications

- Upgraded jackson related libraries to 2.9.8. The jackson used in pulsar-sql can not be upgraded to 2.9.x, so upgraded `jackson-databind` to [2.8.11.3](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8) (cf. #2978).
- Upgraded the version of `commons-configuration` from 1.6 to 1.10. `commons-beanutils` and `commons-beanutils-core` were installed because `commons-configuration-1.6` depends on these, but these dependencies are optional in `commons-configuration-1.10`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.