### PR TITLE
[pulsar-proxy]Add the LookupProxyHandler handle getSchema request and test

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -65,7 +65,7 @@ public class LookupProxyHandler {
             .create()
             .register();
 
-    private static final Counter getSchemaRequestss = Counter
+    private static final Counter getSchemaRequests = Counter
             .build("pulsar_proxy_get_schema_requests", "Counter of schema requests")
             .create()
             .register();
@@ -345,7 +345,7 @@ public class LookupProxyHandler {
     }
 
     public void handleGetSchema(CommandGetSchema commandGetSchema) {
-        getSchemaRequestss.inc();
+        getSchemaRequests.inc();
         if (log.isDebugEnabled()) {
             log.debug("[{}] Received GetSchema", clientAddress);
         }
@@ -391,8 +391,6 @@ public class LookupProxyHandler {
                     Commands.newError(clientRequestId, ServerError.ServiceNotReady, ex.getMessage()));
             return null;
         });
-
-
 
     }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -24,14 +24,19 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetSchema;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.BytesSchemaVersion;
+import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +62,11 @@ public class LookupProxyHandler {
 
     private static final Counter getTopicsOfNamespaceRequestss = Counter
             .build("pulsar_proxy_get_topics_of_namespace_requests", "Counter of getTopicsOfNamespace requests")
+            .create()
+            .register();
+
+    private static final Counter getSchemaRequestss = Counter
+            .build("pulsar_proxy_get_schema_requests", "Counter of schema requests")
             .create()
             .register();
 
@@ -280,26 +290,12 @@ public class LookupProxyHandler {
         }
     }
 
