### PR TITLE
Avoid payload copy when inserting into managed ledger cache

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -437,6 +437,9 @@ managedLedgerNumSchedulerThreads=8
 # running  in the same broker. By default, uses 1/5th of available direct memory
 managedLedgerCacheSizeMB=
 
+# Whether we should make a copy of the entry payloads when inserting in cache
+managedLedgerCacheCopyEntries=false
+
 # Threshold to which bring down the cache level when eviction is triggered
 managedLedgerCacheEvictionWatermark=0.9
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -298,6 +298,9 @@ managedLedgerNumSchedulerThreads=4
 # running  in the same broker. By default, uses 1/5th of available direct memory
 managedLedgerCacheSizeMB=
 
+# Whether we should make a copy of the entry payloads when inserting in cache
+managedLedgerCacheCopyEntries=false
+
 # Threshold to which bring down the cache level when eviction is triggered
 managedLedgerCacheEvictionWatermark=0.9
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -51,4 +51,9 @@ public class ManagedLedgerFactoryConfig {
      * Threshould to consider a cursor as "backlogged"
      */
     private long thresholdBackloggedCursor = 1000;
+
+    /**
+     * Whether we should make a copy of the entry payloads when inserting in cache
+     */
+    private boolean copyEntriesInCache = false;
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -81,7 +81,7 @@ public class EntryCacheManager {
             return new EntryCacheDisabled(ml);
         }
 
-        EntryCache newEntryCache = new EntryCacheImpl(this, ml);
+        EntryCache newEntryCache = new EntryCacheImpl(this, ml, mlFactory.getConfig().isCopyEntriesInCache());
         EntryCache currentEntryCache = caches.putIfAbsent(ml.getName(), newEntryCache);
         if (currentEntryCache != null) {
             return currentEntryCache;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -763,6 +763,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " running in the same broker. By default, uses 1/5th of available direct memory")
     private int managedLedgerCacheSizeMB = Math.max(64,
             (int) (PlatformDependent.maxDirectMemory() / 5 / (1024 * 1024)));
+    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Whether we should make a copy of the entry payloads when inserting in cache")
+    private boolean managedLedgerCacheCopyEntries = false;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "Threshold to which bring down the cache level when eviction is triggered"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -50,6 +50,7 @@ public class ManagedLedgerClientFactory implements Closeable {
         managedLedgerFactoryConfig.setCacheEvictionFrequency(conf.getManagedLedgerCacheEvictionFrequency());
         managedLedgerFactoryConfig.setCacheEvictionTimeThresholdMillis(conf.getManagedLedgerCacheEvictionTimeThresholdMillis());
         managedLedgerFactoryConfig.setThresholdBackloggedCursor(conf.getManagedLedgerCursorBackloggedThreshold());
+        managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
 
         this.managedLedgerFactory = new ManagedLedgerFactoryImpl(bkClient, zkClient, managedLedgerFactoryConfig);
     }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -175,6 +175,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |managedLedgerDefaultWriteQuorum| Number of copies to store for each message  |2|
 |managedLedgerDefaultAckQuorum| Number of guaranteed copies (acks to wait before write is complete) |2|
 |managedLedgerCacheSizeMB|  Amount of memory to use for caching data payload in managed ledger. This memory is allocated from JVM direct memory and it’s shared across all the topics running in the same broker. By default, uses 1/5th of available direct memory ||
+|managedLedgerCacheCopyEntries| Whether we should make a copy of the entry payloads when inserting in cache| false|
 |managedLedgerCacheEvictionWatermark| Threshold to which bring down the cache level when eviction is triggered  |0.9|
 |managedLedgerCacheEvictionFrequency| Configure the cache eviction frequency for the managed ledger cache (evictions/sec) | 100.0 |
 |managedLedgerCacheEvictionTimeThresholdMillis| All entries that have stayed in cache for more than the configured time, will be evicted | 1000 |


### PR DESCRIPTION
### Motivation

After #4066, we now have a strict upper bound for the time spent in cache by entries. Since this was the principal reason to make a copy when inserting into the cache, we can now avoid that data copy and just increment the refcount on the same buffer.

Leaving it as an option to fallback to the original behavior, just in case there is any unforeseen regression in behavior under particular conditions.