### PR TITLE
[issue 4274][pulsar-io]Add double quotation marks for metrics with remote_cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -196,7 +196,7 @@ class TopicStats {
             String topic,
             String name, String remoteCluster, double value) {
         stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace);
-        stream.write("\",topic=\"").write(topic).write("remote_cluster=\"").write(remoteCluster).write("\"} ");
+        stream.write("\",topic=\"").write(topic).write("\",remote_cluster=\"").write(remoteCluster).write("\"} ");
         stream.write(value).write(' ').write(System.currentTimeMillis()).write('\n');
     }
 }


### PR DESCRIPTION

Fixes https://github.com/apache/pulsar/issues/4274

Master Issue: https://github.com/apache/pulsar/issues/4274

### Motivation

Add double quotation marks for metrics with remote_cluste.


