### PR TITLE
[python client] Handle subrecords in JsonSchema encoding

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -80,7 +80,7 @@ class JsonSchema(Schema):
 
     def encode(self, obj):
         self._validate_object_type(obj)
-        return json.dumps(obj.__dict__, indent=True).encode('utf-8')
+        return json.dumps(obj.__dict__, default=lambda o: o.__dict__, indent=True).encode('utf-8')
 
     def decode(self, data):
         return self._record_cls(**json.loads(data))


### PR DESCRIPTION
Fixes  #3916

### Motivation

When using a complex type with subrecord in a JsonSchema, the JSON encoding fails with `Object of type SubType is not JSON serializable` because the actual encoding does not handle a default function  that gets called for objects that can’t be serialized. 

### Modifications

Adding a function using the same behavior (using object dictionary) on objects make the encoding compatible with subrecords. 
