### PR TITLE
[deploy] Provide a flag to choose the container factory to use to run functions

### DIFF
--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -75,6 +75,19 @@ for conf_filename in conf_files:
                 conf_to_modify = conf_to_modify[key_part]
                 modified = True
             i += 1
+
+    containerFactory=os.environ['PF_containerFactory']
+    conf.pop('containerFactory', None)
+    if containerFactory == 'k8s':
+        conf.pop('processContainerFactory', None)
+        conf.pop('threadContainerFactory', None)
+    elif containerFactory == 'process':
+        conf.pop('kubernetesContainerFactory', None)
+        conf.pop('threadContainerFactory', None)
+    elif containerFactory == 'thread':
+        conf.pop('kubernetesContainerFactory', None)
+        conf.pop('processContainerFactory', None)
+
     # Store back the updated config in the same file
     f = open(conf_filename , 'w')
     yaml.dump(conf, f, default_flow_style=False)

--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -76,7 +76,7 @@ for conf_filename in conf_files:
                 modified = True
             i += 1
 
-    containerFactory=os.environ['PF_containerFactory']
+    containerFactory = os.environ.get('PF_containerFactory', None)
     conf.pop('containerFactory', None)
     if containerFactory == 'k8s':
         conf.pop('processContainerFactory', None)


### PR DESCRIPTION

*Motivation*

Currently the default function running mode is `Process`. It is hardly able to configure running
functions in k8s.

Provide a flag in `gen-yml-from-env.py` so that people can choose which container factory to use.

