### PR TITLE
[pulsar-io-elastic-search] Change default document type

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -61,7 +61,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 )
 public class ElasticSearchSink implements Sink<byte[]> {
 
-    protected static final String DOCUMENT = "doc";
+    protected static final String DOCUMENT = "_doc";
 
     private URL url;
     private RestHighLevelClient client;


### PR DESCRIPTION
### Motivation

When running Elasticsearch sink on ES 7.0.1, message indexation fails with the following error :

```
- Encountered exception in sink write: 
org.elasticsearch.ElasticsearchStatusException: Elasticsearch exception [type=illegal_argument_exception, reason=Rejecting mapping update to [geoloc-pulsar] as the final mapping would have more than 1 type: [_doc, doc]]
```

According to https://www.elastic.co/guide/en/elasticsearch/reference/6.3/removal-of-types.html#_schedule_for_removal_of_mapping_types, the recommended document type to use is `_doc`.

### Modifications

Replace document type `doc` with recommended value `_doc`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no

