### PR TITLE
Remove the exception which will never be thrown

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.FileInputStream;
-import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -65,7 +64,7 @@ public class PulsarClientTool {
     CmdProduce produceCommand;
     CmdConsume consumeCommand;
 
-    public PulsarClientTool(Properties properties) throws MalformedURLException {
+    public PulsarClientTool(Properties properties) {
         this.serviceURL = StringUtils.isNotBlank(properties.getProperty("brokerServiceUrl"))
                 ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
         // fallback to previous-version serviceUrl property to maintain backward-compatibility
@@ -90,7 +89,7 @@ public class PulsarClientTool {
         commandParser.addCommand("consume", consumeCommand);
     }
 
-    private void updateConfig() throws UnsupportedAuthenticationException, MalformedURLException {
+    private void updateConfig() throws UnsupportedAuthenticationException {
         ClientBuilder clientBuilder = PulsarClient.builder();
         Authentication authentication = null;
         if (isNotBlank(this.authPluginClassName)) {
@@ -121,10 +120,6 @@ public class PulsarClientTool {
             try {
                 this.updateConfig(); // If the --url, --auth-plugin, or --auth-params parameter are not specified,
                                      // it will default to the values passed in by the constructor
-            } catch (MalformedURLException mue) {
-                System.out.println("Unable to parse URL " + this.serviceURL);
-                commandParser.usage();
-                return -1;
             } catch (UnsupportedAuthenticationException exp) {
                 System.out.println("Failed to load an authentication plugin");
                 commandParser.usage();


### PR DESCRIPTION
The exception ```MalformedURLException``` will never be thrown in ```PulsarClientTool.java```. 