### PR TITLE
Don't create new instances of user classes during validation

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -86,46 +86,34 @@ public class FunctionCommon {
         }
     }
 
-    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig, ClassLoader classLoader) {
-        Object userClass = createInstance(functionConfig.getClassName(), classLoader);
+    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig, ClassLoader classLoader) throws
+            ClassNotFoundException {
         boolean isWindowConfigPresent = functionConfig.getWindowConfig() != null;
-        return getFunctionTypes(userClass, isWindowConfigPresent);
+        Class functionClass = classLoader.loadClass(functionConfig.getClassName());
+        return getFunctionTypes(functionClass, isWindowConfigPresent);
     }
     
-    public static Class<?>[] getFunctionTypes(Object userClass, boolean isWindowConfigPresent) {
-
+    public static Class<?>[] getFunctionTypes(Class userClass, boolean isWindowConfigPresent) {
         Class<?>[] typeArgs;
         // if window function
         if (isWindowConfigPresent) {
-            if (userClass instanceof WindowFunction) {
-                WindowFunction function = (WindowFunction) userClass;
-                if (function == null) {
-                    throw new IllegalArgumentException(
-                            String.format("The WindowFunction class %s could not be instantiated", userClass));
-                }
-                typeArgs = TypeResolver.resolveRawArguments(WindowFunction.class, function.getClass());
+            if (WindowFunction.class.isAssignableFrom(userClass)) {
+                typeArgs = TypeResolver.resolveRawArguments(WindowFunction.class, userClass);
             } else {
-                java.util.function.Function function = (java.util.function.Function) userClass;
-                if (function == null) {
-                    throw new IllegalArgumentException(
-                            String.format("The Java util function class %s could not be instantiated", userClass));
-                }
-                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, function.getClass());
+                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, userClass);
                 if (!typeArgs[0].equals(Collection.class)) {
                     throw new IllegalArgumentException("Window function must take a collection as input");
                 }
-                Type type = TypeResolver.resolveGenericType(java.util.function.Function.class, function.getClass());
+                Type type = TypeResolver.resolveGenericType(java.util.function.Function.class, userClass);
                 Type collectionType = ((ParameterizedType) type).getActualTypeArguments()[0];
                 Type actualInputType = ((ParameterizedType) collectionType).getActualTypeArguments()[0];
                 typeArgs[0] = (Class<?>) actualInputType;
             }
         } else {
-            if (userClass instanceof Function) {
-                Function pulsarFunction = (Function) userClass;
-                typeArgs = TypeResolver.resolveRawArguments(Function.class, pulsarFunction.getClass());
+            if (Function.class.isAssignableFrom(userClass)) {
+                typeArgs = TypeResolver.resolveRawArguments(Function.class, userClass);
             } else {
-                java.util.function.Function function = (java.util.function.Function) userClass;
-                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, function.getClass());
+                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, userClass);
             }
         }
 
@@ -200,30 +188,20 @@ public class FunctionCommon {
     }
 
 
