### PR TITLE
[ERROR] Throw error explicitly on param value not in range

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilder.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilder.java
@@ -158,8 +158,9 @@ public class PulsarSourceBuilder<T> {
     public PulsarSourceBuilder<T> acknowledgementBatchSize(long size) {
         if (size > 0 && size <= MAX_ACKNOWLEDGEMENT_BATCH_SIZE) {
             acknowledgementBatchSize = size;
+            return this;
         }
-        return this;
+        throw new IllegalArgumentException("acknowledgementBatchSize can only take values > 0 and <= " + MAX_ACKNOWLEDGEMENT_BATCH_SIZE);
     }
 
     public SourceFunction<T> build() {


### PR DESCRIPTION

### Motivation
The code checks if value is in valid range. If yes, sets it else ignores param and returns silently doing nothing.

### Modifications

Explicitly throw IllegalArgumentException if param value not in valid range.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: ( no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  - If yes, how is the feature documented? (not applicable )
