### PR TITLE
(WIP) Pulsar SQL supports pulsar's primitive schemas

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaType.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaType.java
@@ -152,27 +152,69 @@ public enum SchemaType {
 
     public static SchemaType valueOf(int value) {
         switch (value) {
-          case 0: return NONE;
-          case 1: return STRING;
-          case 2: return JSON;
-          case 3: return PROTOBUF;
-          case 4: return AVRO;
-          case 5: return BOOLEAN;
-          case 6: return INT8;
-          case 7: return INT16;
-          case 8: return INT32;
-          case 9: return INT64;
-          case 10: return FLOAT;
-          case 11: return DOUBLE;
-          case 12: return DATE;
-          case 13: return TIME;
-          case 14: return TIMESTAMP;
-          case 15: return KEY_VALUE;
-          case -1: return BYTES;
-          case -2: return AUTO;
-          case -3: return AUTO_CONSUME;
-          case -4: return AUTO_PUBLISH;
-          default: return NONE;
+            case 0: return NONE;
+            case 1: return STRING;
+            case 2: return JSON;
+            case 3: return PROTOBUF;
+            case 4: return AVRO;
+            case 5: return BOOLEAN;
+            case 6: return INT8;
+            case 7: return INT16;
+            case 8: return INT32;
+            case 9: return INT64;
+            case 10: return FLOAT;
+            case 11: return DOUBLE;
+            case 12: return DATE;
+            case 13: return TIME;
+            case 14: return TIMESTAMP;
+            case 15: return KEY_VALUE;
+            case -1: return BYTES;
+            case -2: return AUTO;
+            case -3: return AUTO_CONSUME;
+            case -4: return AUTO_PUBLISH;
+            default: return NONE;
         }
-      }
+    }
+
+    public boolean isPrimitive() {
+        return isPrimitiveType(this);
+    }
+
+    public boolean isStruct() {
+        return isStructType(this);
+    }
+
+    public static boolean isPrimitiveType(SchemaType type) {
+        switch (type) {
+            case STRING:
+            case BOOLEAN:
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case FLOAT:
+            case DOUBLE:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case BYTES:
+            case NONE:
+                return true;
+            default:
+                return false;
+        }
+
+    }
+
+    public static boolean isStructType(SchemaType type) {
+        switch (type) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF:
+                return true;
+            default:
+                return false;
+        }
+    }
+
 }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/AvroSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/AvroSchemaHandler.java
@@ -18,13 +18,14 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.airlift.log.Logger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
@@ -33,8 +34,9 @@ import org.apache.avro.io.DecoderFactory;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.pulsar.common.schema.SchemaInfo;
 
