### PR TITLE
Fix: Function auth should ignore exception because it might be anonymous user

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -183,6 +183,7 @@ public class PulsarFunctionE2ESecurityTest {
         propAdmin.setAllowedClusters(Sets.newHashSet(Lists.newArrayList("use")));
         superUserAdmin.tenants().updateTenant(TENANT, propAdmin);
 
+
         final String replNamespace = TENANT + "/" + NAMESPACE;
         superUserAdmin.namespaces().createNamespace(replNamespace);
         Set<String> clusters = Sets.newHashSet(Lists.newArrayList("use"));
@@ -410,6 +411,15 @@ public class PulsarFunctionE2ESecurityTest {
             // admin2 should still fail
             try {
                 admin2.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
+                fail("client admin shouldn't have permissions to create function");
+            } catch (PulsarAdminException.NotAuthorizedException e) {
+
+            }
+
+            // creating on another tenant should also fail
+            try {
+                admin2.functions().createFunctionWithUrl(createFunctionConfig(TENANT2, NAMESPACE, functionName,
+                        sourceTopic, sinkTopic, subscriptionName), jarFilePathUrl);
                 fail("client admin shouldn't have permissions to create function");
             } catch (PulsarAdminException.NotAuthorizedException e) {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -354,6 +354,167 @@ public class PulsarFunctionE2ESecurityTest {
                 // due to publish failure
                 assertNotEquals(admin1.topics().getStats(sourceTopic).subscriptions.values().iterator().next().unackedMessages,
                         totalMsgs);
+
+                // test update functions
+                functionConfig.setParallelism(2);
+                functionConfig2.setParallelism(2);
+
+                try {
+                    admin1.functions().updateFunctionWithUrl(functionConfig2, jarFilePathUrl);
+                    fail("client admin shouldn't have permissions to update function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+
+                admin1.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
+
+                retryStrategically((test) -> {
+                    try {
+                        return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 2;
+                    } catch (PulsarAdminException e) {
+                        return false;
+                    }
+                }, 5, 150);
+
+                assertEquals(admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning(), 2);
+
+                // test getFunctionInfo
+                try {
+                    admin1.functions().getFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to get function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunction(TENANT, NAMESPACE, functionName);
+
+                // test getFunctionInstanceStatus
+                try {
+                    admin1.functions().getFunctionStatus(TENANT2, NAMESPACE, functionName, 0);
+                    fail("client admin shouldn't have permissions to get function status");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName, 0);
+
+                // test getFunctionStatus
+                try {
+                    admin1.functions().getFunctionStatus(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to get function status");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName);
+
+                // test getFunctionStats
+                try {
+                    admin1.functions().getFunctionStats(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to get function stats");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunctionStats(TENANT, NAMESPACE, functionName);
+
+                // test getFunctionInstanceStats
+                try {
+                    admin1.functions().getFunctionStats(TENANT2, NAMESPACE, functionName, 0);
+                    fail("client admin shouldn't have permissions to get function stats");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunctionStats(TENANT, NAMESPACE, functionName, 0);
+
+                // test listFunctions
+                try {
+                    admin1.functions().getFunctions(TENANT2, NAMESPACE);
+                    fail("client admin shouldn't have permissions to list functions");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().getFunctions(TENANT, NAMESPACE);
+
+                // test triggerFunction
+                try {
+                    admin1.functions().triggerFunction(TENANT2, NAMESPACE, functionName, sourceTopic, "foo", null);
+                    fail("client admin shouldn't have permissions to trigger function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().triggerFunction(TENANT, NAMESPACE, functionName, sourceTopic, "foo", null);
+
+                // test restartFunctionInstance
+                try {
+                    admin1.functions().restartFunction(TENANT2, NAMESPACE, functionName, 0);
+                    fail("client admin shouldn't have permissions to restart function instance");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().restartFunction(TENANT, NAMESPACE, functionName, 0);
+
+                // test restartFunctionInstances
+                try {
+                    admin1.functions().restartFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to restart function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().restartFunction(TENANT, NAMESPACE, functionName);
+
+                // test stopFunction instance
+                try {
+                    admin1.functions().stopFunction(TENANT2, NAMESPACE, functionName, 0);
+                    fail("client admin shouldn't have permissions to stop function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().stopFunction(TENANT, NAMESPACE, functionName, 0);
+
+                // test stopFunction all instance
+                try {
+                    admin1.functions().stopFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to restart function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().stopFunction(TENANT, NAMESPACE, functionName);
+
+                // test startFunction instance
+                try {
+                    admin1.functions().startFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to restart function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().restartFunction(TENANT, NAMESPACE, functionName);
+
+                // test startFunction all instances
+                try {
+                    admin1.functions().restartFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to restart function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+                admin1.functions().restartFunction(TENANT, NAMESPACE, functionName);
+
+                // delete functions
+                try {
+                    admin1.functions().deleteFunction(TENANT2, NAMESPACE, functionName);
+                    fail("client admin shouldn't have permissions to delete function");
+                } catch (PulsarAdminException.NotAuthorizedException e) {
+
+                }
+
+                admin1.functions().deleteFunction(TENANT, NAMESPACE, functionName);
+
+                retryStrategically((test) -> {
+                    try {
+                        return admin1.topics().getStats(sourceTopic).subscriptions.size() == 0;
+                    } catch (PulsarAdminException e) {
+                        return false;
+                    }
+                }, 5, 150);
+
+                // make sure subscriptions are cleanup
+                assertEquals(admin1.topics().getStats(sourceTopic).subscriptions.size(), 0);
             }
         }
     }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -102,7 +102,8 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
                 id = createSecret(token, tenant, namespace, name);
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            log.warn("Failed to get token for function {}", FunctionCommon.getFullyQualifiedName(tenant, namespace, name), e);
+            // ignore exception and continue since anonymous user might to used
         }
 
         if (id != null) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1692,10 +1692,12 @@ private FunctionDetails validateUpdateRequestParams(final String tenant,
             if (isSuperUser(clientRole)) {
                 return true;
             }
-            TenantInfo tenantInfo = worker().getBrokerAdmin().tenants().getTenantInfo(tenant);
-            if (clientRole != null && (tenantInfo.getAdminRoles() == null || tenantInfo.getAdminRoles().isEmpty()
-                    || tenantInfo.getAdminRoles().contains(clientRole))) {
-                return true;
+
+            if (clientRole != null) {
+                TenantInfo tenantInfo = worker().getBrokerAdmin().tenants().getTenantInfo(tenant);
+                if (tenantInfo.getAdminRoles() != null && tenantInfo.getAdminRoles().contains(clientRole)) {
+                    return true;
+                }
             }
 
             // check if role has permissions granted


### PR DESCRIPTION
### Motivation

In functions, we shouldn't through an exception when auth is turned on and no token is passed because users can try to use the anonymous role
