### PR TITLE
For functions metrics, avoid having HELP

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
@@ -143,7 +143,7 @@ public abstract class ComponentStatsManager implements AutoCloseable {
     public String getStatsAsString() throws IOException {
         StringWriter outputWriter = new StringWriter();
 
-        TextFormat.write004(outputWriter, collectorRegistry.metricFamilySamples());
+        PrometheusTextFormat.write004(outputWriter, collectorRegistry.metricFamilySamples());
 
         return outputWriter.toString();
     }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusTextFormat.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/PrometheusTextFormat.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance.stats;
+
+import io.prometheus.client.Collector;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Enumeration;
+
+/**
+ * Provide Prometheus text format for a collection of metrics, without the HELP string
+ */
+public class PrometheusTextFormat {
+    /**
+     * Write out the text version 0.0.4 of the given MetricFamilySamples.
+     */
+    public static void write004(Writer writer, Enumeration<Collector.MetricFamilySamples> mfs) throws IOException {
+        /*
+         * See http://prometheus.io/docs/instrumenting/exposition_formats/ for the output format specification.
+         */
+        while (mfs.hasMoreElements()) {
+            Collector.MetricFamilySamples metricFamilySamples = mfs.nextElement();
+            writer.write("# TYPE ");
+            writer.write(metricFamilySamples.name);
+            writer.write(' ');
+            writer.write(typeString(metricFamilySamples.type));
+            writer.write('\n');
+
+            for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
+                writer.write(sample.name);
+                if (sample.labelNames.size() > 0) {
+                    writer.write('{');
+                    for (int i = 0; i < sample.labelNames.size(); ++i) {
+                        writer.write(sample.labelNames.get(i));
+                        writer.write("=\"");
+                        writeEscapedLabelValue(writer, sample.labelValues.get(i));
+                        writer.write("\",");
+                    }
+                    writer.write('}');
+                }
+                writer.write(' ');
+                writer.write(Collector.doubleToGoString(sample.value));
+                if (sample.timestampMs != null) {
+                    writer.write(' ');
+                    writer.write(sample.timestampMs.toString());
+                }
+                writer.write('\n');
+            }
+        }
+    }
+
+    private static String typeString(Collector.Type t) {
+        switch (t) {
+        case GAUGE:
+            return "gauge";
+        case COUNTER:
+            return "counter";
+        case SUMMARY:
+            return "summary";
+        case HISTOGRAM:
+            return "histogram";
+        default:
+            return "untyped";
+        }
+    }
+
+    private static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                writer.append("\\\\");
+                break;
+            case '\"':
+                writer.append("\\\"");
+                break;
+            case '\n':
+                writer.append("\\n");
+                break;
+            default:
+                writer.append(c);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

For functions metrics, we're currently using 1 collector per each function instance,  both in thread and process mode. Then all metrics are merged together and reported to prometheus. 

Prometheus is then complaining that multiple `#HELP` lines are presents in the reported metrics.