### PR TITLE
[schema] Support compatibility check over all existing schemas.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1052,7 +1052,7 @@ public class NonPersistentTopic implements Topic {
         String id = TopicName.get(base).getSchemaName();
         return brokerService.pulsar()
             .getSchemaRegistryService()
-            .isCompatibleWithLatestVersion(id, schema, schemaCompatibilityStrategy);
+            .isCompatible(id, schema, schemaCompatibilityStrategy);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1932,7 +1932,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         String id = TopicName.get(base).getSchemaName();
         return brokerService.pulsar()
             .getSchemaRegistryService()
-            .isCompatibleWithLatestVersion(id, schema, schemaCompatibilityStrategy);
+            .isCompatible(id, schema, schemaCompatibilityStrategy);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.broker.service.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.avro.SchemaValidationException;
@@ -34,45 +36,49 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityCheck {
-    @Override
-    public boolean isWellFormed(SchemaData to) {
-        try {
-            Schema.Parser toParser = new Schema.Parser();
-            Schema toSchema = toParser.parse(new String(to.getData(), UTF_8));
-        } catch (SchemaParseException e) {
-            log.error("Error during schema parsing: {}", e.getMessage(), e);
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
-        try {
-            Schema.Parser fromParser = new Schema.Parser();
-            Schema fromSchema = fromParser.parse(new String(from.getData(), UTF_8));
-            Schema.Parser toParser = new Schema.Parser();
-            Schema toSchema = toParser.parse(new String(to.getData(), UTF_8));
+        return isCompatible(Collections.singletonList(from), to, strategy);
+    }
 
-            SchemaValidator schemaValidator = createSchemaValidator(strategy, true);
-            schemaValidator.validate(toSchema, Arrays.asList(fromSchema));
-        } catch (SchemaParseException | SchemaValidationException e) {
+    @Override
+    public boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        LinkedList<Schema> fromList = new LinkedList<>();
+        try {
+            for (SchemaData schemaData : from) {
+                Schema.Parser parser = new Schema.Parser();
+                fromList.addFirst(parser.parse(new String(schemaData.getData(), UTF_8)));
+            }
+            Schema.Parser parser = new Schema.Parser();
+            Schema toSchema = parser.parse(new String(to.getData(), UTF_8));
+            SchemaValidator schemaValidator = createSchemaValidator(strategy);
+            schemaValidator.validate(toSchema, fromList);
+        } catch (SchemaParseException e) {
+            log.error("Error during schema parsing: {}", e.getMessage(), e);
+            return false;
+        } catch (SchemaValidationException e) {
             log.error("Error during schema compatibility check: {}", e.getMessage(), e);
             return false;
         }
         return true;
     }
 
-    static SchemaValidator createSchemaValidator(SchemaCompatibilityStrategy compatibilityStrategy,
-                                                 boolean onlyLatestValidator) {
+    static SchemaValidator createSchemaValidator(SchemaCompatibilityStrategy compatibilityStrategy) {
         final SchemaValidatorBuilder validatorBuilder = new SchemaValidatorBuilder();
         switch (compatibilityStrategy) {
+            case BACKWARD_TRANSITIVE:
+                return createLatestOrAllValidator(validatorBuilder.canReadStrategy(), false);
             case BACKWARD:
-                return createLatestOrAllValidator(validatorBuilder.canReadStrategy(), onlyLatestValidator);
+                return createLatestOrAllValidator(validatorBuilder.canReadStrategy(), true);
+            case FORWARD_TRANSITIVE:
+                return createLatestOrAllValidator(validatorBuilder.canBeReadStrategy(), false);
             case FORWARD:
-                return createLatestOrAllValidator(validatorBuilder.canBeReadStrategy(), onlyLatestValidator);
+                return createLatestOrAllValidator(validatorBuilder.canBeReadStrategy(), true);
+            case FULL_TRANSITIVE:
+                return createLatestOrAllValidator(validatorBuilder.mutualReadStrategy(), false);
             case FULL:
-                return createLatestOrAllValidator(validatorBuilder.mutualReadStrategy(), onlyLatestValidator);
+                return createLatestOrAllValidator(validatorBuilder.mutualReadStrategy(), true);
             case ALWAYS_COMPATIBLE:
                 return AlwaysSchemaValidator.INSTANCE;
             default:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -129,7 +129,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
             }
 
             if (!locator.isPresent()) {
-                return;
+                result.complete(Collections.emptyList());
             }
 
             SchemaStorageFormat.SchemaLocator schemaLocator = locator.get().locator;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.service.schema;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaVersion;
@@ -36,6 +38,11 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
+    public List<CompletableFuture<SchemaAndMetadata>> getAllSchemas(String schemaId) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                               SchemaCompatibilityStrategy strategy) {
         return completedFuture(null);
@@ -47,14 +54,13 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
-    public SchemaVersion versionFromBytes(byte[] version) {
-        return null;
+    public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
+        return completedFuture(null);
     }
 
     @Override
-    public CompletableFuture<Boolean> isCompatibleWithLatestVersion(String schemaId, SchemaData schema,
-                                                                    SchemaCompatibilityStrategy strategy) {
-        return CompletableFuture.completedFuture(true);
+    public SchemaVersion versionFromBytes(byte[] version) {
+        return null;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.schema;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.common.schema.SchemaData;
@@ -38,7 +39,7 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
 
     @Override
     public CompletableFuture<List<CompletableFuture<SchemaAndMetadata>>> getAllSchemas(String schemaId) {
-        return completedFuture(null);
+        return completedFuture(Collections.emptyList());
     }
 
 
@@ -55,7 +56,7 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
 
     @Override
     public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
-        return completedFuture(null);
+        return completedFuture(false);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.service.schema;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.common.schema.SchemaData;
@@ -38,9 +37,10 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
-    public List<CompletableFuture<SchemaAndMetadata>> getAllSchemas(String schemaId) {
-        return Collections.emptyList();
+    public CompletableFuture<List<CompletableFuture<SchemaAndMetadata>>> getAllSchemas(String schemaId) {
+        return completedFuture(null);
     }
+
 
     @Override
     public CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -22,14 +22,8 @@ import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
 
 public interface SchemaCompatibilityCheck {
-    SchemaType getSchemaType();
 
-    /**
-     *
-     * @param to the future schema i.e. the schema sent by the producer
-     * @return whether the schemas are well-formed
-     */
-    boolean isWellFormed(SchemaData to);
+    SchemaType getSchemaType();
 
     /**
      *
@@ -50,14 +44,10 @@ public interface SchemaCompatibilityCheck {
     boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy);
 
     SchemaCompatibilityCheck DEFAULT = new SchemaCompatibilityCheck() {
+
         @Override
         public SchemaType getSchemaType() {
             return SchemaType.NONE;
-        }
-
-        @Override
-        public boolean isWellFormed(SchemaData to) {
-            return true;
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -40,6 +40,15 @@ public interface SchemaCompatibilityCheck {
      */
     boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy);
 
+    /**
+     *
+     * @param from the current schemas i.e. schemas that the broker has
+     * @param to the future schema i.e. the schema sent by the producer
+     * @param strategy the strategy to use when comparing schemas
+     * @return whether the schemas are compatible
+     */
+    boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy);
+
     SchemaCompatibilityCheck DEFAULT = new SchemaCompatibilityCheck() {
         @Override
         public SchemaType getSchemaType() {
@@ -59,5 +68,15 @@ public interface SchemaCompatibilityCheck {
                 return true;
             }
         }
+
+        @Override
+        public boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+            if (strategy == SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
     };
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
@@ -44,24 +44,49 @@ public enum SchemaCompatibilityStrategy {
     /**
      * Equivalent to both FORWARD and BACKWARD
      */
-    FULL;
+    FULL,
+
+    /**
+     * Be similar to BACKWARD, BACKWARD_TRANSITIVE ensure all previous version schema can
+     * be read by the new schema.
+     */
+    BACKWARD_TRANSITIVE,
+
+    /**
+     * Be similar to FORWARD, FORWARD_TRANSITIVE ensure new schema can be ready by all previous
+     * version schema.
+     */
+    FORWARD_TRANSITIVE,
+
+    /**
+     * Equivalent to both FORWARD_TRANSITIVE and BACKWARD_TRANSITIVE
+     */
+    FULL_TRANSITIVE;
+
+
 
     public static SchemaCompatibilityStrategy fromAutoUpdatePolicy(SchemaAutoUpdateCompatibilityStrategy strategy) {
         if (strategy == null) {
             return SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE;
         }
         switch (strategy) {
-        case Backward:
-            return BACKWARD;
-        case Forward:
-            return FORWARD;
-        case Full:
-            return FULL;
-        case AlwaysCompatible:
-            return ALWAYS_COMPATIBLE;
-        case AutoUpdateDisabled:
-        default:
-            return ALWAYS_INCOMPATIBLE;
+            case Backward:
+                return BACKWARD;
+            case Forward:
+                return FORWARD;
+            case Full:
+                return FULL;
+            case AlwaysCompatible:
+                return ALWAYS_COMPATIBLE;
+            case ForwardTransitive:
+                return FORWARD_TRANSITIVE;
+            case BackwardTransitive:
+                return BACKWARD_TRANSITIVE;
+            case FullTransitive:
+                return FULL_TRANSITIVE;
+            case AutoUpdateDisabled:
+            default:
+                return ALWAYS_INCOMPATIBLE;
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.service.schema;
 
 import com.google.common.base.MoreObjects;
+
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.common.schema.SchemaData;
@@ -30,12 +32,14 @@ public interface SchemaRegistry extends AutoCloseable {
 
     CompletableFuture<SchemaAndMetadata> getSchema(String schemaId, SchemaVersion version);
 
+    List<CompletableFuture<SchemaAndMetadata>> getAllSchemas(String schemaId);
+
     CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                        SchemaCompatibilityStrategy strategy);
 
     CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user);
 
-    CompletableFuture<Boolean> isCompatibleWithLatestVersion(String schemaId, SchemaData schema,
+    CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema,
                                                              SchemaCompatibilityStrategy strategy);
 
     SchemaVersion versionFromBytes(byte[] version);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -32,7 +32,7 @@ public interface SchemaRegistry extends AutoCloseable {
 
     CompletableFuture<SchemaAndMetadata> getSchema(String schemaId, SchemaVersion version);
 
-    List<CompletableFuture<SchemaAndMetadata>> getAllSchemas(String schemaId);
+    CompletableFuture<List<CompletableFuture<SchemaAndMetadata>>> getAllSchemas(String schemaId);
 
     CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                        SchemaCompatibilityStrategy strategy);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -100,16 +100,6 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     public CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                               SchemaCompatibilityStrategy strategy) {
         return getSchema(schemaId)
-<<<<<<< HEAD
-            .thenApply(
-                (existingSchema) -> {
-                    try {
-                        return existingSchema == null
-                            || existingSchema.schema.isDeleted()
-                            || (isCompatible(schemaId, schema, strategy).get());
-                    } catch (Exception e) {
-                        return false;
-=======
             .thenCompose(
                 (existingSchema) ->
                 {
@@ -117,7 +107,6 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                         return completedFuture(true);
                     } else {
                         return isCompatible(schemaId, schema, strategy);
->>>>>>> [schema] avoid doing synchronous calls in async callbacks or methods
                     }
                 }
             )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaStorage.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.schema;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.common.schema.SchemaVersion;
 
@@ -26,6 +27,8 @@ public interface SchemaStorage {
     CompletableFuture<SchemaVersion> put(String key, byte[] value, byte[] hash);
 
     CompletableFuture<StoredSchema> get(String key, SchemaVersion version);
+
+    List<CompletableFuture<StoredSchema>> getAll(String key);
 
     CompletableFuture<SchemaVersion> delete(String key);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaStorage.java
@@ -28,7 +28,7 @@ public interface SchemaStorage {
 
     CompletableFuture<StoredSchema> get(String key, SchemaVersion version);
 
-    List<CompletableFuture<StoredSchema>> getAll(String key);
+    CompletableFuture<List<CompletableFuture<StoredSchema>>> getAll(String key);
 
     CompletableFuture<SchemaVersion> delete(String key);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BaseAvroSchemaCompatibilityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BaseAvroSchemaCompatibilityTest.java
@@ -23,6 +23,9 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 public abstract class BaseAvroSchemaCompatibilityTest {
 
     SchemaCompatibilityCheck schemaCompatibilityCheck;
@@ -69,6 +72,11 @@ public abstract class BaseAvroSchemaCompatibilityTest {
                     "\"type\":\"string\",\"default\":\"bar\"}]}";
     private static final SchemaData schemaData7 = getSchemaData(schemaJson7);
 
+    private static final String schemaJson8 =
+            "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
+                    ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
+                    "{\"name\":\"field2\",\"type\":\"string\"}]}";
+    private static final SchemaData schemaData8 = getSchemaData(schemaJson8);
 
     public abstract SchemaCompatibilityCheck getSchemaCheck();
 
@@ -156,6 +164,45 @@ public abstract class BaseAvroSchemaCompatibilityTest {
                                                                  SchemaCompatibilityStrategy.FULL),
                 "adding a field without default is not fully compatible");
 
+    }
+
+    @Test
+    public void testBackwardTransitive() {
+        SchemaCompatibilityCheck schemaCompatibilityCheck = getSchemaCheck();
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData5,
+                SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE));
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2, schemaData5),
+                schemaData6, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE));
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Collections.singletonList(schemaData2), schemaData8,
+                SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE));
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData8,
+                SchemaCompatibilityStrategy.BACKWARD));
+        Assert.assertFalse(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData8,
+                SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE));
+        Assert.assertFalse(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2, schemaData5),
+                schemaData8, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE));
+    }
+
+    @Test
+    public void testForwardTransitive() {
+        SchemaCompatibilityCheck schemaCompatibilityCheck = getSchemaCheck();
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData3,
+                SchemaCompatibilityStrategy.FORWARD_TRANSITIVE));
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2, schemaData3),
+                schemaData7, SchemaCompatibilityStrategy.FORWARD_TRANSITIVE));
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData3, schemaData2), schemaData1,
+                SchemaCompatibilityStrategy.FORWARD));
+        Assert.assertFalse(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData3, schemaData2), schemaData1,
+                SchemaCompatibilityStrategy.FORWARD_TRANSITIVE));
+    }
+
+    @Test
+    public void testFullTransitive() {
+        SchemaCompatibilityCheck schemaCompatibilityCheck = getSchemaCheck();
+        Assert.assertTrue(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData3,
+                SchemaCompatibilityStrategy.FULL));
+        Assert.assertFalse(schemaCompatibilityCheck.isCompatible(Arrays.asList(schemaData1, schemaData2), schemaData3,
+                SchemaCompatibilityStrategy.FULL_TRANSITIVE));
     }
 
     private static SchemaData getSchemaData(String schemaJson) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -19,15 +19,21 @@
 package org.apache.pulsar.broker.service.schema;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
