### PR TITLE
Avoid potentially blocking method during topic ownership check

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -165,6 +165,11 @@ public class NamespaceService {
                 .thenApply(bundles -> bundles.findBundle(topic));
     }
 
+    public Optional<NamespaceBundle> getBundleIfPresent(TopicName topicName) throws Exception {
+        Optional<NamespaceBundles> bundles = bundleFactory.getBundlesIfPresent(topicName.getNamespaceObject());
+        return bundles.map(b -> b.findBundle(topicName));
+    }
+
     public NamespaceBundle getBundle(TopicName topicName) throws Exception {
         return bundleFactory.getBundles(topicName.getNamespaceObject()).findBundle(topicName);
     }
@@ -824,7 +829,12 @@ public class NamespaceService {
     }
 
     private boolean isTopicOwned(TopicName topicName) throws Exception {
-        return ownershipCache.getOwnedBundle(getBundle(topicName)) != null;
+        Optional<NamespaceBundle> bundle = getBundleIfPresent(topicName);
+        if (!bundle.isPresent()) {
+            return false;
+        } else {
+            return ownershipCache.getOwnedBundle(bundle.get()) != null;
+        }
     }
 
     public void removeOwnedServiceUnit(NamespaceName nsName) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -155,6 +155,10 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
         return bundlesCache.synchronous().get(nsname);
     }
 
+    public Optional<NamespaceBundles> getBundlesIfPresent(NamespaceName nsname) throws Exception {
+        return Optional.ofNullable(bundlesCache.synchronous().getIfPresent(nsname));
+    }
+
     public NamespaceBundle getBundle(NamespaceName nsname, Range<Long> hashRange) {
         return new NamespaceBundle(nsname, hashRange, this);
     }


### PR DESCRIPTION
### Motivation

There is a deadlock when a bundle is being split and consumers are reconnecting immediately. This only happens if there is a large number of producers/cosnumers reconnecting.

The problem is that when doing the topic ownership check there is a sync check on the bundles metadata. That metadata is always cached so it doesn't cause any problem... except when it's not..

The reason why it might not be cached is that it gets invalidated when a broker perform a bundles split.

The solution here is to make the ownership check to not block, by giving up if the bundles metadata is not cached.

Example of deadlocked threads:

```
"ForkJoinPool.commonPool-worker-1" #418 daemon prio=5 os_prio=0 tid=0x00007f0aac00d800 nid=0x1d0 waiting on condition [0x00007f099705b000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000007bd608990> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1693)
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3313)
	at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1729)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1895)
	at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache$LoadingCacheView.get(LocalAsyncLoadingCache.java:400)
	at org.apache.pulsar.common.naming.NamespaceBundleFactory.getBundles(NamespaceBundleFactory.java:155)
	at org.apache.pulsar.broker.namespace.NamespaceService.getBundle(NamespaceService.java:169)
	at org.apache.pulsar.broker.namespace.NamespaceService.isTopicOwned(NamespaceService.java:827)
	at org.apache.pulsar.broker.namespace.NamespaceService.isServiceUnitOwned(NamespaceService.java:795)
	at org.apache.pulsar.broker.service.BrokerService.checkTopicNsOwnership(BrokerService.java:961)
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.addProducer(PersistentTopic.java:352)
	at org.apache.pulsar.broker.service.ServerCnx.lambda$null$19(ServerCnx.java:929)
	at org.apache.pulsar.broker.service.ServerCnx$$Lambda$591/326723938.accept(Unknown Source)


"pulsar-io-23-32" #330 prio=5 os_prio=0 tid=0x00007f0a3c03e000 nid=0x178 waiting on condition [0x00007f099e0a7000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000006c152d658> (a org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section)
	at java.util.concurrent.locks.StampedLock.acquireRead(StampedLock.java:1215)
	at java.util.concurrent.locks.StampedLock.readLock(StampedLock.java:428)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.get(ConcurrentOpenHashMap.java:220)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.get(ConcurrentOpenHashMap.java:105)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:482)
	at org.apache.pulsar.broker.service.BrokerService.getOrCreateTopic(BrokerService.java:477)
	at org.apache.pulsar.broker.service.ServerCnx.lambda$null$22(ServerCnx.java:869)
	at org.apache.pulsar.broker.service.ServerCnx$$Lambda$567/2031319128.apply(Unknown Source)


"pulsar-backlog-quota-checker-28-1" #136 prio=5 os_prio=0 tid=0x00007f0bee60c000 nid=0xb8 waiting on condition [0x00007f09f0ff0000]
   java.lang.Thread.State: TIMED_WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000007a3daa6d8> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1695)
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3323)
	at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1775)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1915)
	at org.apache.pulsar.zookeeper.ZooKeeperDataCache.get(ZooKeeperDataCache.java:95)
	at org.apache.pulsar.broker.service.BacklogQuotaManager.getBacklogQuota(BacklogQuotaManager.java:63)
	at org.apache.pulsar.broker.service.BacklogQuotaManager.getBacklogQuotaLimit(BacklogQuotaManager.java:75)
	at org.apache.pulsar.broker.service.BrokerService.isBacklogExceeded(BrokerService.java:928)
	at org.apache.pulsar.broker.service.BrokerService.lambda$monitorBacklogQuota$30(BrokerService.java:946)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$656/2055647309.accept(Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.lambda$forEachTopic$29(BrokerService.java:911)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$652/1150340576.accept(Unknown Source)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160)
	at org.apache.pulsar.broker.service.BrokerService.forEachTopic(BrokerService.java:908)
	at org.apache.pulsar.broker.service.BrokerService.monitorBacklogQuota(BrokerService.java:943)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$91/123674777.run(Unknown Source)


"bookkeeper-ml-workers-OrderedExecutor-15-0" #111 prio=5 os_prio=0 tid=0x00007f0bee1b8800 nid=0xa1 waiting on condition [0x00007f09f29e8000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000007bff34008> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1693)
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3323)
	at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1729)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1895)
	at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache$LoadingCacheView.get(LocalAsyncLoadingCache.java:400)
	at org.apache.pulsar.common.naming.NamespaceBundleFactory.getBundles(NamespaceBundleFactory.java:155)
	at org.apache.pulsar.broker.namespace.NamespaceService.getBundle(NamespaceService.java:169)
	at org.apache.pulsar.broker.service.BrokerService.addTopicToStatsMaps(BrokerService.java:790)
	at org.apache.pulsar.broker.service.BrokerService.access$600(BrokerService.java:137)
	at org.apache.pulsar.broker.service.BrokerService$3.lambda$openLedgerComplete$1(BrokerService.java:667)
	at org.apache.pulsar.broker.service.BrokerService$3$$Lambda$257/2095730438.run(Unknown Source)
```