### PR TITLE
[schema] AutoConsume should use the schema associated with messages as both writer and reader schema

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.common.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 
@@ -52,4 +55,19 @@ public class SchemaInfo {
      * Additional properties of the schema definition (implementation defined)
      */
     private Map<String, String> properties = Collections.emptyMap();
+
+    public String getSchemaDefinition() {
+        if (null == schema) {
+            return "";
+        }
+
+        switch (type) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF:
+                return new String(schema, UTF_8);
+            default:
+                return Base64.getEncoder().encodeToString(schema);
+        }
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -732,11 +732,14 @@ public class PulsarClientImpl implements PulsarClient {
                 SchemaInfo schemaInfo = schemaInfoProvider.getLatestSchema();
                 if (schemaInfo.getType() != SchemaType.AVRO){
                     throw new RuntimeException("Currently schema detection only works for topics with avro schemas");
-
                 }
-                GenericSchema genericSchema = GenericSchemaImpl.of(schemaInfoProvider.getLatestSchema());
+
+                // when using `AutoConsumeSchema`, we use the schema associated with the messages as schema reader
+                // to decode the messages.
+                GenericSchema genericSchema = GenericSchemaImpl.of(
+                    schemaInfoProvider.getLatestSchema(), false /*useProvidedSchemaAsReaderSchema*/);
                 log.info("Auto detected schema for topic {} : {}",
-                        topicName, new String(schemaInfo.getSchema(), UTF_8));
+                        topicName, schemaInfo.getSchemaDefinition());
                 ((AutoConsumeSchema) schema).setSchema(genericSchema);
             }
             schema.setSchemaInfoProvider(schemaInfoProvider);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -730,7 +730,7 @@ public class PulsarClientImpl implements PulsarClient {
 
             if (schema instanceof AutoConsumeSchema) {
                 SchemaInfo schemaInfo = schemaInfoProvider.getLatestSchema();
-                if (schemaInfo.getType() != SchemaType.AVRO){
+                if (schemaInfo.getType() != SchemaType.AVRO && schemaInfo.getType() != SchemaType.JSON){
                     throw new RuntimeException("Currently schema detection only works for topics with avro schemas");
                 }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -102,11 +102,16 @@ public class AvroSchema<T> extends StructSchema<T> {
     protected SchemaReader<T> loadReader(byte[] schemaVersion) {
         SchemaInfo schemaInfo = schemaInfoProvider.getSchemaByVersion(schemaVersion);
         if (schemaInfo != null) {
-            return new AvroReader<>(parseAvroSchema(new String(schemaInfo.getSchema())), schema);
+            log.info("Load schema reader for version({}), schema is : {}",
+                SchemaUtils.getStringSchemaVersion(schemaVersion),
+                schemaInfo.getSchemaDefinition());
+            return new AvroReader<>(parseAvroSchema(schemaInfo.getSchemaDefinition()), schema);
         } else {
+            log.warn("No schema found for version({}), use latest schema : {}",
+                SchemaUtils.getStringSchemaVersion(schemaVersion),
+                this.schemaInfo.getSchemaDefinition());
             return reader;
         }
     }
-
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.apache.pulsar.client.api.schema.SchemaWriter;
 import org.apache.pulsar.client.impl.schema.reader.JsonReader;
 import org.apache.pulsar.client.impl.schema.writer.JsonWriter;
 import org.apache.pulsar.common.schema.SchemaInfo;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
@@ -27,7 +27,6 @@ import lombok.Getter;
 import org.apache.avro.protobuf.ProtobufData;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.apache.pulsar.client.api.schema.SchemaWriter;
 import org.apache.pulsar.client.impl.schema.reader.ProtobufReader;
 import org.apache.pulsar.client.impl.schema.writer.ProtobufWriter;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -96,7 +95,8 @@ public class ProtobufSchema<T extends com.google.protobuf.GeneratedMessageV3> ex
 
     @Override
     protected SchemaReader<T> loadReader(byte[] schemaVersion) {
-        throw new RuntimeException("ProtobufSchema don't support schema versioning");    }
+        throw new RuntimeException("ProtobufSchema don't support schema versioning");
+    }
 
     public static <T extends com.google.protobuf.GeneratedMessageV3> ProtobufSchema<T> of(Class<T> pojo) {
         return of(pojo, new HashMap<>());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -154,7 +154,11 @@ public final class SchemaUtils {
     public static String getStringSchemaVersion(byte[] schemaVersionBytes) {
         if (null == schemaVersionBytes) {
             return "NULL";
-        } else if (schemaVersionBytes.length == Long.BYTES) {
+        } else if (
+            // the length of schema version is 8 bytes post 2.4.0
+            schemaVersionBytes.length == Long.BYTES
+            // the length of schema version is 64 bytes before 2.4.0
+            || schemaVersionBytes.length == Long.SIZE) {
             ByteBuffer bb = ByteBuffer.wrap(schemaVersionBytes);
             return String.valueOf(bb.getLong());
         } else if (schemaVersionBytes.length == 0) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -22,15 +22,17 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.common.schema.SchemaVersion;
 
 /**
  * Utils for schemas.
  */
-final class SchemaUtils {
+public final class SchemaUtils {
 
     private SchemaUtils() {}
 
@@ -147,6 +149,20 @@ final class SchemaUtils {
         } else {
             return null;
         }
+    }
+
+    public static String getStringSchemaVersion(byte[] schemaVersionBytes) {
+        if (null == schemaVersionBytes) {
+            return "NULL";
+        } else if (schemaVersionBytes.length == Long.BYTES) {
+            ByteBuffer bb = ByteBuffer.wrap(schemaVersionBytes);
+            return String.valueOf(bb.getLong());
+        } else if (schemaVersionBytes.length == 0) {
+            return "EMPTY";
+        } else {
+            return Base64.getEncoder().encodeToString(schemaVersionBytes);
+        }
+
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StructSchema.java
@@ -131,6 +131,12 @@ public abstract class StructSchema<T> implements Schema<T> {
         this.schemaInfoProvider = schemaInfoProvider;
     }
 
+    /**
+     * Load the schema reader for reading messages encoded by the given schema version.
+     *
+     * @param schemaVersion the provided schema version
+     * @return the schema reader for decoding messages encoded by the provided schema version.
+     */
     protected abstract SchemaReader<T> loadReader(byte[] schemaVersion);
 
     protected void setWriter(SchemaWriter<T> writer) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
@@ -18,18 +18,27 @@
  */
 package org.apache.pulsar.client.impl.schema.generic;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 import org.apache.pulsar.client.api.schema.SchemaReader;
+import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.common.schema.SchemaInfo;
 
 /**
  * A generic avro schema.
  */
+@Slf4j
 public class GenericAvroSchema extends GenericSchemaImpl {
 
     public GenericAvroSchema(SchemaInfo schemaInfo) {
-        super(schemaInfo);
+        this(schemaInfo, true);
+    }
+
+    GenericAvroSchema(SchemaInfo schemaInfo,
+                      boolean useProvidedSchemaAsReaderSchema) {
+        super(schemaInfo, useProvidedSchemaAsReaderSchema);
         setReader(new GenericAvroReader(schema));
         setWriter(new GenericAvroWriter(schema));
     }
@@ -48,11 +57,19 @@ public class GenericAvroSchema extends GenericSchemaImpl {
     protected SchemaReader<GenericRecord> loadReader(byte[] schemaVersion) {
          SchemaInfo schemaInfo = schemaInfoProvider.getSchemaByVersion(schemaVersion);
          if (schemaInfo != null) {
+             log.info("Load schema reader for version({}), schema is : {}",
+                 SchemaUtils.getStringSchemaVersion(schemaVersion),
+                 schemaInfo.getSchemaDefinition());
+             Schema writerSchema = parseAvroSchema(schemaInfo.getSchemaDefinition());
+             Schema readerSchema = useProvidedSchemaAsReaderSchema ? schema : writerSchema;
              return new GenericAvroReader(
-                     parseAvroSchema(new String(schemaInfo.getSchema())),
-                     schema,
+                     writerSchema,
+                     readerSchema,
                      schemaVersion);
          } else {
+             log.warn("No schema found for version({}), use latest schema : {}",
+                 SchemaUtils.getStringSchemaVersion(schemaVersion),
+                 this.schemaInfo.getSchemaDefinition());
              return reader;
          }
     }


### PR DESCRIPTION

*Motivation*

AutoConsume should use the schema associated with the messages for decoding the schemas.

*Modifications*

- provide a flag enable or disable using the provided schema as the reader schema
- for AUTO_CONSUME schema, disable usnig the provided schema as the reader schema. so it can use the right
  schema version for decoding messages into right generic records
- provide a few util methods for displaying schema data

