### PR TITLE
Improve tests for ReaderImpl and ManagedLedgerImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -826,12 +827,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         checkManagedLedgerIsOpen();
         checkFenced();
 
-        return new NonDurableCursorImpl(bookKeeper, config, this, null, (PositionImpl) startCursorPosition);
+        return new NonDurableCursorImpl(bookKeeper, config, this, null,
+                (PositionImpl) startCursorPosition);
     }
 
     @Override
     public ManagedCursor newNonDurableCursor(Position startCursorPosition, String cursorName)
             throws ManagedLedgerException {
+        Objects.requireNonNull(cursorName, "cursor name can't be null");
         checkManagedLedgerIsOpen();
         checkFenced();
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -576,5 +576,51 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c2.getNumberOfEntriesInBacklog(), 5);
     }
 
+    @Test
+    void testCursorWithNameIsCachable() throws Exception {
+        final String p1CursorName = "entry-1";
+        final String p2CursorName = "entry-2";
+        ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
+
+        Position p1 = ledger.addEntry(p1CursorName.getBytes());
+        Position p2 = ledger.addEntry(p2CursorName.getBytes());
+
+        ManagedCursor c1 = ledger.newNonDurableCursor(p1, p1CursorName);
+        ManagedCursor c2 = ledger.newNonDurableCursor(p1, p1CursorName);
+        ManagedCursor c3 = ledger.newNonDurableCursor(p2, p2CursorName);
+        ManagedCursor c4 = ledger.newNonDurableCursor(p2, p2CursorName);
+
+        assertEquals(c1, c2);
+        assertEquals(c3, c4);
+
+        assertNotEquals(c1, c3);
+        assertNotEquals(c2, c3);
+        assertNotEquals(c1, c4);
+        assertNotEquals(c2, c4);
+
+        assertNotNull(c1.getName());
+        assertNotNull(c2.getName());
+        assertNotNull(c3.getName());
+        assertNotNull(c4.getName());
+        ledger.close();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    void testCursorWithNameIsNotNull() throws Exception {
+        final String p1CursorName = "entry-1";
+        ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
+
+        Position p1 = ledger.addEntry(p1CursorName.getBytes());
+
+        try {
+            ledger.newNonDurableCursor(p1, null);
+        } catch (NullPointerException npe) {
+            assertEquals(npe.getMessage(), "cursor name can't be null");
+            throw npe;
+        } finally {
+            ledger.close();
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(NonDurableCursorTest.class);
 }


### PR DESCRIPTION
  - Improve timing tests replacing *before* and *after* class annotation instead
    of per method in TopicReaderTest. In this case there isn't any real need to
    setup the entire test environment for each test.
  - Improve tests from latest changes in Reader in order to use
    testMessageOrderAndDuplicates method.
  - Prevents non-durable cursor being built with null cursor name.
  - Add tests to assert cache on non-durable cursor implementation.
  - Fix missed close() method from TopicReaderTest.
