### PR TITLE
Fixed flaky test testActiveSubscriptionWithCache

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -299,8 +299,6 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertNotNull(curosr);
         // (4.2) Validate: validate cursor name
         assertEquals(subName, curosr.getName());
-        // (4.3) Validate: entryCache should have cached messages
-        assertTrue(entryCache.getSize() != 0);
 
         /************* Validation on empty active-cursor **************/
         // (5) Close consumer: which (1)removes activeConsumer and (2)clears the entry-cache


### PR DESCRIPTION
### Modifications

After the changes in #4066, the cache is evicted based on time as well. This test started to fail periodically because it explicitly checks for the cache to not be empty. Right now this check is not correct anymore, since the cache will be empty after a short amount of time.