### PR TITLE
Feature / Interceptor for negative ack redelivery

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.api;
 
+import java.util.Set;
+
 /**
  * A plugin interface that allows you to intercept (and possibly mutate)
  * messages received by the consumer.
@@ -94,4 +96,15 @@ public interface ConsumerInterceptor<T> extends AutoCloseable {
      * @param exception the exception on acknowledge.
      */
     void onAcknowledgeCumulative(Consumer<T> consumer, MessageId messageId, Throwable exception);
+
+    /**
+     *
+     * This method will be called when a redelivery from a negative acknowledge occurs.
+     *
+     * <p>Any exception thrown by this method will be ignored by the caller.
+     *
+     * @param consumer the consumer which contains the interceptor
+     * @param messageIds message to ack, null if acknowledge fail.
+     */
+    void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> messageIds);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -386,6 +386,12 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
     }
 
+    protected void onNegativeAcksSend(Set<MessageId> messageIds) {
+        if (interceptors != null) {
+            interceptors.onNegativeAcksSend(this, messageIds);
+        }
+    }
+
     protected synchronized void incrRefCount() {
         ++refCount;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A container that hold the list {@link org.apache.pulsar.client.api.ConsumerInterceptor} and wraps calls to the chain
@@ -62,7 +63,7 @@ public class ConsumerInterceptors<T> implements Closeable {
      */
     public Message<T> beforeConsume(Consumer<T> consumer, Message<T> message) {
         Message<T> interceptorMessage = message;
-        for (int i = 0; i < interceptors.size(); i++) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
             try {
                 interceptorMessage = interceptors.get(i).beforeConsume(consumer, interceptorMessage);
             } catch (Exception e) {
@@ -88,7 +89,7 @@ public class ConsumerInterceptors<T> implements Closeable {
      * @param exception exception returned by broker.
      */
     public void onAcknowledge(Consumer<T> consumer, MessageId messageId, Throwable exception) {
-        for (int i = 0; i < interceptors.size(); i++) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
             try {
                 interceptors.get(i).onAcknowledge(consumer, messageId, exception);
             } catch (Exception e) {
@@ -109,7 +110,7 @@ public class ConsumerInterceptors<T> implements Closeable {
      * @param exception exception returned by broker.
      */
     public void onAcknowledgeCumulative(Consumer<T> consumer, MessageId messageId, Throwable exception) {
-        for (int i = 0; i < interceptors.size(); i++) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
             try {
                 interceptors.get(i).onAcknowledgeCumulative(consumer, messageId, exception);
             } catch (Exception e) {
@@ -118,9 +119,30 @@ public class ConsumerInterceptors<T> implements Closeable {
         }
     }
 
+    /**
+     * This is called when a redelivery from a negative acknowledge occurs.
+     * <p>
+     * This method calls {@link ConsumerInterceptor#onNegativeAcksSend(Consumer, Set)
+     * onNegativeAcksSend(Consumer, Set&lt;MessageId&gt;)} method for each interceptor.
+     * <p>
+     * This method does not throw exceptions. Exceptions thrown by any of interceptors in the chain are logged, but not propagated.
+     *
+     * @param consumer the consumer which contains the interceptors.
+     * @param messageIds set of message IDs being redelivery due a negative acknowledge.
+     */
+    public void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
+            try {
+                interceptors.get(i).onNegativeAcksSend(consumer, messageIds);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onNegativeAcksSend callback", e);
+            }
+        }
+    }
+
     @Override
     public void close() throws IOException {
-        for (int i = 0; i < interceptors.size(); i++) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
             try {
                 interceptors.get(i).close();
             } catch (Exception e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -67,6 +67,7 @@ class NegativeAcksTracker {
         });
 
         messagesToRedeliver.forEach(nackedMessages::remove);
+        consumer.onNegativeAcksSend(messagesToRedeliver);
         consumer.redeliverUnacknowledgedMessages(messagesToRedeliver);
 
         this.timeout = timer.newTimeout(this::triggerRedelivery, timerIntervalNanos, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
**Motivation**

In some scenarios is it helpful to be able to set interceptor for redeliveries
being happening due to negative acknowledge.

**Modifications**

  - Add onNegativeAcksSend() method in ConsumerInterceptor interface.
  - Add handler for onNegativeAcksSend() interceptor in ConsumerBase.
  - Favor forEach on ConsumerInterceptor instead of classic for loop by index.
  - Add call method to onNegativeAcksSend() from NegativeAcksTracker.

### Verifying this change

- [x] Make sure that the change passes the CI checks.