### PR TITLE
Reduce memory used in ClientCnx for pending lookups

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -156,7 +156,7 @@ public class ClientCnx extends PulsarHandler {
         super(conf.getKeepAliveIntervalSeconds(), TimeUnit.SECONDS);
         checkArgument(conf.getMaxLookupRequest() > conf.getConcurrentLookupRequest());
         this.pendingLookupRequestSemaphore = new Semaphore(conf.getConcurrentLookupRequest(), false);
-        this.maxLookupRequestSemaphore = new Semaphore(conf.getMaxLookupRequest(), false);
+        this.maxLookupRequestSemaphore = new Semaphore(conf.getMaxLookupRequest() - conf.getConcurrentLookupRequest(), false);
         this.waitingLookupRequests = Queues.newConcurrentLinkedQueue();
         this.authentication = conf.getAuthentication();
         this.eventLoopGroup = eventLoopGroup;


### PR DESCRIPTION
### Motivation

Currently, each `ClientCnx` has a blocking queue for the max number of pending lookup requests. By default that ends up using an array of 45K objects. When a single process handles many connections (eg: broker or proxy), that will end up using 200K per connection just for this.

### Modifications

Instead of using the fixed array size, use semaphore and a `ConcurrentLinkedQueue`