### PR TITLE
[Doc] Fix top page title

### DIFF
--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -82,6 +82,7 @@ const siteVariables = {
 
 const siteConfig = {
   title: 'Apache Pulsar' /* title for your website */,
+  disableTitleTagline: true,
   tagline: '',
   url: url /* your website url */,
   baseUrl: baseUrl /* base url for your project */,


### PR DESCRIPTION
### Motivation


* Currently, the top page title of http://pulsar.apache.org/ is `Apache Pulsar · `

### Modifications

* Add `disableTitleTagline: true` in siteConfig and the title is changed from `Apache Pulsar · ` to `Apache Pulsar` .

