### PR TITLE
[pulsar-client-tools] Provide the description of functions command for better usage

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -80,7 +80,15 @@ public class CmdFunctions extends CmdBase {
     abstract class BaseCommand extends CliCommand {
         @Override
         void run() throws Exception {
-            processArguments();
+            try {
+                processArguments();
+            } catch (Exception e) {
+                System.err.println(e.getMessage());
+                System.err.println();
+                String chosenCommand = jcommander.getParsedCommand();
+                jcommander.usage(chosenCommand);
+                return;
+            }
             runCmd();
         }
 


### PR DESCRIPTION
### Motivation

This PR is similar to #3868.

Currently, it shows as bellow when providing zero args in command `functions`:

```
$ bin/pulsar-admin functions get
java.lang.RuntimeException: You must specify a name for the function or a Fully Qualified Function Name (FQFN)
	at org.apache.pulsar.admin.cli.CmdFunctions$FunctionCommand.processArguments(CmdFunctions.java:160)
	at org.apache.pulsar.admin.cli.CmdFunctions$BaseCommand.run(CmdFunctions.java:83)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:62)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:193)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:235)
```

### Expected behavior

```
$ bin/pulsar-admin functions get
You must specify a name for the function or a Fully Qualified Function Name (FQFN)

Fetch information about a Pulsar Function
Usage: get [options]
  Options:
    --fqfn
       The Fully Qualified Function Name (FQFN) for the function
    --name
       The function's name
    --namespace
       The function's namespace
    --tenant
       The function's tenant
```

### Modifications

Add the usage of chosen subcommand when `processArguments` failed.