### PR TITLE
Allow users to update auth data during function update

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionState;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.FunctionStatus;
@@ -100,10 +101,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                                final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                final @FormDataParam("url") String functionPkgUrl,
                                final @FormDataParam("functionConfig") String functionConfigJson,
-                               final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                               final @FormDataParam("updateOptions") UpdateOptions updateOptions) throws IOException {
 
         functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateOptions);
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -49,7 +49,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class FunctionsBase extends AdminResource implements Supplier<WorkerService> {
+public class
+FunctionsBase extends AdminResource implements Supplier<WorkerService> {
 
     private final FunctionsImpl functions;
 
@@ -99,10 +100,11 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                                final @FormDataParam("data") InputStream uploadedInputStream,
                                final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                final @FormDataParam("url") String functionPkgUrl,
-                               final @FormDataParam("functionConfig") String functionConfigJson) {
+                               final @FormDataParam("functionConfig") String functionConfigJson,
+                               final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
         functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData());
+                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateAuthData);
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -49,8 +49,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class
-FunctionsBase extends AdminResource implements Supplier<WorkerService> {
+public class FunctionsBase extends AdminResource implements Supplier<WorkerService> {
 
     private final FunctionsImpl functions;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinkBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinkBase.java
@@ -96,10 +96,11 @@ public class SinkBase extends AdminResource implements Supplier<WorkerService> {
                            final @FormDataParam("data") InputStream uploadedInputStream,
                            final @FormDataParam("data") FormDataContentDisposition fileDetail,
                            final @FormDataParam("url") String functionPkgUrl,
-                           final @FormDataParam("sinkConfig") String sinkConfigJson) {
+                           final @FormDataParam("sinkConfig") String sinkConfigJson,
+                           final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
          sink.updateFunction(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData());
+                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateAuthData);
 
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinkBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinkBase.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.policies.data.SinkStatus;
@@ -97,10 +98,10 @@ public class SinkBase extends AdminResource implements Supplier<WorkerService> {
                            final @FormDataParam("data") FormDataContentDisposition fileDetail,
                            final @FormDataParam("url") String functionPkgUrl,
                            final @FormDataParam("sinkConfig") String sinkConfigJson,
-                           final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                           final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
 
          sink.updateFunction(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateOptions);
 
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourceBase.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.common.policies.data.SourceStatus;
@@ -97,10 +98,10 @@ public class SourceBase extends AdminResource implements Supplier<WorkerService>
                              final @FormDataParam("data") FormDataContentDisposition fileDetail,
                              final @FormDataParam("url") String functionPkgUrl,
                              final @FormDataParam("sourceConfig") String sourceConfigJson,
-                             final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                             final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
 
         source.updateFunction(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-            functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+            functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateOptions);
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourceBase.java
@@ -96,10 +96,11 @@ public class SourceBase extends AdminResource implements Supplier<WorkerService>
                              final @FormDataParam("data") InputStream uploadedInputStream,
                              final @FormDataParam("data") FormDataContentDisposition fileDetail,
                              final @FormDataParam("url") String functionPkgUrl,
-                             final @FormDataParam("sourceConfig") String sourceConfigJson) {
+                             final @FormDataParam("sourceConfig") String sourceConfigJson,
+                             final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
         source.updateFunction(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-            functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData());
+            functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateAuthData);
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -100,6 +100,7 @@ public class PulsarFunctionE2ESecurityTest {
     private SecretKey secretKey;
 
     private static final String SUBJECT = "my-test-subject";
+    private static final String SUBJECT2 = "my-test-subject-2";
     private static final String ADMIN_SUBJECT = "superUser";
     private static final String ANONYMOUS_ROLE = "anonymousUser";
 
@@ -261,138 +262,6 @@ public class PulsarFunctionE2ESecurityTest {
         functionConfig.setOutput(sinkTopic);
         functionConfig.setCleanupSubscription(true);
         return functionConfig;
-    }
-
-    @Test
-    public void testUpdateToken() throws Exception {
-        String token1 = AuthTokenUtils.createToken(secretKey, SUBJECT, Optional.empty());
-        String token2 = AuthTokenUtils.createToken(secretKey, "wrong-subject", Optional.empty());
-
-        final String replNamespace = TENANT + "/" + NAMESPACE;
-        final String sourceTopic = "persistent://" + replNamespace + "/my-topic1";
-        final String sinkTopic = "persistent://" + replNamespace + "/output";
-        final String propertyKey = "key";
-        final String propertyValue = "value";
-        final String functionName = "PulsarFunction-test";
-        final String subscriptionName = "test-sub";
-
-
-        // create user admin client
-        AuthenticationToken authToken1 = new AuthenticationToken();
-        authToken1.configure("token:" +  token1);
-
-        AuthenticationToken authToken2 = new AuthenticationToken();
-        authToken2.configure("token:" +  token2);
-
-        try(PulsarAdmin admin1 = spy(
-                PulsarAdmin.builder().serviceHttpUrl(brokerServiceUrl).authentication(authToken1).build());
-            PulsarAdmin admin2 = spy(
-                    PulsarAdmin.builder().serviceHttpUrl(brokerServiceUrl).authentication(authToken2).build())
-        ) {
-
-            String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-functions-api-examples.jar").getFile();
-
-            FunctionConfig functionConfig = createFunctionConfig(TENANT, NAMESPACE, functionName,
-                    sourceTopic, sinkTopic, subscriptionName);
-
-            // creating function should fail since admin1 doesn't have permissions granted yet
-            try {
-                admin1.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-                fail("client admin shouldn't have permissions to create function");
-            } catch (PulsarAdminException.NotAuthorizedException e) {
-
-            }
-
-            // grant permissions to admin1
-            Set<AuthAction> actions = new HashSet<>();
-            actions.add(AuthAction.functions);
-            actions.add(AuthAction.produce);
-            actions.add(AuthAction.consume);
-            superUserAdmin.namespaces().grantPermissionOnNamespace(replNamespace, SUBJECT, actions);
-
-            // user should be able to create function now
-            admin1.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-
-            // admin2 should still fail
-            try {
-                admin2.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-                fail("client admin shouldn't have permissions to create function");
-            } catch (PulsarAdminException.NotAuthorizedException e) {
-
-            }
-
-            // creating on another tenant should also fail
-            try {
-                admin2.functions().createFunctionWithUrl(createFunctionConfig(TENANT2, NAMESPACE, functionName,
-                        sourceTopic, sinkTopic, subscriptionName), jarFilePathUrl);
-                fail("client admin shouldn't have permissions to create function");
-            } catch (PulsarAdminException.NotAuthorizedException e) {
-
-            }
-
-            retryStrategically((test) -> {
-                try {
-                    return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 1
-                            && admin1.topics().getStats(sourceTopic).subscriptions.size() == 1;
-                } catch (PulsarAdminException e) {
-                    return false;
-                }
-            }, 5, 150);
-            // validate pulsar sink consumer has started on the topic
-            assertEquals(admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning(), 1);
-            assertEquals(admin1.topics().getStats(sourceTopic).subscriptions.size(), 1);
-
-            // create a producer that creates a topic at broker
-            try(Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(sourceTopic).create();
-                Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(sinkTopic).subscriptionName("sub").subscribe()) {
-
-                int totalMsgs = 5;
-                for (int i = 0; i < totalMsgs; i++) {
-                    String data = "my-message-" + i;
-                    producer.newMessage().property(propertyKey, propertyValue).value(data).send();
-                }
-                retryStrategically((test) -> {
-                    try {
-                        SubscriptionStats subStats = admin1.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
-                        return subStats.unackedMessages == 0;
-                    } catch (PulsarAdminException e) {
-                        return false;
-                    }
-                }, 5, 150);
-
-                Message<String> msg = consumer.receive(5, TimeUnit.SECONDS);
-                String receivedPropertyValue = msg.getProperty(propertyKey);
-                assertEquals(propertyValue, receivedPropertyValue);
-
-
-                // validate pulsar-sink consumer has consumed all messages and delivered to Pulsar sink but unacked
-                // messages
-                // due to publish failure
-                assertNotEquals(admin1.topics().getStats(sourceTopic).subscriptions.values().iterator().next().unackedMessages,
-                        totalMsgs);
-            }
-
-            // test update functions
-            functionConfig.setParallelism(2);
-            // admin2 should still fail
-            try {
-                admin2.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
-                fail("client admin shouldn't have permissions to update function");
-            } catch (PulsarAdminException.NotAuthorizedException e) {
-
-            }
-
-            admin1.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
-
-            retryStrategically((test) -> {
-                try {
-                    return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 2;
-                } catch (PulsarAdminException e) {
-                    return false;
-                }
-            }, 5, 150);
-
-            assertEquals(admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning(), 2);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -100,7 +100,6 @@ public class PulsarFunctionE2ESecurityTest {
     private SecretKey secretKey;
 
     private static final String SUBJECT = "my-test-subject";
-    private static final String SUBJECT2 = "my-test-subject-2";
     private static final String ADMIN_SUBJECT = "superUser";
     private static final String ANONYMOUS_ROLE = "anonymousUser";
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
@@ -124,6 +124,25 @@ public interface Functions {
 
     /**
      * Update the configuration for a function.
+     * <p>
+     *
+     * @param functionConfig
+     *            the function configuration object
+     *
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the function
+     *            with the auth data submitted with this call
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateFunction(FunctionConfig functionConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a function.
      * <pre>
      * Update a function by providing url from which fun-pkg can be downloaded. supported url: http/file
      * eg:
@@ -143,6 +162,32 @@ public interface Functions {
      *             Unexpected error
      */
     void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a function.
+     * <pre>
+     * Update a function by providing url from which fun-pkg can be downloaded. supported url: http/file
+     * eg:
+     * File: file:/dir/fileName.jar
+     * Http: http://www.repo.com/fileName.jar
+     * </pre>
+     *
+     * @param functionConfig
+     *            the function configuration object
+     * @param pkgUrl
+     *            url from which pkg can be downloaded
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the function
+     *            with the auth data submitted with this call
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
+
 
     /**
      * Delete an existing function

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedExceptio
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.common.functions.FunctionState;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -128,18 +129,16 @@ public interface Functions {
      *
      * @param functionConfig
      *            the function configuration object
-     *
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the function
-     *            with the auth data submitted with this call
      * @throws NotFoundException
      *             Cluster doesn't exist
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateFunction(FunctionConfig functionConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+    void updateFunction(FunctionConfig functionConfig, String fileName, UpdateOptions updateOptions) throws PulsarAdminException;
 
     /**
      * Update the configuration for a function.
@@ -176,9 +175,8 @@ public interface Functions {
      *            the function configuration object
      * @param pkgUrl
      *            url from which pkg can be downloaded
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the function
-     *            with the auth data submitted with this call
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
      * @throws NotFoundException
@@ -186,7 +184,7 @@ public interface Functions {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
+    void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, UpdateOptions updateOptions) throws PulsarAdminException;
 
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sink.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sink.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.admin;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.SinkStatus;
 import org.apache.pulsar.common.io.SinkConfig;
@@ -125,9 +126,8 @@ public interface Sink {
      *
      * @param sinkConfig
      *            the sink configuration object
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the sink
-     *            with the auth data submitted with this call
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
      * @throws NotFoundException
@@ -135,7 +135,7 @@ public interface Sink {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateSink(SinkConfig sinkConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+    void updateSink(SinkConfig sinkConfig, String fileName, UpdateOptions updateOptions) throws PulsarAdminException;
 
     /**
      * Update the configuration for a sink.
@@ -172,9 +172,8 @@ public interface Sink {
      *            the sink configuration object
      * @param pkgUrl
      *            url from which pkg can be downloaded
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the sink
-     *            with the auth data submitted with this call
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
      * @throws NotFoundException
@@ -182,7 +181,7 @@ public interface Sink {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
+    void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl, UpdateOptions updateOptions) throws PulsarAdminException;
 
     /**
      * Delete an existing sink

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sink.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sink.java
@@ -121,6 +121,24 @@ public interface Sink {
 
     /**
      * Update the configuration for a sink.
+     * <p>
+     *
+     * @param sinkConfig
+     *            the sink configuration object
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the sink
+     *            with the auth data submitted with this call
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateSink(SinkConfig sinkConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a sink.
      * <pre>
      * Update a sink by providing url from which fun-pkg can be downloaded. supported url: http/file
      * eg:
@@ -140,6 +158,31 @@ public interface Sink {
      *             Unexpected error
      */
     void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a sink.
+     * <pre>
+     * Update a sink by providing url from which fun-pkg can be downloaded. supported url: http/file
+     * eg:
+     * File: file:/dir/fileName.jar
+     * Http: http://www.repo.com/fileName.jar
+     * </pre>
+     *
+     * @param sinkConfig
+     *            the sink configuration object
+     * @param pkgUrl
+     *            url from which pkg can be downloaded
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the sink
+     *            with the auth data submitted with this call
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
 
     /**
      * Delete an existing sink

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Source.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Source.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.admin;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.common.policies.data.SourceStatus;
@@ -125,9 +126,8 @@ public interface Source {
      *
      * @param sourceConfig
      *            the source configuration object
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the source
-     *            with the auth data submitted with this call
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
      * @throws NotFoundException
@@ -135,7 +135,7 @@ public interface Source {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateSource(SourceConfig sourceConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+    void updateSource(SourceConfig sourceConfig, String fileName, UpdateOptions updateOptions) throws PulsarAdminException;
 
     /**
      * Update the configuration for a source.
@@ -172,9 +172,8 @@ public interface Source {
      *            the source configuration object
      * @param pkgUrl
      *            url from which pkg can be downloaded
-     * @param updateAuthData
-     *            If authentication is enabled, whether or not to update the auth data of the source
-     *            with the auth data submitted with this call
+     * @param updateOptions
+     *            options for the update operations
      * @throws NotAuthorizedException
      *             You don't have admin permission to create the cluster
      * @throws NotFoundException
@@ -182,7 +181,7 @@ public interface Source {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updateSourceWithUrl(SourceConfig sourceConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
+    void updateSourceWithUrl(SourceConfig sourceConfig, String pkgUrl, UpdateOptions updateOptions) throws PulsarAdminException;
 
     /**
      * Delete an existing source

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Source.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Source.java
@@ -121,6 +121,24 @@ public interface Source {
 
     /**
      * Update the configuration for a source.
+     * <p>
+     *
+     * @param sourceConfig
+     *            the source configuration object
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the source
+     *            with the auth data submitted with this call
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateSource(SourceConfig sourceConfig, String fileName, boolean updateAuthData) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a source.
      * <pre>
      * Update a source by providing url from which fun-pkg can be downloaded. supported url: http/file
      * eg:
@@ -140,6 +158,31 @@ public interface Source {
      *             Unexpected error
      */
     void updateSourceWithUrl(SourceConfig sourceConfig, String pkgUrl) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a source.
+     * <pre>
+     * Update a source by providing url from which fun-pkg can be downloaded. supported url: http/file
+     * eg:
+     * File: file:/dir/fileName.jar
+     * Http: http://www.repo.com/fileName.jar
+     * </pre>
+     *
+     * @param sourceConfig
+     *            the source configuration object
+     * @param pkgUrl
+     *            url from which pkg can be downloaded
+     * @param updateAuthData
+     *            If authentication is enabled, whether or not to update the auth data of the source
+     *            with the auth data submitted with this call
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateSourceWithUrl(SourceConfig sourceConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException;
 
     /**
      * Delete an existing source

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -207,9 +207,15 @@ public class FunctionsImpl extends ComponentResource implements Functions {
 
     @Override
     public void updateFunction(FunctionConfig functionConfig, String fileName) throws PulsarAdminException {
+        updateFunction(functionConfig, fileName, false);
+    }
+
+        @Override
+    public void updateFunction(FunctionConfig functionConfig, String fileName, boolean updateAuthData) throws PulsarAdminException {
         try {
             RequestBuilder builder = put(functions.path(functionConfig.getTenant()).path(functionConfig.getNamespace()).path(functionConfig.getName()).getUri().toASCIIString())
-                    .addBodyPart(new StringPart("functionConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(functionConfig), MediaType.APPLICATION_JSON));
+                    .addBodyPart(new StringPart("functionConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(functionConfig), MediaType.APPLICATION_JSON))
+                    .addBodyPart(new StringPart("updateAuthData", String.valueOf(updateAuthData)));
 
             if (fileName != null && !fileName.startsWith("builtin://")) {
                 // If the function code is built in, we don't need to submit here
@@ -226,20 +232,26 @@ public class FunctionsImpl extends ComponentResource implements Functions {
     }
 
     @Override
-    public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl) throws PulsarAdminException {
+    public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException {
         try {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
+            mp.bodyPart(new FormDataBodyPart("updateAuthData", updateAuthData, MediaType.TEXT_PLAIN_TYPE));
 
             mp.bodyPart(new FormDataBodyPart("functionConfig", new Gson().toJson(functionConfig),
                     MediaType.APPLICATION_JSON_TYPE));
             request(functions.path(functionConfig.getTenant()).path(functionConfig.getNamespace())
                     .path(functionConfig.getName())).put(Entity.entity(mp, MediaType.MULTIPART_FORM_DATA),
-                            ErrorData.class);
+                    ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }
+    }
+
+    @Override
+    public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl) throws PulsarAdminException {
+        updateFunctionWithUrl(functionConfig, pkgUrl, false);
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -237,7 +237,7 @@ public class FunctionsImpl extends ComponentResource implements Functions {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
-            mp.bodyPart(new FormDataBodyPart("updateAuthData", updateAuthData, MediaType.TEXT_PLAIN_TYPE));
+            mp.bodyPart(new FormDataBodyPart("updateAuthData", String.valueOf(updateAuthData), MediaType.TEXT_PLAIN_TYPE));
 
             mp.bodyPart(new FormDataBodyPart("functionConfig", new Gson().toJson(functionConfig),
                     MediaType.APPLICATION_JSON_TYPE));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionState;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.functions.WorkerInfo;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.ErrorData;
@@ -207,15 +208,18 @@ public class FunctionsImpl extends ComponentResource implements Functions {
 
     @Override
     public void updateFunction(FunctionConfig functionConfig, String fileName) throws PulsarAdminException {
-        updateFunction(functionConfig, fileName, false);
+        updateFunction(functionConfig, fileName, null);
     }
 
         @Override
-    public void updateFunction(FunctionConfig functionConfig, String fileName, boolean updateAuthData) throws PulsarAdminException {
+    public void updateFunction(FunctionConfig functionConfig, String fileName, UpdateOptions updateOptions) throws PulsarAdminException {
         try {
             RequestBuilder builder = put(functions.path(functionConfig.getTenant()).path(functionConfig.getNamespace()).path(functionConfig.getName()).getUri().toASCIIString())
-                    .addBodyPart(new StringPart("functionConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(functionConfig), MediaType.APPLICATION_JSON))
-                    .addBodyPart(new StringPart("updateAuthData", String.valueOf(updateAuthData)));
+                    .addBodyPart(new StringPart("functionConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(functionConfig), MediaType.APPLICATION_JSON));
+
+            if (updateOptions != null) {
+                   builder.addBodyPart(new StringPart("updateOptions", ObjectMapperFactory.getThreadLocal().writeValueAsString(updateOptions), MediaType.APPLICATION_JSON));
+            }
 
             if (fileName != null && !fileName.startsWith("builtin://")) {
                 // If the function code is built in, we don't need to submit here
@@ -232,15 +236,24 @@ public class FunctionsImpl extends ComponentResource implements Functions {
     }
 
     @Override
-    public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException {
+    public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl, UpdateOptions updateOptions) throws PulsarAdminException {
         try {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
-            mp.bodyPart(new FormDataBodyPart("updateAuthData", String.valueOf(updateAuthData), MediaType.TEXT_PLAIN_TYPE));
 
-            mp.bodyPart(new FormDataBodyPart("functionConfig", new Gson().toJson(functionConfig),
+            mp.bodyPart(new FormDataBodyPart(
+                    "functionConfig",
+                    ObjectMapperFactory.getThreadLocal().writeValueAsString(functionConfig),
                     MediaType.APPLICATION_JSON_TYPE));
+
+            if (updateOptions != null) {
+                mp.bodyPart(new FormDataBodyPart(
+                        "updateOptions",
+                        ObjectMapperFactory.getThreadLocal().writeValueAsString(updateOptions),
+                        MediaType.APPLICATION_JSON_TYPE));
+            }
+
             request(functions.path(functionConfig.getTenant()).path(functionConfig.getNamespace())
                     .path(functionConfig.getName())).put(Entity.entity(mp, MediaType.MULTIPART_FORM_DATA),
                     ErrorData.class);
@@ -251,7 +264,7 @@ public class FunctionsImpl extends ComponentResource implements Functions {
 
     @Override
     public void updateFunctionWithUrl(FunctionConfig functionConfig, String pkgUrl) throws PulsarAdminException {
-        updateFunctionWithUrl(functionConfig, pkgUrl, false);
+        updateFunctionWithUrl(functionConfig, pkgUrl, null);
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinkImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinkImpl.java
@@ -195,7 +195,7 @@ public class SinkImpl extends ComponentResource implements Sink {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
-            mp.bodyPart(new FormDataBodyPart("updateAuthData", updateAuthData, MediaType.TEXT_PLAIN_TYPE));
+            mp.bodyPart(new FormDataBodyPart("updateAuthData", String.valueOf(updateAuthData), MediaType.TEXT_PLAIN_TYPE));
 
             mp.bodyPart(new FormDataBodyPart("sinkConfig", new Gson().toJson(sinkConfig),
                     MediaType.APPLICATION_JSON_TYPE));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinkImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinkImpl.java
@@ -164,10 +164,11 @@ public class SinkImpl extends ComponentResource implements Sink {
     }
 
     @Override
-    public void updateSink(SinkConfig sinkConfig, String fileName) throws PulsarAdminException {
+    public void updateSink(SinkConfig sinkConfig, String fileName, boolean updateAuthData) throws PulsarAdminException {
         try {
             RequestBuilder builder = put(sink.path(sinkConfig.getTenant()).path(sinkConfig.getNamespace()).path(sinkConfig.getName()).getUri().toASCIIString())
-                    .addBodyPart(new StringPart("sinkConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(sinkConfig), MediaType.APPLICATION_JSON));
+                    .addBodyPart(new StringPart("sinkConfig", ObjectMapperFactory.getThreadLocal().writeValueAsString(sinkConfig), MediaType.APPLICATION_JSON))
+                    .addBodyPart(new StringPart("updateAuthData", String.valueOf(updateAuthData)));
 
             if (fileName != null && !fileName.startsWith("builtin://")) {
                 // If the function code is built in, we don't need to submit here
@@ -184,20 +185,31 @@ public class SinkImpl extends ComponentResource implements Sink {
     }
 
     @Override
-    public void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl) throws PulsarAdminException {
+    public void updateSink(SinkConfig sinkConfig, String fileName) throws PulsarAdminException {
+       updateSink(sinkConfig, fileName, false);
+    }
+
+    @Override
+    public void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl, boolean updateAuthData) throws PulsarAdminException {
         try {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
+            mp.bodyPart(new FormDataBodyPart("updateAuthData", updateAuthData, MediaType.TEXT_PLAIN_TYPE));
 
             mp.bodyPart(new FormDataBodyPart("sinkConfig", new Gson().toJson(sinkConfig),
                     MediaType.APPLICATION_JSON_TYPE));
             request(sink.path(sinkConfig.getTenant()).path(sinkConfig.getNamespace())
                     .path(sinkConfig.getName())).put(Entity.entity(mp, MediaType.MULTIPART_FORM_DATA),
-                            ErrorData.class);
+                    ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }
+    }
+
+    @Override
+    public void updateSinkWithUrl(SinkConfig sinkConfig, String pkgUrl) throws PulsarAdminException {
+        updateSinkWithUrl(sinkConfig, pkgUrl, false);
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourceImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourceImpl.java
@@ -193,7 +193,7 @@ public class SourceImpl extends ComponentResource implements Source {
             final FormDataMultiPart mp = new FormDataMultiPart();
 
             mp.bodyPart(new FormDataBodyPart("url", pkgUrl, MediaType.TEXT_PLAIN_TYPE));
-            mp.bodyPart(new FormDataBodyPart("updateAuthData", updateAuthData, MediaType.TEXT_PLAIN_TYPE));
+            mp.bodyPart(new FormDataBodyPart("updateAuthData", String.valueOf(updateAuthData), MediaType.TEXT_PLAIN_TYPE));
 
             mp.bodyPart(new FormDataBodyPart("sourceConfig", new Gson().toJson(sourceConfig),
                     MediaType.APPLICATION_JSON_TYPE));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.functions.WindowConfig;
 import org.apache.pulsar.common.functions.FunctionState;
@@ -761,10 +762,13 @@ public class CmdFunctions extends CmdBase {
 
         @Override
         void runCmd() throws Exception {
+
+            UpdateOptions updateOptions = new UpdateOptions();
+            updateOptions.setUpdateAuthData(updateAuthData);
             if (Utils.isFunctionPackageUrlSupported(functionConfig.getJar())) {
-                admin.functions().updateFunctionWithUrl(functionConfig, functionConfig.getJar(), updateAuthData);
+                admin.functions().updateFunctionWithUrl(functionConfig, functionConfig.getJar(), updateOptions);
             } else {
-                admin.functions().updateFunction(functionConfig, userCodeFile, updateAuthData);
+                admin.functions().updateFunction(functionConfig, userCodeFile, updateOptions);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -739,6 +739,9 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Update a Pulsar Function that's been deployed to a Pulsar cluster")
     class UpdateFunction extends FunctionDetailsCommand {
 
+        @Parameter(names = "--update-auth-data", description = "Whether or not to update the auth data")
+        protected boolean updateAuthData;
+
         @Override
         protected void validateFunctionConfigs(FunctionConfig functionConfig) {
             if (StringUtils.isEmpty(functionConfig.getClassName())) {
@@ -759,9 +762,9 @@ public class CmdFunctions extends CmdBase {
         @Override
         void runCmd() throws Exception {
             if (Utils.isFunctionPackageUrlSupported(functionConfig.getJar())) {
-                admin.functions().updateFunctionWithUrl(functionConfig, functionConfig.getJar());
+                admin.functions().updateFunctionWithUrl(functionConfig, functionConfig.getJar(), updateAuthData);
             } else {
-                admin.functions().updateFunction(functionConfig, userCodeFile);
+                admin.functions().updateFunction(functionConfig, userCodeFile, updateAuthData);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -211,12 +211,16 @@ public class CmdSinks extends CmdBase {
 
     @Parameters(commandDescription = "Update a Pulsar IO sink connector")
     protected class UpdateSink extends SinkDetailsCommand {
+
+        @Parameter(names = "--update-auth-data", description = "Whether or not to update the auth data")
+        protected boolean updateAuthData;
+
         @Override
         void runCmd() throws Exception {
             if (Utils.isFunctionPackageUrlSupported(archive)) {
-                admin.sink().updateSinkWithUrl(sinkConfig, sinkConfig.getArchive());
+                admin.sink().updateSinkWithUrl(sinkConfig, sinkConfig.getArchive(), updateAuthData);
             } else {
-                admin.sink().updateSink(sinkConfig, sinkConfig.getArchive());
+                admin.sink().updateSink(sinkConfig, sinkConfig.getArchive(), updateAuthData);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.functions.Utils;
@@ -217,10 +218,12 @@ public class CmdSinks extends CmdBase {
 
         @Override
         void runCmd() throws Exception {
+            UpdateOptions updateOptions = new UpdateOptions();
+            updateOptions.setUpdateAuthData(updateAuthData);
             if (Utils.isFunctionPackageUrlSupported(archive)) {
-                admin.sink().updateSinkWithUrl(sinkConfig, sinkConfig.getArchive(), updateAuthData);
+                admin.sink().updateSinkWithUrl(sinkConfig, sinkConfig.getArchive(), updateOptions);
             } else {
-                admin.sink().updateSink(sinkConfig, sinkConfig.getArchive(), updateAuthData);
+                admin.sink().updateSink(sinkConfig, sinkConfig.getArchive(), updateOptions);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.functions.Resources;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.io.SourceConfig;
@@ -221,10 +222,12 @@ public class CmdSources extends CmdBase {
 
         @Override
         void runCmd() throws Exception {
+            UpdateOptions updateOptions = new UpdateOptions();
+            updateOptions.setUpdateAuthData(updateAuthData);
             if (Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive())) {
-                admin.source().updateSourceWithUrl(sourceConfig, sourceConfig.getArchive(), updateAuthData);
+                admin.source().updateSourceWithUrl(sourceConfig, sourceConfig.getArchive(), updateOptions);
             } else {
-                admin.source().updateSource(sourceConfig, sourceConfig.getArchive(), updateAuthData);
+                admin.source().updateSource(sourceConfig, sourceConfig.getArchive(), updateOptions);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -216,12 +216,15 @@ public class CmdSources extends CmdBase {
     @Parameters(commandDescription = "Update a Pulsar IO source connector")
     protected class UpdateSource extends SourceDetailsCommand {
 
+        @Parameter(names = "--update-auth-data", description = "Whether or not to update the auth data")
+        protected boolean updateAuthData;
+
         @Override
         void runCmd() throws Exception {
             if (Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive())) {
-                admin.source().updateSourceWithUrl(sourceConfig, sourceConfig.getArchive());
+                admin.source().updateSourceWithUrl(sourceConfig, sourceConfig.getArchive(), updateAuthData);
             } else {
-                admin.source().updateSource(sourceConfig, sourceConfig.getArchive());
+                admin.source().updateSource(sourceConfig, sourceConfig.getArchive(), updateAuthData);
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.admin.Sink;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.powermock.api.mockito.PowerMockito;
@@ -691,7 +692,7 @@ public class TestCmdSinks {
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSink.name)
                 .archive(updateSink.archive)
-                .build()), eq(updateSink.archive));
+                .build()), eq(updateSink.archive), eq(new UpdateOptions()));
 
 
         updateSink.archive = null;
@@ -700,14 +701,21 @@ public class TestCmdSinks {
 
         updateSink.processArguments();
 
+        updateSink.updateAuthData = true;
+
         updateSink.runCmd();
+
+        UpdateOptions updateOptions = new UpdateOptions();
+        updateOptions.setUpdateAuthData(true);
 
         verify(sink).updateSink(eq(SinkConfig.builder()
                 .tenant(PUBLIC_TENANT)
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSink.name)
                 .parallelism(2)
-                .build()), eq(null));
+                .build()), eq(null), eq(updateOptions));
+
+
 
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.client.admin.Source;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.functions.utils.*;
 import org.powermock.api.mockito.PowerMockito;
@@ -586,7 +587,7 @@ public class TestCmdSources {
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSource.name)
                 .archive(updateSource.archive)
-                .build()), eq(updateSource.archive));
+                .build()), eq(updateSource.archive), eq(new UpdateOptions()));
 
 
         updateSource.archive = null;
@@ -595,6 +596,11 @@ public class TestCmdSources {
 
         updateSource.processArguments();
 
+        updateSource.updateAuthData = true;
+
+        UpdateOptions updateOptions = new UpdateOptions();
+        updateOptions.setUpdateAuthData(true);
+
         updateSource.runCmd();
 
         verify(source).updateSource(eq(SourceConfig.builder()
@@ -602,7 +608,9 @@ public class TestCmdSources {
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSource.name)
                 .parallelism(2)
-                .build()), eq(null));
+                .build()), eq(null), eq(updateOptions));
+
+
 
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/UpdateOptions.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/UpdateOptions.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.functions;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UpdateOptions {
+    private boolean updateAuthData = false;
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProvider.java
@@ -30,10 +30,13 @@ public class ClearTextFunctionTokenAuthProvider implements FunctionAuthProvider 
     @Override
     public void configureAuthenticationConfig(AuthenticationConfig authConfig, Optional<FunctionAuthData> functionAuthData) {
         if (!functionAuthData.isPresent()) {
-            return;
+            // if auth data is not present maybe user is trying to use anonymous role thus don't pass in any auth config
+            authConfig.setClientAuthenticationPlugin(null);
+            authConfig.setClientAuthenticationParameters(null);
+        } else {
+            authConfig.setClientAuthenticationPlugin(AuthenticationToken.class.getName());
+            authConfig.setClientAuthenticationParameters("token:" + new String(functionAuthData.get().getData()));
         }
-        authConfig.setClientAuthenticationPlugin(AuthenticationToken.class.getName());
-        authConfig.setClientAuthenticationParameters("token:" + new String(functionAuthData.get().getData()));
     }
 
     @Override

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthProvider.java
@@ -34,7 +34,7 @@ public interface FunctionAuthProvider {
      * @param authConfig authentication configs passed to the function instance
      * @param functionAuthData function authentication data that is provider specific
      */
-    void configureAuthenticationConfig(AuthenticationConfig authConfig, FunctionAuthData functionAuthData);
+    void configureAuthenticationConfig(AuthenticationConfig authConfig, Optional<FunctionAuthData> functionAuthData);
 
     /**
      * Cache auth data in as part of function metadata for function that runtime may need to configure authentication
@@ -47,6 +47,11 @@ public interface FunctionAuthProvider {
      */
     Optional<FunctionAuthData> cacheAuthData(String tenant, String namespace, String name, AuthenticationDataSource authenticationDataSource) throws Exception;
 
+
+
+    Optional<FunctionAuthData> updateAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> existingFunctionAuthData, AuthenticationDataSource authenticationDataSource) throws Exception;
+
+
     /**
      * Clean up operation for auth when function is terminated
      * @param tenant tenant that the function is running under
@@ -55,5 +60,5 @@ public interface FunctionAuthProvider {
      * @param functionAuthData function auth data
      * @throws Exception
      */
-    void cleanUpAuthData(String tenant, String namespace, String name, FunctionAuthData functionAuthData) throws Exception;
+    void cleanUpAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> functionAuthData) throws Exception;
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthUtils.java
@@ -20,9 +20,14 @@ package org.apache.pulsar.functions.auth;
 
 import org.apache.pulsar.functions.proto.Function;
 
+import java.util.Optional;
+
 public final class FunctionAuthUtils {
 
-    public static final FunctionAuthData getFunctionAuthData(Function.FunctionAuthenticationSpec functionAuthenticationSpec) {
-        return FunctionAuthData.builder().data(functionAuthenticationSpec.getData().toByteArray()).build();
+    public static final FunctionAuthData getFunctionAuthData(Optional<Function.FunctionAuthenticationSpec> functionAuthenticationSpec) {
+        if (functionAuthenticationSpec.isPresent()) {
+            return FunctionAuthData.builder().data(functionAuthenticationSpec.get().getData().toByteArray()).build();
+        }
+        return null;
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.auth;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1StatefulSet;
 
+import java.util.Optional;
+
 /**
  * Kubernetes runtime specific functions authentication provider
  */
@@ -31,5 +33,5 @@ public interface KubernetesFunctionAuthProvider extends FunctionAuthProvider {
      * @param statefulSet statefulset spec for function
      * @param functionAuthData function auth data
      */
-    void configureAuthDataStatefulSet(V1StatefulSet statefulSet, FunctionAuthData functionAuthData);
+    void configureAuthDataStatefulSet(V1StatefulSet statefulSet, Optional<FunctionAuthData> functionAuthData);
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -226,12 +226,9 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
 
         String secretId;
         if (existingFunctionAuthData.isPresent()) {
-            log.info("new String(existingFunctionAuthData.get().getData()): {}", new String(existingFunctionAuthData.get().getData()));
             secretId = new String(existingFunctionAuthData.get().getData());
-            log.info("secretId-1: {}", secretId);
         } else {
             secretId = RandomStringUtils.random(5, true, true).toLowerCase();
-            log.info("secretId-2: {}", secretId);
         }
 
         String token;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -131,12 +131,14 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
 
         String fqfn = FunctionCommon.getFullyQualifiedName(tenant, namespace, name);
 
-        String secretName = new String(functionAuthData.get().getData());
+        String secretId = new String(functionAuthData.get().getData());
         // Make sure secretName is empty.  Defensive programing
-        if (isBlank(secretName)) {
+        if (isBlank(secretId)) {
             log.warn("Secret name for function {} is empty.", fqfn);
             return;
         }
+
+        String secretName = getSecretName(secretId);
 
         Actions.Action deleteSecrets = Actions.Action.builder()
                 .actionName(String.format("Deleting secrets for function %s", fqfn))

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/NoOpFunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/NoOpFunctionAuthProvider.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 public class NoOpFunctionAuthProvider implements FunctionAuthProvider{
     @Override
-    public void configureAuthenticationConfig(AuthenticationConfig authConfig, FunctionAuthData functionAuthData) {
+    public void configureAuthenticationConfig(AuthenticationConfig authConfig, Optional<FunctionAuthData> functionAuthData) {
 
     }
 
@@ -37,7 +37,13 @@ public class NoOpFunctionAuthProvider implements FunctionAuthProvider{
     }
 
     @Override
-    public void cleanUpAuthData(String tenant, String namespace, String name, FunctionAuthData functionAuthData) throws Exception {
+    public Optional<FunctionAuthData> updateAuthData(String tenant, String namespace, String name,
+                                                     Optional<FunctionAuthData> existingFunctionAuthData, AuthenticationDataSource authenticationDataSource) throws Exception {
+        return Optional.empty();
+    }
+
+    @Override
+    public void cleanUpAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> functionAuthData) throws Exception {
 
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -73,6 +73,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -442,9 +443,9 @@ public class KubernetesRuntime implements Runtime {
     private void submitStatefulSet() throws Exception {
         final V1StatefulSet statefulSet = createStatefulSet();
         // Configure function authentication if needed
-        if (authenticationEnabled && instanceConfig.getFunctionAuthenticationSpec() != null) {
+        if (authenticationEnabled) {
             functionAuthDataCacheProvider.configureAuthDataStatefulSet(
-                    statefulSet, getFunctionAuthData(instanceConfig.getFunctionAuthenticationSpec()));
+                    statefulSet, Optional.ofNullable(getFunctionAuthData(Optional.ofNullable(instanceConfig.getFunctionAuthenticationSpec()))));
         }
 
         log.info("Submitting the following spec to k8 {}", appsClient.getApiClient().getJSON().serialize(statefulSet));

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -761,7 +761,8 @@ public class KubernetesRuntime implements Runtime {
         // add auth plugin and parameters if necessary
         if (authenticationEnabled && authConfig != null) {
             if (isNotBlank(authConfig.getClientAuthenticationPlugin())
-                    && isNotBlank(authConfig.getClientAuthenticationParameters())) {
+                    && isNotBlank(authConfig.getClientAuthenticationParameters())
+                    && instanceConfig.getFunctionAuthenticationSpec() != null) {
                 return Arrays.asList(
                         pulsarRootDir + "/bin/pulsar-admin",
                         "--auth-plugin",

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.functions.secretsproviderconfigurator.SecretsProviderCo
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -198,8 +199,9 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         }
 
         // adjust the auth config to support auth
-        if (authenticationEnabled && instanceConfig.getFunctionAuthenticationSpec() != null) {
-            getAuthProvider().configureAuthenticationConfig(authConfig, getFunctionAuthData(instanceConfig.getFunctionAuthenticationSpec()));
+        if (authenticationEnabled) {
+            getAuthProvider().configureAuthenticationConfig(authConfig,
+                    Optional.ofNullable(getFunctionAuthData(Optional.ofNullable(instanceConfig.getFunctionAuthenticationSpec()))));
         }
 
         return new KubernetesRuntime(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.functions.secretsproviderconfigurator.SecretsProviderCo
 import org.apache.pulsar.functions.utils.functioncache.FunctionCacheEntry;
 
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import static org.apache.pulsar.functions.auth.FunctionAuthUtils.getFunctionAuthData;
 
@@ -132,8 +133,9 @@ public class ProcessRuntimeFactory implements RuntimeFactory {
         }
 
         // configure auth if necessary
-        if (authenticationEnabled && instanceConfig.getFunctionAuthenticationSpec() != null) {
-            getAuthProvider().configureAuthenticationConfig(authConfig, getFunctionAuthData(instanceConfig.getFunctionAuthenticationSpec()));
+        if (authenticationEnabled) {
+            getAuthProvider().configureAuthenticationConfig(authConfig,
+                    Optional.ofNullable(getFunctionAuthData(Optional.ofNullable(instanceConfig.getFunctionAuthenticationSpec()))));
         }
 
         return new ProcessRuntime(

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProviderTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProviderTest.java
@@ -50,7 +50,7 @@ public class ClearTextFunctionTokenAuthProviderTest {
         Assert.assertEquals(functionAuthData.get().getData(), "test-token".getBytes());
 
         AuthenticationConfig authenticationConfig = AuthenticationConfig.builder().build();
-        clearTextFunctionTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, functionAuthData.get());
+        clearTextFunctionTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, functionAuthData);
 
         Assert.assertEquals(authenticationConfig.getClientAuthenticationPlugin(), AuthenticationToken.class.getName());
         Assert.assertEquals(authenticationConfig.getClientAuthenticationParameters(), "token:test-token");

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
@@ -59,7 +59,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
                                 new V1PodSpec().containers(
                                         Collections.singletonList(new V1Container())))));
         FunctionAuthData functionAuthData = FunctionAuthData.builder().data("foo".getBytes()).build();
-        kubernetesSecretsTokenAuthProvider.configureAuthDataStatefulSet(statefulSet, functionAuthData);
+        kubernetesSecretsTokenAuthProvider.configureAuthDataStatefulSet(statefulSet, Optional.of(functionAuthData));
 
         Assert.assertEquals(statefulSet.getSpec().getTemplate().getSpec().getVolumes().size(), 1);
         Assert.assertEquals(statefulSet.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), "function-auth");
@@ -99,7 +99,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider(coreV1Api, "default");
         AuthenticationConfig authenticationConfig = AuthenticationConfig.builder().build();
         FunctionAuthData functionAuthData = FunctionAuthData.builder().data("foo".getBytes()).build();
-        kubernetesSecretsTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, functionAuthData);
+        kubernetesSecretsTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, Optional.of(functionAuthData));
 
         Assert.assertEquals(authenticationConfig.getClientAuthenticationPlugin(), AuthenticationToken.class.getName());
         Assert.assertEquals(authenticationConfig.getClientAuthenticationParameters(), "file:///etc/auth/token");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -293,7 +293,9 @@ public class FunctionActioner {
                             .getRuntimeFactory().getAuthProvider()
                             .cleanUpAuthData(
                                     details.getTenant(), details.getNamespace(), details.getName(),
-                                    Optional.ofNullable(getFunctionAuthData(Optional.ofNullable(functionRuntimeInfo.getFunctionInstance().getFunctionMetaData().getFunctionAuthSpec()))));
+                                    Optional.ofNullable(getFunctionAuthData(
+                                            Optional.ofNullable(
+                                                    functionRuntimeInfo.getRuntimeSpawner().getInstanceConfig().getFunctionAuthenticationSpec()))));
 
                 } catch (Exception e) {
                     log.error("Failed to cleanup auth data for function: {}", fqfn, e);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -59,6 +59,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -285,14 +286,14 @@ public class FunctionActioner {
             functionRuntimeInfo.getRuntimeSpawner().close();
 
             // cleanup any auth data cached
-            if (workerConfig.isAuthenticationEnabled() && functionRuntimeInfo.getRuntimeSpawner().getInstanceConfig().getFunctionAuthenticationSpec() != null) {
+            if (workerConfig.isAuthenticationEnabled()) {
                 try {
                     log.info("{}-{} Cleaning up authentication data for function...", fqfn,functionRuntimeInfo.getFunctionInstance().getInstanceId());
                     functionRuntimeInfo.getRuntimeSpawner()
                             .getRuntimeFactory().getAuthProvider()
                             .cleanUpAuthData(
                                     details.getTenant(), details.getNamespace(), details.getName(),
-                                    getFunctionAuthData(functionRuntimeInfo.getFunctionInstance().getFunctionMetaData().getFunctionAuthSpec()));
+                                    Optional.ofNullable(getFunctionAuthData(Optional.ofNullable(functionRuntimeInfo.getFunctionInstance().getFunctionMetaData().getFunctionAuthSpec()))));
 
                 } catch (Exception e) {
                     log.error("Failed to cleanup auth data for function: {}", fqfn, e);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -517,7 +517,8 @@ public abstract class ComponentImpl {
                                final String functionPkgUrl,
                                final String componentConfigJson,
                                final String clientRole,
-                               AuthenticationDataHttps clientAuthenticationDataHttps) {
+                               AuthenticationDataHttps clientAuthenticationDataHttps,
+                               boolean updateAuthData) {
 
         if (!isWorkerServiceAvailable()) {
             throwUnavailableException();
@@ -674,8 +675,8 @@ public abstract class ComponentImpl {
             FunctionMetaData.Builder functionMetaDataBuilder = FunctionMetaData.newBuilder().mergeFrom(existingComponent)
                     .setFunctionDetails(functionDetails);
 
-            // cache auth if need
-            if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+            // update auth data if need
+            if (worker().getWorkerConfig().isAuthenticationEnabled() && updateAuthData) {
                 if (clientAuthenticationDataHttps != null) {
                     // get existing auth data if it exists
                     Optional<FunctionAuthData> existingFunctionAuthData = Optional.empty();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplV2.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplV2.java
@@ -133,7 +133,7 @@ public class FunctionsImplV2 {
         }
 
         delegate.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientRole, null, false);
+                functionPkgUrl, functionConfigJson, clientRole, null, null);
         return Response.ok().build();
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplV2.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplV2.java
@@ -133,7 +133,7 @@ public class FunctionsImplV2 {
         }
 
         delegate.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientRole, null);
+                functionPkgUrl, functionConfigJson, clientRole, null, false);
         return Response.ok().build();
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
@@ -82,10 +82,11 @@ public class FunctionApiV3Resource extends FunctionApiResource {
                                final @FormDataParam("data") InputStream uploadedInputStream,
                                final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                final @FormDataParam("url") String functionPkgUrl,
-                               final @FormDataParam("functionConfig") String functionConfigJson) {
+                               final @FormDataParam("functionConfig") String functionConfigJson,
+                               final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
         functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData());
+                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateAuthData);
 
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3Resource.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionState;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.FunctionStatus;
@@ -83,10 +84,10 @@ public class FunctionApiV3Resource extends FunctionApiResource {
                                final @FormDataParam("data") FormDataContentDisposition fileDetail,
                                final @FormDataParam("url") String functionPkgUrl,
                                final @FormDataParam("functionConfig") String functionConfigJson,
-                               final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                               final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
 
         functions.updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+                functionPkgUrl, functionConfigJson, clientAppId(), clientAuthData(), updateOptions);
 
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3Resource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.policies.data.SinkStatus;
@@ -73,10 +74,10 @@ public class SinkApiV3Resource extends FunctionApiResource {
                            final @FormDataParam("data") FormDataContentDisposition fileDetail,
                            final @FormDataParam("url") String functionPkgUrl,
                            final @FormDataParam("sinkConfig") String sinkConfigJson,
-                           final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                           final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
 
         sink.updateFunction(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateOptions);
     }
 
     @DELETE

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3Resource.java
@@ -72,10 +72,11 @@ public class SinkApiV3Resource extends FunctionApiResource {
                            final @FormDataParam("data") InputStream uploadedInputStream,
                            final @FormDataParam("data") FormDataContentDisposition fileDetail,
                            final @FormDataParam("url") String functionPkgUrl,
-                           final @FormDataParam("sinkConfig") String sinkConfigJson) {
+                           final @FormDataParam("sinkConfig") String sinkConfigJson,
+                           final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
         sink.updateFunction(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData());
+                functionPkgUrl, sinkConfigJson, clientAppId(), clientAuthData(), updateAuthData);
     }
 
     @DELETE

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3Resource.java
@@ -73,10 +73,11 @@ public class SourceApiV3Resource extends FunctionApiResource {
                              final @FormDataParam("data") InputStream uploadedInputStream,
                              final @FormDataParam("data") FormDataContentDisposition fileDetail,
                              final @FormDataParam("url") String functionPkgUrl,
-                             final @FormDataParam("sourceConfig") String sourceConfigJson) {
+                             final @FormDataParam("sourceConfig") String sourceConfigJson,
+                             final @FormDataParam("updateAuthData") boolean updateAuthData) {
 
         source.updateFunction(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData());
+                functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateAuthData);
     }
 
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3Resource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.common.policies.data.SourceStatus;
@@ -74,10 +75,10 @@ public class SourceApiV3Resource extends FunctionApiResource {
                              final @FormDataParam("data") FormDataContentDisposition fileDetail,
                              final @FormDataParam("url") String functionPkgUrl,
                              final @FormDataParam("sourceConfig") String sourceConfigJson,
-                             final @FormDataParam("updateAuthData") boolean updateAuthData) {
+                             final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
 
         source.updateFunction(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-                functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateAuthData);
+                functionPkgUrl, sourceConfigJson, clientAppId(), clientAuthData(), updateOptions);
     }
 
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -918,7 +918,7 @@ public class FunctionApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(functionConfig),
-                null, null, false);
+                null, null, null);
 
     }
 
@@ -942,7 +942,7 @@ public class FunctionApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(functionConfig),
-                null, null, false);
+                null, null, null);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Function test-function doesn't exist")
@@ -1030,7 +1030,7 @@ public class FunctionApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(functionConfig),
-                null, null, false);
+                null, null, null);
 
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -918,7 +918,7 @@ public class FunctionApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(functionConfig),
-                null, null);
+                null, null, false);
 
     }
 
@@ -942,7 +942,7 @@ public class FunctionApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(functionConfig),
-                null, null);
+                null, null, false);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Function test-function doesn't exist")
@@ -1030,7 +1030,7 @@ public class FunctionApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(functionConfig),
-                null, null);
+                null, null, false);
 
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -818,7 +818,7 @@ public class SinkApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(sinkConfig),
-                null, null);
+                null, null, false);
 
     }
 
