### PR TITLE
Fixed error deleted a named non-durable cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -231,15 +231,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     final ManagedLedgerFactoryImpl factory;
     protected final ManagedLedgerMBeanImpl mbean;
     protected final Clock clock;
-    
+
     private static final AtomicLongFieldUpdater<ManagedLedgerImpl> READ_OP_COUNT_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ManagedLedgerImpl.class, "readOpCount");
     private volatile long readOpCount = 0;
-    // last read-operation's callback to check read-timeout on it. 
+    // last read-operation's callback to check read-timeout on it.
     private static final AtomicReferenceFieldUpdater<ManagedLedgerImpl, ReadEntryCallbackWrapper> LAST_READ_CALLBACK = AtomicReferenceFieldUpdater
             .newUpdater(ManagedLedgerImpl.class, ReadEntryCallbackWrapper.class, "lastReadCallback");
     private volatile ReadEntryCallbackWrapper lastReadCallback = null;
-    
+
     /**
      * Queue of pending entries to be added to the managed ledger. Typically entries are queued when a new ledger is
      * created asynchronously and hence there is no ready ledger to write into.
@@ -755,6 +755,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (cursor == null) {
             callback.deleteCursorFailed(new ManagedLedgerException("ManagedCursor not found: " + consumerName), ctx);
             return;
+        } else if (!cursor.isDurable()) {
+            cursors.removeCursor(consumerName);
+            callback.deleteCursorComplete(ctx);
+            return;
         }
 
         // First remove the consumer form the MetaStore. If this operation succeeds and the next one (removing the
@@ -1204,7 +1208,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (this.timeoutTask != null) {
             this.timeoutTask.cancel(false);
         }
-        
+
     }
 
     private void closeAllCursors(CloseCallback callback, final Object ctx) {
@@ -1727,7 +1731,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 recycle();
             }
         }
-        
+
         private boolean checkCallbackCompleted(Object ctx) {
             // if the ctx-readOpCount is different than object's readOpCount means Object is already recycled and
             // assigned to different request
@@ -3136,7 +3140,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             LAST_READ_CALLBACK.set(this, null);
         }
     }
-    
+
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerImpl.class);
 
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -622,5 +622,16 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         }
     }
 
+    @Test
+    void deleteNonDurableCursorWithName() throws Exception {
+        ManagedLedger ledger = factory.open("deleteManagedLedgerWithNonDurableCursor");
+
+        ManagedCursor c = ledger.newNonDurableCursor(PositionImpl.earliest, "custom-name");
+        assertEquals(Iterables.size(ledger.getCursors()), 1);
+
+        ledger.deleteCursor(c.getName());
+        assertEquals(Iterables.size(ledger.getCursors()), 0);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(NonDurableCursorTest.class);
 }


### PR DESCRIPTION
### Motivation

Deleting a managed-ledger with existing non-durable cursors is failing if the cursors are "named" (as it's the case for Pulsar topic readers). 

The failure is because it's follow the usual path and tries to remove metadata which is not there.

This is making the Health check topic to fail to be deleted in background.