### PR TITLE
Allow use of pulsar-client-all shaded jar from java-module-system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>javax.activation</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>
         <version>${opencensus.version}</version>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -65,15 +65,21 @@
       <artifactId>jersey-hk2</artifactId>
     </dependency>
 
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>jaxb-api</artifactId>
-   </dependency>
-
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>activation</artifactId>
-   </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -98,6 +98,7 @@
                 <includes>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
+                  <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>


### PR DESCRIPTION
### Motivation

I am attempting to use the pulsar-client and/or pulsar-admin-client from an application that uses Java 11 with the java-module-system enabled. Using maven, the following dependencies were included:

        <dependency>
            <groupId>org.apache.pulsar</groupId>
            <artifactId>pulsar-client-original</artifactId>
            <version>2.3.1</version>
        </dependency>
        <dependency>
            <groupId>org.apache.pulsar</groupId>
            <artifactId>pulsar-client-admin-original</artifactId>
            <version>2.3.1</version>
        </dependency>

I quickly ran into a split-package issue where packages with the same name are declared in more than one different transitive dependency. One problem was the org.apache.pulsar.common.api and org.apache.pulsar.common.schema packages. Another problem was that there were multiple versions of the javax.activation framework included.

After discussion here with @sijie I attempted to use the pulsar-client-all shaded jar. This did work after I made a few modifications which are included here in this PR.

### Modifications

pulsar-client-all now include the pulsar-client-api within the shaded jar. This avoids a split-package issue and allows the shaded jar to be used as a module within the java-module-system.

Maven module pulsar-client-admin module have been changed to use the dependency com.sun.activation:javax.activation:1.2.0 instead of other activation apis. This is the same activation dependency that is used by the pulsar-client module making them compatible with regards to the java-module-system. The change should also be beneficial when shading jars by avoiding conflicting classes from activation dependencies.

### Verifying this change

The changes passes CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - *Anything that affects deployment: don't know*

### Documentation

  - Does this pull request introduce a new feature? no