### PR TITLE
Ensure Pulsar HTTP proxy carries over Authorization header after 307 redirects

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -39,9 +39,11 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.util.SecurityUtility;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.ProtocolHandlers;
 import org.eclipse.jetty.client.RedirectProtocolHandler;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.util.HttpCookieStore;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -130,6 +132,33 @@ class AdminProxyHandler extends ProxyServlet {
         }
     }
 
+
+    private static class JettyHttpClient extends HttpClient {
+        public JettyHttpClient() {
+            super();
+        }
+
+        public JettyHttpClient(SslContextFactory sslContextFactory) {
+            super(sslContextFactory);
+        }
+
+        /**
+         * Ensure the Authorization header is carried over after a 307 redirect
+         * from brokers.
+         */
+        @Override
+        protected Request copyRequest(HttpRequest oldRequest, URI newURI) {
+            String authorization = oldRequest.getHeaders().get(HttpHeader.AUTHORIZATION);
+            Request newRequest = super.copyRequest(oldRequest, newURI);
+            if (authorization != null) {
+                newRequest.header(HttpHeader.AUTHORIZATION, authorization);
+            }
+
+            return newRequest;
+        }
+
+    }
+
     @Override
     protected HttpClient newHttpClient() {
         try {
@@ -166,7 +195,7 @@ class AdminProxyHandler extends ProxyServlet {
                     SslContextFactory contextFactory = new SslContextFactory();
                     contextFactory.setSslContext(sslCtx);
 
-                    return new HttpClient(contextFactory);
+                    return new JettyHttpClient(contextFactory);
                 } catch (Exception e) {
                     try {
                         auth.close();
@@ -181,7 +210,7 @@ class AdminProxyHandler extends ProxyServlet {
         }
 
         // return an unauthenticated client, every request will fail.
-        return new HttpClient();
+        return new JettyHttpClient();
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
@@ -247,8 +247,8 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
 
         admin.topics().getList(namespace);
 
-        // Test multiple stats request to make sure the proxy will try will all broker and receive 307 responses
-        // that it will handle internally.
+        // Test multiple stats request to make sure the proxy will try against all brokers and receive 307
+        // responses that it will handle internally.
         for (int i = 0; i < 10; i++) {
             admin.topics().getStats(topic);
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
@@ -246,5 +246,11 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
                 .close();
 
         admin.topics().getList(namespace);
+
+        // Test multiple stats request to make sure the proxy will try will all broker and receive 307 responses
+        // that it will handle internally.
+        for (int i = 0; i < 10; i++) {
+            admin.topics().getStats(topic);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Similar to what done in #3869 for PulsarAdmin, this is fixing HTTP redirects when are internally followed by the Pulsar proxy. The `Authorization` header with the token info needs to be carried over after the redirect.