-public class AvroSchemaHandler implements SchemaHandler {
+class AvroSchemaHandler implements SchemaHandler {
 
     private final DatumReader<GenericRecord> datumReader;
 
@@ -45,8 +47,11 @@ public class AvroSchemaHandler implements SchemaHandler {
 
     private static final Logger log = Logger.get(AvroSchemaHandler.class);
 
-    public AvroSchemaHandler(Schema schema, List<PulsarColumnHandle> columnHandles) {
-        this.datumReader = new GenericDatumReader<>(schema);
+    public AvroSchemaHandler(SchemaInfo schemaInfo, List<PulsarColumnHandle> columnHandles) {
+        this.datumReader = new GenericDatumReader<>(
+            PulsarConnectorUtils.parseSchema(
+                new String(schemaInfo.getSchema(), UTF_8))
+        );
         this.columnHandles = columnHandles;
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/JSONSchemaHandler.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 
-public class JSONSchemaHandler implements SchemaHandler {
+class JSONSchemaHandler implements SchemaHandler {
 
     private static final Logger log = Logger.get(JSONSchemaHandler.class);
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.sql.presto;
 
 import org.apache.avro.Schema;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPrimitiveSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPrimitiveSchemaHandler.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+/**
+ * A presto schema handler that interprets data using pulsar schema.
+ */
+public class PulsarPrimitiveSchemaHandler implements SchemaHandler {
+
+    private final SchemaInfo schemaInfo;
+    private final Schema<?> schema;
+
+    public PulsarPrimitiveSchemaHandler(SchemaInfo schemaInfo) {
+        this.schemaInfo = schemaInfo;
+        this.schema = AutoConsumeSchema.getSchema(schemaInfo);
+    }
+
+    @Override
+    public Object deserialize(ByteBuf payload) {
+        byte[] data = ByteBufUtil.getBytes(payload);
+        return schema.decode(data);
+    }
+
+    @Override
+    public Object extractField(int index, Object currentRecord) {
+        // convert the pulsar objects to the type that presto knows
+        switch (schemaInfo.getType()) {
+            case DATE:
+                return ((Date) currentRecord).getTime();
+            case TIME:
+                return ((Time) currentRecord).getTime();
+            case TIMESTAMP:
+                return ((Timestamp) currentRecord).getTime();
+            default:
+                return currentRecord;
+        }
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.avro.Schema;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -61,7 +60,6 @@ import org.apache.pulsar.common.api.raw.MessageParser;
 import org.apache.pulsar.common.api.raw.RawMessage;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.schema.SchemaType;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.SpscArrayQueue;
 
@@ -139,9 +137,10 @@ public class PulsarRecordCursor implements RecordCursor {
         this.metricsTracker = pulsarConnectorMetricsTracker;
         this.readOffloaded = pulsarConnectorConfig.getManagedLedgerOffloadDriver() != null;
 
-        Schema schema = PulsarConnectorUtils.parseSchema(pulsarSplit.getSchema());
-
-        this.schemaHandler = getSchemaHandler(schema, pulsarSplit.getSchemaType(), columnHandles);
+        this.schemaHandler = PulsarSchemaHandlers.newPulsarSchemaHandler(
+            pulsarSplit.getSchemaInfo(),
+            columnHandles
+        );
 
         log.info("Initializing split with parameters: %s", pulsarSplit);
 
@@ -153,22 +152,6 @@ public class PulsarRecordCursor implements RecordCursor {
             close();
             throw new RuntimeException(e);
         }
-    }
-
-    private SchemaHandler getSchemaHandler(Schema schema, SchemaType schemaType,
-                                           List<PulsarColumnHandle> columnHandles) {
-        SchemaHandler schemaHandler;
-        switch (schemaType) {
-            case JSON:
-                schemaHandler = new JSONSchemaHandler(columnHandles);
-                break;
-            case AVRO:
-                schemaHandler = new AvroSchemaHandler(schema, columnHandles);
-                break;
-            default:
-                throw new PrestoException(NOT_SUPPORTED, "Not supported schema type: " + schemaType);
-        }
-        return schemaHandler;
     }
 
     private ReadOnlyCursor getCursor(TopicName topicName, Position startPosition, ManagedLedgerFactory

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSchemaHandlers.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSchemaHandlers.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+
+import com.facebook.presto.spi.PrestoException;
+import java.util.List;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+class PulsarSchemaHandlers {
+
+    static SchemaHandler newPulsarSchemaHandler(SchemaInfo schemaInfo,
+                                                List<PulsarColumnHandle> columnHandles) {
+        if (schemaInfo.getType().isPrimitive()) {
+            return new PulsarPrimitiveSchemaHandler(schemaInfo);
+        } else if (schemaInfo.getType().isStruct()) {
+            // TODO: change avro and json schema to use pulsar's generic schema. because
+            //       it takes care of schema versionings.
+            switch (schemaInfo.getType()) {
+                case JSON:
+                    return new JSONSchemaHandler(columnHandles);
+                case AVRO:
+                    return new AvroSchemaHandler(schemaInfo, columnHandles);
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "Not supported schema type: " + schemaInfo.getType());
+            }
+
+        } else {
+            throw new PrestoException(
+                NOT_SUPPORTED,
+                "Schema `" + schemaInfo.getType() + "` is not supported by presto yet : " + schemaInfo);
+        }
+    }
+
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.common.schema.SchemaInfo;
 
 import java.util.List;
 
@@ -39,8 +39,7 @@ public class PulsarSplit implements ConnectorSplit {
     private final String schemaName;
     private final String tableName;
     private final long splitSize;
-    private final String schema;
-    private final SchemaType schemaType;
+    private final SchemaInfo schemaInfo;
     private final long startPositionEntryId;
     private final long endPositionEntryId;
     private final long startPositionLedgerId;
@@ -57,8 +56,7 @@ public class PulsarSplit implements ConnectorSplit {
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("splitSize") long splitSize,
-            @JsonProperty("schema") String schema,
-            @JsonProperty("schemaType") SchemaType schemaType,
+            @JsonProperty("schema") SchemaInfo schemaInfo,
             @JsonProperty("startPositionEntryId") long startPositionEntryId,
             @JsonProperty("endPositionEntryId") long endPositionEntryId,
             @JsonProperty("startPositionLedgerId") long startPositionLedgerId,
@@ -69,8 +67,7 @@ public class PulsarSplit implements ConnectorSplit {
         this.connectorId = requireNonNull(connectorId, "connector id is null");
         this.tableName = requireNonNull(tableName, "table name is null");
         this.splitSize = splitSize;
-        this.schema = schema;
-        this.schemaType = schemaType;
+        this.schemaInfo = schemaInfo;
         this.startPositionEntryId = startPositionEntryId;
         this.endPositionEntryId = endPositionEntryId;
         this.startPositionLedgerId = startPositionLedgerId;
@@ -96,11 +93,6 @@ public class PulsarSplit implements ConnectorSplit {
     }
 
     @JsonProperty
-    public SchemaType getSchemaType() {
-        return schemaType;
-    }
-
-    @JsonProperty
     public String getTableName() {
         return tableName;
     }
@@ -111,8 +103,8 @@ public class PulsarSplit implements ConnectorSplit {
     }
 
     @JsonProperty
-    public String getSchema() {
-        return schema;
+    public SchemaInfo getSchemaInfo() {
+        return schemaInfo;
     }
 
     @JsonProperty
@@ -171,8 +163,7 @@ public class PulsarSplit implements ConnectorSplit {
                 ", schemaName='" + schemaName + '\'' +
                 ", tableName='" + tableName + '\'' +
                 ", splitSize=" + splitSize +
-                ", schema='" + schema + '\'' +
-                ", schemaType=" + schemaType +
+                ", schemaInfo='" + schemaInfo + '\'' +
                 ", startPositionEntryId=" + startPositionEntryId +
                 ", endPositionEntryId=" + endPositionEntryId +
                 ", startPositionLedgerId=" + startPositionLedgerId +

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
@@ -209,7 +209,8 @@ public class PulsarSplitManager implements ConnectorSplitManager {
                                               ManagedLedgerFactory managedLedgerFactory,
                                               int numSplits,
                                               PulsarTableHandle tableHandle,
-                                              SchemaInfo schemaInfo, String tableName,
+                                              SchemaInfo schemaInfo,
+                                              String tableName,
                                               TupleDomain<ColumnHandle> tupleDomain)
             throws ManagedLedgerException, InterruptedException {
 
@@ -260,8 +261,7 @@ public class PulsarSplitManager implements ConnectorSplitManager {
                         tableHandle.getSchemaName(),
                         tableName,
                         entriesForSplit,
-                        new String(schemaInfo.getSchema()),
-                        schemaInfo.getType(),
+                        schemaInfo,
                         startPosition.getEntryId(),
                         endPosition.getEntryId(),
                         startPosition.getLedgerId(),


### PR DESCRIPTION
*Changes*

There is no *struct* in pulsar's primitive schemas. So introduced an internal fields `__value__`
for representing pulsar values.

Refactor following places:

- use `SchemaInfo` everywhere possible. We shouldn't strip out the information from schema info.
- avoid using avro schema directly.
- use pulsar `Schema` for serializing and deserializing and avoid reimplementing the same logic again and again, which can be problematic.
  also it allows taking all the changes we made to pulsar schema

*Tests*

WIP

*NOT IN SCOPE*

We should avoid handling avro schema or json schema here directly, because it doesn't handle schema versioning properly.
The right approach is to use Pulsar's GenericSchema which can handle schema versioning properly. But that refactor should
be done in a separated pull request.

