### PR TITLE
Added pulsar-client-api to shaded jar

### DIFF
--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -98,6 +98,7 @@
                 <includes>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
+                  <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>


### PR DESCRIPTION
Motivation

I am attempting to use the pulsar-client and/or pulsar-admin-client from an application that uses Java 11 with the java-module-system enabled. Using maven, the following dependencies were included:

    <dependency>
        <groupId>org.apache.pulsar</groupId>
        <artifactId>pulsar-client-original</artifactId>
        <version>2.3.1</version>
    </dependency>
    <dependency>
        <groupId>org.apache.pulsar</groupId>
        <artifactId>pulsar-client-admin-original</artifactId>
        <version>2.3.1</version>
    </dependency>
I quickly ran into a split-package issue where packages with the same name are declared in more than one different transitive dependency. Problem was the org.apache.pulsar.common.api and org.apache.pulsar.common.schema packages.


Modifications

pulsar-client-all now include the pulsar-client-api within the shaded jar. This avoids a split-package issue and allows the shaded jar to be used as a module within the java-module-system.


Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API: no
The schema: no
The default values of configurations: no
The wire protocol: no
The rest endpoints: no
The admin cli options: no
Anything that affects deployment: don't know
Documentation

Does this pull request introduce a new feature? no