@@ -859,7 +859,7 @@ public class SinkApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(sinkConfig),
-                null, null);
+                null, null, false);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Sink test-sink doesn't exist")
@@ -961,7 +961,7 @@ public class SinkApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(sinkConfig),
-                null, null);
+                null, null, false);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "sink failed to register")

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -818,7 +818,7 @@ public class SinkApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(sinkConfig),
-                null, null, false);
+                null, null, null);
 
     }
 
@@ -859,7 +859,7 @@ public class SinkApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(sinkConfig),
-                null, null, false);
+                null, null, null);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Sink test-sink doesn't exist")
@@ -961,7 +961,7 @@ public class SinkApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(sinkConfig),
-                null, null, false);
+                null, null, null);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "sink failed to register")

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -835,7 +835,7 @@ public class SourceApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(sourceConfig),
-                null, null, false);
+                null, null, null);
 
     }
 
@@ -872,7 +872,7 @@ public class SourceApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(sourceConfig),
-                null, null, false);
+                null, null, null);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Source test-source doesn't exist")
@@ -973,7 +973,7 @@ public class SourceApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(sourceConfig),
-                null, null, false);
+                null, null, null);
 
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -835,7 +835,7 @@ public class SourceApiV3ResourceTest {
             details,
             null,
             new Gson().toJson(sourceConfig),
-                null, null);
+                null, null, false);
 
     }
 
@@ -872,7 +872,7 @@ public class SourceApiV3ResourceTest {
             mockedFormData,
             null,
             new Gson().toJson(sourceConfig),
-                null, null);
+                null, null, false);
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Source test-source doesn't exist")
@@ -973,7 +973,7 @@ public class SourceApiV3ResourceTest {
             null,
             filePackageUrl,
             new Gson().toJson(sourceConfig),
-                null, null);
+                null, null, false);
 
     }
 


### PR DESCRIPTION
### Motivation

Currently, after a function is submitted there is no way to update the auth data associated with the function.  

Users may want to be able to update the auth data of a function that is running.

This will especially support use cases involving initially running Pulsar without authentication enabled but then enabling authentication.  Functions need to be able to be updated to have auth data for a seamless transition 

### Modifications

Allow users to update the auth data when updating a function. 

Have a flag to control whether to update the auth data of the function or simply keep using the existing auth data

Improve the FunctionAuthProvider interface to support this use case
