### PR TITLE
[client] Upgrade athenz libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ flexible messaging model and an intuitive client API.</description>
     <storm.version>1.0.5</storm.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jersey.version>2.27</jersey.version>
-    <athenz.version>1.7.17</athenz.version>
+    <athenz.version>1.8.17</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
     <rocksdb.version>5.13.3</rocksdb.version>

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -59,6 +59,10 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
     private String providerDomain;
     private PrivateKey privateKey;
     private String keyId = "0";
+    // If auto prefetching is enabled, application will not complete until the static method
+    // ZTSClient.cancelPrefetch() is called.
+    // cf. https://github.com/yahoo/athenz/issues/544
+    private boolean autoPrefetchEnabled = false;
     private long cachedRoleTokenTimestamp;
     private String roleToken;
     private final int minValidity = 2 * 60 * 60; // athenz will only give this token if it's at least valid for 2hrs
@@ -136,6 +140,8 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         }
 
         this.keyId = authParams.getOrDefault("keyId", "0");
+        this.autoPrefetchEnabled = Boolean.valueOf(authParams.getOrDefault("autoPrefetchEnabled", "false"));
+
         if (authParams.containsKey("athenzConfPath")) {
             System.setProperty("athenz.athenz_conf", authParams.get("athenzConfPath"));
         }
@@ -156,6 +162,9 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
 
     @Override
     public void close() throws IOException {
+        if (ztsClient != null) {
+            ztsClient.close();
+        }
     }
 
     private ZTSClient getZtsClient() {
@@ -163,6 +172,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
             ServiceIdentityProvider siaProvider = new SimpleServiceIdentityProvider(tenantDomain, tenantService,
                     privateKey, keyId);
             ztsClient = new ZTSClient(ztsUrl, tenantDomain, tenantService, siaProvider);
+            ztsClient.setPrefetchAutoEnable(this.autoPrefetchEnabled);
         }
         return ztsClient;
     }

--- a/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
+++ b/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl.auth;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 import org.apache.pulsar.client.impl.auth.AuthenticationAthenz;
@@ -170,5 +171,28 @@ public class AuthenticationAthenzTest {
         } catch (Exception e) {
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testAutoPrefetchEnabled() throws Exception {
+        Field field = auth.getClass().getDeclaredField("autoPrefetchEnabled");
+        field.setAccessible(true);
+        assertFalse((boolean) field.get(auth));
+
+        String paramsStr = new String(Files.readAllBytes(Paths.get("./src/test/resources/authParams.json")));
+        ObjectMapper jsonMapper = ObjectMapperFactory.create();
+        Map<String, String> authParamsMap = jsonMapper.readValue(paramsStr, new TypeReference<HashMap<String, String>>() { });
+
+        authParamsMap.put("autoPrefetchEnabled", "true");
+        AuthenticationAthenz auth1 = new AuthenticationAthenz();
+        auth1.configure(jsonMapper.writeValueAsString(authParamsMap));
+        assertTrue((boolean) field.get(auth1));
+        auth1.close();
+
+        authParamsMap.put("autoPrefetchEnabled", "false");
+        AuthenticationAthenz auth2 = new AuthenticationAthenz();
+        auth2.configure(jsonMapper.writeValueAsString(authParamsMap));
+        assertFalse((boolean) field.get(auth2));
+        auth2.close();
     }
 }


### PR DESCRIPTION
### Motivation

The version of Athenz libraries that Pulsar is using now is 1.7.17, which is a little old. Athenz v1.7.17 has a dependency on a library with security vulnerable (i.e. jackson-databind-2.5.4).

```
[INFO] +- org.apache.pulsar:pulsar-client-auth-athenz:jar:2.3.1:compile
[INFO] |  \- com.yahoo.athenz:athenz-zts-java-client:jar:1.7.17:compile
[INFO] |     +- com.yahoo.athenz:athenz-zts-core:jar:1.7.17:compile
[INFO] |     |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.5.4:compile
[INFO] |     |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.5.4:compile
[INFO] |     +- com.yahoo.athenz:athenz-client-common:jar:1.7.17:compile
[INFO] |     |  \- com.yahoo.athenz:athenz-zms-core:jar:1.7.17:compile
[INFO] |     +- com.yahoo.athenz:athenz-auth-core:jar:1.7.17:compile
[INFO] |     |  \- org.kohsuke:libpam4j:jar:1.6:compile
[INFO] |     |     \- net.java.dev.jna:jna:jar:3.4.0:compile
[INFO] |     \- com.yahoo.rdl:rdl-java:jar:1.4.13:compile
[INFO] |        \- com.fasterxml.jackson.core:jackson-core:jar:2.3.2:compile
```

### Modifications

Upgraded the Athenz libraries to 1.8.17.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.