### PR TITLE
[pulsar-clients]Support nested struct for GenericRecord

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/RecordSchemaBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/RecordSchemaBuilder.java
@@ -44,6 +44,15 @@ public interface RecordSchemaBuilder {
     FieldSchemaBuilder field(String fieldName);
 
     /**
+     * Add a field with the given name and genericSchema to the record.
+     *
+     * @param fieldName name of the field
+     * @param genericSchema schema of the field
+     * @return field schema builder to build the field.
+     */
+    FieldSchemaBuilder field(String fieldName, GenericSchema genericSchema);
+
+    /**
      * Add doc to the record schema.
      *
      * @param doc documentation

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FieldSchemaBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FieldSchemaBuilderImpl.java
@@ -28,6 +28,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaBuilder;
 import org.apache.pulsar.client.api.schema.FieldSchemaBuilder;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
 import org.apache.pulsar.common.schema.SchemaType;
 
 /**
@@ -44,8 +46,15 @@ class FieldSchemaBuilderImpl implements FieldSchemaBuilder<FieldSchemaBuilderImp
     private String doc;
     private String[] aliases;
 
+    private GenericSchema genericSchema;
+
     FieldSchemaBuilderImpl(String fieldName) {
+        this(fieldName, null);
+    }
+
+    FieldSchemaBuilderImpl(String fieldName, GenericSchema genericSchema) {
         this.fieldName = fieldName;
+        this.genericSchema = genericSchema;
     }
 
     @Override
@@ -131,6 +140,10 @@ class FieldSchemaBuilderImpl implements FieldSchemaBuilder<FieldSchemaBuilderImp
                 break;
             case TIMESTAMP:
                 baseSchema = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+                break;
+            case AVRO:
+                GenericAvroSchema genericAvroSchema = (GenericAvroSchema) genericSchema;
+                baseSchema = genericAvroSchema.getAvroSchema();
                 break;
             default:
                 throw new RuntimeException("Schema `" + type + "` is not supported to be used as a field for now");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/RecordSchemaBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/RecordSchemaBuilderImpl.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pulsar.client.api.schema.FieldSchemaBuilder;
+import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -56,6 +57,13 @@ public class RecordSchemaBuilderImpl implements RecordSchemaBuilder {
     @Override
     public FieldSchemaBuilder field(String fieldName) {
         FieldSchemaBuilderImpl field = new FieldSchemaBuilderImpl(fieldName);
+        fields.add(field);
+        return field;
+    }
+
+    @Override
+    public FieldSchemaBuilder field(String fieldName, GenericSchema genericSchema) {
+        FieldSchemaBuilderImpl field = new FieldSchemaBuilderImpl(fieldName, genericSchema);
         fields.add(field);
         return field;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/AvroRecordBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/AvroRecordBuilderImpl.java
@@ -22,6 +22,8 @@ import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 
+import java.util.List;
+
 /**
  * Builder to build {@link org.apache.pulsar.client.api.schema.GenericRecord}.
  */
@@ -45,7 +47,12 @@ class AvroRecordBuilderImpl implements GenericRecordBuilder {
      */
     @Override
     public GenericRecordBuilder set(String fieldName, Object value) {
-        avroRecordBuilder.set(fieldName, value);
+        if (value instanceof GenericRecord) {
+            List<Field> fields = ((GenericRecord) value).getFields();
+            fields.stream().forEach(field -> avroRecordBuilder.set(fieldName, ((GenericAvroRecord)value).getAvroRecord()));
+        } else {
+            avroRecordBuilder.set(fieldName, value);
+        }
         return this;
     }
 
@@ -70,10 +77,18 @@ class AvroRecordBuilderImpl implements GenericRecordBuilder {
      * @return a reference to the RecordBuilder.
      */
     protected GenericRecordBuilder set(int index, Object value) {
-        avroRecordBuilder.set(
-            genericSchema.getAvroSchema().getFields().get(index),
-            value
-        );
+        if (value instanceof GenericRecord) {
+            List<Field> fields = ((GenericRecord) value).getFields();
+            fields.stream().forEach(field -> {
+                avroRecordBuilder.set(genericSchema.getAvroSchema().getFields().get(index),
+                        ((GenericAvroRecord) value).getAvroRecord());
+            });
+        } else {
+            avroRecordBuilder.set(
+                    genericSchema.getAvroSchema().getFields().get(index),
+                    value
+            );
+        }
         return this;
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaBuilderTest.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.Test;
@@ -199,5 +200,135 @@ public class SchemaBuilderTest {
         assertEquals(true, fields.boolField);
         assertEquals(0.7f, fields.floatField);
         assertEquals(1.34d, fields.doubleField);
+    }
+
+    @Test
+    public void testGenericRecordBuilderAvroByFilename() {
+        RecordSchemaBuilder people1SchemaBuilder = SchemaBuilder.record("People1");
+        people1SchemaBuilder.field("age").type(SchemaType.INT32);
+        people1SchemaBuilder.field("height").type(SchemaType.INT32);
+        people1SchemaBuilder.field("name").type(SchemaType.STRING);
+
+
+        SchemaInfo people1SchemaInfo = people1SchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema people1Schema = Schema.generic(people1SchemaInfo);
+
+
+        GenericRecordBuilder people1RecordBuilder = people1Schema.newRecordBuilder();
+        people1RecordBuilder.set("age", 20);
+        people1RecordBuilder.set("height", 180);
+        people1RecordBuilder.set("name", "people1");
+        GenericRecord people1GenericRecord = people1RecordBuilder.build();
+
+        RecordSchemaBuilder people2SchemaBuilder = SchemaBuilder.record("People2");
+        people2SchemaBuilder.field("age").type(SchemaType.INT32);
+        people2SchemaBuilder.field("height").type(SchemaType.INT32);
+        people2SchemaBuilder.field("name").type(SchemaType.STRING);
+
+        SchemaInfo people2SchemaInfo = people2SchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema people2Schema = Schema.generic(people2SchemaInfo);
+
+        GenericRecordBuilder people2RecordBuilder = people2Schema.newRecordBuilder();
+        people2RecordBuilder.set("age", 20);
+        people2RecordBuilder.set("height", 180);
+        people2RecordBuilder.set("name", "people2");
+        GenericRecord people2GenericRecord = people2RecordBuilder.build();
+
+        RecordSchemaBuilder peopleSchemaBuilder = SchemaBuilder.record("People");
+        peopleSchemaBuilder.field("people1", people1Schema).type(SchemaType.AVRO);
+        peopleSchemaBuilder.field("people2", people2Schema).type(SchemaType.AVRO);
+
+
+        SchemaInfo schemaInfo = peopleSchemaBuilder.build(SchemaType.AVRO);
+
+        GenericSchema peopleSchema = Schema.generic(schemaInfo);
+        GenericRecordBuilder peopleRecordBuilder = peopleSchema.newRecordBuilder();
+        peopleRecordBuilder.set("people1", people1GenericRecord);
+        peopleRecordBuilder.set("people2", people2GenericRecord);
+        GenericRecord peopleRecord = peopleRecordBuilder.build();
+
+        byte[] peopleEncode = peopleSchema.encode(peopleRecord);
+
+        GenericRecord people = (GenericRecord) peopleSchema.decode(peopleEncode);
+
+        assertEquals(people.getFields(), peopleRecord.getFields());
+        assertEquals(((GenericRecord)people.getField("people1")).getField("age"),
+                people1GenericRecord.getField("age"));
+        assertEquals(((GenericRecord)people.getField("people1")).getField("heigth"),
+                people1GenericRecord.getField("heigth"));
+        assertEquals(((GenericRecord)people.getField("people1")).getField("name"),
+                people1GenericRecord.getField("name"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("age"),
+                people2GenericRecord.getField("age"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("height"),
+                people2GenericRecord.getField("height"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("name"),
+                people2GenericRecord.getField("name"));
+
+    }
+
+    @Test
+    public void testGenericRecordBuilderAvroByFiled() {
+        RecordSchemaBuilder people1SchemaBuilder = SchemaBuilder.record("People1");
+        people1SchemaBuilder.field("age").type(SchemaType.INT32);
+        people1SchemaBuilder.field("height").type(SchemaType.INT32);
+        people1SchemaBuilder.field("name").type(SchemaType.STRING);
+
+
+        SchemaInfo people1SchemaInfo = people1SchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> people1Schema = Schema.generic(people1SchemaInfo);
+
+
+        GenericRecordBuilder people1RecordBuilder = people1Schema.newRecordBuilder();
+        people1RecordBuilder.set(people1Schema.getFields().get(0), 20);
+        people1RecordBuilder.set(people1Schema.getFields().get(1), 180);
+        people1RecordBuilder.set(people1Schema.getFields().get(2), "people1");
+        GenericRecord people1GenericRecord = people1RecordBuilder.build();
+
+        RecordSchemaBuilder people2SchemaBuilder = SchemaBuilder.record("People2");
+        people2SchemaBuilder.field("age").type(SchemaType.INT32);
+        people2SchemaBuilder.field("height").type(SchemaType.INT32);
+        people2SchemaBuilder.field("name").type(SchemaType.STRING);
+
+        SchemaInfo people2SchemaInfo = people2SchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> people2Schema = Schema.generic(people2SchemaInfo);
+
+        GenericRecordBuilder people2RecordBuilder = people2Schema.newRecordBuilder();
+        people2RecordBuilder.set(people2Schema.getFields().get(0), 20);
+        people2RecordBuilder.set(people2Schema.getFields().get(1), 180);
+        people2RecordBuilder.set(people2Schema.getFields().get(2), "people2");
+        GenericRecord people2GenericRecord = people2RecordBuilder.build();
+
+        RecordSchemaBuilder peopleSchemaBuilder = SchemaBuilder.record("People");
+        peopleSchemaBuilder.field("people1", people1Schema).type(SchemaType.AVRO);
+        peopleSchemaBuilder.field("people2", people2Schema).type(SchemaType.AVRO);
+
+
+        SchemaInfo schemaInfo = peopleSchemaBuilder.build(SchemaType.AVRO);
+
+        GenericSchema<GenericRecord> peopleSchema = Schema.generic(schemaInfo);
+        GenericRecordBuilder peopleRecordBuilder = peopleSchema.newRecordBuilder();
+        peopleRecordBuilder.set(peopleSchema.getFields().get(0), people1GenericRecord);
+        peopleRecordBuilder.set(peopleSchema.getFields().get(1), people2GenericRecord);
+        GenericRecord peopleRecord = peopleRecordBuilder.build();
+
+        byte[] peopleEncode = peopleSchema.encode(peopleRecord);
+
+        GenericRecord people = (GenericRecord) peopleSchema.decode(peopleEncode);
+
+        assertEquals(people.getFields(), peopleRecord.getFields());
+        assertEquals(((GenericRecord)people.getField("people1")).getField("age"),
+                people1GenericRecord.getField("age"));
+        assertEquals(((GenericRecord)people.getField("people1")).getField("heigth"),
+                people1GenericRecord.getField("heigth"));
+        assertEquals(((GenericRecord)people.getField("people1")).getField("name"),
+                people1GenericRecord.getField("name"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("age"),
+                people2GenericRecord.getField("age"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("height"),
+                people2GenericRecord.getField("height"));
+        assertEquals(((GenericRecord)people.getField("people2")).getField("name"),
+                people2GenericRecord.getField("name"));
+
     }
 }


### PR DESCRIPTION

### Motivation

Currently, GenericRecordBuilder only supports primitive types, e.g. int, long, string. But it doesn’t support struct type. 

### Modifications

Support nested struct for GenericRecordBuilder, for example AVRO

### Verifying this change

Unit Test Pass


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
