### PR TITLE
Fix segfault in c++ producer

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -673,7 +673,9 @@ void ProducerImpl::start() { HandlerBase::start(); }
 void ProducerImpl::shutdown() {
     Lock lock(mutex_);
     state_ = Closed;
-    sendTimer_->cancel();
+    if (sendTimer_) {
+        sendTimer_->cancel();
+    }
     producerCreatedPromise_.setFailed(ResultAlreadyClosed);
 }
 


### PR DESCRIPTION
The sendTimer_ may not be initialized if connection doesn't come up
correctly.
