### PR TITLE
Create more offloader indices per each block uploaded to 2nd tier

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -413,7 +413,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         .calculateBlockSize(maxBlockSize, readHandle, startEntry, entryBytesWritten);
 
                     try (BlockAwareSegmentInputStream blockStream = new BlockAwareSegmentInputStreamImpl(
-                        readHandle, startEntry, blockSize)) {
+                        readHandle, startEntry, blockSize, partId, indexBuilder)) {
 
                         Payload partPayload = Payloads.newInputStreamPayload(blockStream);
                         partPayload.getContentMetadata().setContentLength((long)blockSize);
@@ -421,8 +421,6 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         parts.add(writeBlobStore.uploadMultipartPart(mpu, partId, partPayload));
                         log.debug("UploadMultipartPart. container: {}, blobName: {}, partId: {}, mpu: {}",
                             writeBucket, dataBlockKey, partId, mpu.id());
-
-                        indexBuilder.addBlock(startEntry, partId, blockSize);
 
                         if (blockStream.getEndEntryId() != -1) {
                             startEntry = blockStream.getEndEntryId() + 1;

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
@@ -33,6 +33,7 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.offload.jcloud.BlockAwareSegmentInputStream;
+import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlockBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,14 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
     // Keep a list of all entries ByteBuf, each ByteBuf contains 2 buf: entry header and entry content.
     private List<ByteBuf> entriesByteBuf = null;
 
+    private final int blockId;
+    private final OffloadIndexBlockBuilder index;
+
     public BlockAwareSegmentInputStreamImpl(ReadHandle ledger, long startEntryId, int blockSize) {
+        this(ledger, startEntryId, blockSize, 0, null);
+    }
+
+    public BlockAwareSegmentInputStreamImpl(ReadHandle ledger, long startEntryId, int blockSize, int blockId, OffloadIndexBlockBuilder index) {
         this.ledger = ledger;
         this.startEntryId = startEntryId;
         this.blockSize = blockSize;
@@ -75,6 +83,8 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
         this.blockEntryCount = 0;
         this.dataBlockFullOffset = blockSize;
         this.entriesByteBuf = Lists.newLinkedList();
+        this.index = index;
+        this.blockId = blockId;
     }
 
     // read ledger entries.
@@ -87,6 +97,11 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
             && entriesByteBuf.isEmpty()
             && startEntryId + blockEntryCount <= ledger.getLastAddConfirmed()) {
             entriesByteBuf = readNextEntriesFromLedger(startEntryId + blockEntryCount, ENTRIES_PER_READ);
+
+            // Update index
+            int sizeOfEntries = entriesByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
+            long firstEntryId = startEntryId + blockEntryCount;
+            index.addBlock(firstEntryId, blockId, sizeOfEntries);
         }
 
         if (!entriesByteBuf.isEmpty() && bytesReadOffset + entriesByteBuf.get(0).readableBytes() <= blockSize) {


### PR DESCRIPTION
### Motivation

The offloaded data is uploaded in blocks (for the multipart upload). The default block size is 64 MB and the min block size is 5 MB (for S3). 

For each block the offloader is added 1 entry to the data index.

This is problematic because when reading the offloaded data, we only have 1 index entry every 64MB. When we create the `ReadHandle` for the offloader, we then try to read entries and internally this will use the index to position on the right offset within the S3 object. 

In addition to that there's a 1 MB prefetch buffer.

What happens is that after reading one batch of entries (let say 100 entries), when reading the next batch we'll check the index again and it will point at the beginning of the 64MB block. The reader will then rescan the whole block (fetching all the content from S3 in 1MB chunks) until it reaches the end. Basically the data is fetched all over again and that leads to poor performance.

### Modifications

When offloading, ensure we add index every few entries in order to minimize and keep controlled the overhead of entries alignment with index when reading.

The size of the index will still be negligible compared to the data (eg: 4KB for a 26 MB data file contain many very small entries).