### PR TITLE
Feature / interceptor for ack timeout

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
@@ -107,4 +107,15 @@ public interface ConsumerInterceptor<T> extends AutoCloseable {
      * @param messageIds message to ack, null if acknowledge fail.
      */
     void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> messageIds);
+
+    /**
+     *
+     * This method will be called when a redelivery from an acknowledge timeout occurs.
+     *
+     * <p>Any exception thrown by this method will be ignored by the caller.
+     *
+     * @param consumer the consumer which contains the interceptor
+     * @param messageIds message to ack, null if acknowledge fail.
+     */
+    void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> messageIds);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -393,4 +393,10 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             interceptors.onNegativeAcksSend(this, messageIds);
         }
     }
+
+    protected void onAckTimeoutSend(Set<MessageId> messageIds) {
+        if (interceptors != null) {
+            interceptors. onAckTimeoutSend(this, messageIds);
+        }
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -140,6 +140,27 @@ public class ConsumerInterceptors<T> implements Closeable {
         }
     }
 
+    /**
+     * This is called when a redelivery from an acknowledge timeout occurs.
+     * <p>
+     * This method calls {@link ConsumerInterceptor#onAckTimeoutSend(Consumer, Set)
+     * onAckTimeoutSend(Consumer, Set&lt;MessageId&gt;)} method for each interceptor.
+     * <p>
+     * This method does not throw exceptions. Exceptions thrown by any of interceptors in the chain are logged, but not propagated.
+     *
+     * @param consumer the consumer which contains the interceptors.
+     * @param messageIds set of message IDs being redelivery due an acknowledge timeout.
+     */
+    public void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
+            try {
+                interceptors.get(i).onAckTimeoutSend(consumer, messageIds);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onAckTimeoutSend callback", e);
+            }
+        }
+    }
+
     @Override
     public void close() throws IOException {
         for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -123,6 +123,7 @@ public class UnAckedMessageTracker implements Closeable {
                     writeLock.unlock();
                 }
                 if (messageIds.size() > 0) {
+                    consumerBase.onAckTimeoutSend(messageIds);
                     consumerBase.redeliverUnacknowledgedMessages(messageIds);
                 }
                 timeout = client.timer().newTimeout(this, tickDurationInMs, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
*Motivation*

Provide proper interceptor for messages being redelivered due to ack timeout.

*Modifications*

  - Add test case for onAckTimeoutSend interceptor.
  - Add onAckTimeoutSend() method in ConsumerInterceptor interface.
  - Add handler for onAckTimeoutSend() interceptor in ConsumerBase.
  - Add method call to onAckTimeoutSend() in UnAckedMessageTracker.
