### PR TITLE
[pulsar-io] Add a Pulsar IO connector for InfluxDB sink

### DIFF
--- a/pulsar-io/influxdb/pom.xml
+++ b/pulsar-io/influxdb/pom.xml
@@ -1,0 +1,76 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pulsar-io</artifactId>
+        <groupId>org.apache.pulsar</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pulsar-io-influxdb</artifactId>
+    <name>Pulsar IO :: InfluxDB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>pulsar-io-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-functions-instance</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-client-original</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.influxdb</groupId>
+            <artifactId>influxdb-java</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-nar-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBAbstractSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBAbstractSink.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.Sink;
+import org.apache.pulsar.io.core.SinkContext;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A simple abstract class for InfluxDB sink
+ */
+@Slf4j
+public abstract class InfluxDBAbstractSink<T> implements Sink<T> {
+
+    private InfluxDBSinkConfig influxDBSinkConfig;
+    private InfluxDB influxDB;
+    private InfluxDB.ConsistencyLevel consistencyLevel;
+    private String influxDatabase;
+    private String retentionPolicy;
+
+    protected InfluxDBBuilder influxDBBuilder = new InfluxDBBuilderImpl();
+
+    private long batchTimeMs;
+    private int batchSize;
+    private List<Record<T>> incomingList;
+    private ScheduledExecutorService flushExecutor;
+
+    @Override
+    public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
+        influxDBSinkConfig = InfluxDBSinkConfig.load(config);
+        influxDBSinkConfig.validate();
+
+        try {
+            consistencyLevel = InfluxDB.ConsistencyLevel.valueOf(influxDBSinkConfig.getConsistencyLevel().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Illegal Consistency Level, valid values are: "
+                + Arrays.asList(InfluxDB.ConsistencyLevel.values()));
+        }
+
+        influxDatabase = influxDBSinkConfig.getDatabase();
+        retentionPolicy = influxDBSinkConfig.getRetentionPolicy();
+
+        influxDB = influxDBBuilder.build(influxDBSinkConfig);
+
+        // create the database if not exists
+        List<String> databases = influxDB.describeDatabases();
+        if (!databases.contains(influxDatabase)) {
+            influxDB.createDatabase(influxDatabase);
+        }
+
+        batchTimeMs = influxDBSinkConfig.getBatchTimeMs();
+        batchSize = influxDBSinkConfig.getBatchSize();
+        incomingList = Lists.newArrayList();
+        flushExecutor = Executors.newScheduledThreadPool(1);
+        flushExecutor.scheduleAtFixedRate(() -> flush(), batchTimeMs, batchTimeMs, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void write(Record<T> record) throws Exception {
+        int currentSize;
+        synchronized (this) {
+            if (null != record) {
+                incomingList.add(record);
+            }
+            currentSize = incomingList.size();
+        }
+
+        if (currentSize == batchSize) {
+            flushExecutor.submit(() -> flush());
+        }
+    }
+
+    private void flush() {
+        BatchPoints.Builder batchBuilder = BatchPoints
+            .database(influxDatabase)
+            .retentionPolicy(retentionPolicy)
+            .consistency(consistencyLevel);
+
+        List<Record<T>>  toFlushList;
+
+        synchronized (this) {
+            if (incomingList.isEmpty()) {
+                return;
+            }
+            toFlushList = incomingList;
+            incomingList = Lists.newArrayList();
+        }
+
+        if (CollectionUtils.isNotEmpty(toFlushList)) {
+            for (Record<T> record: toFlushList) {
+                try {
+                    buildBatch(record, batchBuilder);
+                } catch (Exception e) {
+                    record.fail();
+                    toFlushList.remove(record);
+                    log.warn("Record flush thread was exception ", e);
+                }
+            }
+        }
+
+        BatchPoints batch = batchBuilder.build();
+        try {
+            if (CollectionUtils.isNotEmpty(batch.getPoints())) {
+                influxDB.write(batch);
+            }
+            toFlushList.forEach(tRecord -> tRecord.ack());
+            batch.getPoints().clear();
+            toFlushList.clear();
+        } catch (Exception e) {
+            toFlushList.forEach(tRecord -> tRecord.fail());
+            log.error("InfluxDB write batch data exception ", e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (null != influxDB) {
+            influxDB.close();
+        }
+
+        if (null != flushExecutor) {
+            flushExecutor.shutdown();
+        }
+    }
+
+    // build Point in BatchPoints builder
+    public abstract void buildBatch(Record<T> message, BatchPoints.Builder batchBuilder) throws Exception;
+}

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBBuilder.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBBuilder.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import org.influxdb.InfluxDB;
+
+public interface InfluxDBBuilder {
+    InfluxDB build(InfluxDBSinkConfig config);
+}

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBBuilderImpl.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBBuilderImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+
+import java.util.Arrays;
+
+@Slf4j
+public class InfluxDBBuilderImpl implements InfluxDBBuilder {
+
+    @Override
+    public InfluxDB build(InfluxDBSinkConfig config) {
+        InfluxDB influxDB;
+
+        boolean enableAuth = !Strings.isNullOrEmpty(config.getUsername());
+        if (enableAuth) {
+            log.info("Authenticating to {} as {}", config.getInfluxdbUrl(), config.getUsername());
+            influxDB = InfluxDBFactory.connect(config.getInfluxdbUrl(), config.getUsername(), config.getPassword());
+        } else {
+            log.info("Connecting to {}", config.getInfluxdbUrl());
+            influxDB = InfluxDBFactory.connect(config.getInfluxdbUrl());
+        }
+
+        if (config.isGzipEnable()) {
+            influxDB.enableGzip();
+        }
+
+        InfluxDB.LogLevel logLevel;
+        try {
+            logLevel = InfluxDB.LogLevel.valueOf(config.getLogLevel().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Illegal Log Level, valid values are: "
+                + Arrays.asList(InfluxDB.LogLevel.values()));
+        }
+        influxDB.setLogLevel(logLevel);
+
+        return influxDB;
+    }
+}

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSink.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.annotations.Connector;
+import org.apache.pulsar.io.core.annotations.IOType;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * A Simple InfluxDB sink, which interprets input Record in generic record.
+ * In order to successfully parse and write points to InfluxDB, points must be in InfluxDB’s Line Protocol format.
+ * This class expects records from Pulsar to have a field named 'measurement', a field named 'tags' if necessary.
+ */
+@Connector(
+    name = "influxdb",
+    type = IOType.SINK,
+    help = "The InfluxDBGenericRecordSink is used for moving messages from Pulsar to InfluxDB.",
+    configClass = InfluxDBSinkConfig.class
+)
+@Slf4j
+public class InfluxDBGenericRecordSink extends InfluxDBAbstractSink<GenericRecord> {
+
+    private final Set<String> FIELDS_TO_SKIP = ImmutableSet.of("measurement", "tags");
+
+    @Override
+    public void buildBatch(Record<GenericRecord> message, BatchPoints.Builder batchBuilder) throws Exception {
+        Map<String, String> tags;
+        Map<String, Object> fields = Maps.newHashMap();
+
+        GenericRecord record = message.getValue();
+
+        Field measurementField = getFiled(record, "measurement");
+        if (null == measurementField) {
+            throw new SchemaSerializationException("measurement is a required field.");
+        }
+
+        String measurement = record.getField(measurementField).toString();
+
+        // Looking for tags
+        Field tagsField = getFiled(record, "tags");
+        if (null == tagsField) {
+            tags = ImmutableMap.of();
+        } else if (Map.class.isAssignableFrom(record.getField(tagsField).getClass())) {
+            tags = ((Map<Object, Object>) record.getField(tagsField)).entrySet()
+                .stream().collect(Collectors.toMap(
+                    entry -> entry.getKey().toString(),
+                    entry -> entry.getValue().toString())
+                );
+        } else {
+            // Field 'tags' that is not of Map type will be ignored
+            tags = ImmutableMap.of();
+        }
+
+        // Just insert the current time millis
+        long timestamp = System.currentTimeMillis();
+
+        for (Field field : record.getFields()) {
+            String fieldName = field.getName();
+            if (FIELDS_TO_SKIP.contains(fieldName)) {
+                continue;
+            }
+            Object fieldValue = record.getField(field);
+            if (null != fieldValue) {
+                fields.put(fieldName, fieldValue);
+            }
+        }
+
+        Point.Builder builder = Point.measurement(measurement)
+            .time(timestamp, TimeUnit.MILLISECONDS)
+            .tag(tags)
+            .fields(fields);
+        Point point = builder.build();
+        batchBuilder.point(point);
+    }
+
+    private Field getFiled(GenericRecord record, String fieldName) {
+        List<Field> fields = record.getFields();
+        return fields.stream()
+            .filter(field -> fieldName.equals(field.getName()))
+            .findAny()
+            .orElse(null);
+    }
+}

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfig.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.apache.pulsar.io.core.annotations.FieldDoc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Configuration class for the InfluxDB Sink Connector.
+ */
+@Data
+@Setter
+@Getter
+@EqualsAndHashCode
+@ToString
+@Accessors(chain = true)
+public class InfluxDBSinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "The url of the InfluxDB instance to connect to"
+    )
+    private String influxdbUrl;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "The username used to authenticate to InfluxDB"
+    )
+    private String username;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "The password used to authenticate to InfluxDB"
+    )
+    private String password;
+
+    @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "The InfluxDB database to write to"
+    )
+    private String database;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "ONE",
+        help = "The consistency level for writing data to InfluxDB. Possible values [ALL, ANY, ONE, QUORUM]")
+    private String consistencyLevel = "ONE";
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "NONE",
+        help = "The log level for InfluxDB request and response. Possible values [NONE, BASIC, HEADERS, FULL]")
+    private String logLevel = "NONE";
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "autogen",
+        help = "The retention policy for the InfluxDB database")
+    private String retentionPolicy = "autogen";
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "false",
+        help = "Flag to determine if gzip should be enabled")
+    private boolean gzipEnable = false;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "1000L",
+        help = "The InfluxDB operation time in milliseconds")
+    private long batchTimeMs = 1000L;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "200",
+        help = "The batch size of write to InfluxDB database"
+    )
+    private int batchSize = 200;
+
+    public static InfluxDBSinkConfig load(String yamlFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        return mapper.readValue(new File(yamlFile), InfluxDBSinkConfig.class);
+    }
+
+    public static InfluxDBSinkConfig load(Map<String, Object> map) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(new ObjectMapper().writeValueAsString(map), InfluxDBSinkConfig.class);
+    }
+
+    public void validate() {
+        Preconditions.checkNotNull(influxdbUrl, "influxdbUrl property not set.");
+        Preconditions.checkNotNull(database, "database property not set.");
+        Preconditions.checkArgument(batchSize > 0, "batchSize must be a positive integer.");
+        Preconditions.checkArgument(batchTimeMs > 0, "batchTimeMs must be a positive long.");
+    }
+}

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfig.java
@@ -57,6 +57,7 @@ public class InfluxDBSinkConfig implements Serializable {
     @FieldDoc(
         required = false,
         defaultValue = "",
+        sensitive = true,
         help = "The username used to authenticate to InfluxDB"
     )
     private String username;
@@ -64,6 +65,7 @@ public class InfluxDBSinkConfig implements Serializable {
     @FieldDoc(
         required = false,
         defaultValue = "",
+        sensitive = true,
         help = "The password used to authenticate to InfluxDB"
     )
     private String password;

--- a/pulsar-io/influxdb/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/influxdb/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: influxdb
+description: Writes data into InfluxDB database
+sinkClass: org.apache.pulsar.io.influxdb.InfluxDBGenericRecordSink

--- a/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSinkTest.java
+++ b/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSinkTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import com.google.common.collect.Maps;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.pulsar.io.core.SinkContext;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * InfluxDB Sink test
+ */
+@Slf4j
+public class InfluxDBGenericRecordSinkTest {
+
+    /**
+     * A Simple class to test InfluxDB class
+     */
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    public static class Cpu {
+        private String measurement;
+        private String model;
+        private int value;
+        private Map<String, String> tags;
+    }
+
+    @Mock
+    private SinkContext mockSinkContext;
+
+    InfluxDB influxDB;
+
+    InfluxDBAbstractSink influxSink;
+
+    private Map<String, Object> configMap = Maps.newHashMap();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        influxSink = new InfluxDBGenericRecordSink();
+
+        configMap.put("influxdbUrl", "http://localhost:8086");
+        configMap.put("database", "testDB");
+        configMap.put("consistencyLevel", "ONE");
+        configMap.put("logLevel", "NONE");
+        configMap.put("retentionPolicy", "autogen");
+        configMap.put("gzipEnable", "false");
+        configMap.put("batchTimeMs", "200");
+        configMap.put("batchSize", "1");
+
+        mockSinkContext = mock(SinkContext.class);
+        influxSink.influxDBBuilder = mock(InfluxDBBuilder.class);
+        influxDB = mock(InfluxDB.class);
+
+        when(influxSink.influxDBBuilder.build(any())).thenReturn(influxDB);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        influxSink.close();
+        verify(influxDB, times(1)).close();
+    }
+
+    @Test
+    public void testOpenAndWrite() throws Exception {
+        // prepare a cpu Record
+        Cpu cpu = new Cpu();
+        cpu.setMeasurement("cpu");
+        cpu.setModel("lenovo");
+        cpu.setValue(10);
+
+        Map<String, String> tags = Maps.newHashMap();
+        tags.put("host", "server-1");
+        tags.put("region", "us-west");
+
+        cpu.setTags(tags);
+        AvroSchema<Cpu> schema = AvroSchema.of(Cpu.class);
+
+        byte[] bytes = schema.encode(cpu);
+        ByteBuf payload = Unpooled.copiedBuffer(bytes);
+        AutoConsumeSchema autoConsumeSchema = new AutoConsumeSchema();
+        autoConsumeSchema.setSchema(GenericSchemaImpl.of(schema.getSchemaInfo()));
+
+        Message<GenericRecord> message = new MessageImpl("influx_cpu", "77:777",
+            configMap, payload, autoConsumeSchema);
+        Record<GenericRecord> record = PulsarRecord.<GenericRecord>builder()
+            .message(message)
+            .topicName("influx_cpu")
+            .build();
+
+        log.info("cpu:{}, Message.getValue: {}, record.getValue: {}",
+            cpu.toString(),
+            message.getValue().toString(),
+            record.getValue().toString());
+
+        influxSink.open(configMap, mockSinkContext);
+
+        verify(this.influxDB, times(1)).describeDatabases();
+        verify(this.influxDB, times(1)).createDatabase("testDB");
+
+        doAnswer(invocationOnMock -> {
+            BatchPoints batchPoints = invocationOnMock.getArgumentAt(0, BatchPoints.class);
+            Assert.assertNotNull(batchPoints, "batchPoints should not be null.");
+            return null;
+        }).when(influxDB).write(any(BatchPoints.class));
+
+        influxSink.write(record);
+
+        Thread.sleep(1000);
+
+        verify(influxDB, times(1)).write(any(BatchPoints.class));
+    }
+}

--- a/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfigTest.java
+++ b/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/InfluxDBSinkConfigTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb;
+
+import org.influxdb.InfluxDB;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * InfluxDBSinkConfig test
+ */
+public class InfluxDBSinkConfigTest {
+    @Test
+    public final void loadFromYamlFileTest() throws IOException {
+        File yamlFile = getFile("sinkConfig.yaml");
+        String path = yamlFile.getAbsolutePath();
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(path);
+        assertNotNull(config);
+        assertEquals("http://localhost:8086", config.getInfluxdbUrl());
+        assertEquals("test_db", config.getDatabase());
+        assertEquals("ONE", config.getConsistencyLevel());
+        assertEquals("NONE", config.getLogLevel());
+        assertEquals("autogen", config.getRetentionPolicy());
+        assertEquals(Boolean.parseBoolean("false"), config.isGzipEnable());
+        assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
+        assertEquals(Integer.parseInt("100"), config.getBatchSize());
+    }
+
+    @Test
+    public final void loadFromMapTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("influxdbUrl", "http://localhost:8086");
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "ONE");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "100");
+
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        assertNotNull(config);
+        assertEquals("http://localhost:8086", config.getInfluxdbUrl());
+        assertEquals("test_db", config.getDatabase());
+        assertEquals("ONE", config.getConsistencyLevel());
+        assertEquals("NONE", config.getLogLevel());
+        assertEquals("autogen", config.getRetentionPolicy());
+        assertEquals(Boolean.parseBoolean("false"), config.isGzipEnable());
+        assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
+        assertEquals(Integer.parseInt("100"), config.getBatchSize());
+    }
+
+    @Test
+    public final void validValidateTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("influxdbUrl", "http://localhost:8086");
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "ONE");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "100");
+
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        config.validate();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class,
+        expectedExceptionsMessageRegExp = "influxdbUrl property not set.")
+    public final void missingInfluxdbUrlValidateTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "ONE");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "100");
+
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        config.validate();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "batchSize must be a positive integer.")
+    public final void invalidBatchSizeTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("influxdbUrl", "http://localhost:8086");
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "ONE");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "-100");
+
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        config.validate();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "No enum constant org.influxdb.InfluxDB.ConsistencyLevel.NOTSUPPORT")
+    public final void invalidConsistencyLevelTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("influxdbUrl", "http://localhost:8086");
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "NotSupport");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "100");
+
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        config.validate();
+
+        InfluxDB.ConsistencyLevel.valueOf(config.getConsistencyLevel().toUpperCase());
+    }
+
+    private File getFile(String name) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return new File(classLoader.getResource(name).getFile());
+    }
+}

