### PR TITLE
fix function authorization bug involving a tenant with no admin

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1702,7 +1702,6 @@ private FunctionDetails validateUpdateRequestParams(final String tenant,
 
             // check if role has permissions granted
             if (clientRole != null && authenticationData != null) {
-                log.info("allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData): {}", allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData));
                 return allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData);
             } else {
                 return false;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1692,14 +1692,17 @@ private FunctionDetails validateUpdateRequestParams(final String tenant,
             if (isSuperUser(clientRole)) {
                 return true;
             }
-            TenantInfo tenantInfo = worker().getBrokerAdmin().tenants().getTenantInfo(tenant);
-            if (clientRole != null && (tenantInfo.getAdminRoles() == null || tenantInfo.getAdminRoles().isEmpty()
-                    || tenantInfo.getAdminRoles().contains(clientRole))) {
-                return true;
+
+            if (clientRole != null) {
+                TenantInfo tenantInfo = worker().getBrokerAdmin().tenants().getTenantInfo(tenant);
+                if (tenantInfo.getAdminRoles() != null && tenantInfo.getAdminRoles().contains(clientRole)) {
+                    return true;
+                }
             }
 
             // check if role has permissions granted
             if (clientRole != null && authenticationData != null) {
+                log.info("allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData): {}", allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData));
                 return allowFunctionOps(NamespaceName.get(tenant, namespace), clientRole, authenticationData);
             } else {
                 return false;


### PR DESCRIPTION

### Motivation

When a tenant does not have any admins, functions will allow any authenticated user to submit functions with in that tenant which is the incorrect behavior
