### PR TITLE
[Websockets] Add support for eventtime on producer message

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/DateFormatter.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/DateFormatter.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.util;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Date-time String formatter utility class
@@ -49,6 +50,17 @@ public class DateFormatter {
      */
     public static String format(Instant instant) {
         return DATE_FORMAT.format(instant);
+    }
+
+    /**
+     * @param datetime
+     * @return the parsed timestamp (in milliseconds) of the provided datetime
+     * @throws DateTimeParseException
+     */
+    public static long parse(String datetime) throws DateTimeParseException {
+        Instant instant = Instant.from(DATE_FORMAT.parse(datetime));
+
+        return instant.toEpochMilli();
     }
 
     private DateFormatter() {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -28,6 +28,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Enums;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -48,6 +52,7 @@ import org.apache.pulsar.client.api.PulsarClientException.ProducerBlockedQuotaEx
 import org.apache.pulsar.client.api.PulsarClientException.ProducerBusyException;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ProducerAck;
 import org.apache.pulsar.websocket.data.ProducerMessage;
@@ -188,6 +193,14 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         }
         if (sendRequest.replicationClusters != null) {
             builder.replicationClusters(sendRequest.replicationClusters);
+        }
+        if (sendRequest.eventTime != null) {
+            try {
+                builder.eventTime(DateFormatter.parse(sendRequest.eventTime));
+            } catch (DateTimeParseException e) {
+                sendAckResponse(new ProducerAck(PayloadEncodingError, e.getMessage(), null, requestContext));
+                return;
+            }
         }
 
         final long now = System.nanoTime();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessage.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessage.java
@@ -27,4 +27,5 @@ public class ProducerMessage {
     public String context;
     public String key;
     public List<String> replicationClusters;
+    public String eventTime;
 }


### PR DESCRIPTION
### Motivation
Websockets producer API lacks the message property `eventTime`, even when the client message supports it. This PR introduces support for WS producers to be able to optionally provide such property.

### Modifications
The change impacts 2 packages:
1. `pulsar-common`: within the utilities that this package provides, there's the `DateFormatter` which is used by the WS consumer API to format both the `eventTime` an the `publishTime`. The method `parse(String datetime)` is added to do the reverse process of `format(long timestamp)`. The method was added to this class as it's very close to it's functionality and depends on a private property that already contains proper timezone management.
2. `pulsar-websocket`: the `eventTime` property is added to `ProducerMessage` class for adequate mapping as a string. If the property is not null when processing the message (`ProducerHandler.onWebSocketText()`) and the parsing fails, a `FailedToDeserializeFromJSON` error is returned (I didn't want to introduce a new type of error); if parsing is successful, the provided `eventTime` is converted to milliseconds and passed to the builder.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change does not include tests. No existing tests for websocket messages were found.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (`yes` / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (`yes` / no)
  - If yes, how is the feature documented? (not applicable / `docs` / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
