### PR TITLE
[pulsar-flink] Add subscription initial position

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSource.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSource.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.Authentication;
 import org.slf4j.Logger;
@@ -71,6 +72,7 @@ class PulsarConsumerSource<T> extends MessageAcknowledgingSourceBase<T, MessageI
 
     private final long acknowledgementBatchSize;
     private long batchCount;
+    private final SubscriptionInitialPosition initialPosition;
 
     private transient volatile boolean isRunning;
 
@@ -83,6 +85,7 @@ class PulsarConsumerSource<T> extends MessageAcknowledgingSourceBase<T, MessageI
         this.deserializer = builder.deserializationSchema;
         this.subscriptionName = builder.subscriptionName;
         this.acknowledgementBatchSize = builder.acknowledgementBatchSize;
+        this.initialPosition = builder.initialPosition;
     }
 
     @Override
@@ -203,12 +206,14 @@ class PulsarConsumerSource<T> extends MessageAcknowledgingSourceBase<T, MessageI
             return client.newConsumer().topicsPattern(topicsPattern)
                     .subscriptionName(subscriptionName)
                     .subscriptionType(SubscriptionType.Failover)
+                    .subscriptionInitialPosition(initialPosition)
                     .subscribe();
         } else {
             return client.newConsumer()
                     .topics(Lists.newArrayList(topicNames))
                     .subscriptionName(subscriptionName)
                     .subscriptionType(SubscriptionType.Failover)
+                    .subscriptionInitialPosition(initialPosition)
                     .subscribe();
         }
     }

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilder.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilder.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +52,7 @@ public class PulsarSourceBuilder<T> {
     Pattern topicsPattern;
     String subscriptionName = "flink-sub";
     long acknowledgementBatchSize = ACKNOWLEDGEMENT_BATCH_SIZE;
+    SubscriptionInitialPosition initialPosition = SubscriptionInitialPosition.Latest;
 
     private PulsarSourceBuilder(DeserializationSchema<T> deserializationSchema) {
         this.deserializationSchema = deserializationSchema;
@@ -150,6 +152,18 @@ public class PulsarSourceBuilder<T> {
         Preconditions.checkArgument(StringUtils.isNotBlank(subscriptionName),
                 "subscriptionName cannot be blank");
         this.subscriptionName = subscriptionName;
+        return this;
+    }
+
+    /**
+     * Sets the subscription initial position for the topic consumer. Default is {@link SubscriptionInitialPosition#Latest}
+     *
+     * @param initialPosition the subscription initial position.
+     * @return this builder
+     */
+    public PulsarSourceBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition initialPosition) {
+        Preconditions.checkNotNull(initialPosition,"subscription initial position cannot be null");
+        this.initialPosition = initialPosition;
         return this;
     }
 

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilderTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilderTest.java
@@ -114,7 +114,7 @@ public class PulsarSourceBuilderTest {
         pulsarSourceBuilder.subscriptionName(" ");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void testSubscriptionInitialPosition() {
         pulsarSourceBuilder.subscriptionInitialPosition(null);
     }

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilderTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarSourceBuilderTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.pulsar;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,6 +48,7 @@ public class PulsarSourceBuilderTest {
                 .serviceUrl("testServiceUrl")
                 .topic("testTopic")
                 .subscriptionName("testSubscriptionName")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .build();
         Assert.assertNotNull(sourceFunction);
     }
@@ -110,6 +112,11 @@ public class PulsarSourceBuilderTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSubscriptionNameWithBlank() {
         pulsarSourceBuilder.subscriptionName(" ");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSubscriptionInitialPosition() {
+        pulsarSourceBuilder.subscriptionInitialPosition(null);
     }
 
     private class TestDeserializationSchema<T> implements DeserializationSchema<T> {


### PR DESCRIPTION
### Motivation

Allow user to specify the initial position for consumer source builder.

### Modifications

Add initial position for PulsarConsumerSource.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
