### PR TITLE
Provide a mechanism to disable uploading distribution packages

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -38,4 +38,15 @@
     <module>io</module>
     <module>offloaders</module>
   </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>${skipBuildDistribution}</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
*Motivation*

Currently all the distribution packages are very large. We should provide a way to skip uploading distribution packages.

