### PR TITLE
[docs] Replace site.current_version with pulsar.version in site2

### DIFF
--- a/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-docker.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-docker.md
@@ -18,7 +18,7 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v $PWD/data:/pulsar/data \
-  apachepulsar/pulsar:{{site.current_version}} \
+  apachepulsar/pulsar:{{pulsar:version}} \
   bin/pulsar standalone
 ```
 
@@ -29,7 +29,7 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v "$PWD/data:/pulsar/data".ToLower() \
-  apachepulsar/pulsar:{{site.current_version}} \
+  apachepulsar/pulsar:{{pulsar:version}} \
   bin/pulsar standalone
 ```
 

--- a/site2/website/versioned_docs/version-2.2.1/getting-started-docker.md
+++ b/site2/website/versioned_docs/version-2.2.1/getting-started-docker.md
@@ -18,7 +18,7 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v $PWD/data:/pulsar/data \
-  apachepulsar/pulsar:{{site.current_version}} \
+  apachepulsar/pulsar:{{pulsar:version}} \
   bin/pulsar standalone
 ```
 
@@ -29,7 +29,7 @@ $ docker run -it \
   -p 6650:6650 \
   -p 8080:8080 \
   -v "$PWD/data:/pulsar/data".ToLower() \
-  apachepulsar/pulsar:{{site.current_version}} \
+  apachepulsar/pulsar:{{pulsar:version}} \
   bin/pulsar standalone
 ```
 


### PR DESCRIPTION
In the page [Pulsar in docker](https://pulsar.apache.org/docs/en/standalone-docker/), the variable ```site.current_version``` is not rendered correctly. I think we need to replace it with ```pulsar:version``` as there is no ```site.current_version``` in ```replace.js``` any more. 