### PR TITLE
Fix connectors nested configs

### DIFF
--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -53,7 +53,15 @@ public class SinkConfigUtilsTest {
         inputSpecs.put("test-input", ConsumerConfig.builder().isRegexPattern(true).serdeClassName("test-serde").build());
         sinkConfig.setInputSpecs(inputSpecs);
         sinkConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
-        sinkConfig.setConfigs(new HashMap<>());
+
+        Map<String, String> producerConfigs = new HashMap<>();
+        producerConfigs.put("security.protocal", "SASL_PLAINTEXT");
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("topic", "kafka");
+        configs.put("bootstrapServers", "server-1,server-2");
+        configs.put("producerConfigProperties", producerConfigs);
+
+        sinkConfig.setConfigs(configs);
         sinkConfig.setRetainOrdering(false);
         sinkConfig.setAutoAck(true);
         sinkConfig.setTimeoutMs(2000l);

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -51,7 +51,15 @@ public class SourceConfigUtilsTest {
         sourceConfig.setParallelism(1);
         sourceConfig.setRuntimeFlags("-DKerberos");
         sourceConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
-        sourceConfig.setConfigs(new HashMap<>());
+
+        Map<String, String> consumerConfigs = new HashMap<>();
+        consumerConfigs.put("security.protocal", "SASL_PLAINTEXT");
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("topic", "kafka");
+        configs.put("bootstrapServers", "server-1,server-2");
+        configs.put("consumerConfigProperties", consumerConfigs);
+
+        sourceConfig.setConfigs(configs);
         Function.FunctionDetails functionDetails = SourceConfigUtils.convert(sourceConfig, new SourceConfigUtils.ExtractedSourceDetails(null, null));
         SourceConfig convertedConfig = SourceConfigUtils.convertFromDetails(functionDetails);
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -597,7 +597,6 @@ public abstract class ComponentImpl {
                 SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(existingSinkConfig, sinkConfig);
                 mergedComponentConfigJson = new Gson().toJson(mergedConfig);
             } catch (Exception e) {
-                log.error("error: {}", e);
                 throw new RestException(Status.BAD_REQUEST, e.getMessage());
             }
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -597,6 +597,7 @@ public abstract class ComponentImpl {
                 SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(existingSinkConfig, sinkConfig);
                 mergedComponentConfigJson = new Gson().toJson(mergedConfig);
             } catch (Exception e) {
+                log.error("error: {}", e);
                 throw new RestException(Status.BAD_REQUEST, e.getMessage());
             }
         }


### PR DESCRIPTION


### Motivation

Updating a source or sink with configs that have nested structures with cause client error:

```
org.apache.pulsar.client.admin.PulsarAdminException$ServerSideErrorException: HTTP 500 Internal Server Error
    at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:163)
```

Error in broker/worker log:

```
Caused by: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 140 path $.
	at com.google.gson.Gson.fromJson(Gson.java:900) ~[com.google.code.gson-gson-2.8.2.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:853) ~[com.google.code.gson-gson-2.8.2.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:802) ~[com.google.code.gson-gson-2.8.2.jar:?]
	at org.apache.pulsar.functions.utils.SinkConfigUtils.convertFromDetails(SinkConfigUtils.java:244) ~[org.apache.pulsar-pulsar-functions-utils-2.3.1.jar:2.3.1]
	at org.apache.pulsar.functions.worker.rest.api.ComponentImpl.updateFunction(ComponentImpl.java:528) ~[org.apache.pulsar-pulsar-functions-worker-2.3.1.jar:2.3.1]
	at org.apache.pulsar.broker.admin.impl.SinkBase.updateSink(SinkBase.java:102) ~[org.apache.pulsar-pulsar-broker-2.3.1.jar:2.3.1]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_181]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:76) 
```

Originally, I think we were only expecting source/sink configs to be Map<String, String> but that has changed


### Modifications


Allow nested structures in source/sink configs.