### PR TITLE
Allow configurble Request timeout for pulsar cli

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -69,6 +69,7 @@ public class PulsarAdmin implements Closeable {
 
     public static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 60;
     public static final int DEFAULT_READ_TIMEOUT_SECONDS = 60;
+    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
 
     private final Clusters clusters;
     private final Brokers brokers;
@@ -96,6 +97,8 @@ public class PulsarAdmin implements Closeable {
     private final TimeUnit connectTimeoutUnit;
     private final int readTimeout;
     private final TimeUnit readTimeoutUnit;
+    private final int requestTimeout;
+    private final TimeUnit requestTimeoutUnit;
 
     static {
         /**
@@ -125,7 +128,8 @@ public class PulsarAdmin implements Closeable {
 
     public PulsarAdmin(String serviceUrl, ClientConfigurationData clientConfigData) throws PulsarClientException {
         this(serviceUrl, clientConfigData, DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS,
-                DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                DEFAULT_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     }
 
@@ -134,11 +138,15 @@ public class PulsarAdmin implements Closeable {
                        int connectTimeout,
                        TimeUnit connectTimeoutUnit,
                        int readTimeout,
-                       TimeUnit readTimeoutUnit) throws PulsarClientException {
+                       TimeUnit readTimeoutUnit,
+                       int requestTimeout,
+                       TimeUnit requestTimeoutUnit) throws PulsarClientException {
         this.connectTimeout = connectTimeout;
         this.connectTimeoutUnit = connectTimeoutUnit;
         this.readTimeout = readTimeout;
         this.readTimeoutUnit = readTimeoutUnit;
+        this.requestTimeout = requestTimeout;
+        this.requestTimeoutUnit = requestTimeoutUnit;
         this.clientConfigData = clientConfigData;
         this.auth = clientConfigData != null ? clientConfigData.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
@@ -170,8 +178,9 @@ public class PulsarAdmin implements Closeable {
         root = client.target(serviceUrl);
 
         this.httpAsyncClient = asyncConnectorProvider.getConnector(
-                Math.toIntExact(TimeUnit.SECONDS.toMillis(this.connectTimeout)),
-                Math.toIntExact(TimeUnit.SECONDS.toMillis(this.readTimeout))).getHttpClient();
+                Math.toIntExact(connectTimeoutUnit.toMillis(this.connectTimeout)),
+                Math.toIntExact(readTimeoutUnit.toMillis(this.readTimeout)),
+                Math.toIntExact(requestTimeoutUnit.toMillis(this.requestTimeout))).getHttpClient();
 
         this.clusters = new ClustersImpl(root, auth);
         this.brokers = new BrokersImpl(root, auth);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -187,4 +187,12 @@ public interface PulsarAdminBuilder {
      */
     PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit);
 
+    /**
+     * This sets the server request time out for the pulsar admin client for any request.
+     *
+     * @param requestTimeout
+     * @param requestTimeoutUnit
+     */
+    PulsarAdminBuilder requestTimeout(int requestTimeout, TimeUnit requestTimeoutUnit);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -34,13 +34,16 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
     protected final ClientConfigurationData conf;
     private int connectTimeout = PulsarAdmin.DEFAULT_CONNECT_TIMEOUT_SECONDS;
     private int readTimeout = PulsarAdmin.DEFAULT_READ_TIMEOUT_SECONDS;
+    private int requestTimeout = PulsarAdmin.DEFAULT_REQUEST_TIMEOUT_SECONDS;
     private TimeUnit connectTimeoutUnit = TimeUnit.SECONDS;
     private TimeUnit readTimeoutUnit = TimeUnit.SECONDS;
+    private TimeUnit requestTimeoutUnit = TimeUnit.SECONDS;
 
     @Override
     public PulsarAdmin build() throws PulsarClientException {
         return new PulsarAdmin(conf.getServiceUrl(),
-                conf, connectTimeout, connectTimeoutUnit, readTimeout, readTimeoutUnit);
+                conf, connectTimeout, connectTimeoutUnit, readTimeout, readTimeoutUnit,
+                requestTimeout, requestTimeoutUnit);
     }
 
     public PulsarAdminBuilderImpl() {
@@ -111,6 +114,13 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
     public PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit) {
         this.readTimeout = readTimeout;
         this.readTimeoutUnit = readTimeoutUnit;
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder requestTimeout(int requestTimeout, TimeUnit requestTimeoutUnit) {
+        this.requestTimeout = requestTimeout;
+        this.requestTimeoutUnit = requestTimeoutUnit;
         return this;
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.util.SecurityUtility;
@@ -66,16 +67,19 @@ public class AsyncHttpConnector implements Connector {
     public AsyncHttpConnector(Client client, ClientConfigurationData conf) {
         this((int) client.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT),
                 (int) client.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT),
+                PulsarAdmin.DEFAULT_REQUEST_TIMEOUT_SECONDS * 1000,
                 conf);
     }
 
     @SneakyThrows
-    public AsyncHttpConnector(int connectTimeoutMs, int readTimeoutMs, ClientConfigurationData conf) {
+    public AsyncHttpConnector(int connectTimeoutMs, int readTimeoutMs,
+                              int requestTimeoutMs, ClientConfigurationData conf) {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setFollowRedirect(true);
         confBuilder.setConnectTimeout(connectTimeoutMs);
         confBuilder.setReadTimeout(readTimeoutMs);
         confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
+        confBuilder.setRequestTimeout(requestTimeoutMs);
         confBuilder.setKeepAliveStrategy(new DefaultKeepAliveStrategy() {
             @Override
             public boolean keepAlive(Request ahcRequest, HttpRequest request, HttpResponse response) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
@@ -39,7 +39,7 @@ public class AsyncHttpConnectorProvider implements ConnectorProvider {
     }
 
 
-    public AsyncHttpConnector getConnector(int connectTimeoutMs, int readTimeoutMs) {
-        return new AsyncHttpConnector(connectTimeoutMs, readTimeoutMs, conf);
+    public AsyncHttpConnector getConnector(int connectTimeoutMs, int readTimeoutMs, int requestTimeoutMs) {
+        return new AsyncHttpConnector(connectTimeoutMs, readTimeoutMs, requestTimeoutMs, conf);
     }
 }


### PR DESCRIPTION
### Motivation

Currently there is no way to configure the request timeout of a pulsar-admin command. It defaults to 60seconds which might pose issues while submitting big function jars over internet.
This pr makes request timeout configurable as well as increase the default timeout to 5min.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
