### PR TITLE
[Issue 3989][Doc] Update Geo Replication docs

### DIFF
--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -12,24 +12,24 @@ The diagram below illustrates the process of geo-replication across Pulsar clust
 
 ![Replication Diagram](assets/geo-replication.png)
 
-In this diagram, whenever producers **P1**, **P2**, and **P3** publish messages to the topic **T1** on clusters **Cluster-A**, **Cluster-B**, and **Cluster-C**, respectively, those messages are instantly replicated across clusters. Once replicated, consumers **C1** and **C2** can consume those messages from their respective clusters.
+In this diagram, whenever **P1**, **P2**, and **P3** producers publish messages to the **T1** topic on **Cluster-A**, **Cluster-B**, and **Cluster-C** clusters respectively, those messages are instantly replicated across clusters. Once replicated, **C1** and **C2** consumers can consume those messages from their respective clusters.
 
-Without geo-replication, consumers **C1** and **C2** wouldn't be able to consume messages published by producer **P3**.
+Without geo-replication, **C1** and **C2** consumers are not able to consume messages published by **P3** producer.
 
 ## Geo-replication and Pulsar properties
 
 Geo-replication must be enabled on a per-tenant basis in Pulsar. Geo-replication can be enabled between clusters only when a tenant has been created that allows access to both clusters.
 
-Although geo-replication must be enabled between two clusters, it's actually managed at the namespace level. You must do the following to enable geo-replication for a namespace:
+Although geo-replication must be enabled between two clusters, it's actually managed at the namespace level. You must complete the following tasks to enable geo-replication for a namespace:
 
-* [Create a global namespace](#creating-global-namespaces)
-* Configure that namespace to replicate between two or more provisioned clusters
+* [Create geo-replication namespaces](#creating-geo-replication-namespaces)
+* Configure that namespace to replicate across two or more provisioned clusters
 
-Any message published on *any* topic in that namespace will then be replicated to all clusters in the specified set.
+Any message published on *any* topic in that namespace will be replicated to all clusters in the specified set.
 
 ## Local persistence and forwarding
 
-When messages are produced on a Pulsar topic, they are first persisted in the local cluster and then forwarded asynchronously to the remote clusters.
+When messages are produced on a Pulsar topic, they are first persisted in the local cluster, and then forwarded asynchronously to the remote clusters.
 
 In normal cases, when there are no connectivity issues, messages are replicated immediately, at the same time as they are dispatched to local consumers. Typically, end-to-end delivery latency is defined by the network [round-trip time](https://en.wikipedia.org/wiki/Round-trip_delay_time) (RTT) between the remote regions.
 
@@ -38,19 +38,19 @@ Applications can create producers and consumers in any of the clusters, even whe
 > #### Subscriptions are local to a cluster
 > While producers and consumers can publish to and consume from any cluster in a Pulsar instance, subscriptions are local to the clusters in which they are created and cannot be transferred between clusters. If you do need to transfer a subscription, you’ll need to create a new subscription in the desired cluster.
 
-In the example in the image above, the topic **T1** is being replicated between 3 clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
+In the aforementioned example, the **T1** topic is being replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any cluster will be delivered to all subscriptions in all the other clusters. In this case, consumers **C1** and **C2** will receive all messages published by producers **P1**, **P2**, and **P3**. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers will receive all messages published by **P1**, **P2**, and **P3** producers. Ordering is still guaranteed on a per-producer basis.
 
 ## Configuring replication
 
-As stated [above](#geo-replication-and-pulsar-properties), geo-replication in Pulsar is managed at the [tenant](reference-terminology.md#tenant) level.
+As stated in [Geo-replication and Pulsar properties](#geo-replication-and-pulsar-properties) section, geo-replication in Pulsar is managed at the [tenant](reference-terminology.md#tenant) level.
 
 ### Granting permissions to properties
 
-To establish replication to a cluster, the tenant needs permission to use that cluster. This permission can be granted when the tenant is created or later on.
+To replicate to a cluster, the tenant needs permission to use that cluster. You can grant permission to the tenant when you create it or grant later.
 
-At creation time, specify all the intended clusters:
+Specify all the intended clusters when creating a tenant:
 
 ```shell
 $ bin/pulsar-admin properties create my-tenant \
@@ -60,11 +60,9 @@ $ bin/pulsar-admin properties create my-tenant \
 
 To update permissions of an existing tenant, use `update` instead of `create`.
 
-### Creating global namespaces
+### Creating geo-replication namespaces
 
-Replication must be used with *global* topics, meaning topics that belong to a global namespace and are thus not tied to any particular cluster.
-
-Global namespaces need to be created in the `global` virtual cluster. For example:
+You can create a namespace with the following command sample.
 
 ```shell
 $ bin/pulsar-admin namespaces create my-tenant/my-namespace
@@ -77,17 +75,17 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
   --clusters us-west,us-east,us-cent
 ```
 
-The replication clusters for a namespace can be changed at any time, with no disruption to ongoing traffic. Replication channels will be immediately set up or stopped in all the clusters as soon as the configuration changes.
+The replication clusters for a namespace can be changed at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 
-### Using global topics
+### Using geo-replication topics
 
-Once you've created a global namespace, any topics that producers or consumers create within that namespace will be global. Typically, each application will use the `serviceUrl` for the local cluster.
+Once you've created a geo-replication namespace, any topics that producers or consumers create within that namespace will be replicated across clusters. Typically, each application will use the `serviceUrl` for the local cluster.
 
 #### Selective replication
 
-By default, messages are replicated to all clusters configured for the namespace. You can restrict replication selectively by specifying a replication list for a message. That message will then be replicated only to the subset in the replication list.
+By default, messages are replicated to all clusters configured for the namespace. You can restrict replication selectively by specifying a replication list for a message, and then that message will be replicated only to the subset in the replication list.
 
-Below is an example for the [Java API](client-libraries-java.md). Note the use of the `setReplicationClusters` method when constructing the {@inject: javadoc:Message:/client/org/apache/pulsar/client/api/Message} object:
+The following is an example for the [Java API](client-libraries-java.md). Note the use of the `setReplicationClusters` method when constructing the {@inject: javadoc:Message:/client/org/apache/pulsar/client/api/Message} object:
 
 ```java
 List<String> restrictReplicationTo = Arrays.asList(
@@ -107,20 +105,24 @@ producer.newMessage()
 
 #### Topic stats
 
-Topic-specific statistics for global topics are available via the [`pulsar-admin`](reference-pulsar-admin.md) tool and {@inject: rest:REST:/} API:
+Topic-specific statistics for geo-replication topics are available via the [`pulsar-admin`](reference-pulsar-admin.md) tool and {@inject: rest:REST:/} API:
 
 ```shell
 $ bin/pulsar-admin persistent stats persistent://my-tenant/my-namespace/my-topic
 ```
 
-Each cluster reports its own local stats, including incoming and outgoing replication rates and backlogs.
+Each cluster reports its own local stats, including the incoming and outgoing replication rates and backlogs.
 
-#### Deleting a global topic
+#### Deleting a geo-replication topic
 
-Given that global topics exist in multiple regions, it's not possible to directly delete a global topic. Instead, you should rely on automatic topic garbage collection.
+Given that geo-replication topics exist in multiple regions, it's not possible to directly delete a geo-replication topic. Instead, you should rely on automatic topic garbage collection.
 
-In Pulsar, a topic is automatically deleted when it's no longer used, that is to say, when no producers or consumers are connected *and* there are no subscriptions *and* no more messages are kept for retention. For global topics, each region will use a fault-tolerant mechanism to decide when it's safe to delete the topic locally.
+In Pulsar, a topic is automatically deleted when it meets the following three conditions:
+- when no producers or consumers are connected to it;
+- there are no subscriptions to it;
+- no more messages are kept for retention. 
+For geo-replication topics, each region uses a fault-tolerant mechanism to decide when it's safe to delete the topic locally.
 
-You can explicitly disable topic garbage collection by setting `brokerDeleteInactiveTopicsEnabled` to `false` in your [broker configuration](reference-configuration#broker).
+You can explicitly disable topic garbage collection by setting `brokerDeleteInactiveTopicsEnabled` to `false` in your [broker configuration](reference-configuration.md#broker).
 
-To delete a global topic, close all producers and consumers on the topic and delete all its local subscriptions in every replication cluster. When Pulsar determines that no valid subscription for the topic remains across the system, it will garbage collect the topic.
+To delete a geo-replication topic, close all producers and consumers on the topic, and delete all of its local subscriptions in every replication cluster. When Pulsar determines that no valid subscription for the topic remains across the system, it will garbage collect the topic.

--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -22,7 +22,7 @@ Geo-replication must be enabled on a per-tenant basis in Pulsar. Geo-replication
 
 Although geo-replication must be enabled between two clusters, it's actually managed at the namespace level. You must complete the following tasks to enable geo-replication for a namespace:
 
-* [Create geo-replication namespaces](#creating-geo-replication-namespaces)
+* [Enable geo-replication namespaces](#enabling-geo-replication-namespaces)
 * Configure that namespace to replicate across two or more provisioned clusters
 
 Any message published on *any* topic in that namespace will be replicated to all clusters in the specified set.
@@ -53,14 +53,14 @@ To replicate to a cluster, the tenant needs permission to use that cluster. You 
 Specify all the intended clusters when creating a tenant:
 
 ```shell
-$ bin/pulsar-admin properties create my-tenant \
+$ bin/pulsar-admin tenants create my-tenant \
   --admin-roles my-admin-role \
   --allowed-clusters us-west,us-east,us-cent
 ```
 
 To update permissions of an existing tenant, use `update` instead of `create`.
 
-### Creating geo-replication namespaces
+### Enabling geo-replication namespaces
 
 You can create a namespace with the following command sample.
 
@@ -77,7 +77,7 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 The replication clusters for a namespace can be changed at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 
-### Using geo-replication topics
+### Using topics with geo-replication
 
 Once you've created a geo-replication namespace, any topics that producers or consumers create within that namespace will be replicated across clusters. Typically, each application will use the `serviceUrl` for the local cluster.
 


### PR DESCRIPTION
Fixes #3989 

### Motivation
The content on creating global namespaces is out of date, i've updated the content.

### Modifications
1. Update content on creating global namespaces;
2. Fix the bad link on "broker configuration";
3. Refine language.