### PR TITLE
Misc fixes for state querying via pulsar admin

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -260,7 +260,7 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
     @GET
     @ApiOperation(
         value = "Fetch the current state associated with a Pulsar Function",
-        response = String.class
+        response = FunctionState.class
     )
     @ApiResponses(value = {
         @ApiResponse(code = 400, message = "Invalid request"),

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -471,8 +471,7 @@ public class FunctionsImpl extends ComponentResource implements Functions {
             if (!response.getStatusInfo().equals(Response.Status.OK)) {
                 throw getApiException(response);
             }
-            String value = response.readEntity(String.class);
-            return new Gson().fromJson(value, new TypeToken<FunctionState>() {}.getType());
+            return response.readEntity(FunctionState.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -815,7 +815,7 @@ public class CmdFunctions extends CmdBase {
                     FunctionState functionState = admin.functions()
                                                        .getFunctionState(tenant, namespace, functionName, key);
                     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                    gson.toJson(functionState);
+                    System.out.println(gson.toJson(functionState));
                 } catch (PulsarAdminException pae) {
                     if (pae.getStatusCode() == 404 && watch) {
                         System.err.println(pae.getMessage());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionState.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionState.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
+@Setter
+@Data
+@EqualsAndHashCode
 @ToString
-@JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+@Builder(toBuilder=true)
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FunctionState {
     private String key;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1478,6 +1478,10 @@ public abstract class ComponentImpl {
             }
         } catch (RestException e) {
             throw e;
+        } catch (org.apache.bookkeeper.clients.exceptions.NamespaceNotFoundException e) {
+            log.error("Error while getFunctionState request @ /{}/{}/{}/{}",
+                    tenant, namespace, functionName, key, e);
+            throw new RestException(Status.NOT_FOUND, e.getMessage());
         } catch (Exception e) {
             log.error("Error while getFunctionState request @ /{}/{}/{}/{}",
                     tenant, namespace, functionName, key, e);


### PR DESCRIPTION
### Motivation

This pr fixes a bunch of errors encountered while querying function state
1. Bubble up BK namespace not found exception as not found
2. Actually print the FunctionState after getting it
3. Fix swagger doc errors for the state api

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
