### PR TITLE
Fix Flink Example broken for dependency problems

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -110,6 +110,7 @@
                     <include>org/apache/flink/streaming/examples/kafka/**</include>
                     <include>org/apache/flink/streaming/**</include>
                     <include>org/apache/pulsar/**</include>
+                    <include>org/bouncycastle/**</include>
                     <include>org/apache/flink/batch/**</include>
                     <include>net/jpountz/**</include>
                     <include>com/scurrilous/circe/**</include>


### PR DESCRIPTION
Signed-off-by: forjingma <forjingma@dingtalk.com>

### Motivation

In pulsar 2.3 Flink example is broken. User will encountere java.lang.NoClassDefFoundError when running PulsarConsumerSourceWordCount example.

![WechatIMG6](https://user-images.githubusercontent.com/6348208/55270062-635c0f00-52d5-11e9-8942-9ebe4d45e7d4.jpeg)


### Modifications
The fix is add bouncycastle into shaded fat jar.

### Verifying this change
Verified by flink-1.6.1 and pulsar-2.3.0.

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
