### PR TITLE
 deprecate and relocate connector related endpoints in functions REST API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -400,6 +400,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
             @ApiResponse(code = 408, message = "Request timeout")
     })
     @Path("/connectors")
+    @Deprecated
+    /**
+     * Deprecated in favor of moving endpoint to {@link org.apache.pulsar.broker.admin.v2.Worker}
+     */
     public List<ConnectorDefinition> getConnectorsList() throws IOException {
         return functions.getListOfConnectors();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.common.functions.WorkerInfo;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.api.WorkerImpl;
 
@@ -31,6 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -95,5 +97,21 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Collection<String>> getAssignments() {
         return worker.getAssignments();
+    }
+
+    @GET
+    @ApiOperation(
+            value = "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+            response = List.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+            @ApiResponse(code = 400, message = "Invalid request"),
+            @ApiResponse(code = 408, message = "Request timeout")
+    })
+    @Path("/connectors")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<ConnectorDefinition> getConnectorsList() throws IOException {
+        return worker.getListOfConnectors();
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
@@ -379,30 +379,39 @@ public interface Functions {
     void downloadFunction(String destinationFile, String path) throws PulsarAdminException;
 
     /**
+     * Deprecated in favor of getting sources and sinks for their own APIs
+     *
      * Fetches a list of supported Pulsar IO connectors currently running in cluster mode
      *
      * @throws PulsarAdminException
      *             Unexpected error
      *
      */
+    @Deprecated
     List<ConnectorDefinition> getConnectorsList() throws PulsarAdminException;
 
     /**
+     * Deprecated in favor of getting sources and sinks for their own APIs
+     *
      * Fetches a list of supported Pulsar IO sources currently running in cluster mode
      *
      * @throws PulsarAdminException
      *             Unexpected error
      *
      */
+    @Deprecated
     Set<String> getSources() throws PulsarAdminException;
 
     /**
+     * Deprecated in favor of getting sources and sinks for their own APIs
+     *
      * Fetches a list of supported Pulsar IO sinks currently running in cluster mode
      *
      * @throws PulsarAdminException
      *             Unexpected error
      *
      */
+    @Deprecated
     Set<String> getSinks() throws PulsarAdminException;
 
     /**

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/RestUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/RestUtils.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import javax.ws.rs.core.Response;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RestUtils {
 
@@ -36,4 +38,8 @@ public final class RestUtils {
         return createBaseMessage(message).toString();
     }
 
+    public static void throwUnavailableException() {
+        throw new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                "Function worker service is not done initializing. " + "Please try again in a little while.");
+    }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -77,7 +77,6 @@ import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.functions.worker.rest.RestException;
-import org.apache.pulsar.functions.worker.rest.RestUtils;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 import javax.ws.rs.WebApplicationException;
@@ -118,6 +117,7 @@ import static org.apache.pulsar.functions.utils.ComponentType.SOURCE;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getStateNamespace;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getUniquePackageName;
 import static org.apache.pulsar.functions.worker.WorkerUtils.isFunctionCodeBuiltin;
+import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 
 @Slf4j
 public abstract class ComponentImpl {
@@ -295,7 +295,7 @@ public abstract class ComponentImpl {
                                  AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         if (tenant == null) {
@@ -515,7 +515,7 @@ public abstract class ComponentImpl {
                                AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         if (tenant == null) {
@@ -700,7 +700,7 @@ public abstract class ComponentImpl {
                                    AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -775,7 +775,7 @@ public abstract class ComponentImpl {
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -841,7 +841,7 @@ public abstract class ComponentImpl {
                                              final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -899,7 +899,7 @@ public abstract class ComponentImpl {
                                         final String clientRole,
                                         final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -969,7 +969,7 @@ public abstract class ComponentImpl {
                                                  final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1024,7 +1024,7 @@ public abstract class ComponentImpl {
                                          final String clientRole,
                                          final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1076,7 +1076,7 @@ public abstract class ComponentImpl {
                                           final String clientRole,
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1132,7 +1132,7 @@ public abstract class ComponentImpl {
                                                                                                    final String clientRole,
                                                                                                    final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1193,7 +1193,7 @@ public abstract class ComponentImpl {
                                       final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1249,7 +1249,7 @@ public abstract class ComponentImpl {
 
     public List<ConnectorDefinition> getListOfConnectors() {
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         return this.worker().getConnectorsManager().getConnectors();
@@ -1265,7 +1265,7 @@ public abstract class ComponentImpl {
                                   final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {
@@ -1380,7 +1380,7 @@ public abstract class ComponentImpl {
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         try {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.functions.worker.rest.RestException;
+import org.apache.pulsar.functions.worker.rest.RestUtils;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 import javax.ws.rs.WebApplicationException;
@@ -114,7 +115,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.functions.utils.ComponentType.FUNCTION;
 import static org.apache.pulsar.functions.utils.ComponentType.SINK;
 import static org.apache.pulsar.functions.utils.ComponentType.SOURCE;
-import static org.apache.pulsar.functions.utils.FunctionCommon.extractFileFromPkgURL;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getStateNamespace;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getUniquePackageName;
 import static org.apache.pulsar.functions.worker.WorkerUtils.isFunctionCodeBuiltin;
@@ -295,7 +295,7 @@ public abstract class ComponentImpl {
                                  AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         if (tenant == null) {
@@ -515,7 +515,7 @@ public abstract class ComponentImpl {
                                AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         if (tenant == null) {
@@ -700,7 +700,7 @@ public abstract class ComponentImpl {
                                    AuthenticationDataHttps clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -775,7 +775,7 @@ public abstract class ComponentImpl {
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -841,7 +841,7 @@ public abstract class ComponentImpl {
                                              final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -899,7 +899,7 @@ public abstract class ComponentImpl {
                                         final String clientRole,
                                         final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -969,7 +969,7 @@ public abstract class ComponentImpl {
                                                  final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1024,7 +1024,7 @@ public abstract class ComponentImpl {
                                          final String clientRole,
                                          final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1076,7 +1076,7 @@ public abstract class ComponentImpl {
                                           final String clientRole,
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1132,7 +1132,7 @@ public abstract class ComponentImpl {
                                                                                                    final String clientRole,
                                                                                                    final AuthenticationDataSource clientAuthenticationDataHttps) {
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1193,7 +1193,7 @@ public abstract class ComponentImpl {
                                       final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1249,7 +1249,7 @@ public abstract class ComponentImpl {
 
     public List<ConnectorDefinition> getListOfConnectors() {
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         return this.worker().getConnectorsManager().getConnectors();
@@ -1265,7 +1265,7 @@ public abstract class ComponentImpl {
                                   final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1380,7 +1380,7 @@ public abstract class ComponentImpl {
                                           final AuthenticationDataSource clientAuthenticationDataHttps) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         try {
@@ -1673,11 +1673,6 @@ private FunctionDetails validateUpdateRequestParams(final String tenant,
         if (uploadedInputStream == null && input == null) {
             throw new IllegalArgumentException("Trigger Data is not provided");
         }
-    }
-
-    protected static void throwUnavailableException() {
-        throw new RestException(Status.SERVICE_UNAVAILABLE,
-                "Function worker service is not done initializing. " + "Please try again in a little while.");
     }
 
     private void throwStateStoreUnvailableResponse() {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinkImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinkImpl.java
@@ -32,7 +32,6 @@ import org.apache.pulsar.functions.utils.SinkConfigUtils;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.RestException;
-import org.apache.pulsar.functions.worker.rest.RestUtils;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -41,6 +40,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 
 @Slf4j
 public class SinkImpl extends ComponentImpl {
@@ -262,7 +263,7 @@ public class SinkImpl extends ComponentImpl {
                                   final String componentName) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         // validate parameters

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinkImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinkImpl.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.functions.utils.SinkConfigUtils;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.RestException;
+import org.apache.pulsar.functions.worker.rest.RestUtils;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -261,7 +262,7 @@ public class SinkImpl extends ComponentImpl {
                                   final String componentName) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         // validate parameters

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourceImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourceImpl.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.functions.utils.SourceConfigUtils;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.RestException;
+import org.apache.pulsar.functions.worker.rest.RestUtils;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -259,7 +260,7 @@ public class SourceImpl extends ComponentImpl {
                                       final String componentName) {
 
         if (!isWorkerServiceAvailable()) {
-            throwUnavailableException();
+            RestUtils.throwUnavailableException();
         }
 
         // validate parameters

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourceImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourceImpl.java
@@ -32,7 +32,6 @@ import org.apache.pulsar.functions.utils.SourceConfigUtils;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.RestException;
-import org.apache.pulsar.functions.worker.rest.RestUtils;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -41,6 +40,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 
 @Slf4j
 public class SourceImpl extends ComponentImpl {
@@ -260,7 +261,7 @@ public class SourceImpl extends ComponentImpl {
                                       final String componentName) {
 
         if (!isWorkerServiceAvailable()) {
-            RestUtils.throwUnavailableException();
+            throwUnavailableException();
         }
 
         // validate parameters

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
@@ -311,6 +311,10 @@ public class FunctionApiV2Resource extends FunctionApiResource {
             @ApiResponse(code = 408, message = "Request timeout")
     })
     @Path("/connectors")
+    /**
+     * Deprecated in favor of moving endpoint to {@link org.apache.pulsar.broker.admin.v2.Worker}
+     */
+    @Deprecated
     public List<ConnectorDefinition> getConnectorsList() throws IOException {
         return functions.getListOfConnectors();
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/WorkerApiV2Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/WorkerApiV2Resource.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.common.functions.WorkerInfo;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.api.WorkerImpl;
 
@@ -36,6 +37,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -119,5 +121,15 @@ public class WorkerApiV2Resource implements Supplier<WorkerService> {
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Collection<String>> getAssignments() {
         return worker.getAssignments();
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+            @ApiResponse(code = 400, message = "Invalid request"),
+            @ApiResponse(code = 408, message = "Request timeout")
+    })
+    @Path("/connectors")
+    public List<ConnectorDefinition> getConnectorsList() throws IOException {
+        return worker.getListOfConnectors();
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
@@ -306,6 +306,10 @@ public class FunctionApiV3Resource extends FunctionApiResource {
 
     @GET
     @Path("/connectors")
+    /**
+     * Deprecated in favor of moving endpoint to {@link org.apache.pulsar.broker.admin.v2.Worker}
+     */
+    @Deprecated
     public List<ConnectorDefinition> getConnectorsList() throws IOException {
         return functions.getListOfConnectors();
     }


### PR DESCRIPTION
### Motivation

There are several connectors (sources/sinks) related admin APIs and REST endpoints that reside within functions admin API and REST endpoints which isn't necessary any more since sources and sinks having their own separate admin API and REST API now.  

Also move getting a complete list of connectors (sources and sinks) for a worker from functions REST API to Worker API since that more sense.