-import com.google.common.collect.Maps;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -79,7 +85,9 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         BookkeeperSchemaStorage storage = new BookkeeperSchemaStorage(pulsar);
         storage.init();
         storage.start();
-        schemaRegistryService = new SchemaRegistryServiceImpl(storage, Maps.newHashMap(), MockClock);
+        Map<SchemaType, SchemaCompatibilityCheck> checkMap = new HashMap<>();
+        checkMap.put(SchemaType.AVRO, new AvroSchemaCompatibilityCheck());
+        schemaRegistryService = new SchemaRegistryServiceImpl(storage, checkMap, MockClock);
     }
 
     @AfterMethod
@@ -137,6 +145,18 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
 
         SchemaData version1 = getSchema(schemaId1, version(0));
         assertEquals(schema1, version1);
+    }
+
+    @Test
+    public void getAllVersionSchema() throws Exception {
+        putSchema(schemaId1, schema1, version(0));
+        putSchema(schemaId1, schema2, version(1));
+        putSchema(schemaId1, schema3, version(2));
+
+        List<SchemaData> allSchemas = getAllSchemas(schemaId1);
+        assertEquals(schema1, allSchemas.get(0));
+        assertEquals(schema2, allSchemas.get(1));
+        assertEquals(schema3, allSchemas.get(2));
     }
 
     @Test
