### PR TITLE
Fixed functions default value of processing guarantees

### DIFF
--- a/site2/docs/functions-guarantees.md
+++ b/site2/docs/functions-guarantees.md
@@ -28,7 +28,7 @@ The available options are:
 * `ATLEAST_ONCE`
 * `EFFECTIVELY_ONCE`
 
-> By default, Pulsar Functions provide at-most-once delivery guarantees. So if you create a function without supplying a value for the `--processingGuarantees` flag, then the function will provide at-most-once guarantees.
+> By default, Pulsar Functions provide at-least-once delivery guarantees. So if you create a function without supplying a value for the `--processingGuarantees` flag, then the function will provide at-least-once guarantees.
 
 ## Updating the processing guarantees of a function
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Modifications

In `Function.proto`

```
enum ProcessingGuarantees {
    ATLEAST_ONCE = 0; // [default value]
    ATMOST_ONCE = 1;
    EFFECTIVELY_ONCE = 2;
}
```

We use `at-least-once` as the default value for processing guarantees, but in the official documentation, the default value for processing guarantees is `at-most-once`.


