### PR TITLE
Update Scala maven plugin to compile on java 11

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -32,6 +32,8 @@
   <name>Pulsar Examples :: Flink</name>
 
   <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <log4j2.version>2.10.0</log4j2.version>
   </properties>
 
@@ -131,7 +133,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.4.4</version>
+        <version>4.0.1</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This updates the scala compiler plugin and also add java source and target properties to successfully start compilation and packaging with openjdk11.