### PR TITLE
Use certifi cert collection for TLS in python client

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -120,7 +120,7 @@ static Result getResult(ServerError serverError) {
 
 static bool file_exists(const std::string& path) {
     std::ifstream f(path);
-    return !f.bad();
+    return f.good();
 }
 
 ClientConnection::ClientConnection(const std::string& logicalAddress, const std::string& physicalAddress,
@@ -170,12 +170,16 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
             }
 
             std::string trustCertFilePath = clientConfiguration.getTlsTrustCertsFilePath();
-            if (file_exists(trustCertFilePath)) {
-                ctx.load_verify_file(trustCertFilePath);
+            if (!trustCertFilePath.empty()) {
+                if (file_exists(trustCertFilePath)) {
+                    ctx.load_verify_file(trustCertFilePath);
+                } else {
+                    LOG_ERROR(trustCertFilePath << ": No such trustCertFile");
+                    close();
+                    return;
+                }
             } else {
-                LOG_ERROR(trustCertFilePath << ": No such trustCertFile");
-                close();
-                return;
+                ctx.set_default_verify_paths();
             }
         }
 

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -112,6 +112,7 @@ _schema = schema
 import re
 _retype = type(re.compile('x'))
 
+import certifi
 
 class MessageId:
     """
@@ -323,7 +324,8 @@ class Client:
           is deprecated. TLS will be automatically enabled if the `serviceUrl` is
           set to `pulsar+ssl://` or `https://`
         * `tls_trust_certs_file_path`:
-          Set the path to the trusted TLS certificate file.
+          Set the path to the trusted TLS certificate file. If empty defaults to
+          certifi.
         * `tls_allow_insecure_connection`:
           Configure whether the Pulsar client accepts untrusted TLS certificates
           from the broker.
@@ -352,6 +354,8 @@ class Client:
             conf.use_tls(True)
         if tls_trust_certs_file_path:
             conf.tls_trust_certs_file_path(tls_trust_certs_file_path)
+        else:
+            conf.tls_trust_certs_file_path(certifi.where())
         conf.tls_allow_insecure_connection(tls_allow_insecure_connection)
         self._client = _pulsar.Client(service_url, conf)
         self._consumers = []

--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -66,6 +66,7 @@ dependencies = [
     'grpcio',
     'protobuf>=3.6.1',
     'six',
+    'certifi',
 
     # functions dependencies
     "apache-bookkeeper-client>=4.9.1",


### PR DESCRIPTION
The python library is built using a statically linked pulsar
library. Since it is statically linked, the paths for the default
certificates are hard coded and likely wrong on most platforms the
python client runs on.

This patch changes the python library to pull a set of certs from
certifi, which is then uses as the trust store if the no trust cert is
specified. For C++, if the trust cert is unspecified, SSL defaults are
used. This should work fine for C++ if a shared library is being used.
