### PR TITLE
AlwaysCompatible doesn't use AlwaysSchemaValidator in 2.3.1

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
@@ -65,6 +65,8 @@ public class AvroSchemaCompatibilityCheck implements SchemaCompatibilityCheck {
                 return createLatestOrAllValidator(validatorBuilder.canBeReadStrategy(), onlyLatestValidator);
             case FULL:
                 return createLatestOrAllValidator(validatorBuilder.mutualReadStrategy(), onlyLatestValidator);
+            case ALWAYS_COMPATIBLE:
+                return AlwaysSchemaValidator.INSTANCE;
             default:
                 return NeverSchemaValidator.INSTANCE;
         }


### PR DESCRIPTION
*Motivation*

AlwaysCompatible flag doesn't work in 2.3.1 because the flag is using NeverSchemaValidator

*Modifications*

Change to use AlwaysSchemaValidator

