### PR TITLE
add kerberos into server distribution

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -54,6 +54,12 @@
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-broker-auth-sasl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>


### PR DESCRIPTION
Currently kerberos auth is not placed into server distribution.
It would be good to add kerberos into server distribution, so user could use it in server distribution directly.