### PR TITLE
[Issue 3837][pulsar-client-tools]Delete schema when deleting a topic

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -566,6 +567,7 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -d"));
         verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockSchemas).deleteSchema("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("unload persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
@@ -620,6 +622,7 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -d"));
         verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockSchemas, times(2)).deleteSchema("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
         verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.ResourceQuotas;
 import org.apache.pulsar.client.admin.Tenants;
 import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.admin.Schemas;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -558,10 +559,12 @@ public class PulsarAdminToolTest {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
         Topics mockTopics = mock(Topics.class);
         when(admin.topics()).thenReturn(mockTopics);
+        Schemas mockSchemas = mock(Schemas.class);
+        when(admin.schemas()).thenReturn(mockSchemas);
 
         CmdTopics cmdTopics = new CmdTopics(admin);
 
-        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -d"));
         verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("unload persistent://myprop/clust/ns1/ds1"));
@@ -615,7 +618,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -d"));
         verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -270,10 +270,17 @@ public class CmdTopics extends CmdBase {
                 "--force" }, description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
+        @Parameter(names = { "-d",
+                "--deleteSchema" }, description = "Delete schema while deleting topic")
+        private boolean deleteSchema = false;
+
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
             topics.deletePartitionedTopic(topic, force);
+            if (deleteSchema) {
+                admin.schemas().deleteSchema(topic);
+            }
         }
     }
 
@@ -287,10 +294,17 @@ public class CmdTopics extends CmdBase {
                 "--force" }, description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
+        @Parameter(names = { "-d",
+                "--deleteSchema" }, description = "Delete schema while deleting topic")
+        private boolean deleteSchema = false;
+
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
             topics.delete(topic, force);
+            if (deleteSchema) {
+                admin.schemas().deleteSchema(topic);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #3837 

### Motivation


* Providing an option to delete schema when deleting a topic.

### Modifications

* Add deleteSchema parameter for delete and delete-partitioned-topic

### Verifying this change

Test pass

