### PR TITLE
Allow to configure Postgres in pulsar dashboard with a docker volume

### DIFF
--- a/dashboard/conf/postgresql.conf
+++ b/dashboard/conf/postgresql.conf
@@ -23,7 +23,7 @@ full_page_writes = off
 synchronous_commit = off
 
 # Default configs
-data_directory = '/var/lib/postgresql/9.6/main'
+data_directory = '/data'
 hba_file = '/etc/postgresql/9.6/main/pg_hba.conf'
 ident_file = '/etc/postgresql/9.6/main/pg_ident.conf'
 external_pid_file = '/var/run/postgresql/9.6-main.pid'

--- a/dashboard/conf/supervisor-app.conf
+++ b/dashboard/conf/supervisor-app.conf
@@ -17,26 +17,6 @@
 # under the License.
 #
 
-[program:postgres]
-command=/usr/lib/postgresql/9.6/bin/postgres -D /etc/postgresql/9.6/main
-user = postgres
-autostart=true
-autorestart=true
-startsecs=5
-stopasgroup=true
-killasgroup=true
-stopsignal=TERM
-log_stdout=true
-log_stderr=true
-priority=500
-stdout_logfile=/var/log/supervisor/postgres.log
-stderr_logfile=/var/log/supervisor/postgres-error.log
-stdout_logfile_maxbytes=50MB
-stdout_logfile_backups=2
-stderr_logfile_maxbytes=50MB
-stderr_logfile_backups=2
-
-
 [program:uwsgi]
 command=/usr/local/bin/uwsgi --ini /pulsar/conf/uwsgi.ini
 autostart=true

--- a/dashboard/start.sh
+++ b/dashboard/start.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,35 +18,10 @@
 # under the License.
 #
 
-FROM python:3.7
+echo "Starting Pulsar dasboard"
 
-MAINTAINER Pulsar
+set -e -x
 
-RUN apt-get update
-RUN apt-get -y install postgresql python sudo nginx supervisor
+/pulsar/init-postgres.sh
 
-# Python dependencies
-RUN pip install uwsgi 'Django<2.0' psycopg2 pytz requests
-
-# Postgres configuration
-COPY conf/postgresql.conf /etc/postgresql/9.6/main/
-
-# Configure nginx and supervisor
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-COPY conf/nginx-app.conf /etc/nginx/sites-available/default
-COPY conf/supervisor-app.conf /etc/supervisor/conf.d/
-
-# Copy web-app sources
-RUN mkdir /pulsar
-COPY . /pulsar/
-
-# Collect all static files needed by Django in a
-# single place. Needed to run the app outside the
-# Django test web server
-RUN cd /pulsar/django && ./manage.py collectstatic --no-input
-
-RUN mkdir /data
-
-EXPOSE 80
-
-CMD ["/pulsar/start.sh"]
+supervisord -n


### PR DESCRIPTION
### Motivation

Pulsar dashboard is creating the database in the docker-build phase. That's bad practice and prevent to mount an external volume to use as metrics cache.