### PR TITLE
Add python3 kazoo in Dockerimage

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -20,7 +20,7 @@
 FROM openjdk:8-jdk
 
 # Install some utilities
-RUN apt-get update && apt-get install -y netcat dnsutils python-kazoo python-yaml python-pip python3 python3-pip python3-yaml python3-pip
+RUN apt-get update && apt-get install -y netcat dnsutils python-kazoo python-yaml python-pip python3 python3-kazoo python3-yaml python3-pip
 
 ARG PULSAR_TARBALL
 


### PR DESCRIPTION
We are adding the python3-kazoo lib to allow containers to use python 3 if they need to.
