### PR TITLE
[pulsar-storm] provide auto-unsubscribe option in pulsar-spout

### DIFF
--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
@@ -103,6 +103,11 @@ public class PulsarSpout extends BaseRichSpout implements IMetric {
     public void close() {
         try {
             LOG.info("[{}] Closing Pulsar consumer for topic {}", spoutId, pulsarSpoutConf.getTopic());
+            
+            if (pulsarSpoutConf.isAutoUnsubscribe()) {
+                consumer.unsubscribe();
+            }
+            
             if (!pulsarSpoutConf.isSharedConsumerEnabled() && consumer != null) {
                 consumer.close();
             }

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConfiguration.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConfiguration.java
@@ -45,6 +45,7 @@ public class PulsarSpoutConfiguration extends PulsarStormConfiguration {
     private boolean sharedConsumerEnabled = false;
 
     private SubscriptionType subscriptionType = SubscriptionType.Shared;
+    private boolean autoUnsubscribe = false;
 
     /**
      * @return the subscription name for the consumer in the spout
@@ -145,5 +146,18 @@ public class PulsarSpoutConfiguration extends PulsarStormConfiguration {
      */
     public void setSharedConsumerEnabled(boolean sharedConsumerEnabled) {
         this.sharedConsumerEnabled = sharedConsumerEnabled;
+    }
+    
+    public boolean isAutoUnsubscribe() {
+        return autoUnsubscribe;
+    }
+
+    /**
+     * It unsubscribes the subscription when spout gets closed in the topology.
+     * 
+     * @param autoUnsubscribe
+     */
+    public void setAutoUnsubscribe(boolean autoUnsubscribe) {
+        this.autoUnsubscribe = autoUnsubscribe;
     }
 }


### PR DESCRIPTION
### Motivation

We have multiple customer ask where they have usecase to unsubscribe subscription when spout closes and topology is down. 
many times user uses pulsar-spout to interact with pulsar and wants to process messages without loosing them on the topic in case ack-failure. But user wants unsubscribe from the topic once the topology is going down. Right now, user has to implement custom logic to unsubscribe while closing the spout so, if pulsar-spout has this option then user can directly utilize it.