### PR TITLE
Add operation to message of BkException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -611,7 +611,8 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     }
 
     public static Exception bkException(String operation, int rc, long ledgerId, long entryId) {
-        String message = org.apache.bookkeeper.client.api.BKException.getMessage(rc) + " -  ledger=" + ledgerId;
+        String message = org.apache.bookkeeper.client.api.BKException.getMessage(rc)
+                + " -  ledger=" + ledgerId + " - operation=" + operation;
 
         if (entryId != -1) {
             message += " - entry=" + entryId;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorageTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.schema;
+
+
+import org.apache.bookkeeper.client.api.BKException;
+import org.testng.annotations.Test;
+
+import static org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.bkException;
+import static org.testng.Assert.assertEquals;
+
+public class BookkeeperSchemaStorageTest {
+
+    @Test
+    public void testBkException() {
+        Exception ex = bkException("test", BKException.Code.ReadException, 1, -1);
+        assertEquals("Error while reading ledger -  ledger=1 - operation=test", ex.getMessage());
+        ex = bkException("test", BKException.Code.ReadException, 1, 0);
+        assertEquals("Error while reading ledger -  ledger=1 - operation=test - entry=0",
+                ex.getMessage());
+        ex = bkException("test", BKException.Code.QuorumException, 1, -1);
+        assertEquals("Invalid quorum size on ensemble size -  ledger=1 - operation=test",
+                ex.getMessage());
+        ex = bkException("test", BKException.Code.QuorumException, 1, 0);
+        assertEquals("Invalid quorum size on ensemble size -  ledger=1 - operation=test - entry=0",
+                ex.getMessage());
+    }
+}


### PR DESCRIPTION
Currently, the operation is expected to be included in BkException's message, however it's been ignored when creating the message. 