### PR TITLE
[c++][pulsar-client-cpp] Protect against double joining the worker thread in ExecutorService::close()

### DIFF
--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -55,9 +55,13 @@ DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
 }
 
 void ExecutorService::close() {
-    io_service_.stop();
-    work_.reset();
-    worker_.join();
+    // Ensure this service has not already been closed. This is
+    // because worker_.join() is not re-entrant on Windows
+    if (work_) {
+        io_service_.stop();
+        work_.reset();
+        worker_.join();
+    }
 }
 
 void ExecutorService::postWork(std::function<void(void)> task) { io_service_.post(task); }


### PR DESCRIPTION
### Motivation

This change is to prevent a crash on Windows when an ExecutorService is closed before it is destroyed. Since the ExecutorService destructor calls close(), join() will be invoked on the worker thread twice and this call is not re-entrant on Windows.

### Modifications

In ExecutorService::close(), the work_ pointer's validity is checked before taking any action. If the work_ pointer is valid, the thread must still be active and joining it is safe. If it is null, then the Service has already been closed and no actions need to be taken.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: No
  - The schema: No
  - The default values of configurations: No
  - The wire protocol: No
  - The rest endpoints: No
  - The admin cli options: No
  - Anything that affects deployment: No

### Documentation

  - Does this pull request introduce a new feature? No