--- a/pulsar-io/influxdb/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/influxdb/src/test/resources/sinkConfig.yaml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{
+"influxdbUrl": "http://localhost:8086",
+"database": "test_db",
+"consistencyLevel": "ONE",
+"logLevel": "NONE",
+"retentionPolicy": "autogen",
+"gzipEnable": "false",
+"batchTimeMs": "1000",
+"batchSize": "100"
+}

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -55,6 +55,7 @@
     <module>flume</module>
     <module>redis</module>
     <module>solr</module>
+    <module>influxdb</module>
   </modules>
 
 </project>

--- a/site2/docs/io-connectors.md
+++ b/site2/docs/io-connectors.md
@@ -25,3 +25,4 @@ Pulsar Functions cluster.
 - [Hdfs Sink Connector](io-hdfs.md#sink)
 - [MongoDB Sink Connector](io-mongo.md#sink)
 - [Solr Sink Connector](io-solr.md#sink)
+- [InfluxDB Sink Connector](io-influxdb.md#sink)

--- a/site2/docs/io-influxdb.md
+++ b/site2/docs/io-influxdb.md
@@ -1,0 +1,25 @@
+---
+id: io-influxdb
+title: InfluxDB Connector
+sidebar_label: InfluxDB Connector
+---
+
+## Sink
+
+The InfluxDB Sink Connector is used to pull messages from Pulsar topics and persist the messages
+to an InfluxDB database.
+
+## Sink Configuration Options
+
+| Name | Default | Required | Description |
+|------|---------|----------|-------------|
+| `influxdbUrl` | `null` | `true` | The url of the InfluxDB instance to connect to. |
+| `username` | `null` | `false` | The username used to authenticate to InfluxDB. |
+| `password` | `null` | `false` | The password used to authenticate to InfluxDB. |
+| `database` | `null` | `true` | The InfluxDB database to write to. |
+| `consistencyLevel` | `ONE` | `false` | The consistency level for writing data to InfluxDB. Possible values [ALL, ANY, ONE, QUORUM]. |
+| `logLevel` | `NONE` | `false` | The log level for InfluxDB request and response. Possible values [NONE, BASIC, HEADERS, FULL]. |
+| `retentionPolicy` | `autogen` | `false` | The retention policy for the InfluxDB database. |
+| `gzipEnable` | `false` | `false` | Flag to determine if gzip should be enabled. |
+| `batchTimeMs` | `1000` | `false` | The InfluxDB operation time in milliseconds. |
+| `batchSize` | `200` | `false` | The batch size of write to InfluxDB database. |


### PR DESCRIPTION
### Motivation

Provides a builtin InfluxDB sink Connector, in order to persist pulsar messages to a InfluxDB database.

### Modifications

Add a InfluxDB Sink and some unit tests.

### Verifying this change

This change can be verified as follows:

* deploy the InfluxDB Sink connector with configuration file containing the following fields:

```
configs:
    influxdbUrl: "http://localhost:8086"
    database: "test_db"
    consistencyLevel: "ONE"
    logLevel: "NONE"
    retentionPolicy: "autogen"
    gzipEnable: "false"
    batchTimeMs: "1000"
    batchSize: "100"
```
* deploy an InfluxDB instance and create the above elements
* send messages in the topic with specified schema declared when deploying the connector
* use `influx` CLI to query messages in the specified database