### PR TITLE
Fixed regex for Pulsar version correction

### DIFF
--- a/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
+++ b/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
@@ -23,7 +23,10 @@ import java.util.regex.Pattern;
 
 public class PulsarVersion {
 
-    private static final Pattern majorMinorPatchPattern = Pattern.compile("([1-9]+[0-9]*)\\.([1-9]+[0-9]*)\\.([1-9]+[0-9]*)(.*)");
+    private static final Pattern majorMinorPatchPattern = Pattern.compile("([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)");
+
+    // Pattern for version missing the patch number: eg: 1.14-SNAPSHOT
+    private static final Pattern majorMinorPatter = Pattern.compile("([0-9]+)\\.([0-9]+)(.*)");
 
     // If the version string does not contain a patch version, add one so the
     // version becomes valid according to the SemVer library (see https://github.com/zafarkhaja/jsemver).
@@ -41,8 +44,7 @@ public class PulsarVersion {
             return version;
         } else {
             // the patch version is missing, so add one ("0")
-            Pattern pattern2 = Pattern.compile("([1-9]+[0-9]*)\\.([1-9]+[0-9]*)(.*)");
-            Matcher matcher2 = pattern2.matcher(version);
+            Matcher matcher2 = majorMinorPatter.matcher(version);
 
             if (matcher2.matches()) {
                 int startMajorVersion = matcher2.start(1);

--- a/pulsar-common/src/test/java/org/apache/pulsar/AddMissingPatchVersionTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/AddMissingPatchVersionTest.java
@@ -33,6 +33,9 @@ public class AddMissingPatchVersionTest {
 
         // Already valid versions get returned unchanged
         Assert.assertEquals(PulsarVersion.fixVersionString("1.2.3"), "1.2.3");
+        Assert.assertEquals(PulsarVersion.fixVersionString("2.2.0"), "2.2.0");
+        Assert.assertEquals(PulsarVersion.fixVersionString("3.0.0"), "3.0.0");
+        Assert.assertEquals(PulsarVersion.fixVersionString("3.0.0-SNAPSHOT"), "3.0.0-SNAPSHOT");
         Assert.assertEquals(PulsarVersion.fixVersionString("1.2.3-SNAPSHOT"), "1.2.3-SNAPSHOT");
         Assert.assertEquals(PulsarVersion.fixVersionString("1.2.3-SNAPSHOT+BUILD"), "1.2.3-SNAPSHOT+BUILD");
         Assert.assertEquals(PulsarVersion.fixVersionString("1.2.3+BUILD"), "1.2.3+BUILD");


### PR DESCRIPTION
### Motivation

There's a method that is correcting the version to make sure it complies with SemVer (eg: has 1.2.3 format and not just 1.2). The regex is not correct and it ends up changing the version into `2.4.0.0-SNAPSHOT` instead of leaving the correct `2.4.0-SNAPSHOT`.