### PR TITLE
Fixed python function context.publish with properties

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -152,7 +152,7 @@ class ContextImpl(pulsar.Context):
   def publish(self, topic_name, message, serde_class_name="serde.IdentitySerDe", properties=None, compression_type=None, callback=None):
     self.publish(topic_name, message, serde_class_name=serde_class_name, compression_type=compression_type, callback=callback, message_conf={"properties": properties})
 
-  def publish(self, topic_name, message, serde_class_name="serde.IdentitySerDe", compression_type=None, callback=None, message_conf=None):
+  def publish(self, topic_name, message, serde_class_name="serde.IdentitySerDe", compression_type=None, callback=None, message_conf=None, properties=None):
     # Just make sure that user supplied values are properly typed
     topic_name = str(topic_name)
     serde_class_name = str(serde_class_name)
@@ -178,6 +178,12 @@ class ContextImpl(pulsar.Context):
       self.publish_serializers[serde_class_name] = serde_klass()
 
     output_bytes = bytes(self.publish_serializers[serde_class_name].serialize(message))
+
+    if properties:
+        # The deprecated properties args was passed. Need to merge into message_conf
+        if not message_conf:
+            message_conf = {}
+        message_conf['properties'] = properties
 
     if message_conf:
       self.publish_producers[topic_name].send_async(


### PR DESCRIPTION
### Motivation

In `context.publish()` the `properties` args was deprecated. There are now 2 `context.publish()` methods with different args. The problem is that a function using the old deprecated list of param is ending up with the new method even though it's passing `properties` arg. 

We need to make sure the old function keeps working in this scenario.