### PR TITLE
[Kubernetes] Added ingress resource to dashboard

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.dashboard.ingress.enabled }}
+apiVersion: extensions/v1beta1                                                                                                                                                            
+kind: Ingress                                                                                                                                                                             
+metadata:                                                                                                                                                                                 
+  labels:                                                                                                                                                                                 
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
+  annotations:                                                                                                                                                                            
+{{- with .Values.dashboard.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
+  namespace: {{ .Values.namespace }}
+spec:                                                                                                                                                                                     
+{{- if .Values.dashboard.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.dashboard.ingress.hostname }}
+      secretName: {{ .Values.dashboard.ingress.tls.secretName }}
+{{- end }}
+  rules:
+    - host: {{ required "Dashboard ingress hostname not provided" .Values.dashboard.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.dashboard.ingress.path }}
+            backend:
+              serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
+              servicePort: {{ .Values.dashboard.ingress.port }}
+{{- end }}

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -301,6 +301,8 @@ dashboard:
     ports:
     - name: server
       port: 80
+  ingress:
+    enabled: false
 
 ## Pulsar Extra: Bastion
 ## templates/bastion-deployment.yaml

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -323,6 +323,14 @@ dashboard:
     ports:
     - name: server
       port: 80
+  ingress:
+    enabled: false
+    annotations: {}
+    tls: {}
+    hostname: ""
+    path: "/"
+    port: server
+
 
 ## Pulsar Extra: Bastion
 ## templates/bastion-deployment.yaml


### PR DESCRIPTION
Allows to opt-in for an ingress on top of the dashboard service.

This is very important in production-grade deployments where you want to expose the Pulsar dashboard through an easy to remember URL.
