### PR TITLE
WorkerService should inherit authentication configs from broker when running as part of it

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -167,6 +167,9 @@ public class PulsarBrokerStarter {
                         + "-fw-" + hostname
                         + "-" + workerConfig.getWorkerPort());
                 // inherit broker authorization setting
+                workerConfig.setAuthenticationEnabled(brokerConfig.isAuthenticationEnabled());
+                workerConfig.setAuthenticationProviders(brokerConfig.getAuthenticationProviders());
+
                 workerConfig.setAuthorizationEnabled(brokerConfig.isAuthorizationEnabled());
                 workerConfig.setAuthorizationProvider(brokerConfig.getAuthorizationProvider());
                 workerConfig.setConfigurationStoreServers(brokerConfig.getConfigurationStoreServers());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -298,6 +298,9 @@ public class PulsarStandalone implements AutoCloseable {
                     + "-fw-" + hostname
                     + "-" + workerConfig.getWorkerPort());
             // inherit broker authorization setting
+            workerConfig.setAuthenticationEnabled(config.isAuthenticationEnabled());
+            workerConfig.setAuthenticationProviders(config.getAuthenticationProviders());
+
             workerConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());
             workerConfig.setAuthorizationProvider(config.getAuthorizationProvider());
             workerConfig.setConfigurationStoreServers(config.getConfigurationStoreServers());


### PR DESCRIPTION
### Motivation

Currently, when users are running the worker service with the broker and they want to turn authentication on, the user will have to set authenticationEnabled in both the broker conf as well as the function_worker conf.  This is unnecessary, there is really no point for the user to have to set both since its doesn't make since for the function worker service to not turn on authentication when auth is turned on for the broker