### PR TITLE
Fix website build with required Python dependency

### DIFF
--- a/site2/tools/python-doc-gen.sh
+++ b/site2/tools/python-doc-gen.sh
@@ -29,11 +29,12 @@ find $ROOT_DIR -name CMakeFiles | xargs rm -rf
 find $ROOT_DIR -name PulsarApi.pb.h | xargs rm -rf
 find $ROOT_DIR -name PulsarApi.pb.cc | xargs rm -rf
 cd $ROOT_DIR/pulsar-client-cpp
-cmake . 
+cmake .
 make -j8 _pulsar
 pip install enum34
 pip install six
 pip install fastavro
+pip install certifi
 
 DESTINATION=$ROOT_DIR/generated-site/api/python
 rm -fr $DESTINATION/{index.html,functions,pulsar}


### PR DESCRIPTION
### Motivation

Website build is currently failing because one Python dependency is missing when trying to generated the PDoc documentation.