### PR TITLE
[Issue 4251][Schemas] add schema parsing verification before update

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityCheck {
     @Override
-    public Boolean isWellFormed(SchemaData to) {
+    public boolean isWellFormed(SchemaData to) {
         try {
             Schema.Parser toParser = new Schema.Parser();
             Schema toSchema = toParser.parse(new String(to.getData(), UTF_8));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -27,15 +27,13 @@ import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
 import org.apache.avro.SchemaValidatorBuilder;
 import org.apache.pulsar.common.schema.SchemaData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The abstract implementation of {@link SchemaCompatibilityCheck} using Avro Schema.
  */
+@Slf4j
 abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityCheck {
-    Logger log = LoggerFactory.getLogger(SchemaRegistryService.class);
-
     @Override
     public Boolean isWellFormed(SchemaData to) {
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -22,27 +22,44 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Arrays;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
 import org.apache.avro.SchemaValidatorBuilder;
 import org.apache.pulsar.common.schema.SchemaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The abstract implementation of {@link SchemaCompatibilityCheck} using Avro Schema.
  */
 abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityCheck {
+    Logger log = LoggerFactory.getLogger(SchemaRegistryService.class);
+
+    @Override
+    public Boolean isWellFormed(SchemaData to) {
+        try {
+            Schema.Parser toParser = new Schema.Parser();
+            Schema toSchema = toParser.parse(new String(to.getData(), UTF_8));
+        } catch (SchemaParseException e) {
+            log.error("Error during schema parsing: {}", e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
 
     @Override
     public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
-        Schema.Parser fromParser = new Schema.Parser();
-        Schema fromSchema = fromParser.parse(new String(from.getData(), UTF_8));
-        Schema.Parser toParser = new Schema.Parser();
-        Schema toSchema =  toParser.parse(new String(to.getData(), UTF_8));
-
-        SchemaValidator schemaValidator = createSchemaValidator(strategy, true);
         try {
+            Schema.Parser fromParser = new Schema.Parser();
+            Schema fromSchema = fromParser.parse(new String(from.getData(), UTF_8));
+            Schema.Parser toParser = new Schema.Parser();
+            Schema toSchema = toParser.parse(new String(to.getData(), UTF_8));
+
+            SchemaValidator schemaValidator = createSchemaValidator(strategy, true);
             schemaValidator.validate(toSchema, Arrays.asList(fromSchema));
-        } catch (SchemaValidationException e) {
+        } catch (SchemaParseException | SchemaValidationException e) {
+            log.error("Error during schema compatibility check: {}", e.getMessage(), e);
             return false;
         }
         return true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -26,6 +26,13 @@ public interface SchemaCompatibilityCheck {
 
     /**
      *
+     * @param to the future schema i.e. the schema sent by the producer
+     * @return whether the schemas are well-formed
+     */
+    Boolean isWellFormed(SchemaData to);
+
+    /**
+     *
      * @param from the current schema i.e. schema that the broker has
      * @param to the future schema i.e. the schema sent by the producer
      * @param strategy the strategy to use when comparing schemas
@@ -37,6 +44,11 @@ public interface SchemaCompatibilityCheck {
         @Override
         public SchemaType getSchemaType() {
             return SchemaType.NONE;
+        }
+
+        @Override
+        public Boolean isWellFormed(SchemaData to) {
+            return true;
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -29,7 +29,7 @@ public interface SchemaCompatibilityCheck {
      * @param to the future schema i.e. the schema sent by the producer
      * @return whether the schemas are well-formed
      */
-    Boolean isWellFormed(SchemaData to);
+    boolean isWellFormed(SchemaData to);
 
     /**
      *
@@ -47,7 +47,7 @@ public interface SchemaCompatibilityCheck {
         }
 
         @Override
-        public Boolean isWellFormed(SchemaData to) {
+        public boolean isWellFormed(SchemaData to) {
             return true;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -88,11 +88,12 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
         return getSchema(schemaId)
             .thenApply(
                 (existingSchema) ->
-                    existingSchema == null
-                        || existingSchema.schema.isDeleted()
-                        || isCompatible(existingSchema, schema, strategy))
-            .thenCompose(isCompatible -> {
-                    if (isCompatible) {
+                    existingSchema == null ||
+                    existingSchema.schema.isDeleted() ||
+                    (isWellFormed(schema) &&
+                    isCompatible(existingSchema, schema, strategy)))
+            .thenCompose(isValid -> {
+                    if (isValid) {
                         byte[] context = hashFunction.hashBytes(schema.getData()).asBytes();
                         SchemaRegistryFormat.SchemaInfo info = SchemaRegistryFormat.SchemaInfo.newBuilder()
                             .setType(Functions.convertFromDomainType(schema.getType()))
@@ -142,6 +143,11 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
             .setDeleted(true)
             .setTimestamp(clock.millis())
             .build();
+    }
+
+    private Boolean isWellFormed(SchemaData schema) {
+        return compatibilityChecks.getOrDefault(schema.getType(), SchemaCompatibilityCheck.DEFAULT)
+            .isWellFormed(schema);
     }
 
     private boolean isCompatible(SchemaAndMetadata existingSchema, SchemaData newSchema,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -145,7 +145,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
             .build();
     }
 
-    private Boolean isWellFormed(SchemaData schema) {
+    private boolean isWellFormed(SchemaData schema) {
         return compatibilityChecks.getOrDefault(schema.getType(), SchemaCompatibilityCheck.DEFAULT)
             .isWellFormed(schema);
     }


### PR DESCRIPTION
Fixes #4251 

### Motivation

Add a way to validate new schema before try to check compatibility and add stacktrace printing on parsing schema error.