### PR TITLE
Add bookkeeper client version constraint

### DIFF
--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -68,7 +68,7 @@ dependencies = [
     'six',
 
     # functions dependencies
-    "apache-bookkeeper-client",
+    "apache-bookkeeper-client>=4.9.1",
     "prometheus_client",
     "ratelimit"
 ]


### PR DESCRIPTION
We require a certain version of bookkeeper client to operate python function state correctly.