-    public static Class<?> getSourceType(String className, ClassLoader classloader) {
+    public static Class<?> getSourceType(String className, ClassLoader classLoader) throws ClassNotFoundException {
 
-        Object userClass = Reflections.createInstance(className, classloader);
-        Class<?> typeArg;
-        Source source = (Source) userClass;
-        if (source == null) {
-            throw new IllegalArgumentException(String.format("The Pulsar source class %s could not be instantiated",
-                    className));
-        }
-        typeArg = TypeResolver.resolveRawArgument(Source.class, source.getClass());
+        Class userClass = classLoader.loadClass(className);
+
+        Class<?> typeArg = TypeResolver.resolveRawArgument(Source.class, userClass);
 
         return typeArg;
     }
 
-    public static Class<?> getSinkType(String className, ClassLoader classLoader) {
+    public static Class<?> getSinkType(String className, ClassLoader classLoader) throws ClassNotFoundException {
 
-        Object userClass = Reflections.createInstance(className, classLoader);
-        Class<?> typeArg;
-        Sink sink = (Sink) userClass;
-        if (sink == null) {
-            throw new IllegalArgumentException(String.format("The Pulsar sink class %s could not be instantiated",
-                    className));
-        }
-        typeArg = TypeResolver.resolveRawArgument(Sink.class, sink.getClass());
+        Class userClass = classLoader.loadClass(className);
+
+        Class<?> typeArg = TypeResolver.resolveRawArgument(Sink.class, userClass);
 
         return typeArg;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -86,8 +86,7 @@ public class FunctionCommon {
         }
     }
 
-    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig, ClassLoader classLoader) throws
-            ClassNotFoundException {
+    public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig, ClassLoader classLoader) throws ClassNotFoundException {
         boolean isWindowConfigPresent = functionConfig.getWindowConfig() != null;
         Class functionClass = classLoader.loadClass(functionConfig.getClassName());
         return getFunctionTypes(functionClass, isWindowConfigPresent);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -50,7 +50,11 @@ public class FunctionConfigUtils {
         Class<?>[] typeArgs = null;
         if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
             if (classLoader != null) {
-                typeArgs = FunctionCommon.getFunctionTypes(functionConfig, classLoader);
+                try {
+                    typeArgs = FunctionCommon.getFunctionTypes(functionConfig, classLoader);
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException(e);
+                }
             }
         }
 
@@ -360,7 +364,7 @@ public class FunctionConfigUtils {
         }
     }
 
-    private static void doJavaChecks(FunctionConfig functionConfig, ClassLoader clsLoader) {
+    private static void doJavaChecks(FunctionConfig functionConfig, ClassLoader clsLoader) throws ClassNotFoundException {
         Class<?>[] typeArgs = FunctionCommon.getFunctionTypes(functionConfig, clsLoader);
         // inputs use default schema, so there is no check needed there
 
@@ -612,7 +616,11 @@ public class FunctionConfigUtils {
             } else {
                 throw new IllegalArgumentException("Function Package is not provided");
             }
-            doJavaChecks(functionConfig, classLoader);
+            try {
+                doJavaChecks(functionConfig, classLoader);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
             return classLoader;
         } else if (functionConfig.getRuntime() == FunctionConfig.Runtime.GO) {
             doGolangChecks(functionConfig);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -53,7 +53,8 @@ public class FunctionConfigUtils {
                 try {
                     typeArgs = FunctionCommon.getFunctionTypes(functionConfig, classLoader);
                 } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException(e);
+                    throw new IllegalArgumentException(
+                            String.format("Function class %s must be in class path", functionConfig.getClassName()), e);
                 }
             }
         }
@@ -364,8 +365,15 @@ public class FunctionConfigUtils {
         }
     }
 
-    private static void doJavaChecks(FunctionConfig functionConfig, ClassLoader clsLoader) throws ClassNotFoundException {
-        Class<?>[] typeArgs = FunctionCommon.getFunctionTypes(functionConfig, clsLoader);
+    private static void doJavaChecks(FunctionConfig functionConfig, ClassLoader clsLoader) {
+
+        Class<?>[] typeArgs;
+        try {
+            typeArgs = FunctionCommon.getFunctionTypes(functionConfig, clsLoader);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(
+                    String.format("Function class %s must be in class path", functionConfig.getClassName()), e);
+        }
         // inputs use default schema, so there is no check needed there
 
         // Check if the Input serialization/deserialization class exists in jar or already loaded and that it
@@ -616,11 +624,8 @@ public class FunctionConfigUtils {
             } else {
                 throw new IllegalArgumentException("Function Package is not provided");
             }
-            try {
-                doJavaChecks(functionConfig, classLoader);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(e);
-            }
+
+            doJavaChecks(functionConfig, classLoader);
             return classLoader;
         } else if (functionConfig.getRuntime() == FunctionConfig.Runtime.GO) {
             doGolangChecks(functionConfig);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -343,7 +343,11 @@ public class SinkConfigUtils {
                 tmptypeArg = getSinkType(sinkClassName, narClassLoader);
                 tmpclassLoader = narClassLoader;
             } catch (Exception e) {
-                tmptypeArg = getSinkType(sinkClassName, jarClassLoader);
+                try {
+                    tmptypeArg = getSinkType(sinkClassName, jarClassLoader);
+                } catch (ClassNotFoundException e1) {
+                    throw new IllegalArgumentException(e1);
+                }
                 tmpclassLoader = jarClassLoader;
             }
             typeArg = tmptypeArg;
@@ -360,7 +364,11 @@ public class SinkConfigUtils {
             } catch (IOException e1) {
                 throw new IllegalArgumentException("Failed to extract sink class from archive", e1);
             }
-            typeArg = getSinkType(sinkClassName, classLoader);
+            try {
+                typeArg = getSinkType(sinkClassName, classLoader);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
         }
 
         if (sinkConfig.getTopicToSerdeClassName() != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -346,7 +346,8 @@ public class SinkConfigUtils {
                 try {
                     tmptypeArg = getSinkType(sinkClassName, jarClassLoader);
                 } catch (ClassNotFoundException e1) {
-                    throw new IllegalArgumentException(e1);
+                    throw new IllegalArgumentException(
+                            String.format("Sink class %s must be in class path", sinkClassName), e1);
                 }
                 tmpclassLoader = jarClassLoader;
             }
@@ -367,7 +368,8 @@ public class SinkConfigUtils {
             try {
                 typeArg = getSinkType(sinkClassName, classLoader);
             } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalArgumentException(
+                        String.format("Sink class %s must be in class path", sinkClassName), e);
             }
         }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -251,7 +251,8 @@ public class SourceConfigUtils {
                 try {
                     tmptypeArg = getSourceType(sourceClassName, jarClassLoader);
                 } catch (ClassNotFoundException e1) {
-                    throw new IllegalArgumentException(e1);
+                    throw new IllegalArgumentException(
+                            String.format("Source class %s must be in class path", sourceClassName), e1);
                 }
                 tmpclassLoader = jarClassLoader;
             }
@@ -272,7 +273,8 @@ public class SourceConfigUtils {
             try {
                 typeArg = getSourceType(sourceClassName, classLoader);
             } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalArgumentException(
+                        String.format("Source class %s must be in class path", sourceClassName), e);
             }
         }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -248,7 +248,11 @@ public class SourceConfigUtils {
                 tmptypeArg = getSourceType(sourceClassName, narClassLoader);
                 tmpclassLoader = narClassLoader;
             } catch (Exception e) {
-                tmptypeArg = getSourceType(sourceClassName, jarClassLoader);
+                try {
+                    tmptypeArg = getSourceType(sourceClassName, jarClassLoader);
+                } catch (ClassNotFoundException e1) {
+                    throw new IllegalArgumentException(e1);
+                }
                 tmpclassLoader = jarClassLoader;
             }
             typeArg = tmptypeArg;
@@ -265,7 +269,11 @@ public class SourceConfigUtils {
             } catch (IOException e1) {
                 throw new IllegalArgumentException("Failed to extract source class from archive", e1);
             }
-            typeArg = getSourceType(sourceClassName, classLoader);
+            try {
+                typeArg = getSourceType(sourceClassName, classLoader);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
         }
 
         // Only one of serdeClassName or schemaType should be set

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ValidatorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ValidatorUtils.java
@@ -132,75 +132,75 @@ public class ValidatorUtils {
         }
     }
 
-    public static void validateFunctionClassTypes(ClassLoader classLoader, Function.FunctionDetails.Builder functionDetailsBuilder) {
-
-        // validate only if classLoader is provided
-        if (classLoader == null) {
-            return;
-        }
-
-        if (isBlank(functionDetailsBuilder.getClassName())) {
-            throw new IllegalArgumentException("Function class-name can't be empty");
-        }
-
-        // validate function class-type
-        Object functionObject = createInstance(functionDetailsBuilder.getClassName(), classLoader);
-        Class<?>[] typeArgs = FunctionCommon.getFunctionTypes(functionObject, false);
-
-        if (!(functionObject instanceof org.apache.pulsar.functions.api.Function)
-                && !(functionObject instanceof java.util.function.Function)) {
-            throw new RuntimeException("User class must either be Function or java.util.Function");
-        }
-
-        if (functionDetailsBuilder.hasSource() && functionDetailsBuilder.getSource() != null
-                && isNotBlank(functionDetailsBuilder.getSource().getClassName())) {
-            try {
-                String sourceClassName = functionDetailsBuilder.getSource().getClassName();
-                String argClassName = FunctionCommon.getTypeArg(sourceClassName, Source.class, classLoader).getName();
-                functionDetailsBuilder
-                        .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
-
-                // if sink-class not present then set same arg as source
-                if (!functionDetailsBuilder.hasSink() || isBlank(functionDetailsBuilder.getSink().getClassName())) {
-                    functionDetailsBuilder
-                            .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
-                }
-
-            } catch (IllegalArgumentException ie) {
-                throw ie;
-            } catch (Exception e) {
-                log.error("Failed to validate source class", e);
-                throw new IllegalArgumentException("Failed to validate source class-name", e);
-            }
-        } else if (isBlank(functionDetailsBuilder.getSourceBuilder().getTypeClassName())) {
-            // if function-src-class is not present then set function-src type-class according to function class
-            functionDetailsBuilder
-                    .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(typeArgs[0].getName()));
-        }
-
-        if (functionDetailsBuilder.hasSink() && functionDetailsBuilder.getSink() != null
-                && isNotBlank(functionDetailsBuilder.getSink().getClassName())) {
-            try {
-                String sinkClassName = functionDetailsBuilder.getSink().getClassName();
-                String argClassName = FunctionCommon.getTypeArg(sinkClassName, Sink.class, classLoader).getName();
-                functionDetailsBuilder.setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
-
-                // if source-class not present then set same arg as sink
-                if (!functionDetailsBuilder.hasSource() || isBlank(functionDetailsBuilder.getSource().getClassName())) {
-                    functionDetailsBuilder
-                            .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
-                }
-
-            } catch (IllegalArgumentException ie) {
-                throw ie;
-            } catch (Exception e) {
-                log.error("Failed to validate sink class", e);
-                throw new IllegalArgumentException("Failed to validate sink class-name", e);
-            }
-        } else if (isBlank(functionDetailsBuilder.getSinkBuilder().getTypeClassName())) {
-            // if function-sink-class is not present then set function-sink type-class according to function class
-            functionDetailsBuilder
-                    .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(typeArgs[1].getName()));
-        }
-    }
+//    public static void validateFunctionClassTypes(ClassLoader classLoader, Function.FunctionDetails.Builder functionDetailsBuilder) {
+//
+//        // validate only if classLoader is provided
+//        if (classLoader == null) {
+//            return;
+//        }
+//
+//        if (isBlank(functionDetailsBuilder.getClassName())) {
+//            throw new IllegalArgumentException("Function class-name can't be empty");
+//        }
+//
+//        // validate function class-type
+//        Object functionObject = createInstance(functionDetailsBuilder.getClassName(), classLoader);
+//        Class<?>[] typeArgs = FunctionCommon.getFunctionTypes(functionObject, false);
+//
+//        if (!(functionObject instanceof org.apache.pulsar.functions.api.Function)
+//                && !(functionObject instanceof java.util.function.Function)) {
+//            throw new RuntimeException("User class must either be Function or java.util.Function");
+//        }
+//
+//        if (functionDetailsBuilder.hasSource() && functionDetailsBuilder.getSource() != null
+//                && isNotBlank(functionDetailsBuilder.getSource().getClassName())) {
+//            try {
+//                String sourceClassName = functionDetailsBuilder.getSource().getClassName();
+//                String argClassName = FunctionCommon.getTypeArg(sourceClassName, Source.class, classLoader).getName();
+//                functionDetailsBuilder
+//                        .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
+//
+//                // if sink-class not present then set same arg as source
+//                if (!functionDetailsBuilder.hasSink() || isBlank(functionDetailsBuilder.getSink().getClassName())) {
+//                    functionDetailsBuilder
+//                            .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
+//                }
+//
+//            } catch (IllegalArgumentException ie) {
+//                throw ie;
+//            } catch (Exception e) {
+//                log.error("Failed to validate source class", e);
+//                throw new IllegalArgumentException("Failed to validate source class-name", e);
+//            }
+//        } else if (isBlank(functionDetailsBuilder.getSourceBuilder().getTypeClassName())) {
+//            // if function-src-class is not present then set function-src type-class according to function class
+//            functionDetailsBuilder
+//                    .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(typeArgs[0].getName()));
+//        }
+//
+//        if (functionDetailsBuilder.hasSink() && functionDetailsBuilder.getSink() != null
+//                && isNotBlank(functionDetailsBuilder.getSink().getClassName())) {
+//            try {
+//                String sinkClassName = functionDetailsBuilder.getSink().getClassName();
+//                String argClassName = FunctionCommon.getTypeArg(sinkClassName, Sink.class, classLoader).getName();
+//                functionDetailsBuilder.setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
+//
+//                // if source-class not present then set same arg as sink
+//                if (!functionDetailsBuilder.hasSource() || isBlank(functionDetailsBuilder.getSource().getClassName())) {
+//                    functionDetailsBuilder
+//                            .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
+//                }
+//
+//            } catch (IllegalArgumentException ie) {
+//                throw ie;
+//            } catch (Exception e) {
+//                log.error("Failed to validate sink class", e);
+//                throw new IllegalArgumentException("Failed to validate sink class-name", e);
+//            }
+//        } else if (isBlank(functionDetailsBuilder.getSinkBuilder().getTypeClassName())) {
+//            // if function-sink-class is not present then set function-sink type-class according to function class
+//            functionDetailsBuilder
+//                    .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(typeArgs[1].getName()));
+//        }
+//    }
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -58,8 +58,8 @@ public class ConnectorUtils {
 
         try {
             // Try to load source class and check it implements Source interface
-            Object instance = ncl.loadClass(conf.getSourceClass()).newInstance();
-            if (!(instance instanceof Source)) {
+            Class sourceClass = ncl.loadClass(conf.getSourceClass());
+            if (!(Source.class.isAssignableFrom(sourceClass))) {
                 throw new IOException("Class " + conf.getSourceClass() + " does not implement interface "
                         + Source.class.getName());
             }
@@ -86,8 +86,8 @@ public class ConnectorUtils {
 
         try {
             // Try to load source class and check it implements Sink interface
-            Object instance = ncl.loadClass(conf.getSinkClass()).newInstance();
-            if (!(instance instanceof Sink)) {
+            Class sinkClass = ncl.loadClass(conf.getSinkClass());
+            if (!(Sink.class.isAssignableFrom(sinkClass))) {
                 throw new IOException(
                         "Class " + conf.getSinkClass() + " does not implement interface " + Sink.class.getName());
             }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -390,7 +390,7 @@ public class FunctionActioner {
                 File.separatorChar);
     }
 
-    private File getBuiltinArchive(FunctionDetails.Builder functionDetails) throws IOException {
+    private File getBuiltinArchive(FunctionDetails.Builder functionDetails) throws IOException, ClassNotFoundException {
         if (functionDetails.hasSource()) {
             SourceSpec sourceSpec = functionDetails.getSource();
             if (!StringUtils.isEmpty(sourceSpec.getBuiltin())) {
@@ -423,7 +423,7 @@ public class FunctionActioner {
     }
 
     private void fillSourceTypeClass(FunctionDetails.Builder functionDetails, File archive, String className)
-            throws IOException {
+            throws IOException, ClassNotFoundException {
         try (NarClassLoader ncl = NarClassLoader.getFromArchive(archive, Collections.emptySet())) {
             String typeArg = getSourceType(className, ncl).getName();
 
@@ -441,7 +441,7 @@ public class FunctionActioner {
     }
 
     private void fillSinkTypeClass(FunctionDetails.Builder functionDetails, File archive, String className)
-            throws IOException {
+            throws IOException, ClassNotFoundException {
         try (NarClassLoader ncl = NarClassLoader.getFromArchive(archive, Collections.emptySet())) {
             String typeArg = getSinkType(className, ncl).getName();
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -340,7 +340,7 @@ public class FunctionApiV2ResourceTest {
         }
     }
 
-    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class must be in class path")
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Function class UnknownClass must be in class path")
     public void testRegisterFunctionWrongClassName() {
         try {
             testRegisterFunctionMissingArguments(

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -47,9 +47,9 @@ import org.apache.pulsar.functions.utils.ComponentType;
 import org.apache.pulsar.functions.utils.FunctionConfigUtils;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
-import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
+import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.functions.worker.rest.RestException;
 import org.apache.pulsar.functions.worker.rest.api.FunctionsImpl;
@@ -78,9 +78,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.pulsar.functions.utils.ComponentType.FUNCTION;
-import static org.apache.pulsar.functions.utils.ComponentType.SINK;
-import static org.apache.pulsar.functions.utils.ComponentType.SOURCE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -88,7 +85,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.testng.Assert.assertEquals;
@@ -97,7 +93,7 @@ import static org.testng.Assert.assertEquals;
  * Unit test of {@link FunctionApiV2Resource}.
  */
 @PrepareForTest({WorkerUtils.class, InstanceUtils.class})
-@PowerMockIgnore({ "javax.management.*", "javax.ws.*", "org.apache.logging.log4j.*" })
+@PowerMockIgnore({ "javax.management.*", "javax.ws.*", "org.apache.logging.log4j.*", "org.apache.pulsar.functions.api.*" })
 @Slf4j
 public class FunctionApiV3ResourceTest {
 
@@ -337,7 +333,7 @@ public class FunctionApiV3ResourceTest {
         }
     }
 
-    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "User class must be in class path")
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Function class UnknownClass must be in class path")
     public void testRegisterFunctionWrongClassName() {
         try {
             testRegisterFunctionMissingArguments(

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -915,7 +915,7 @@ public class SinkApiV3ResourceTest {
     }
 
     @Test
-    public void testUpdateSinkWithUrl() throws IOException {
+    public void testUpdateSinkWithUrl() throws IOException, ClassNotFoundException {
         Configurator.setRootLevel(Level.DEBUG);
 
         String filePackageUrl = "file://" + JAR_FILE_PATH;

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -226,7 +226,7 @@ public class SinkApiV3ResourceTest {
     }
 
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Sink Name is not provided")
-    public void testRegisterSinkMissingFunctionName() {
+    public void testRegisterSinkMissingSinkName() {
         try {
             testRegisterSinkMissingArguments(
                 tenant,
@@ -258,6 +258,26 @@ public class SinkApiV3ResourceTest {
             parallelism,
                 null
             );
+        } catch (RestException re){
+            assertEquals(re.getResponse().getStatusInfo(), Response.Status.BAD_REQUEST);
+            throw re;
+        }
+    }
+
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Sink class UnknownClass must be in class path")
+    public void testRegisterSinkWrongClassName() {
+            try {
+                testRegisterSinkMissingArguments(
+                        tenant,
+                        namespace,
+                        sink,
+                        mockedInputStream,
+                        mockedFormData,
+                        topicsToSerDeClassName,
+                        "UnknownClass",
+                        parallelism,
+                        null
+                );
         } catch (RestException re){
             assertEquals(re.getResponse().getStatusInfo(), Response.Status.BAD_REQUEST);
             throw re;
@@ -490,7 +510,7 @@ public class SinkApiV3ResourceTest {
 
         RequestResult rr = new RequestResult()
             .setSuccess(true)
-            .setMessage("source registered");
+            .setMessage("sink registered");
         CompletableFuture<RequestResult> requestResult = CompletableFuture.completedFuture(rr);
         when(mockedManager.updateFunction(any(FunctionMetaData.class))).thenReturn(requestResult);
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -929,7 +929,7 @@ public class SourceApiV3ResourceTest {
     }
 
     @Test
-    public void testUpdateSourceWithUrl() throws IOException {
+    public void testUpdateSourceWithUrl() throws IOException, ClassNotFoundException {
         Configurator.setRootLevel(Level.DEBUG);
 
         String filePackageUrl = "file://" + JAR_FILE_PATH;

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -243,6 +243,27 @@ public class SourceApiV3ResourceTest {
         }
     }
 
+    @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Source class UnknownClass must be in class path")
+    public void testRegisterSourceWrongClassName() {
+        try {
+            testRegisterSourceMissingArguments(
+                    tenant,
+                    namespace,
+                    source,
+                    mockedInputStream,
+                    mockedFormData,
+                    outputTopic,
+                    outputSerdeClassName,
+                    "UnknownClass",
+                    parallelism,
+                    null
+            );
+        } catch (RestException re){
+            assertEquals(re.getResponse().getStatusInfo(), Response.Status.BAD_REQUEST);
+            throw re;
+        }
+    }
+
     @Test(expectedExceptions = RestException.class, expectedExceptionsMessageRegExp = "Source Package is not provided")
     public void testRegisterSourceMissingPackage() {
         try {
@@ -444,6 +465,7 @@ public class SourceApiV3ResourceTest {
         }
     }
 
+    @Test
     public void testRegisterSourceSuccess() throws Exception {
         mockStatic(WorkerUtils.class);
         doNothing().when(WorkerUtils.class);
@@ -451,6 +473,8 @@ public class SourceApiV3ResourceTest {
                 anyString(),
                 any(File.class),
                 any(Namespace.class));
+
+        PowerMockito.when(WorkerUtils.class, "dumpToTmpFile", any()).thenCallRealMethod();
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(false);
 


### PR DESCRIPTION
### Motivation

Currently when users submit functions/source/sinks, the function worker does some pretty extensive checks for java functions. This checks involve loading the user submitted JARs.  The problem with this is that user's can put static blocks in their code to execute the code in the environment of the worker/broker which is a security concern.  However, static blocks only execute the first time a method (could be constructor) from a user class is called.  

We can avoid static blocks being executed by simply not creating new instances of the user code.

I think this is a more light handed way to solve this problem compared with:
https://github.com/apache/pulsar/pull/4223
