### PR TITLE
With multi-host HTTP client, stop after trying all the addresses

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
@@ -38,6 +38,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
 
     private volatile ServiceURI serviceUri;
     private volatile String serviceUrl;
+    private volatile int currentIndex;
     private volatile List<InetSocketAddress> addressList;
 
     @Override
@@ -50,7 +51,9 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
         if (list.size() == 1) {
             return list.get(0);
         } else {
-            return list.get(randomIndex(list.size()));
+            currentIndex = (currentIndex + 1) % list.size();
+            return list.get(currentIndex);
+
         }
     }
 
@@ -96,6 +99,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
         this.addressList = addresses;
         this.serviceUrl = serviceUrl;
         this.serviceUri = uri;
+        this.currentIndex = randomIndex(addresses.size());
     }
 
     private static int randomIndex(int numAddresses) {


### PR DESCRIPTION
### Motivation

The current multi-host handler for HTTP request in pulsar-client-admin (from #4018) is going into an infinite loop of retries when there is a failure, up to the request timeout (of 5min).

We need to break it immediately after having tried all the addresses.

This is currently making tests to fail all the times on master.