### PR TITLE
Make generate_protobuf_docker.sh usable on windows

### DIFF
--- a/pulsar-common/generate_protobuf_docker.sh
+++ b/pulsar-common/generate_protobuf_docker.sh
@@ -35,6 +35,8 @@ echo $IMAGE
 # Force to pull image in case it was updated
 docker pull $IMAGE
 
+WORKDIR=/workdir
 docker run -i \
-    -v ${COMMON_DIR}:${COMMON_DIR} $IMAGE \
-    bash -c "cd ${COMMON_DIR}; /pulsar/protobuf/src/protoc --java_out=src/main/java src/main/proto/PulsarApi.proto"
+    -v ${COMMON_DIR}:${WORKDIR} $IMAGE \
+    bash -c "cd ${WORKDIR}; /pulsar/protobuf/src/protoc --java_out=src/main/java src/main/proto/PulsarApi.proto"
+


### PR DESCRIPTION
### Motivation

On windows, `generate_protobuf_docker.sh` cannot work well, because a ':' is contained in windows path.  Just make it work. 

### Modifications

change generate_protobuf_docker.sh

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.