### PR TITLE
[pulsar-broker]Support key value schema compatibility checker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -75,6 +75,11 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
     }
 
     @Override
+    public boolean isWellFormed(SchemaData to) {
+        return true;
+    }
+
+    @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
         KeyValue<byte[], byte[]> fromKeyValue = this.splitKeyValueSchemaData(from.getData());
         KeyValue<byte[], byte[]> toKeyValue = this.splitKeyValueSchemaData(to.getData());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -1,0 +1,73 @@
+package org.apache.pulsar.broker.service.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import lombok.Getter;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
+import org.apache.pulsar.client.impl.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaData;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * {@link KeyValueSchemaCompatibilityCheck} for {@link SchemaType#KEY_VALUE}.
+ */
+public class KeyValueSchemaCompatibilityCheck extends AvroSchemaBasedCompatibilityCheck {
+
+
+    private KeyValue<byte[], byte[]> decode(byte[] bytes, SchemaData schemaData) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        int keyLength = byteBuffer.getInt();
+        byte[] keySchema = new byte[keyLength];
+        byteBuffer.get(keySchema);
+
+        int valueLength = byteBuffer.getInt();
+        byte[] valueSchema = new byte[valueLength];
+        byteBuffer.get(valueSchema);
+        return new KeyValue<>(keySchema, valueSchema);
+    }
+
+    @Override
+    public SchemaType getSchemaType() {
+        return SchemaType.KEY_VALUE;
+    }
+
+
+    @Override
+    public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        KeyValue<byte[], byte[]> fromKeyValue = this.decode(from.getData(), from);
+        KeyValue<byte[], byte[]> toKeyValue = this.decode(to.getData(), to);
+
+        SchemaData fromKeySchemaData = SchemaData.builder().data(fromKeyValue.getKey())
+                .type(SchemaType.valueOf(from.getProps().get("key.schema.type"))).build();
+        SchemaData fromValueSchemaData = SchemaData.builder().data(fromKeyValue.getValue())
+                .type(SchemaType.valueOf(from.getProps().get("value.schema.type"))).build();
+        SchemaData toKeySchemaData = SchemaData.builder().data(toKeyValue.getKey())
+                .type(SchemaType.valueOf(to.getProps().get("key.schema.type"))).build();
+        SchemaData toValueSchemaData = SchemaData.builder().data(toKeyValue.getValue())
+                .type(SchemaType.valueOf(to.getProps().get("value.schema.type"))).build();
+        if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.AVRO) {
+            if (super.isCompatible(fromKeySchemaData, toKeySchemaData, strategy)
+                    && super.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
+                return true;
+            }
+            return false;
+        } else if (SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.JSON) {
+            JsonSchemaCompatibilityCheck jsonSchemaCompatibilityCheck = new JsonSchemaCompatibilityCheck();
+            if (jsonSchemaCompatibilityCheck.isCompatible(fromKeySchemaData, fromValueSchemaData, strategy)
+                    && jsonSchemaCompatibilityCheck.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -42,7 +42,7 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
         this.checkers = checkers;
     }
 
-    private KeyValue<byte[], byte[]> splitKeyValueSchemaData(byte[] bytes) {
+    private KeyValue<byte[], byte[]> splitKeyValueSchema(byte[] bytes) {
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
         int keyLength = byteBuffer.getInt();
         byte[] keySchema = new byte[keyLength];
@@ -73,8 +73,8 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
                 .props(Collections.emptyMap()).build();
     }
 
-    private KeyValue<SchemaData, SchemaData> parseSchemaData(SchemaData schemaData) {
-        KeyValue<byte[], byte[]> keyValue = this.splitKeyValueSchemaData(schemaData.getData());
+    private KeyValue<SchemaData, SchemaData> splitKeyValueSchemaData(SchemaData schemaData) {
+        KeyValue<byte[], byte[]> keyValue = this.splitKeyValueSchema(schemaData.getData());
         Map<String, String> properties = schemaData.getProps();
         SchemaType keyType = fetchSchemaType(properties, "key.schema.type");
         SchemaType valueType = fetchSchemaType(properties, "value.schema.type");
@@ -107,7 +107,7 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
         LinkedList<SchemaData> fromKeyList = new LinkedList<>();
         LinkedList<SchemaData> fromValueList = new LinkedList<>();
         KeyValue<SchemaData, SchemaData> fromKeyValue;
-        KeyValue<SchemaData, SchemaData> toKeyValue = parseSchemaData(to);
+        KeyValue<SchemaData, SchemaData> toKeyValue = splitKeyValueSchemaData(to);
         SchemaType toKeyType = toKeyValue.getKey().getType();
         SchemaType toValueType = toKeyValue.getValue().getType();
 
@@ -115,7 +115,7 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
             if (schemaData.getType() != SchemaType.KEY_VALUE) {
                 return false;
             }
-            fromKeyValue = parseSchemaData(schemaData);
+            fromKeyValue = splitKeyValueSchemaData(schemaData);
             if (fromKeyValue.getKey().getType() != toKeyType || fromKeyValue.getValue().getType() != toValueType) {
                 return false;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -90,13 +90,11 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
     @Override
     public boolean isWellFormed(SchemaData to) {
         KeyValue<SchemaData, SchemaData> keyValue = parseSchemaData(to);
-        SchemaCompatibilityCheck valueCheck;
-        if (checkers.get(keyValue.getValue().getType()) != null) {
-            valueCheck = checkers.get(keyValue.getValue().getType());
-        } else {
-            valueCheck = SchemaCompatibilityCheck.DEFAULT;
-        }
-        return valueCheck.isWellFormed(keyValue.getKey()) && valueCheck.isWellFormed(keyValue.getValue());
+        SchemaCompatibilityCheck keyCheck = checkers.getOrDefault(
+                keyValue.getKey().getType(), SchemaCompatibilityCheck.DEFAULT);
+        SchemaCompatibilityCheck valueCheck = checkers.getOrDefault(
+                keyValue.getValue().getType(), SchemaCompatibilityCheck.DEFAULT);
+        return keyCheck.isWellFormed(keyValue.getKey()) && valueCheck.isWellFormed(keyValue.getValue());
     }
 
     @Override
@@ -118,19 +116,8 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
         if (fromKeyType != toKeyType || fromValueType != toValueType) {
             return false;
         }
-
-        SchemaCompatibilityCheck keyCheck;
-        if (checkers.get(toKeyType) != null) {
-            keyCheck = checkers.get(toKeyType);
-        } else {
-            keyCheck = SchemaCompatibilityCheck.DEFAULT;
-        }
-        SchemaCompatibilityCheck valueCheck;
-        if (checkers.get(toValueType) != null) {
-            valueCheck = checkers.get(toValueType);
-        } else {
-            valueCheck = SchemaCompatibilityCheck.DEFAULT;
-        }
+        SchemaCompatibilityCheck keyCheck = checkers.getOrDefault(toKeyType, SchemaCompatibilityCheck.DEFAULT);
+        SchemaCompatibilityCheck valueCheck = checkers.getOrDefault(toValueType, SchemaCompatibilityCheck.DEFAULT);
 
         return keyCheck.isCompatible(fromKeyValue.getKey(), toKeyValue.getKey(), strategy)
                 && valueCheck.isCompatible(fromKeyValue.getValue(), toKeyValue.getValue(), strategy);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -100,7 +100,7 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
     @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
         if (from.getType() != SchemaType.KEY_VALUE || to.getType() != SchemaType.KEY_VALUE) {
-            if (strategy == SchemaCompatibilityStrategy.FULL || strategy == SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE) {
+            if (strategy == SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE) {
                 return true;
             }
             return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -1,25 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.service.schema;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
-import lombok.Getter;
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaParseException;
-import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * {@link KeyValueSchemaCompatibilityCheck} for {@link SchemaType#KEY_VALUE}.
  */
 public class KeyValueSchemaCompatibilityCheck extends AvroSchemaBasedCompatibilityCheck {
-
 
     private KeyValue<byte[], byte[]> decode(byte[] bytes, SchemaData schemaData) {
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
@@ -38,7 +46,6 @@ public class KeyValueSchemaCompatibilityCheck extends AvroSchemaBasedCompatibili
         return SchemaType.KEY_VALUE;
     }
 
-
     @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
         KeyValue<byte[], byte[]> fromKeyValue = this.decode(from.getData(), from);
@@ -46,28 +53,43 @@ public class KeyValueSchemaCompatibilityCheck extends AvroSchemaBasedCompatibili
 
         SchemaData fromKeySchemaData = SchemaData.builder().data(fromKeyValue.getKey())
                 .type(SchemaType.valueOf(from.getProps().get("key.schema.type"))).build();
+
         SchemaData fromValueSchemaData = SchemaData.builder().data(fromKeyValue.getValue())
                 .type(SchemaType.valueOf(from.getProps().get("value.schema.type"))).build();
+
         SchemaData toKeySchemaData = SchemaData.builder().data(toKeyValue.getKey())
                 .type(SchemaType.valueOf(to.getProps().get("key.schema.type"))).build();
+
+
         SchemaData toValueSchemaData = SchemaData.builder().data(toKeyValue.getValue())
                 .type(SchemaType.valueOf(to.getProps().get("value.schema.type"))).build();
-        if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.AVRO) {
+
+        JsonSchemaCompatibilityCheck jsonSchemaCompatibilityCheck = new JsonSchemaCompatibilityCheck();
+        if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.AVRO
+                && SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.AVRO) {
             if (super.isCompatible(fromKeySchemaData, toKeySchemaData, strategy)
                     && super.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
                 return true;
             }
-            return false;
-        } else if (SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.JSON) {
-            JsonSchemaCompatibilityCheck jsonSchemaCompatibilityCheck = new JsonSchemaCompatibilityCheck();
-            if (jsonSchemaCompatibilityCheck.isCompatible(fromKeySchemaData, fromValueSchemaData, strategy)
+        } else if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.JSON
+                && SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.JSON) {
+            if (jsonSchemaCompatibilityCheck.isCompatible(fromKeySchemaData, toKeySchemaData, strategy)
                     && jsonSchemaCompatibilityCheck.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
                 return true;
             }
-            return false;
+        } else if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.AVRO
+                && SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.JSON) {
+            if (super.isCompatible(fromKeySchemaData, toKeySchemaData, strategy)
+                    && jsonSchemaCompatibilityCheck.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
+                return true;
+            }
+        } else if (SchemaType.valueOf(to.getProps().get("key.schema.type")) == SchemaType.JSON
+                && SchemaType.valueOf(to.getProps().get("value.schema.type")) == SchemaType.AVRO) {
+            if (jsonSchemaCompatibilityCheck.isCompatible(fromKeySchemaData, toKeySchemaData, strategy)
+                    && super.isCompatible(fromValueSchemaData, toValueSchemaData, strategy)) {
+                return true;
+            }
         }
         return false;
     }
-
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -52,7 +52,7 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
 
     private SchemaType fetchSchemaType(Map<String, String> properties, String key) {
         if (properties.get(key) != null) {
-            return SchemaType.valueOf(properties.get("key.schema.type"));
+            return SchemaType.valueOf(properties.get(key));
         }
         return SchemaType.BYTES;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -54,6 +54,8 @@ public interface SchemaRegistryService extends SchemaRegistry {
             Map<SchemaType, SchemaCompatibilityCheck> checkers =
                 getCheckers(config.getSchemaRegistryCompatibilityCheckers());
 
+            checkers.put(SchemaType.KEY_VALUE, new KeyValueSchemaCompatibilityCheck());
+
             schemaStorage.start();
 
             return new SchemaRegistryServiceImpl(schemaStorage, checkers);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -54,7 +54,7 @@ public interface SchemaRegistryService extends SchemaRegistry {
             Map<SchemaType, SchemaCompatibilityCheck> checkers =
                 getCheckers(config.getSchemaRegistryCompatibilityCheckers());
 
-            checkers.put(SchemaType.KEY_VALUE, new KeyValueSchemaCompatibilityCheck());
+            checkers.put(SchemaType.KEY_VALUE, new KeyValueSchemaCompatibilityCheck(checkers));
 
             schemaStorage.start();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -32,7 +33,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class KeyValueSchemaCompatibilityCheckTest {
@@ -470,5 +470,41 @@ public class KeyValueSchemaCompatibilityCheckTest {
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(toProperties).build();
         Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckSchemaTypeFullCompatibility() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        StringSchema stringSchema = new StringSchema();
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.STRING)
+                .data(stringSchema.getSchemaInfo().getSchema()).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckSchemaTypeAlwaysCompatibility() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        StringSchema stringSchema = new StringSchema();
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.STRING)
+                .data(stringSchema.getSchemaInfo().getSchema()).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE));
+    }
+
+    @Test
+    public void testCheckSchemaTypeOtherCompatibility() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        StringSchema stringSchema = new StringSchema();
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.STRING)
+                .data(stringSchema.getSchemaInfo().getSchema()).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -1,0 +1,14 @@
+package org.apache.pulsar.broker.service.schema;
+
+import org.testng.annotations.Test;
+
+public class KeyValueSchemaCompatibilityCheckTest extends BaseAvroSchemaCompatibilityTest {
+
+    @Override
+    public SchemaCompatibilityCheck getSchemaCheck() {
+        return new KeyValueSchemaCompatibilityCheck();
+    }
+
+//    @Test
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -29,11 +29,14 @@ import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
 public class KeyValueSchemaCompatibilityCheckTest {
+
+    private final Map<SchemaType, SchemaCompatibilityCheck> checkers = Maps.newHashMap();
 
     @Data
     @ToString
@@ -52,6 +55,13 @@ public class KeyValueSchemaCompatibilityCheckTest {
         private boolean field1;
     }
 
+    @BeforeClass
+    protected void setup() {
+        checkers.put(SchemaType.AVRO, new AvroSchemaCompatibilityCheck());
+        checkers.put(SchemaType.JSON, new JsonSchemaCompatibilityCheck());
+        checkers.put(SchemaType.KEY_VALUE, new KeyValueSchemaCompatibilityCheck(checkers));
+    }
+
     @Test
     public void testCheckKeyValueAvroCompatibilityFull() {
         AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
@@ -63,8 +73,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -78,8 +87,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -93,8 +101,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -108,8 +115,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -123,8 +129,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -138,8 +143,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -153,8 +157,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -168,8 +171,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -183,8 +185,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -198,8 +199,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -213,8 +213,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -228,8 +227,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -243,8 +241,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -258,8 +255,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -273,8 +269,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -288,8 +283,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -303,8 +297,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -318,8 +311,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -333,8 +325,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -348,8 +339,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 
     @Test
@@ -363,8 +353,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
     @Test
@@ -378,8 +367,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
     }
 
 
@@ -394,8 +382,7 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 
     @Test
@@ -409,7 +396,40 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
-        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
-        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroKeyTypeInCompatibility() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> fromProperties = Maps.newHashMap();
+        fromProperties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        fromProperties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        Map<String, String> toProperties = Maps.newHashMap();
+        toProperties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        toProperties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(fromProperties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, barSchema).getSchemaInfo().getSchema()).props(toProperties).build();
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroValueTypeInCompatibility() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> fromProperties = Maps.newHashMap();
+        fromProperties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        fromProperties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        Map<String, String> toProperties = Maps.newHashMap();
+        toProperties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        toProperties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(fromProperties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, fooSchema).getSchemaInfo().getSchema()).props(toProperties).build();
+        Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -1,14 +1,415 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.service.schema;
 
+import com.google.common.collect.Maps;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.SchemaData;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class KeyValueSchemaCompatibilityCheckTest extends BaseAvroSchemaCompatibilityTest {
+import java.util.Map;
 
-    @Override
-    public SchemaCompatibilityCheck getSchemaCheck() {
-        return new KeyValueSchemaCompatibilityCheck();
+public class KeyValueSchemaCompatibilityCheckTest {
+
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    private static class Foo {
+        private String field1;
+        private String field2;
+        private int field3;
+        private KeyValueSchemaCompatibilityCheckTest.Bar field4;
     }
 
-//    @Test
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    private static class Bar {
+        private boolean field1;
+    }
 
+    @Test
+    public void testCheckKeyValueAvroCompatibilityFull() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyValueAvroInCompatibilityFull() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyValueAvroCompatibilityBackward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueAvroInCompatibilityBackward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueAvroCompatibilityForward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueAvroInCompatibilityForward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonCompatibilityFull() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonInCompatibilityFull() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonCompatibilityBackward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonInCompatibilityBackWard() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonCompatibilityForward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyValueJsonInCompatibilityForward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonCompatibilityFull() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonInCompatibilityFull() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonCompatibilityBackward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonInCompatibilityBackward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonCompatibilityForward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyAvroValueJsonInCompatibilityForward() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        JSONSchema<Bar> barSchema = JSONSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        properties.put("value.schema.type", String.valueOf(SchemaType.JSON));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroCompatibilityFull() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroInCompatibilityFull() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroCompatibilityBackward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroInCompatibilityBackward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.BACKWARD));
+    }
+
+
+    @Test
+    public void testCheckKeyJsonValueAvroCompatibilityForward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertTrue(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckKeyJsonValueAvroInCompatibilityForward() {
+        JSONSchema<Foo> fooSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key.schema.type", String.valueOf(SchemaType.JSON));
+        properties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(barSchema, fooSchema).getSchemaInfo().getSchema()).props(properties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(properties).build();
+        KeyValueSchemaCompatibilityCheck keyValueSchemaCompatibilityCheck = new KeyValueSchemaCompatibilityCheck();
+        Assert.assertFalse(keyValueSchemaCompatibilityCheck.isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -497,13 +497,4 @@ public class KeyValueSchemaCompatibilityCheckTest {
         Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE));
     }
 
-    @Test
-    public void testCheckIsWellFormed() {
-        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
-        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
-        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
-                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
-        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isWellFormed(toSchemaData));
-    }
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -32,6 +32,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class KeyValueSchemaCompatibilityCheckTest {
@@ -431,5 +432,43 @@ public class KeyValueSchemaCompatibilityCheckTest {
         SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
                 .data(KeyValueSchema.of(fooSchema, fooSchema).getSchemaInfo().getSchema()).props(toProperties).build();
         Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FORWARD));
+    }
+
+    @Test
+    public void testCheckPropertiesNullTypeCompatibility() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> fromProperties = Maps.newHashMap();
+        fromProperties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        fromProperties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        fromProperties.put("key.schema.properties", null);
+        fromProperties.put("value.schema.properties", null);
+        Map<String, String> toProperties = Maps.newHashMap();
+        toProperties.put("key.schema.type", String.valueOf(SchemaType.AVRO));
+        toProperties.put("value.schema.type", String.valueOf(SchemaType.AVRO));
+        toProperties.put("key.schema.properties", null);
+        toProperties.put("value.schema.properties", null);
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(fromProperties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(toProperties).build();
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
+    }
+
+    @Test
+    public void testCheckSchemaTypeNullCompatibility() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        Map<String, String> fromProperties = Maps.newHashMap();
+        fromProperties.put("key.schema.type", null);
+        fromProperties.put("value.schema.type", null);
+        Map<String, String> toProperties = Maps.newHashMap();
+        toProperties.put("key.schema.type", null);
+        toProperties.put("value.schema.type", null);
+        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(fromProperties).build();
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).props(toProperties).build();
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheckTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
@@ -473,18 +474,6 @@ public class KeyValueSchemaCompatibilityCheckTest {
     }
 
     @Test
-    public void testCheckSchemaTypeFullCompatibility() {
-        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
-        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
-        StringSchema stringSchema = new StringSchema();
-        SchemaData fromSchemaData = SchemaData.builder().type(SchemaType.STRING)
-                .data(stringSchema.getSchemaInfo().getSchema()).build();
-        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
-                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
-        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.FULL));
-    }
-
-    @Test
     public void testCheckSchemaTypeAlwaysCompatibility() {
         AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
         AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
@@ -507,4 +496,14 @@ public class KeyValueSchemaCompatibilityCheckTest {
                 .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
         Assert.assertFalse(checkers.get(SchemaType.KEY_VALUE).isCompatible(fromSchemaData, toSchemaData, SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE));
     }
+
+    @Test
+    public void testCheckIsWellFormed() {
+        AvroSchema<Foo> fooSchema = AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+        AvroSchema<Bar> barSchema = AvroSchema.of(SchemaDefinition.<Bar>builder().withPojo(Bar.class).build());
+        SchemaData toSchemaData = SchemaData.builder().type(SchemaType.KEY_VALUE)
+                .data(KeyValueSchema.of(fooSchema, barSchema).getSchemaInfo().getSchema()).build();
+        Assert.assertTrue(checkers.get(SchemaType.KEY_VALUE).isWellFormed(toSchemaData));
+    }
+
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -42,12 +42,14 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.FunctionStatus;
 import org.apache.pulsar.common.policies.data.SinkStatus;
 import org.apache.pulsar.common.policies.data.SourceStatus;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.examples.AutoSchemaFunction;
 import org.apache.pulsar.functions.api.examples.serde.CustomObject;
 import org.apache.pulsar.tests.integration.containers.DebeziumMySQLContainer;
@@ -1563,7 +1565,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             .build();
 
         @Cleanup
-        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+        Consumer<KeyValue<byte[], byte[]>> consumer = client.newConsumer(KeyValueSchema.kvBytes())
             .topic(consumeTopicName)
             .subscriptionName("debezium-source-tester")
             .subscriptionType(SubscriptionType.Exclusive)


### PR DESCRIPTION

### Motivation

The key/value types can be AVRO or JSON. Both AVRO and JSON supports schema evolution. We should add a key/value schema compatibility checker to allow schema evolution in broker side.

### Modifications

Add KeyValueSchemaCompatibilityCheck class
Add Unit Test

### Verifying this change
Unit Test Pass

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
