### PR TITLE
[Issue-4266][pulsar-flink] Flink Pulsar Producer should reused across threads

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -96,6 +96,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
         this.producer = getProducerInstance();
+
         this.failureCallback = cause -> {
             LOG.error("Error while sending record to Pulsar: " + cause.getMessage(), cause);
             return null;

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -50,7 +50,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     private static final ProducerPool<byte[]> producerPool = new ProducerPool<>();
 
-    private volatile Producer<byte[]> producer;
+    private transient Producer<byte[]> producer;
 
     private final String producerName;
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -123,10 +123,12 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     private Producer<byte[]> getProducerInstance()
             throws PulsarClientException {
-        synchronized (PulsarOutputFormat.class) {
-            if (producer == null) {
-                producer = Preconditions.checkNotNull(createPulsarProducer(),
-                        "Pulsar producer cannot be null.");
+        if (producer == null) {
+            synchronized (PulsarOutputFormat.class) {
+                if (producer == null) {
+                    producer = Preconditions.checkNotNull(createPulsarProducer(),
+                            "Pulsar producer cannot be null.");
+                }
             }
         }
         return producer;

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -123,9 +123,9 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     private Producer<byte[]> getProducerInstance()
             throws PulsarClientException {
-        if (producer == null) {
+        if(producer == null){
             synchronized (PulsarOutputFormat.class) {
-                if (producer == null) {
+                if(producer == null){
                     producer = Preconditions.checkNotNull(createPulsarProducer(),
                             "Pulsar producer cannot be null.");
                 }

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -95,7 +95,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
 
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
-        createProducerInstance();
+        this.producer = getProducerInstance();
         this.failureCallback = cause -> {
             LOG.error("Error while sending record to Pulsar: " + cause.getMessage(), cause);
             return null;
@@ -120,7 +120,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
         }
     }
 
-    private void createProducerInstance()
+    private Producer<byte[]> getProducerInstance()
             throws PulsarClientException {
         synchronized (PulsarOutputFormat.class) {
             if (producer == null) {
@@ -128,6 +128,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
                         "Pulsar producer cannot be null.");
             }
         }
+        return producer;
     }
 
     private Producer<byte[]> createPulsarProducer()

--- a/pulsar-flink/src/main/java/org/apache/flink/common/ProducerPool.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/common/ProducerPool.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.common;
+
+import org.apache.pulsar.client.api.Producer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is used for share Pulsar Producer across Flink Tasks.
+ * @param <T> type of {@link Producer}
+ */
+public class ProducerPool<T> {
+
+	/**
+	 * producer name to Producer.
+	 */
+	private final Map<String, Producer<T>> producers = new HashMap<>();
+
+	/**
+	 * keep record of reference count of each Producer.
+	 */
+	private final Map<String, Integer> refCntMap = new HashMap<>();
+
+	public synchronized boolean contains(String producerName) {
+		return producers.get(producerName) != null;
+	}
+
+	public synchronized Producer<T> getProducer(String name) {
+		if (!contains(name)) {
+			throw new RuntimeException("Can't find a producer with name: " + name);
+		}
+
+		Integer refCnt = refCntMap.get(name);
+		refCntMap.put(name, refCnt + 1);
+		return producers.get(name);
+	}
+
+	public synchronized void addProducer(String name, Producer<T> producer) {
+		if (contains(name)) {
+			throw new RuntimeException("Producer already exists with name: " + name);
+		}
+
+		refCntMap.put(name, 1);
+		producers.put(name, producer);
+	}
+
+	/**
+	 *
+	 * @param name the name of producer
+	 * @return return true indicates the producer is no longer occupied by other threads
+	 */
+	public synchronized boolean removeProducer(String name) {
+		Integer refCnt = refCntMap.get(name);
+		if (refCnt == null) {
+			return false;
+		}
+
+		if (refCnt == 1) {
+			producers.remove(name);
+			refCntMap.remove(name);
+			return true;
+		} else {
+			refCntMap.put(name, refCnt - 1);
+			return false;
+		}
+	}
+}

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
@@ -84,7 +84,7 @@ public class FlinkPulsarProducer<IN>
 
     private static final ProducerPool<byte[]> producerPool = new ProducerPool<>();
 
-    protected volatile Producer<byte[]> producer;
+    protected transient Producer<byte[]> producer;
 
     private final String producerName;
 
@@ -193,7 +193,7 @@ public class FlinkPulsarProducer<IN>
         }
     }
 
-    private void createProducer() throws Exception {
+    private Producer<byte[]> createProducer() throws Exception {
         synchronized (FlinkPulsarProducer.class) {
             Producer<byte[]> createdProducer;
             if (!producerPool.contains(producerName)) {
@@ -203,7 +203,7 @@ public class FlinkPulsarProducer<IN>
             } else {
                 createdProducer = producerPool.getProducer(producerName);
             }
-            producer = createdProducer;
+            return createdProducer;
         }
     }
 
@@ -215,7 +215,7 @@ public class FlinkPulsarProducer<IN>
      */
     @Override
     public void open(Configuration parameters) throws Exception {
-        createProducer();
+        this.producer = createProducer();
 
         RuntimeContext ctx = getRuntimeContext();
 

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
@@ -201,6 +201,7 @@ public class FlinkPulsarProducer<IN>
                 producer = client.createProducerAsync(producerConf).get();
             }
         }
+        producerRefCnt.incrementAndGet();
     }
 
     /**
@@ -212,7 +213,6 @@ public class FlinkPulsarProducer<IN>
     @Override
     public void open(Configuration parameters) throws Exception {
         createProducer();
-        producerRefCnt.incrementAndGet();
 
         RuntimeContext ctx = getRuntimeContext();
 

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
@@ -82,9 +82,12 @@ public class FlinkPulsarProducer<IN>
 
     // -------------------------------- Runtime fields ------------------------------------------
 
-    private static final ProducerPool<byte[]> producerPool = new ProducerPool<>();
-
+    /**
+     * Pulsar Producer instance.
+     */
     protected transient Producer<byte[]> producer;
+
+    private static final ProducerPool<byte[]> producerPool = new ProducerPool<>();
 
     private final String producerName;
 


### PR DESCRIPTION

Master Issue: #4266

### Motivation

* Reuse Pulsar Producer for Apache Flink Connector.

### Modifications

* Make Producer static

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API:  no
  - The schema:  no
  - The default values of configurations: no
  - The wire protocol:  no
  - The rest endpoints:  no
  - The admin cli options:  no
  - Anything that affects deployment:  no

### Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
