### PR TITLE
Set supportSchemaVersioning to true by default in GenericAvroSchema

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
@@ -39,6 +39,10 @@ public class GenericAvroSchema extends GenericSchemaImpl {
         return new AvroRecordBuilderImpl(this);
     }
 
+    @Override
+    public boolean supportSchemaVersioning() {
+        return true;
+    }
 
     @Override
     protected SchemaReader<GenericRecord> loadReader(byte[] schemaVersion) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningAvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningAvroSchemaTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class SupportVersioningAvroSchemaTest {
     private MultiVersionSchemaInfoProvider multiVersionSchemaInfoProvider;
@@ -59,6 +60,7 @@ public class SupportVersioningAvroSchemaTest {
         SchemaTestUtils.FooV2 fooV2 = new SchemaTestUtils.FooV2();
         fooV2.setField1(SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_STRING);
         SchemaTestUtils.Foo foo = (SchemaTestUtils.Foo)schema.decode(avroFooV2Schema.encode(fooV2), new byte[10]);
+        assertTrue(schema.supportSchemaVersioning());
         assertEquals(SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_STRING, foo.getField1());
         assertEquals(SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_DEFAULT_STRING, foo.getFieldUnableNull());
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchemaTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema.generic;
+
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.SchemaTestUtils;
+import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Foo;
+import org.apache.pulsar.client.impl.schema.SchemaTestUtils.FooV2;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class GenericAvroSchemaTest {
+
+    private GenericAvroSchema writerSchema;
+    private GenericAvroSchema readerSchema;
+
+    @BeforeMethod
+    public void init() {
+        AvroSchema<FooV2> avroFooV2Schema = AvroSchema.of(SchemaDefinition.<SchemaTestUtils.FooV2>builder()
+            .withAlwaysAllowNull(false).withPojo(SchemaTestUtils.FooV2.class).build());
+        AvroSchema<Foo> avroFooSchema = AvroSchema.of(SchemaDefinition.<SchemaTestUtils.Foo>builder()
+            .withAlwaysAllowNull(false).withPojo(SchemaTestUtils.Foo.class).build());
+        writerSchema = new GenericAvroSchema(avroFooV2Schema.getSchemaInfo());
+        readerSchema = new GenericAvroSchema(avroFooSchema.getSchemaInfo());
+    }
+
+    @Test
+    public void testSupportMultiVersioningSupportByDefault() {
+        Assert.assertTrue(writerSchema.supportSchemaVersioning());
+        Assert.assertTrue(readerSchema.supportSchemaVersioning());
+    }
+
+    @Test(expectedExceptions = org.apache.pulsar.client.api.SchemaSerializationException.class)
+    public void testFailDecodeWithoutMultiVersioningSupport() {
+        GenericRecord dataForWriter = writerSchema.newRecordBuilder()
+            .set("field1", SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_STRING)
+            .set("field3", 0)
+            .build();
+        readerSchema.decode(writerSchema.encode(dataForWriter));
+    }
+
+    @Test
+    public void testDecodeWithMultiVersioningSupport() {
+        MultiVersionSchemaInfoProvider provider = mock(MultiVersionSchemaInfoProvider.class);
+        readerSchema.setSchemaInfoProvider(provider);
+        when(provider.getSchemaByVersion(any(byte[].class)))
+            .thenReturn(writerSchema.getSchemaInfo());
+        GenericRecord dataForWriter = writerSchema.newRecordBuilder()
+            .set("field1", SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_STRING)
+            .set("field3", 0)
+            .build();
+        GenericRecord record = readerSchema.decode(writerSchema.encode(dataForWriter), new byte[10]);
+        Assert.assertEquals(SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_STRING, record.getField("field1"));
+        Assert.assertEquals(0, record.getField("field3"));
+        Assert.assertEquals(SchemaTestUtils.TEST_MULTI_VERSION_SCHEMA_DEFAULT_STRING, record.getField("fieldUnableNull"));
+    }
+}


### PR DESCRIPTION
Fixes #4182 

### Modifications

Set supportSchemaVersioning to true by default in GenericAvroSchema

### Verifying this change

Add unit test for support schema versioning in GenericAvroSchema

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (yes)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
