### PR TITLE
PIP-34 Add flag to enable or disable Key_Shared subscription.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -107,6 +107,9 @@ subscriptionRedeliveryTrackerEnabled=true
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5
 
+# Enable Key_Shared subscription (default is disabled)
+subscriptionKeySharedEnable=false
+
 # Set the default behavior for message deduplication in the broker
 # This can be overridden per-namespace. If enabled, broker will reject
 # messages that were already stored in the topic

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -107,8 +107,8 @@ subscriptionRedeliveryTrackerEnabled=true
 # How frequently to proactively check and purge expired subscription
 subscriptionExpiryCheckIntervalInMinutes=5
 
-# Enable Key_Shared subscription (default is disabled)
-subscriptionKeySharedEnable=false
+# Enable Key_Shared subscription (default is enabled)
+subscriptionKeySharedEnable=true
 
 # Set the default behavior for message deduplication in the broker
 # This can be overridden per-namespace. If enabled, broker will reject

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -268,6 +268,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        dynamic = true,
+        doc = "Enable Key_Shared subscription (default is disabled)"
+    )
+    private boolean subscriptionKeySharedEnable = false;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "Set the default behavior for message deduplication in the broker.\n\n"
             + "This can be overridden per-namespace. If enabled, broker will reject"
             + " messages that were already stored in the topic"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -269,9 +269,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_POLICIES,
         dynamic = true,
-        doc = "Enable Key_Shared subscription (default is disabled)"
+        doc = "Enable Key_Shared subscription (default is enabled)"
     )
-    private boolean subscriptionKeySharedEnable = false;
+    private boolean subscriptionKeySharedEnable = true;
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -498,6 +498,14 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                     new NotAllowedException("readCompacted only allowed on failover or exclusive subscriptions"));
             return future;
         }
+
+        if (subType == SubType.Key_Shared
+            && !brokerService.pulsar().getConfiguration().isSubscriptionKeySharedEnable()) {
+            future.completeExceptionally(
+                new NotAllowedException("Key_Shared subscription is disabled by broker.")
+            );
+            return future;
+        }
         if (isBlank(subscriptionName)) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Empty subscription name", topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -50,7 +50,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @Test
     public void testSendAndReceiveWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
-
+        this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared";
 
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
@@ -152,7 +152,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @Test
     public void testNonKeySendAndReceiveWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
-
+        this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_none_key";
 
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
@@ -250,6 +250,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @Test
     public void testOrderingKeyWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_ordering_key";
 
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -35,11 +35,9 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     private static final Logger log = LoggerFactory.getLogger(KeySharedSubscriptionTest.class);
 
-
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        this.conf.setSubscriptionKeySharedEnable(true);
         super.internalSetup();
         super.producerBaseSetup();
     }
@@ -327,5 +325,17 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Assert.assertEquals(consumer1ExpectMessages, consumer1Received);
         Assert.assertEquals(consumer2ExpectMessages, consumer2Received);
         Assert.assertEquals(consumer3ExpectMessages, consumer3Received);
+    }
+
+    @Test(expectedExceptions = PulsarClientException.class)
+    public void testDisableKeySharedSubscription() throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(false);
+        String topic = "persistent://public/default/key_shared_disabled";
+        pulsarClient.newConsumer()
+            .topic(topic)
+            .subscriptionName("key_shared")
+            .subscriptionType(SubscriptionType.Key_Shared)
+            .ackTimeout(10, TimeUnit.SECONDS)
+            .subscribe();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -39,6 +39,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
+        this.conf.setSubscriptionKeySharedEnable(true);
         super.internalSetup();
         super.producerBaseSetup();
     }

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -150,7 +150,7 @@ In *Key_Shared* mode, multiple consumers can attach to the same subscription. Me
 
 ![Key_Shared subscriptions](assets/pulsar-key-shared-subscriptions.png)
 
-**Key_Shared subscription is a beta feature and it will be disabled by default. If you want to use this feature, you can enable it at broker.config.**
+**Key_Shared subscription is a beta feature. You can disable it at broker.config.**
 
 ## Multi-topic subscriptions
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -150,6 +150,8 @@ In *Key_Shared* mode, multiple consumers can attach to the same subscription. Me
 
 ![Key_Shared subscriptions](assets/pulsar-key-shared-subscriptions.png)
 
+**Key_Shared subscription is a beta feature and it will be disabled by default. If you want to use this feature, you can enable it at broker.config.**
+
 ## Multi-topic subscriptions
 
 When a consumer subscribes to a Pulsar topic, by default it subscribes to one specific topic, such as `persistent://public/default/my-topic`. As of Pulsar version 1.23.0-incubating, however, Pulsar consumers can simultaneously subscribe to multiple topics. You can define a list of topics in two ways:


### PR DESCRIPTION
### Motivation

Add a broker level flag to enable or disable Key_Shared subscription, disabled by default.

### Modifications

Add a flag named `subscriptionRedeliveryTrackerEnabled`
Add documentation to describe Key_Shared subscription is a beta feature.

### Verifying this change

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (yes)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)