@@ -218,9 +238,43 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         putSchema(schemaId1, schema2, version(1));
     }
 
+    @Test(expectedExceptions = ExecutionException.class)
+    public void checkIsCompatible() throws Exception {
+        String schemaJson1 =
+                "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
+                        ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
+        SchemaData schemaData1 = getSchemaData(schemaJson1);
+
+        String schemaJson2 =
+                "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
+                        ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
+                        "{\"name\":\"field2\",\"type\":\"string\",\"default\":\"foo\"}]}";
+        SchemaData schemaData2 = getSchemaData(schemaJson2);
+
+        String schemaJson3 =
+                "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
+                        ".AvroSchemaCompatibilityCheckTest$\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
+                        "{\"name\":\"field2\",\"type\":\"string\"}]}";
+        SchemaData schemaData3 = getSchemaData(schemaJson3);
+
+        putSchema(schemaId1, schemaData1, version(0), SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+        putSchema(schemaId1, schemaData2, version(1), SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+
+        assertTrue(schemaRegistryService.isCompatible(schemaId1, schemaData3,
+                SchemaCompatibilityStrategy.BACKWARD).get());
+        assertFalse(schemaRegistryService.isCompatible(schemaId1, schemaData3,
+                SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE).get());
+        putSchema(schemaId1, schemaData3, version(2), SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+    }
+
     private void putSchema(String schemaId, SchemaData schema, SchemaVersion expectedVersion) throws Exception {
+        putSchema(schemaId, schema, expectedVersion, SchemaCompatibilityStrategy.FULL);
+    }
+
+    private void putSchema(String schemaId, SchemaData schema, SchemaVersion expectedVersion,
+                           SchemaCompatibilityStrategy strategy) throws ExecutionException, InterruptedException {
         CompletableFuture<SchemaVersion> put = schemaRegistryService.putSchemaIfAbsent(
-                schemaId, schema, SchemaCompatibilityStrategy.FULL);
+                schemaId, schema, strategy);
         SchemaVersion newVersion = put.get();
         assertEquals(expectedVersion, newVersion);
     }
@@ -239,6 +293,16 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         return schemaAndVersion.schema;
     }
 
+    private List<SchemaData> getAllSchemas(String schemaId) throws Exception {
+        List<CompletableFuture<SchemaRegistry.SchemaAndMetadata>> allSchemas =
+                schemaRegistryService.getAllSchemas(schemaId);
+        List<SchemaData> result = new ArrayList<>();
+        for (CompletableFuture<SchemaRegistry.SchemaAndMetadata> schema : allSchemas) {
+            result.add(schema.get().schema);
+        }
+        return result;
+    }
+
     private void deleteSchema(String schemaId, SchemaVersion expectedVersion) throws Exception {
         SchemaVersion version = schemaRegistryService.deleteSchema(schemaId, userId).get();
         assertEquals(expectedVersion, version);
@@ -254,6 +318,10 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
             .data(randomString.toString().getBytes())
             .props(new TreeMap<>())
             .build();
+    }
+
+    private SchemaData getSchemaData(String schemaJson) {
+        return SchemaData.builder().data(schemaJson.getBytes()).type(SchemaType.AVRO).user(userId).build();
     }
 
     private SchemaVersion version(long version) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -294,10 +294,9 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
     }
 
     private List<SchemaData> getAllSchemas(String schemaId) throws Exception {
-        List<CompletableFuture<SchemaRegistry.SchemaAndMetadata>> allSchemas =
-                schemaRegistryService.getAllSchemas(schemaId);
         List<SchemaData> result = new ArrayList<>();
-        for (CompletableFuture<SchemaRegistry.SchemaAndMetadata> schema : allSchemas) {
+        for (CompletableFuture<SchemaRegistry.SchemaAndMetadata> schema :
+                schemaRegistryService.getAllSchemas(schemaId).get()) {
             result.add(schema.get().schema);
         }
         return result;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SchemaAutoUpdateCompatibilityStrategy.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SchemaAutoUpdateCompatibilityStrategy.java
@@ -51,5 +51,22 @@ public enum SchemaAutoUpdateCompatibilityStrategy {
      * Always Compatible - The new schema will not be checked for compatibility against
      * old schemas. In other words, new schemas will always be marked assumed compatible.
      */
-    AlwaysCompatible
+    AlwaysCompatible,
+
+    /**
+     * Be similar to Backward. BackwardTransitive ensure all previous version schema can
+     * be read by the new schema.
+     */
+    BackwardTransitive,
+
+    /**
+     * Be similar to Forward, ForwardTransitive ensure new schema can be ready by all previous
+     * version schema.
+     */
+    ForwardTransitive,
+
+    /**
+     * BackwardTransitive and ForwardTransitive
+     */
+    FullTransitive
 }


### PR DESCRIPTION
Fixes #4170 

### Motivation

Currently the schema compatibility check is only done with the latest schema. That's probably not enough especially we now support schema versions for Struct schema. We need to the ability for check the compatibility with all existing schema version.

### Modifications

Add `FORWARD_TRANSITIVE`, `BACKWARD_TRANSITIVE` and `FULL_TRANSITIVE` compatibility strategy.

### Verifying this change

This change is already covered by existing tests, such as SchemaServiceTest, BaseAvroSchemaCompatibilityTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (yes)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
