### PR TITLE
[client] Make dependency from client side auth plugins to pulsar-client-original optional

### DIFF
--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -39,11 +39,22 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <version>${project.parent.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>com.yahoo.athenz</groupId>
       <artifactId>athenz-zts-java-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
   </dependencies>

--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -39,6 +39,22 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <version>${project.parent.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### Motivation

If building a producer application with the following dependencies, `NoSuchMethodError` may occur and fail to publish messages.

```xml
<dependencies>

  <dependency>
    <groupId>org.apache.pulsar</groupId>
    <artifactId>pulsar-client</artifactId>
    <version>2.3.0</version>
  </dependency>

  <dependency>
    <groupId>org.apache.pulsar</groupId>
    <artifactId>pulsar-client-auth-athenz</artifactId>
    <version>2.3.0</version>
  </dependency>
  
</dependencies>
```
```
[pulsar-timer-4-1] WARN org.apache.pulsar.client.impl.ProducerImpl - [persistent://pulsar/global/ns1/pt1-partition-1] [cluster1-804-107184] error while closing out batch -- {}
java.lang.NoSuchMethodError: com.scurrilous.circe.checksum.Crc32cIntChecksum.computeChecksum(Lorg/apache/pulsar/shade/io/netty/buffer/ByteBuf;)I
        at org.apache.pulsar.common.api.Commands.serializeCommandSendWithSize(Commands.java:948)
        at org.apache.pulsar.common.api.Commands.newSend(Commands.java:315)
        at org.apache.pulsar.client.impl.ProducerImpl.sendMessage(ProducerImpl.java:449)
        at org.apache.pulsar.client.impl.ProducerImpl.batchMessageAndSend(ProducerImpl.java:1289)
        at org.apache.pulsar.client.impl.ProducerImpl.access$500(ProducerImpl.java:76)
        at org.apache.pulsar.client.impl.ProducerImpl$2.run(ProducerImpl.java:1246)
        at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:682)
        at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:757)
        at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:485)
        at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```

This is because `pulsar-client-auth-athenz` depends on `pulsar-client-original`, and both `pulsar-client` and `pulsar-client-original` are included in the classpath.

We can avoid this error by removing either `pulsar-client` or `pulsar-client-original` from the classpath.

### Modifications

Made the dependency from `pulsar-client-auth-athenz` and `pulsar-client-auth-sasl` to `pulsar-client-original` [optional](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html). With this change, `pulsar-client-original` is not automatically added to the classpath.

Users need to describe either `pulsar-client` or `pulsar-client-original` in their dependencies, but many users already do so.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.