### PR TITLE
Allow to configure TypedMessageBuilder through a Map conf object

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
@@ -634,7 +634,7 @@ public class SimpleTypedProducerConsumerTest extends ProducerConsumerBase {
 
     @Test
     public void testMessageBuilderLoadConf() throws Exception {
-        String topic = "persistent://my-property/use/my-ns/my-topic-" + System.nanoTime();
+        String topic = "my-topic-" + System.nanoTime();
 
         @Cleanup
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
@@ -18,15 +18,23 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import java.time.Clock;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Cleanup;
+
 import org.apache.pulsar.broker.service.schema.SchemaCompatibilityStrategy;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -623,4 +631,76 @@ public class SimpleTypedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
 
     }
+
+    @Test
+    public void testMessageBuilderLoadConf() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/my-topic-" + System.nanoTime();
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("my-subscriber-name")
+                .subscribe();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("a", "1");
+        properties.put("b", "2");
+
+        Map<String, Object> msgConf = new HashMap<>();
+        msgConf.put("key", "key-1");
+        msgConf.put("properties", properties);
+        msgConf.put("eventTime", 1234);
+        msgConf.put("sequenceId", 5);
+        msgConf.put("replicationClusters", Lists.newArrayList("a", "b", "c"));
+        msgConf.put("disableReplication", false);
+
+        producer.newMessage()
+            .value("my-message")
+            .loadConf(msgConf)
+            .send();
+
+
+        Message<String> msg = consumer.receive();
+        assertEquals(msg.getKey(), "key-1");
+        assertEquals(msg.getProperties().get("a"), "1");
+        assertEquals(msg.getProperties().get("b"), "2");
+        assertEquals(msg.getEventTime(), 1234);
+        assertEquals(msg.getSequenceId(), 5);
+
+        consumer.acknowledge(msg);
+
+        // Try with invalid confs
+        msgConf.clear();
+        msgConf.put("nonExistingKey", "key-1");
+
+        try {
+            producer.newMessage()
+                    .value("my-message")
+                    .loadConf(msgConf)
+                    .send();
+            fail("Should have failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        // Try with invalid type
+        msgConf.clear();
+        msgConf.put("eventTime", "hello");
+
+        try {
+            producer.newMessage()
+                    .value("my-message")
+                    .loadConf(msgConf)
+                    .send();
+            fail("Should have failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleTypedProducerConsumerTest.java
@@ -654,8 +654,8 @@ public class SimpleTypedProducerConsumerTest extends ProducerConsumerBase {
         Map<String, Object> msgConf = new HashMap<>();
         msgConf.put("key", "key-1");
         msgConf.put("properties", properties);
-        msgConf.put("eventTime", 1234);
-        msgConf.put("sequenceId", 5);
+        msgConf.put("eventTime", 1234L);
+        msgConf.put("sequenceId", 5L);
         msgConf.put("replicationClusters", Lists.newArrayList("a", "b", "c"));
         msgConf.put("disableReplication", false);
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -174,4 +174,39 @@ public interface TypedMessageBuilder<T> extends Serializable {
      * @return the message builder instance
      */
     TypedMessageBuilder<T> disableReplication();
+
+    /**
+     * Configure the {@link TypedMessageBuilder} from a config map, as an alternative compared
+     * to call the individual builder methods.
+     * <p>
+     * The "value" of the message itself cannot be set on the config map.
+     * <p>
+     * Example:
+     *
+     * <pre>{@code
+     * Map<String, Object> conf = new HashMap<>();
+     * conf.put("key", "my-key");
+     * conf.put("eventTime", System.currentTimeMillis());
+     *
+     * producer.newMessage()
+     *             .value("my-message")
+     *             .loadConf(conf)
+     *             .send();
+     * }</pre>
+     *
+     * The available options are:
+     * <table border="1">
+     *  <tr><th>Name</th><th>Type</th><th>Doc</th></tr>
+     *  <tr><td>{@code key}</td><td>{@code String}</td><td>{@link #key(String)}</td></tr>
+     *  <tr><td>{@code properties}</td><td>{@code Map<String,String>}</td><td>{@link #properties(Map)}</td></tr>
+     *  <tr><td>{@code eventTime}</td><td>{@code long}</td><td>{@link #eventTime(long)}</td></tr>
+     *  <tr><td>{@code sequenceId}</td><td>{@code long}</td><td>{@link #sequenceId(long)}</td></tr>
+     *  <tr><td>{@code replicationClusters}</td><td>{@code List<String>}</td><td>{@link #replicationClusters(List)}</td></tr>
+     *  <tr><td>{@code disableReplication}</td><td>{@code boolean}</td><td>{@link #disableReplication()}</td></tr>
+     * </table>
+     *
+     * @param config a map with the configuration options for the message
+     * @return the message builder instance
+     */
+    TypedMessageBuilder<T> loadConf(Map<String, Object> config);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -196,17 +196,24 @@ public interface TypedMessageBuilder<T> extends Serializable {
      *
      * The available options are:
      * <table border="1">
-     *  <tr><th>Name</th><th>Type</th><th>Doc</th></tr>
-     *  <tr><td>{@code key}</td><td>{@code String}</td><td>{@link #key(String)}</td></tr>
-     *  <tr><td>{@code properties}</td><td>{@code Map<String,String>}</td><td>{@link #properties(Map)}</td></tr>
-     *  <tr><td>{@code eventTime}</td><td>{@code long}</td><td>{@link #eventTime(long)}</td></tr>
-     *  <tr><td>{@code sequenceId}</td><td>{@code long}</td><td>{@link #sequenceId(long)}</td></tr>
-     *  <tr><td>{@code replicationClusters}</td><td>{@code List<String>}</td><td>{@link #replicationClusters(List)}</td></tr>
-     *  <tr><td>{@code disableReplication}</td><td>{@code boolean}</td><td>{@link #disableReplication()}</td></tr>
+     *  <tr><th>Constant</th><th>Name</th><th>Type</th><th>Doc</th></tr>
+     *  <tr><td>{@link #CONF_KEY}</td><td>{@code key}</td><td>{@code String}</td><td>{@link #key(String)}</td></tr>
+     *  <tr><td>{@link #CONF_PROPERTIES}</td><td>{@code properties}</td><td>{@code Map<String,String>}</td><td>{@link #properties(Map)}</td></tr>
+     *  <tr><td>{@link #CONF_EVENT_TIME}</td><td>{@code eventTime}</td><td>{@code long}</td><td>{@link #eventTime(long)}</td></tr>
+     *  <tr><td>{@link #CONF_SEQUENCE_ID}</td><td>{@code sequenceId}</td><td>{@code long}</td><td>{@link #sequenceId(long)}</td></tr>
+     *  <tr><td>{@link #CONF_REPLICATION_CLUSTERS}</td><td>{@code replicationClusters}</td><td>{@code List<String>}</td><td>{@link #replicationClusters(List)}</td></tr>
+     *  <tr><td>{@link #CONF_DISABLE_REPLICATION}</td><td>{@code disableReplication}</td><td>{@code boolean}</td><td>{@link #disableReplication()}</td></tr>
      * </table>
      *
      * @param config a map with the configuration options for the message
      * @return the message builder instance
      */
     TypedMessageBuilder<T> loadConf(Map<String, Object> config);
+
+    static final String CONF_KEY = "key";
+    static final String CONF_PROPERTIES = "properties";
+    static final String CONF_EVENT_TIME = "eventTime";
+    static final String CONF_SEQUENCE_ID = "sequenceId";
+    static final String CONF_REPLICATION_CLUSTERS = "replicationClusters";
+    static final String CONF_DISABLE_REPLICATION = "disableReplication";
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -135,17 +135,17 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     @Override
     public TypedMessageBuilder<T> loadConf(Map<String, Object> config) {
         config.forEach((key, value) -> {
-            if (key.equals("key")) {
+            if (key.equals(CONF_KEY)) {
                 this.key(checkType(value, String.class));
-            } else if (key.equals("properties")) {
+            } else if (key.equals(CONF_PROPERTIES)) {
                 this.properties(checkType(value, Map.class));
-            } else if (key.equals("eventTime")) {
+            } else if (key.equals(CONF_EVENT_TIME)) {
                 this.eventTime(checkType(value, Number.class).longValue());
-            } else if (key.equals("sequenceId")) {
+            } else if (key.equals(CONF_SEQUENCE_ID)) {
                 this.sequenceId(checkType(value, Number.class).longValue());
-            } else if (key.equals("replicationClusters")) {
+            } else if (key.equals(CONF_REPLICATION_CLUSTERS)) {
                 this.replicationClusters(checkType(value, List.class));
-            } else if (key.equals("disableReplication")) {
+            } else if (key.equals(CONF_DISABLE_REPLICATION)) {
                 boolean disableReplication = checkType(value, Boolean.class);
                 if (disableReplication) {
                     this.disableReplication();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -140,9 +140,9 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             } else if (key.equals(CONF_PROPERTIES)) {
                 this.properties(checkType(value, Map.class));
             } else if (key.equals(CONF_EVENT_TIME)) {
-                this.eventTime(checkType(value, Number.class).longValue());
+                this.eventTime(checkType(value, Long.class));
             } else if (key.equals(CONF_SEQUENCE_ID)) {
-                this.sequenceId(checkType(value, Number.class).longValue());
+                this.sequenceId(checkType(value, Long.class));
             } else if (key.equals(CONF_REPLICATION_CLUSTERS)) {
                 this.replicationClusters(checkType(value, List.class));
             } else if (key.equals(CONF_DISABLE_REPLICATION)) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.pulsar.client.util.TypeCheckUtil.checkType;
 
 import com.google.common.base.Preconditions;
 
@@ -127,6 +128,32 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     public TypedMessageBuilder<T> disableReplication() {
         msgMetadataBuilder.clearReplicateTo();
         msgMetadataBuilder.addReplicateTo("__local__");
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public TypedMessageBuilder<T> loadConf(Map<String, Object> config) {
+        config.forEach((key, value) -> {
+            if (key.equals("key")) {
+                this.key(checkType(value, String.class));
+            } else if (key.equals("properties")) {
+                this.properties(checkType(value, Map.class));
+            } else if (key.equals("eventTime")) {
+                this.eventTime(checkType(value, Number.class).longValue());
+            } else if (key.equals("sequenceId")) {
+                this.sequenceId(checkType(value, Number.class).longValue());
+            } else if (key.equals("replicationClusters")) {
+                this.replicationClusters(checkType(value, List.class));
+            } else if (key.equals("disableReplication")) {
+                boolean disableReplication = checkType(value, Boolean.class);
+                if (disableReplication) {
+                    this.disableReplication();
+                }
+            } else {
+                throw new RuntimeException("Invalid message config key '" + key + "'");
+            }
+        });
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -18,27 +18,45 @@
  */
 package org.apache.pulsar.client.impl.conf;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
-
+import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.util.Map;
-
-import lombok.experimental.UtilityClass;
-
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 /**
  * Utils for loading configuration data.
  */
-@UtilityClass
 public final class ConfigurationDataUtils {
 
-    @SuppressWarnings("unchecked")
+    public static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        // forward compatibility for the properties may go away in the future
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+        return mapper;
+    }
+
+    private static final FastThreadLocal<ObjectMapper> mapper = new FastThreadLocal<ObjectMapper>() {
+        @Override
+        protected ObjectMapper initialValue() throws Exception {
+            return create();
+        }
+    };
+
+    public static ObjectMapper getThreadLocal() {
+        return mapper.get();
+    }
+
+    private ConfigurationDataUtils() {}
+
     public static <T> T loadData(Map<String, Object> config,
                                  T existingData,
                                  Class<T> dataCls) {
-        ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
+        ObjectMapper mapper = getThreadLocal();
         try {
             String existingConfigJson = mapper.writeValueAsString(existingData);
             Map<String, Object> existingConfig = mapper.readValue(existingConfigJson, Map.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -18,45 +18,27 @@
  */
 package org.apache.pulsar.client.impl.conf;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
-import io.netty.util.concurrent.FastThreadLocal;
+
 import java.io.IOException;
 import java.util.Map;
+
+import lombok.experimental.UtilityClass;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 /**
  * Utils for loading configuration data.
  */
+@UtilityClass
 public final class ConfigurationDataUtils {
 
-    public static ObjectMapper create() {
-        ObjectMapper mapper = new ObjectMapper();
-        // forward compatibility for the properties may go away in the future
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
-        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper;
-    }
-
-    private static final FastThreadLocal<ObjectMapper> mapper = new FastThreadLocal<ObjectMapper>() {
-        @Override
-        protected ObjectMapper initialValue() throws Exception {
-            return create();
-        }
-    };
-
-    public static ObjectMapper getThreadLocal() {
-        return mapper.get();
-    }
-
-    private ConfigurationDataUtils() {}
-
+    @SuppressWarnings("unchecked")
     public static <T> T loadData(Map<String, Object> config,
                                  T existingData,
                                  Class<T> dataCls) {
-        ObjectMapper mapper = getThreadLocal();
+        ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
         try {
             String existingConfigJson = mapper.writeValueAsString(existingData);
             Map<String, Object> existingConfig = mapper.readValue(existingConfigJson, Map.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/TypeCheckUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/TypeCheckUtil.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TypeCheckUtil {
+    @SuppressWarnings("unchecked")
+    public static <T> T checkType(Object o, Class<T> clazz) {
+        if (!clazz.isInstance(o)) {
+            throw new RuntimeException(
+                    String.format("Invalid object type '%s' when exepcting '%s'", o.getClass(), clazz));
+        }
+        return (T) o;
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/TypeCheckUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/TypeCheckUtil.java
@@ -26,7 +26,7 @@ public class TypeCheckUtil {
     public static <T> T checkType(Object o, Class<T> clazz) {
         if (!clazz.isInstance(o)) {
             throw new RuntimeException(
-                    String.format("Invalid object type '%s' when exepcting '%s'", o.getClass(), clazz));
+                    String.format("Invalid object type '%s' when exepcting '%s'", o.getClass().getName(), clazz.getName()));
         }
         return (T) o;
     }


### PR DESCRIPTION
### Motivation

Similarly to the `ProducerBuilder` and `ConsumerBuilder`, we should also let user to pass a config map when building a message.

The primary use case for this, right now, is to allow to configure all message options from the functions `context.publish()` method.