### PR TITLE
Fix exit when qureystate and specify watch

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -46,12 +46,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.functions.WindowConfig;
 import org.apache.pulsar.common.functions.FunctionState;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
 
 @Slf4j
 @Parameters(commandDescription = "Interface for managing Pulsar Functions (lightweight, Lambda-style compute processes that work with Pulsar)")
@@ -778,9 +781,18 @@ public class CmdFunctions extends CmdBase {
         @Override
         void runCmd() throws Exception {
             do {
-                FunctionState functionState = admin.functions().getFunctionState(tenant, namespace, functionName, key);
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                System.out.println(gson.toJson(functionState));
+                try {
+                    FunctionState functionState = admin.functions()
+                                                       .getFunctionState(tenant, namespace, functionName, key);
+                    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                    gson.toJson(functionState);
+                } catch (PulsarAdminException pae) {
+                    if (pae.getStatusCode() == 404 && watch) {
+                        System.out.println(pae.getMessage());
+                    } else {
+                        throw pae;
+                    }
+                }
                 if (watch) {
                     Thread.sleep(1000);
                 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -786,7 +786,7 @@ public class CmdFunctions extends CmdBase {
                     gson.toJson(functionState);
                 } catch (PulsarAdminException pae) {
                     if (pae.getStatusCode() == 404 && watch) {
-                        System.out.println(pae.getMessage());
+                        System.err.println(pae.getMessage());
                     } else {
                         throw pae;
                     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -53,8 +53,6 @@ import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.functions.WindowConfig;
 import org.apache.pulsar.common.functions.FunctionState;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.WebApplicationException;
 
 @Slf4j
 @Parameters(commandDescription = "Interface for managing Pulsar Functions (lightweight, Lambda-style compute processes that work with Pulsar)")


### PR DESCRIPTION
---

*Motivation*

It's shouldn't exit when querystate and specify watched. When watched specify, it
watches all changes.

*Modifications*

Add `catch` for watch, When server return NOT_FOUND and user was watched it still watch
all changes.
