### PR TITLE
Print cli args error for standalone

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -53,6 +53,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             }
         } catch (Exception e) {
             jcommander.usage();
+            log.error(e.getMessage());
             return;
         }
 


### PR DESCRIPTION
### Motivation

Standalone starter is not printing the reason why the arguments are not being accepted.