-
     private void handleGetTopicsOfNamespace(CommandGetTopicsOfNamespace commandGetTopicsOfNamespace,
                                             long clientRequestId) {
-        String serviceUrl;
-        if (isBlank(brokerServiceURL)) {
-            ServiceLookupData availableBroker;
-            try {
-                availableBroker = service.getDiscoveryProvider().nextBroker();
-            } catch (Exception e) {
-                log.warn("[{}] Failed to get next active broker {}", clientAddress, e.getMessage(), e);
-                proxyConnection.ctx().writeAndFlush(Commands.newError(
-                    clientRequestId, ServerError.ServiceNotReady, e.getMessage()
-                ));
-                return;
-            }
-            serviceUrl = this.connectWithTLS ?
-                availableBroker.getPulsarServiceUrlTls() : availableBroker.getPulsarServiceUrl();
-        } else {
-            serviceUrl = this.connectWithTLS ?
-                service.getConfiguration().getBrokerServiceURLTLS() : service.getConfiguration().getBrokerServiceURL();
+        String serviceUrl = getServiceUrl(clientRequestId);
+
+        if(!StringUtils.isNotBlank(serviceUrl)) {
+            return;
         }
         performGetTopicsOfNamespace(clientRequestId, commandGetTopicsOfNamespace.getNamespace(), serviceUrl, 10,
             commandGetTopicsOfNamespace.getMode());
@@ -316,16 +312,12 @@ public class LookupProxyHandler {
             return;
         }
 
-        URI brokerURI;
-        try {
-            brokerURI = new URI(brokerServiceUrl);
-        } catch (URISyntaxException e) {
-            proxyConnection.ctx().writeAndFlush(
-                    Commands.newError(clientRequestId, ServerError.MetadataError, e.getMessage()));
+        InetSocketAddress addr = getAddr(brokerServiceUrl, clientRequestId);
+
+        if(addr == null){
             return;
         }
 
-        InetSocketAddress addr = InetSocketAddress.createUnresolved(brokerURI.getHost(), brokerURI.getPort());
         if (log.isDebugEnabled()) {
             log.debug("Getting connections to '{}' for getting TopicsOfNamespace '{}' with clientReq Id '{}'",
                 addr, namespaceName, clientRequestId);
@@ -350,6 +342,91 @@ public class LookupProxyHandler {
                     Commands.newError(clientRequestId, ServerError.ServiceNotReady, ex.getMessage()));
             return null;
         });
+    }
+
+    public void handleGetSchema(CommandGetSchema commandGetSchema) {
+        getSchemaRequestss.inc();
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Received GetSchema", clientAddress);
+        }
+
+        final long clientRequestId = commandGetSchema.getRequestId();
+        String serviceUrl = getServiceUrl(clientRequestId);
+
+        if(!StringUtils.isNotBlank(serviceUrl)) {
+            return;
+        }
+        InetSocketAddress addr = getAddr(serviceUrl, clientRequestId);
+
+        if(addr == null){
+            return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Getting connections to '{}' for getting schema of topic '{}' with clientReq Id '{}'",
+                    addr, commandGetSchema.getTopic(), clientRequestId);
+        }
+
+        proxyConnection.getConnectionPool().getConnection(addr).thenAccept(clientCnx -> {
+            // Connected to backend broker
+            long requestId = proxyConnection.newRequestId();
+            ByteBuf command;
+            byte[] schemaVersion = commandGetSchema.getSchemaVersion().toByteArray();
+            command = Commands.newGetSchema(requestId, commandGetSchema.getTopic(),
+                    Optional.ofNullable(BytesSchemaVersion.of(schemaVersion)));
+            clientCnx.sendGetSchema(command, requestId).thenAccept(optionalSchemaInfo -> {
+                        SchemaInfo schemaInfo = optionalSchemaInfo.get();
+                        proxyConnection.ctx().writeAndFlush(
+                                Commands.newGetSchemaResponse(clientRequestId,
+                                        schemaInfo,
+                                        BytesSchemaVersion.of(schemaVersion)));
+            }).exceptionally(ex -> {
+                log.warn("[{}] Failed to get schema {}: {}", clientAddress, commandGetSchema.getTopic(), ex.getMessage());
+                proxyConnection.ctx().writeAndFlush(
+                        Commands.newError(clientRequestId, ServerError.ServiceNotReady, ex.getMessage()));
+                return null;
+            });
+        }).exceptionally(ex -> {
+            // Failed to connect to backend broker
+            proxyConnection.ctx().writeAndFlush(
+                    Commands.newError(clientRequestId, ServerError.ServiceNotReady, ex.getMessage()));
+            return null;
+        });
+
+
+
+    }
+
+    private String getServiceUrl(long clientRequestId) {
+        if (isBlank(brokerServiceURL)) {
+            ServiceLookupData availableBroker;
+            try {
+                availableBroker = service.getDiscoveryProvider().nextBroker();
+            } catch (Exception e) {
+                log.warn("[{}] Failed to get next active broker {}", clientAddress, e.getMessage(), e);
+                proxyConnection.ctx().writeAndFlush(Commands.newError(
+                        clientRequestId, ServerError.ServiceNotReady, e.getMessage()
+                ));
+                return null;
+            }
+            return this.connectWithTLS ?
+                    availableBroker.getPulsarServiceUrlTls() : availableBroker.getPulsarServiceUrl();
+        } else {
+            return this.connectWithTLS ?
+                    service.getConfiguration().getBrokerServiceURLTLS() : service.getConfiguration().getBrokerServiceURL();
+        }
+
+    }
+
+    private InetSocketAddress getAddr(String brokerServiceUrl, long clientRequestId) {
+        URI brokerURI;
+        try {
+            brokerURI = new URI(brokerServiceUrl);
+        } catch (URISyntaxException e) {
+            proxyConnection.ctx().writeAndFlush(
+                    Commands.newError(clientRequestId, ServerError.MetadataError, e.getMessage()));
+            return null;
+        }
+        return InetSocketAddress.createUnresolved(brokerURI.getHost(), brokerURI.getPort());
     }
 
     private static final Logger log = LoggerFactory.getLogger(LookupProxyHandler.class);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandAuthResponse;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetSchema;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.slf4j.Logger;
@@ -370,6 +371,12 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
         checkArgument(state == State.ProxyLookupRequests);
 
         lookupProxyHandler.handleGetTopicsOfNamespace(commandGetTopicsOfNamespace);
+    }
+    @Override
+    protected void handleGetSchema(CommandGetSchema commandGetSchema) {
+        checkArgument(state == State.ProxyLookupRequests);
+
+        lookupProxyHandler.handleGetSchema(commandGetSchema);
     }
 
     /**


### PR DESCRIPTION
### Motivation
In order to support #3742 #3876.
Now, proxy handle ProxyLookupRequests don't support GetSchema.

### Modifications
Add the getSchema method implementation in ProxyConnection 

### Verifying this change
Add new a test in ProxyTest testGetSchema()

### Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (yes)
The admin cli options: (no)
Anything that affects deployment: (no)
### Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (no)
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation