### PR TITLE
Support https links for Source/Sinks

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
@@ -27,11 +27,13 @@ import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 
 public class Utils {
     public static String HTTP = "http";
+    public static String HTTPS = "https";
     public static String FILE = "file";
     public static String BUILTIN = "builtin";
 
     public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
         return isNotBlank(functionPkgUrl) && (functionPkgUrl.startsWith(HTTP)
+                || functionPkgUrl.startsWith(HTTPS)
                 || functionPkgUrl.startsWith(FILE));
     }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -265,7 +265,8 @@ public class Utils {
                 throw new IOException(destPkgUrl + " does not exists locally");
             }
             return file;
-        } else if (destPkgUrl.startsWith("http")) {
+        } else if (destPkgUrl.startsWith(org.apache.pulsar.common.functions.Utils.HTTP)
+                || destPkgUrl.startsWith(org.apache.pulsar.common.functions.Utils.HTTPS)) {
             URL website = new URL(destPkgUrl);
             File tempFile = File.createTempFile("function", ".tmp");
             ReadableByteChannel rbc = Channels.newChannel(website.openStream());
@@ -331,7 +332,8 @@ public class Utils {
                     throw new IllegalArgumentException(
                             "Corrupt User PackageFile " + pkgUrl + " with error " + e.getMessage());
                 }
-            } else if (pkgUrl.startsWith("http")) {
+            } else if (pkgUrl.startsWith(org.apache.pulsar.common.functions.Utils.HTTP)
+                    || pkgUrl.startsWith(org.apache.pulsar.common.functions.Utils.HTTPS)) {
                 try {
                     URL website = new URL(pkgUrl);
                     File tempFile = File.createTempFile("function", ".tmp");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.pulsar.common.functions.Utils.FILE;
 import static org.apache.pulsar.common.functions.Utils.HTTP;
+import static org.apache.pulsar.common.functions.Utils.HTTPS;
 import static org.apache.pulsar.common.functions.Utils.isFunctionPackageUrlSupported;
 import static org.apache.pulsar.functions.auth.FunctionAuthUtils.getFunctionAuthData;
 import static org.apache.pulsar.functions.utils.Utils.getSinkType;
@@ -202,7 +203,7 @@ public class FunctionActioner {
             }
         }
         String pkgLocationPath = functionMetaData.getPackageLocation().getPackagePath();
-        boolean downloadFromHttp = isPkgUrlProvided && pkgLocationPath.startsWith(HTTP);
+        boolean downloadFromHttp = isPkgUrlProvided && (pkgLocationPath.startsWith(HTTP) || pkgLocationPath.startsWith(HTTPS));
         log.info("{}/{}/{} Function package file {} will be downloaded from {}", tempPkgFile, details.getTenant(),
                 details.getNamespace(), details.getName(),
                 downloadFromHttp ? pkgLocationPath : functionMetaData.getPackageLocation());

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1401,7 +1401,8 @@ public abstract class ComponentImpl {
         final StreamingOutput streamingOutput = new StreamingOutput() {
             @Override
             public void write(final OutputStream output) throws IOException {
-                if (path.startsWith(org.apache.pulsar.common.functions.Utils.HTTP)) {
+                if (path.startsWith(org.apache.pulsar.common.functions.Utils.HTTP)
+                || path.startsWith(org.apache.pulsar.common.functions.Utils.HTTPS)) {
                     URL url = new URL(path);
                     IOUtils.copy(url.openStream(), output);
                 } else if (path.startsWith(org.apache.pulsar.common.functions.Utils.FILE)) {


### PR DESCRIPTION
### Motivation
Currently we support submitting sources/sinks with an archive thats a weblink. This support is restricted to http links only. This pr adds support for https links as well.
### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
