### PR TITLE
Detect duplicate consumers by consumer name

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3007,13 +3007,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final CompletableFuture<Void> future = new CompletableFuture<>();
         final String topic = "persistent://my-property/my-ns/my-topic";
         final String subName = "my-subscription";
+        final String consumerName = "my-consumer";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
         Consumer<byte[]> consumerB = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
 
@@ -3043,13 +3046,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final CompletableFuture<Void> future = new CompletableFuture<>();
         final String topic = "persistent://my-property/my-ns/my-topic";
         final String subName = "my-subscription";
+        final String consumerName = "my-consumer";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
         Consumer<byte[]> consumerB = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
 
@@ -3057,6 +3063,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // even though has the same subscription name.
         Consumer<byte[]> consumerC = pulsarClient.newConsumer().topic(topic + "-different-topic")
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
 
@@ -3086,17 +3093,48 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumerC.close();
     }
 
-    @Test
-    public void testRefCount_OnCloseConsumer() throws Exception {
+
+    @Test()
+    public void testConsumersWithNotEqualsConsumerName() throws Exception {
         final String topic = "persistent://my-property/my-ns/my-topic";
         final String subName = "my-subscription";
+        final String consumerName = "my-consumer";
 
         Consumer<byte[]> consumerA = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
         Consumer<byte[]> consumerB = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName(subName)
+                .consumerName(consumerName + "-different")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+
+        Assert.assertNotEquals(consumerA, consumerB);
+
+        consumerA.close();
+        assertFalse(consumerA.isConnected());
+        assertTrue(consumerB.isConnected());
+
+        consumerB.close();
+        assertFalse(consumerB.isConnected());
+    }
+
+    @Test
+    public void testRefCount_OnCloseConsumer() throws Exception {
+        final String topic = "persistent://my-property/my-ns/my-topic";
+        final String subName = "my-subscription";
+        final String consumerName = "my-consumer";
+
+        Consumer<byte[]> consumerA = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName(subName)
+                .consumerName(consumerName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+        Consumer<byte[]> consumerB = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName(subName)
+                .consumerName(consumerName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -682,6 +682,7 @@ public class PulsarClientImpl implements PulsarClient {
             Optional<ConsumerBase<?>> subscriber = consumers.keySet().stream()
                     .filter(c -> c.getSubType().equals(PulsarApi.CommandSubscribe.SubType.Shared))
                     .filter(c -> conf.getTopicNames().contains(c.getTopic()))
+                    .filter(c -> c.getConsumerName().equals(conf.getConsumerName()))
                     .filter(c -> c.getSubscription().equals(conf.getSubscriptionName()))
                     .filter(Consumer::isConnected)
                     .findFirst();


### PR DESCRIPTION


Use consumer name from a subscription in order to identify duplicate consumers.

*Modifications*

  - Add filter. to verify consumer name also.
  - Add test to verify that different consumer name created a different consumer
    instance.