### PR TITLE
[Issue 3987][pulsar-broker]Handle config is null when create tenant

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -91,6 +91,9 @@ public class TenantsBase extends AdminResource {
 
         try {
             NamedEntity.checkName(tenant);
+            if (config == null) {
+                config = new TenantInfo();
+            }
             zkCreate(path(POLICIES, tenant), jsonMapper().writeValueAsBytes(config));
             log.info("[{}] Created tenant {}", clientAppId(), tenant);
         } catch (KeeperException.NodeExistsException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -499,8 +499,15 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
 
+        // Check tenantInfo is null
+        TenantInfo nullTenantInfo = new TenantInfo();
+        properties.createTenant("tenant-config-is-null", null);
+        assertEquals(properties.getTenantAdmin("tenant-config-is-null"), nullTenantInfo);
+
+
         namespaces.deleteNamespace("my-tenant", "use", "my-namespace", false);
         properties.deleteTenant("my-tenant");
+        properties.deleteTenant("tenant-config-is-null");
     }
 
     @Test


### PR DESCRIPTION
Fixes #3987 

### Motivation

Config will not appear null when create tenant use pulsar-admin create foo3, but use the following command, config is null.
```
curl -X PUT http://localhost:8080/admin/v2/tenants/foo3
```

### Modifications

Handle config is null when create tenant use curl.

### Verifying this change
Test pass
```
curl -X PUT http://localhost:8080/admin/v2/tenants/foo3
curl -X GET http://localhost:8080/admin/v2/tenants/foo3
{"adminRoles":[],"allowedClusters":[]}
```