### PR TITLE
Use same activation dependency in pulsar-client-admin and pulsar-client

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -515,9 +515,7 @@ Protocol Buffers License
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
     - javax.annotation-javax.annotation-api-1.2.jar
-    - javax.activation-javax.activation-api-1.2.0.jar
     - com.sun.activation-javax.activation-1.2.0.jar
-    - javax.xml.bind-activation-1.0.2.jar
     - javax.xml.bind-jaxb-api-2.3.1.jar
  * Java Servlet API -- javax.servlet-javax.servlet-api-3.1.0.jar
  * WebSocket Server API -- javax.websocket-javax.websocket-client-api-1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>javax.activation</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>
         <version>${opencensus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -963,12 +963,6 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.0.2</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>javax.activation</artifactId>
         <version>1.2.0</version>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -286,11 +286,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>activation</artifactId>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
     </dependency>
   </dependencies>
 

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -65,15 +65,21 @@
       <artifactId>jersey-hk2</artifactId>
     </dependency>
 
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>jaxb-api</artifactId>
-   </dependency>
-
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>activation</artifactId>
-   </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -138,8 +138,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>activation</artifactId>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -99,15 +99,15 @@
       <artifactId>jersey-hk2</artifactId>
     </dependency>
 
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>jaxb-api</artifactId>
-   </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
 
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>activation</artifactId>
-   </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -503,9 +503,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
    - javax.annotation-api-1.2.jar
    - javax.annotation-api-1.3.1.jar
-   - javax.activation-api-1.2.0.jar
    - javax.activation-1.2.0.jar
-   - activation-1.0.2.jar
  * HK2 - Dependency Injection Kernel
    - hk2-api-2.5.0-b42.jar
    - hk2-locator-2.5.0-b42.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -517,7 +517,6 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-media-jaxb-2.26.jar
     - jersey-server-2.26.jar
     - jersey-common-2.26.jar
- * JavaBeans(TM) Activation Framework -- activation-1.1.1.jar
  * JAXB
     - jaxb-api-2.2.6.jar
     - jaxb-api-2.3.1.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -64,6 +64,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Maven module pulsar-client-admin module have been changed to use the dependency com.sun.activation:javax.activation:1.2.0 instead of other activation apis. This is the same activation dependency that is used by the pulsar-client module making them compatible with regards to the java-module-system. The change should also be beneficial when shading jars by avoiding conflicting classes from activation dependencies.