### PR TITLE
Moved entries filtering from consumer to dispatcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.service;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.concurrent.FastThreadLocal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.Commands;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+
+public abstract class AbstractBaseDispatcher {
+
+    protected final Subscription subscription;
+
+    protected AbstractBaseDispatcher(Subscription subscription) {
+        this.subscription = subscription;
+    }
+
+    /**
+     * Filter messages that are being sent to a consumers.
+     * <p>
+     * Messages can be filtered out for multiple reasons:
+     * <ul>
+     * <li>Checksum or metadata corrupted
+     * <li>Message is an internal marker
+     * <li>Message is not meant to be delivered immediately
+     * </ul>
+     *
+     * @param entries
+     *            a list of entries as read from storage
+     *
+     * @param batchSizes
+     *            an array where the batch size for each entry (the number of messages within an entry) is stored. This
+     *            array needs to be of at least the same size as the entries list
+     *
+     * @param sendMessageInfo
+     *            an object where the total size in messages and bytes will be returned back to the caller
+     * @param subscription
+     *            the subscription object
+     */
+    public void filterEntriesForConsumer(List<Entry> entries, int[] batchSizes, SendMessageInfo sendMessageInfo) {
+        checkArgument(batchSizes.length >= entries.size());
+        int totalMessages = 0;
+        long totalBytes = 0;
+
+        for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {
+            Entry entry = entries.get(i);
+            ByteBuf metadataAndPayload = entry.getDataBuffer();
+            PositionImpl pos = (PositionImpl) entry.getPosition();
+
+            MessageMetadata msgMetadata = Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1);
+
+            try {
+                if (msgMetadata == null) {
+                    // Message metadata was corrupted
+                    entries.set(i, null);
+                    entry.release();
+                    subscription.acknowledgeMessage(Collections.singletonList(pos), AckType.Individual,
+                            Collections.emptyMap());
+                    continue;
+                }
+
+                int batchSize = msgMetadata.getNumMessagesInBatch();
+                totalMessages += batchSize;
+                totalBytes += metadataAndPayload.readableBytes();
+                batchSizes[i] = batchSize;
+            } finally {
+                msgMetadata.recycle();
+            }
+        }
+
+        sendMessageInfo.setTotalMessages(totalMessages);
+        sendMessageInfo.setTotalBytes(totalBytes);
+    }
+
+    private static final FastThreadLocal<int[]> threadLocalBatchSizes = new FastThreadLocal<int[]>() {
+        protected int[] initialValue() throws Exception {
+            return new int[100];
+        };
+    };
+
+    protected int[] getThreadLocalBatchSizes(int entries) {
+        int[] a = threadLocalBatchSizes.get();
+        if (a.length < entries) {
+            a = new int[entries];
+            threadLocalBatchSizes.set(a);
+        }
+
+        return a;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -19,10 +19,7 @@
 
 package org.apache.pulsar.broker.service;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import io.netty.buffer.ByteBuf;
-import io.netty.util.concurrent.FastThreadLocal;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,8 +60,7 @@ public abstract class AbstractBaseDispatcher {
      * @param subscription
      *            the subscription object
      */
-    public void filterEntriesForConsumer(List<Entry> entries, int[] batchSizes, SendMessageInfo sendMessageInfo) {
-        checkArgument(batchSizes.length >= entries.size());
+    public void filterEntriesForConsumer(List<Entry> entries, EntryBatchSizes batchSizes, SendMessageInfo sendMessageInfo) {
         int totalMessages = 0;
         long totalBytes = 0;
 
@@ -88,7 +84,7 @@ public abstract class AbstractBaseDispatcher {
                 int batchSize = msgMetadata.getNumMessagesInBatch();
                 totalMessages += batchSize;
                 totalBytes += metadataAndPayload.readableBytes();
-                batchSizes[i] = batchSize;
+                batchSizes.setBatchSize(i, batchSize);
             } finally {
                 msgMetadata.recycle();
             }
@@ -96,21 +92,5 @@ public abstract class AbstractBaseDispatcher {
 
         sendMessageInfo.setTotalMessages(totalMessages);
         sendMessageInfo.setTotalBytes(totalBytes);
-    }
-
-    private static final FastThreadLocal<int[]> threadLocalBatchSizes = new FastThreadLocal<int[]>() {
-        protected int[] initialValue() throws Exception {
-            return new int[100];
-        };
-    };
-
-    protected int[] getThreadLocalBatchSizes(int entries) {
-        int[] a = threadLocalBatchSizes.get();
-        if (a.length < entries) {
-            a = new int[entries];
-            threadLocalBatchSizes.set(a);
-        }
-
-        return a;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -28,7 +28,7 @@ import com.carrotsearch.hppc.ObjectSet;
 
 /**
  */
-public abstract class AbstractDispatcherMultipleConsumers {
+public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDispatcher {
 
     protected final CopyOnWriteArrayList<Consumer> consumerList = new CopyOnWriteArrayList<>();
     protected final ObjectSet<Consumer> consumerSet = new ObjectHashSet<>();
@@ -39,6 +39,11 @@ public abstract class AbstractDispatcherMultipleConsumers {
     protected static final AtomicIntegerFieldUpdater<AbstractDispatcherMultipleConsumers> IS_CLOSED_UPDATER = AtomicIntegerFieldUpdater
             .newUpdater(AbstractDispatcherMultipleConsumers.class, "isClosed");
     private volatile int isClosed = FALSE;
+
+    protected AbstractDispatcherMultipleConsumers(Subscription subscription) {
+        super(subscription);
+    }
+
     public boolean isConsumerConnected() {
         return !consumerList.isEmpty();
     }
@@ -127,7 +132,7 @@ public abstract class AbstractDispatcherMultipleConsumers {
 
     /**
      * Finds index of first available consumer which has higher priority then given targetPriority
-     * 
+     *
      * @param targetPriority
      * @return -1 if couldn't find any available consumer
      */
@@ -187,7 +192,7 @@ public abstract class AbstractDispatcherMultipleConsumers {
 
     /**
      * Finds index of first consumer in list which has same priority as given targetPriority
-     * 
+     *
      * @param targetPriority
      * @return
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -33,7 +33,7 @@ import org.apache.pulsar.utils.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractDispatcherSingleActiveConsumer {
+public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBaseDispatcher {
 
     protected final String topicName;
     protected static final AtomicReferenceFieldUpdater<AbstractDispatcherSingleActiveConsumer, Consumer> ACTIVE_CONSUMER_UPDATER =
@@ -53,7 +53,8 @@ public abstract class AbstractDispatcherSingleActiveConsumer {
     private volatile int isClosed = FALSE;
 
     public AbstractDispatcherSingleActiveConsumer(SubType subscriptionType, int partitionIndex,
-            String topicName) {
+            String topicName, Subscription subscription) {
+        super(subscription);
         this.topicName = topicName;
         this.consumers = new CopyOnWriteArrayList<>();
         this.partitionIndex = partitionIndex;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -185,7 +185,7 @@ public class Consumer {
         final ChannelHandlerContext ctx = cnx.ctx();
         final ChannelPromise writePromise = ctx.newPromise();
 
-        if (entries.isEmpty()) {
+        if (entries.isEmpty() || sendMessageInfo.getTotalMessages() == 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}-{}] List of messages is empty, triggering write future immediately for consumerId {}",
                         topicName, subscription, consumerId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -182,7 +182,7 @@ public class Consumer {
      * @return a SendMessageInfo object that contains the detail of what was sent to consumer
      */
     public ChannelPromise sendMessages(final List<Entry> entries, EntryBatchSizes batchSizes, int totalMessages,
-            long totalBytes) {
+            long totalBytes, RedeliveryTracker redeliveryTracker) {
         final ChannelHandlerContext ctx = cnx.ctx();
         final ChannelPromise writePromise = ctx.newPromise();
 
@@ -244,7 +244,7 @@ public class Consumer {
                             consumerId, entry.getLedgerId(), entry.getEntryId());
                 }
 
-                int redeliveryCount = subscription.getDispatcher().getRedeliveryTracker()
+                int redeliveryCount = redeliveryTracker
                         .getRedeliveryCount(PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId()));
                 ctx.write(Commands.newMessage(consumerId, messageId, redeliveryCount, metadataAndPayload), ctx.voidPromise());
                 messageId.recycle();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -181,23 +181,25 @@ public class Consumer {
      *
      * @return a SendMessageInfo object that contains the detail of what was sent to consumer
      */
-    public ChannelPromise sendMessages(final List<Entry> entries, int[] batchSizes, SendMessageInfo sendMessageInfo) {
+    public ChannelPromise sendMessages(final List<Entry> entries, EntryBatchSizes batchSizes, int totalMessages,
+            long totalBytes) {
         final ChannelHandlerContext ctx = cnx.ctx();
         final ChannelPromise writePromise = ctx.newPromise();
 
-        if (entries.isEmpty() || sendMessageInfo.getTotalMessages() == 0) {
+        if (entries.isEmpty() || totalMessages == 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}-{}] List of messages is empty, triggering write future immediately for consumerId {}",
                         topicName, subscription, consumerId);
             }
             writePromise.setSuccess();
+            batchSizes.recyle();
             return writePromise;
         }
 
         // reduce permit and increment unackedMsg count with total number of messages in batch-msgs
-        MESSAGE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());
-        incrementUnackedMessages(sendMessageInfo.getTotalMessages());
-        msgOut.recordMultipleEvents(sendMessageInfo.getTotalMessages(), sendMessageInfo.getTotalBytes());
+        MESSAGE_PERMITS_UPDATER.addAndGet(this, -totalMessages);
+        incrementUnackedMessages(totalMessages);
+        msgOut.recordMultipleEvents(totalMessages, totalBytes);
 
         ctx.channel().eventLoop().execute(() -> {
             for (int i = 0; i < entries.size(); i++) {
@@ -207,10 +209,10 @@ public class Consumer {
                     continue;
                 }
 
-                int batchSize = batchSizes[i];
+                int batchSize = batchSizes.getBatchSize(i);
 
                 if (pendingAcks != null) {
-                    pendingAcks.put(entry.getLedgerId(), entry.getEntryId(), batchSizes[i], 0);
+                    pendingAcks.put(entry.getLedgerId(), entry.getEntryId(), batchSize, 0);
                 }
 
                 if (batchSize > 1 && !cnx.isBatchMessageCompatibleVersion()) {
@@ -252,6 +254,7 @@ public class Consumer {
 
             // Use an empty write here so that we can just tie the flush with the write promise for last entry
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER, writePromise);
+            batchSizes.recyle();
         });
 
         return writePromise;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -24,14 +24,13 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,18 +38,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Collectors;
 
-import lombok.Data;
-
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.Rate;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
-import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.common.api.Commands;
-import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
@@ -107,10 +102,6 @@ public class Consumer {
     private volatile boolean blockedConsumerOnUnackedMsgs = false;
 
     private final Map<String, String> metadata;
-
-    public interface SendListener {
-        void sendComplete(ChannelFuture future, SendMessageInfo sendMessageInfo);
-    }
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
@@ -190,25 +181,9 @@ public class Consumer {
      *
      * @return a SendMessageInfo object that contains the detail of what was sent to consumer
      */
-    public SendMessageInfo sendMessages(final List<Entry> entries) {
-        // Empty listener
-        return sendMessages(entries, null);
-    }
-
-    /**
-     * Dispatch a list of entries to the consumer. <br/>
-     * <b>It is also responsible to release entries data and recycle entries object.</b>
-     *
-     * @return a SendMessageInfo object that contains the detail of what was sent to consumer
-     */
-    public SendMessageInfo sendMessages(final List<Entry> entries, SendListener listener) {
+    public ChannelPromise sendMessages(final List<Entry> entries, int[] batchSizes, SendMessageInfo sendMessageInfo) {
         final ChannelHandlerContext ctx = cnx.ctx();
-        final SendMessageInfo sentMessages = new SendMessageInfo();
-        final ChannelPromise writePromise = listener != null ? ctx.newPromise() : ctx.voidPromise();
-
-        if (listener != null) {
-            writePromise.addListener(future -> listener.sendComplete(writePromise, sentMessages));
-        }
+        final ChannelPromise writePromise = ctx.newPromise();
 
         if (entries.isEmpty()) {
             if (log.isDebugEnabled()) {
@@ -216,29 +191,22 @@ public class Consumer {
                         topicName, subscription, consumerId);
             }
             writePromise.setSuccess();
-            sentMessages.totalSentMessages = 0;
-            sentMessages.totalSentMessageBytes = 0;
-            return sentMessages;
+            return writePromise;
         }
 
-        try {
-            updatePermitsAndPendingAcks(entries, sentMessages);
-        } catch (PulsarServerException pe) {
-            log.warn("[{}] [{}] consumer doesn't support batch-message {}", subscription, consumerId,
-                    cnx.getRemoteEndpointProtocolVersion());
-
-            subscription.markTopicWithBatchMessagePublished();
-            sentMessages.totalSentMessages = 0;
-            sentMessages.totalSentMessageBytes = 0;
-            // disconnect consumer: it will update dispatcher's availablePermits and resend pendingAck-messages of this
-            // consumer to other consumer
-            disconnect();
-            return sentMessages;
-        }
+        // reduce permit and increment unackedMsg count with total number of messages in batch-msgs
+        MESSAGE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());
+        incrementUnackedMessages(sendMessageInfo.getTotalMessages());
+        msgOut.recordMultipleEvents(sendMessageInfo.getTotalMessages(), sendMessageInfo.getTotalBytes());
 
         ctx.channel().eventLoop().execute(() -> {
             for (int i = 0; i < entries.size(); i++) {
                 Entry entry = entries.get(i);
+                if (entry == null) {
+                    // Entry was filtered out
+                    continue;
+                }
+
                 PositionImpl pos = (PositionImpl) entry.getPosition();
                 MessageIdData.Builder messageIdBuilder = MessageIdData.newBuilder();
                 MessageIdData messageId = messageIdBuilder
@@ -260,92 +228,25 @@ public class Consumer {
                             consumerId, pos.getLedgerId(), pos.getEntryId());
                 }
 
-                // We only want to pass the "real" promise on the last entry written
-                ChannelPromise promise = ctx.voidPromise();
-                if (i == (entries.size() - 1)) {
-                    promise = writePromise;
-                }
-                int redeliveryCount = subscription.getDispatcher().getRedeliveryTracker().getRedeliveryCount(PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId()));
-                ctx.write(Commands.newMessage(consumerId, messageId, redeliveryCount, metadataAndPayload), promise);
+                int redeliveryCount = subscription.getDispatcher().getRedeliveryTracker()
+                        .getRedeliveryCount(PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId()));
+                ctx.write(Commands.newMessage(consumerId, messageId, redeliveryCount, metadataAndPayload), ctx.voidPromise());
                 messageId.recycle();
                 messageIdBuilder.recycle();
                 entry.release();
             }
 
-            ctx.flush();
+            // Use an empty write here so that we can just tie the flush with the write promise for last entry
+            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER, writePromise);
         });
 
-        return sentMessages;
+        return writePromise;
     }
 
     private void incrementUnackedMessages(int ackedMessages) {
         if (shouldBlockConsumerOnUnackMsgs() && addAndGetUnAckedMsgs(this, ackedMessages) >= maxUnackedMessages) {
             blockedConsumerOnUnackedMsgs = true;
         }
-    }
-
-    public static int getBatchSizeforEntry(ByteBuf metadataAndPayload, Subscription subscription, long consumerId) {
-        try {
-            // save the reader index and restore after parsing
-            metadataAndPayload.markReaderIndex();
-            PulsarApi.MessageMetadata metadata = Commands.parseMessageMetadata(metadataAndPayload);
-            metadataAndPayload.resetReaderIndex();
-            int batchSize = metadata.getNumMessagesInBatch();
-            metadata.recycle();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] num messages in batch are {} ", subscription, consumerId, batchSize);
-            }
-            return batchSize;
-        } catch (Throwable t) {
-            log.error("[{}] [{}] Failed to parse message metadata", subscription, consumerId, t);
-        }
-        return -1;
-    }
-
-    void updatePermitsAndPendingAcks(final List<Entry> entries, SendMessageInfo sentMessages) throws PulsarServerException {
-        int permitsToReduce = 0;
-        Iterator<Entry> iter = entries.iterator();
-        boolean unsupportedVersion = false;
-        long totalReadableBytes = 0;
-        boolean clientSupportBatchMessages = cnx.isBatchMessageCompatibleVersion();
-        while (iter.hasNext()) {
-            Entry entry = iter.next();
-            ByteBuf metadataAndPayload = entry.getDataBuffer();
-            int batchSize = getBatchSizeforEntry(metadataAndPayload, subscription, consumerId);
-            if (batchSize == -1) {
-                // this would suggest that the message might have been corrupted
-                iter.remove();
-                PositionImpl pos = (PositionImpl) entry.getPosition();
-                entry.release();
-                subscription.acknowledgeMessage(Collections.singletonList(pos), AckType.Individual, Collections.emptyMap());
-                continue;
-            }
-            if (pendingAcks != null) {
-                pendingAcks.put(entry.getLedgerId(), entry.getEntryId(), batchSize, 0);
-            }
-            // check if consumer supports batch message
-            if (batchSize > 1 && !clientSupportBatchMessages) {
-                unsupportedVersion = true;
-            }
-            totalReadableBytes += metadataAndPayload.readableBytes();
-            permitsToReduce += batchSize;
-        }
-        // reduce permit and increment unackedMsg count with total number of messages in batch-msgs
-        int permits = MESSAGE_PERMITS_UPDATER.addAndGet(this, -permitsToReduce);
-        incrementUnackedMessages(permitsToReduce);
-        if (unsupportedVersion) {
-            throw new PulsarServerException("Consumer does not support batch-message");
-        }
-        if (permits < 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] [{}] message permits dropped below 0 - {}", topicName, subscription, consumerId,
-                        permits);
-            }
-        }
-
-        msgOut.recordMultipleEvents(permitsToReduce, totalReadableBytes);
-        sentMessages.totalSentMessages = permitsToReduce;
-        sentMessages.totalSentMessageBytes = totalReadableBytes;
     }
 
     public boolean isWritable() {
@@ -678,27 +579,6 @@ public class Consumer {
     private void clearUnAckedMsgs(Consumer consumer) {
         int unaAckedMsgs = UNACKED_MESSAGES_UPDATER.getAndSet(this, 0);
         subscription.addUnAckedMessages(-unaAckedMsgs);
-    }
-
-    public static final class SendMessageInfo {
-        private int totalSentMessages;
-        private long totalSentMessageBytes;
-
-        public int getTotalSentMessages() {
-            return totalSentMessages;
-        }
-
-        public void setTotalSentMessages(int totalSentMessages) {
-            this.totalSentMessages = totalSentMessages;
-        }
-
-        public long getTotalSentMessageBytes() {
-            return totalSentMessageBytes;
-        }
-
-        public void setTotalSentMessageBytes(long totalSentMessageBytes) {
-            this.totalSentMessageBytes = totalSentMessageBytes;
-        }
     }
 
     private static final Logger log = LoggerFactory.getLogger(Consumer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchSizes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchSizes.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.util.Recycler;
+
+public class EntryBatchSizes {
+    private int[] sizes = new int[100];
+
+    public int getBatchSize(int entryIdx) {
+        return sizes[entryIdx];
+    }
+
+    public int setBatchSize(int entryIdx, int batchSize) {
+        return sizes[entryIdx] = batchSize;
+    }
+
+    public void recyle() {
+        handle.recycle(this);
+    }
+
+    public static EntryBatchSizes get(int entriesListSize) {
+        EntryBatchSizes ebs = RECYCLER.get();
+
+        if (ebs.sizes.length < entriesListSize) {
+            ebs.sizes = new int[entriesListSize];
+        }
+        return ebs;
+    }
+
+    private EntryBatchSizes(Recycler.Handle<EntryBatchSizes> handle) {
+        this.handle = handle;
+    }
+
+    private final Recycler.Handle<EntryBatchSizes> handle;
+    private static final Recycler<EntryBatchSizes> RECYCLER = new Recycler<EntryBatchSizes>() {
+        @Override
+        protected EntryBatchSizes newObject(Handle<EntryBatchSizes> handle) {
+            return new EntryBatchSizes(handle);
+        }
+    };
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SendMessageInfo.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SendMessageInfo.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.util.concurrent.FastThreadLocal;
+
+import lombok.Data;
+
+@Data
+public class SendMessageInfo {
+    private int totalMessages;
+    private long totalBytes;
+
+    private SendMessageInfo() {
+        // Private constructor so that all usages are through the thread-local instance
+    }
+
+    public static SendMessageInfo getThreadLocal() {
+        SendMessageInfo smi = THREAD_LOCAL.get();
+        smi.totalMessages = 0;
+        smi.totalBytes = 0;
+        return smi;
+    }
+
+    private static final FastThreadLocal<SendMessageInfo> THREAD_LOCAL = new FastThreadLocal<SendMessageInfo>() {
+        protected SendMessageInfo initialValue() throws Exception {
+            return new SendMessageInfo();
+        };
+    };
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.service.nonpersistent;
 
-import static org.apache.pulsar.broker.service.Consumer.getBatchSizeforEntry;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -33,7 +31,9 @@ import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyExcep
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
+import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.utils.CopyOnWriteArrayList;
 import org.slf4j.Logger;
@@ -59,6 +59,7 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     private final RedeliveryTracker redeliveryTracker;
 
     public NonPersistentDispatcherMultipleConsumers(NonPersistentTopic topic, Subscription subscription) {
+        super(subscription);
         this.topic = topic;
         this.subscription = subscription;
         this.name = topic.getName() + " / " + subscription.getName();
@@ -191,10 +192,15 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     public void sendMessages(List<Entry> entries) {
         Consumer consumer = TOTAL_AVAILABLE_PERMITS_UPDATER.get(this) > 0 ? getNextConsumer() : null;
         if (consumer != null) {
-            TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -consumer.sendMessages(entries).getTotalSentMessages());
+            SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+            int[] batchSizes = getThreadLocalBatchSizes(entries.size());
+            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
+            consumer.sendMessages(entries, batchSizes, sendMessageInfo);
+
+            TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());
         } else {
             entries.forEach(entry -> {
-                int totalMsgs = getBatchSizeforEntry(entry.getDataBuffer(), subscription, -1);
+                int totalMsgs = Commands.getNumberOfMessagesInBatch(entry.getDataBuffer(), subscription.toString(), -1);
                 if (totalMsgs > 0) {
                     msgDrop.recordEvent(totalMsgs);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.broker.service.AbstractDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
 import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.SendMessageInfo;
@@ -193,9 +194,10 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
         Consumer consumer = TOTAL_AVAILABLE_PERMITS_UPDATER.get(this) > 0 ? getNextConsumer() : null;
         if (consumer != null) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
-            int[] batchSizes = getThreadLocalBatchSizes(entries.size());
+            EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
-            consumer.sendMessages(entries, batchSizes, sendMessageInfo);
+            consumer.sendMessages(entries, batchSizes, sendMessageInfo.getTotalMessages(),
+                    sendMessageInfo.getTotalBytes());
 
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -197,7 +197,7 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
             consumer.sendMessages(entries, batchSizes, sendMessageInfo.getTotalMessages(),
-                    sendMessageInfo.getTotalBytes());
+                    sendMessageInfo.getTotalBytes(), getRedeliveryTracker());
 
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
-import static org.apache.pulsar.broker.service.Consumer.getBatchSizeforEntry;
 
 import java.util.List;
 
@@ -31,7 +30,9 @@ import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
+import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -43,10 +44,10 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     private final Subscription subscription;
     private final ServiceConfiguration serviceConfig;
     private final RedeliveryTracker redeliveryTracker;
-    
+
     public NonPersistentDispatcherSingleActiveConsumer(SubType subscriptionType, int partitionIndex,
             NonPersistentTopic topic, Subscription subscription) {
-        super(subscriptionType, partitionIndex, topic.getName());
+        super(subscriptionType, partitionIndex, topic.getName(), subscription);
         this.topic = topic;
         this.subscription = subscription;
         this.msgDrop = new Rate();
@@ -58,10 +59,13 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     public void sendMessages(List<Entry> entries) {
         Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
         if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0 && currentConsumer.isWritable()) {
-            currentConsumer.sendMessages(entries);
+            SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+            int[] batchSizes = getThreadLocalBatchSizes(entries.size());
+            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
+            currentConsumer.sendMessages(entries, batchSizes, sendMessageInfo);
         } else {
             entries.forEach(entry -> {
-                int totalMsgs = getBatchSizeforEntry(entry.getDataBuffer(), subscription, -1);
+                int totalMsgs = Commands.getNumberOfMessagesInBatch(entry.getDataBuffer(), subscription.toString(), -1);
                 if (totalMsgs > 0) {
                     msgDrop.recordEvent(totalMsgs);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.SendMessageInfo;
@@ -60,9 +61,10 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
         Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
         if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0 && currentConsumer.isWritable()) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
-            int[] batchSizes = getThreadLocalBatchSizes(entries.size());
+            EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
-            currentConsumer.sendMessages(entries, batchSizes, sendMessageInfo);
+            currentConsumer.sendMessages(entries, batchSizes, sendMessageInfo.getTotalMessages(),
+                    sendMessageInfo.getTotalBytes());
         } else {
             entries.forEach(entry -> {
                 int totalMsgs = Commands.getNumberOfMessagesInBatch(entry.getDataBuffer(), subscription.toString(), -1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -64,7 +64,7 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
             currentConsumer.sendMessages(entries, batchSizes, sendMessageInfo.getTotalMessages(),
-                    sendMessageInfo.getTotalBytes());
+                    sendMessageInfo.getTotalBytes(), getRedeliveryTracker());
         } else {
             entries.forEach(entry -> {
                 int totalMsgs = Commands.getNumberOfMessagesInBatch(entry.getDataBuffer(), subscription.toString(), -1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -73,7 +73,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
 
     private CompletableFuture<Void> closeFuture = null;
     LongPairSet messagesToReplay = new ConcurrentSortedLongPairSet(128, 2);
-    private final RedeliveryTracker redeliveryTracker;
+    protected final RedeliveryTracker redeliveryTracker;
 
     private boolean havePendingRead = false;
     private boolean havePendingReplayRead = false;
@@ -450,7 +450,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
                 filterEntriesForConsumer(entriesForThisConsumer, batchSizes, sendMessageInfo);
 
                 c.sendMessages(entriesForThisConsumer, batchSizes, sendMessageInfo.getTotalMessages(),
-                        sendMessageInfo.getTotalBytes());
+                        sendMessageInfo.getTotalBytes(), redeliveryTracker);
 
                 long msgSent = sendMessageInfo.getTotalMessages();
                 start += messagesForC;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -42,6 +42,8 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
+import org.apache.pulsar.broker.service.SendMessageInfo;
+import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
@@ -68,8 +70,8 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
     private final RedeliveryTracker redeliveryTracker;
 
     public PersistentDispatcherSingleActiveConsumer(ManagedCursor cursor, SubType subscriptionType, int partitionIndex,
-            PersistentTopic topic) {
-        super(subscriptionType, partitionIndex, topic.getName());
+            PersistentTopic topic, Subscription subscription) {
+        super(subscriptionType, partitionIndex, topic.getName(), subscription);
         this.topic = topic;
         this.name = topic.getName() + " / " + (cursor.getName() != null ? Codec.decode(cursor.getName())
                 : ""/* NonDurableCursor doesn't have name */);
@@ -208,38 +210,46 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
                 readMoreEntries(currentConsumer);
             }
         } else {
-            currentConsumer.sendMessages(entries, (future, sentMsgInfo) -> {
-                if (future.isSuccess()) {
-                    // acquire message-dispatch permits for already delivered messages
-                    if (serviceConfig.isDispatchThrottlingOnNonBacklogConsumerEnabled() || !cursor.isActive()) {
-                        if (topic.getDispatchRateLimiter().isPresent()) {
-                            topic.getDispatchRateLimiter().get().tryDispatchPermit(sentMsgInfo.getTotalSentMessages(),
-                                    sentMsgInfo.getTotalSentMessageBytes());
-                        }
+            int[] batchSizes = getThreadLocalBatchSizes(entries.size());
+            SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo);
 
-                        if (dispatchRateLimiter.isPresent()) {
-                            dispatchRateLimiter.get().tryDispatchPermit(sentMsgInfo.getTotalSentMessages(),
-                                    sentMsgInfo.getTotalSentMessageBytes());
-                        }
-                    }
+            int totalMessages = sendMessageInfo.getTotalMessages();
+            long totalBytes = sendMessageInfo.getTotalBytes();
 
-                    // Schedule a new read batch operation only after the previous batch has been written to the socket
-                    topic.getBrokerService().getTopicOrderedExecutor().executeOrdered(topicName, SafeRun.safeRun(() -> {
-                        synchronized (PersistentDispatcherSingleActiveConsumer.this) {
-                            Consumer newConsumer = getActiveConsumer();
-                            if (newConsumer != null && !havePendingRead) {
-                                readMoreEntries(newConsumer);
-                            } else {
-                                if (log.isDebugEnabled()) {
-                                    log.debug(
-                                            "[{}-{}] Ignoring write future complete. consumerAvailable={} havePendingRead={}",
-                                            name, newConsumer, newConsumer != null, havePendingRead);
+            currentConsumer.sendMessages(entries, batchSizes, sendMessageInfo)
+                    .addListener(future -> {
+                        if (future.isSuccess()) {
+                            // acquire message-dispatch permits for already delivered messages
+                            if (serviceConfig.isDispatchThrottlingOnNonBacklogConsumerEnabled() || !cursor.isActive()) {
+                                if (topic.getDispatchRateLimiter().isPresent()) {
+                                    topic.getDispatchRateLimiter().get().tryDispatchPermit(totalMessages, totalBytes);
+                                }
+
+                                if (dispatchRateLimiter.isPresent()) {
+                                    dispatchRateLimiter.get().tryDispatchPermit(totalMessages, totalBytes);
                                 }
                             }
+
+                            // Schedule a new read batch operation only after the previous batch has been written to the
+                            // socket
+                            topic.getBrokerService().getTopicOrderedExecutor().executeOrdered(topicName,
+                                    SafeRun.safeRun(() -> {
+                                        synchronized (PersistentDispatcherSingleActiveConsumer.this) {
+                                            Consumer newConsumer = getActiveConsumer();
+                                            if (newConsumer != null && !havePendingRead) {
+                                                readMoreEntries(newConsumer);
+                                            } else {
+                                                if (log.isDebugEnabled()) {
+                                                    log.debug(
+                                                            "[{}-{}] Ignoring write future complete. consumerAvailable={} havePendingRead={}",
+                                                            name, newConsumer, newConsumer != null, havePendingRead);
+                                                }
+                                            }
+                                        }
+                                    }));
                         }
-                    }));
-                }
-            });
+                    });
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -220,7 +220,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
 
             currentConsumer
                     .sendMessages(entries, batchSizes, sendMessageInfo.getTotalMessages(),
-                            sendMessageInfo.getTotalBytes())
+                            sendMessageInfo.getTotalBytes(), redeliveryTracker)
                     .addListener(future -> {
                         if (future.isSuccess()) {
                             // acquire message-dispatch permits for already delivered messages

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
@@ -98,10 +99,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     }
 
                     SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
-                    int[] batchSizes = getThreadLocalBatchSizes(subList.size());
+                    EntryBatchSizes batchSizes = EntryBatchSizes.get(subList.size());
                     filterEntriesForConsumer(subList, batchSizes, sendMessageInfo);
 
-                    consumer.sendMessages(subList, batchSizes, sendMessageInfo);
+                    consumer.sendMessages(subList, batchSizes, sendMessageInfo.getTotalMessages(),
+                            sendMessageInfo.getTotalBytes());
                     entriesWithSameKey.getValue().removeAll(subList);
 
                     totalAvailablePermits -= sendMessageInfo.getTotalMessages();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -19,19 +19,6 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.bookkeeper.mledger.Entry;
-import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.broker.service.BrokerServiceException;
-import org.apache.pulsar.broker.service.Consumer;
-import org.apache.pulsar.broker.service.Consumer.SendMessageInfo;
-import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
-import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
-import org.apache.pulsar.common.api.Commands;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
-import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -39,14 +26,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
+import org.apache.pulsar.broker.service.SendMessageInfo;
+import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.common.api.Commands;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDispatcherMultipleConsumers {
 
     public static final String NONE_KEY = "NONE_KEY";
 
     private final StickyKeyConsumerSelector selector;
 
-    PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor) {
-        super(topic, cursor);
+    PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor, Subscription subscription) {
+        super(topic, cursor, subscription);
         //TODO: Consumer selector Pluggable
         selector = new HashRangeStickyKeyConsumerSelector();
     }
@@ -94,12 +96,17 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     if (readType == ReadType.Replay) {
                         subList.forEach(entry -> messagesToReplay.remove(entry.getLedgerId(), entry.getEntryId()));
                     }
-                    final SendMessageInfo sentMsgInfo = consumer.sendMessages(subList);
+
+                    SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+                    int[] batchSizes = getThreadLocalBatchSizes(subList.size());
+                    filterEntriesForConsumer(subList, batchSizes, sendMessageInfo);
+
+                    consumer.sendMessages(subList, batchSizes, sendMessageInfo);
                     entriesWithSameKey.getValue().removeAll(subList);
-                    final long msgSent = sentMsgInfo.getTotalSentMessages();
-                    totalAvailablePermits -= msgSent;
-                    totalMessagesSent += sentMsgInfo.getTotalSentMessages();
-                    totalBytesSent += sentMsgInfo.getTotalSentMessageBytes();
+
+                    totalAvailablePermits -= sendMessageInfo.getTotalMessages();
+                    totalMessagesSent += sendMessageInfo.getTotalMessages();
+                    totalBytesSent += sendMessageInfo.getTotalBytes();
 
                     if (entriesWithSameKey.getValue().size() == 0) {
                         iterator.remove();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -103,7 +103,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     filterEntriesForConsumer(subList, batchSizes, sendMessageInfo);
 
                     consumer.sendMessages(subList, batchSizes, sendMessageInfo.getTotalMessages(),
-                            sendMessageInfo.getTotalBytes());
+                            sendMessageInfo.getTotalBytes(), getRedeliveryTracker());
                     entriesWithSameKey.getValue().removeAll(subList);
 
                     totalAvailablePermits -= sendMessageInfo.getTotalMessages();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -140,12 +140,12 @@ public class PersistentSubscription implements Subscription {
             switch (consumer.subType()) {
             case Exclusive:
                 if (dispatcher == null || dispatcher.getType() != SubType.Exclusive) {
-                    dispatcher = new PersistentDispatcherSingleActiveConsumer(cursor, SubType.Exclusive, 0, topic);
+                    dispatcher = new PersistentDispatcherSingleActiveConsumer(cursor, SubType.Exclusive, 0, topic, this);
                 }
                 break;
             case Shared:
                 if (dispatcher == null || dispatcher.getType() != SubType.Shared) {
-                    dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursor);
+                    dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursor, this);
                 }
                 break;
             case Failover:
@@ -157,12 +157,12 @@ public class PersistentSubscription implements Subscription {
 
                 if (dispatcher == null || dispatcher.getType() != SubType.Failover) {
                     dispatcher = new PersistentDispatcherSingleActiveConsumer(cursor, SubType.Failover, partitionIndex,
-                            topic);
+                            topic, this);
                 }
                 break;
             case Key_Shared:
                 if (dispatcher == null || dispatcher.getType() != SubType.Key_Shared) {
-                    dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor);
+                    dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this);
                 }
                 break;
             default:

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -267,7 +267,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         int partitionIndex = 0;
         PersistentDispatcherSingleActiveConsumer pdfc = new PersistentDispatcherSingleActiveConsumer(cursorMock,
-                SubType.Failover, partitionIndex, topic);
+                SubType.Failover, partitionIndex, topic, sub);
 
         // 1. Verify no consumers connected
         assertFalse(pdfc.isConsumerConnected());
@@ -306,7 +306,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         int partitionIndex = 0;
         PersistentDispatcherSingleActiveConsumer pdfc = new PersistentDispatcherSingleActiveConsumer(cursorMock,
-                SubType.Failover, partitionIndex, topic);
+                SubType.Failover, partitionIndex, topic, sub);
 
         // 1. Verify no consumers connected
         assertFalse(pdfc.isConsumerConnected());
@@ -421,7 +421,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     public void testMultipleDispatcherGetNextConsumerWithDifferentPriorityLevel() throws Exception {
 
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock, null);
         Consumer consumer1 = createConsumer(0, 2, false, 1);
         Consumer consumer2 = createConsumer(0, 2, false, 2);
         Consumer consumer3 = createConsumer(0, 2, false, 3);
@@ -465,7 +465,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     @Test
     public void testFewBlockedConsumerSamePriority() throws Exception{
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock, null);
         Consumer consumer1 = createConsumer(0, 2, false, 1);
         Consumer consumer2 = createConsumer(0, 2, false, 2);
         Consumer consumer3 = createConsumer(0, 2, false, 3);
@@ -492,7 +492,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     @Test
     public void testFewBlockedConsumerDifferentPriority() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock, null);
         Consumer consumer1 = createConsumer(0, 2, false, 1);
         Consumer consumer2 = createConsumer(0, 2, false, 2);
         Consumer consumer3 = createConsumer(0, 2, false, 3);
@@ -546,7 +546,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     @Test
     public void testFewBlockedConsumerDifferentPriority2() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock, null);
         Consumer consumer1 = createConsumer(0, 2, true, 1);
         Consumer consumer2 = createConsumer(0, 2, true, 2);
         Consumer consumer3 = createConsumer(0, 2, true, 3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -285,7 +285,7 @@ public class PersistentTopicTest {
         PersistentTopic topic = spy(new PersistentTopic(successTopicName, ledgerMock, brokerService));
         ManagedCursor cursor = mock(ManagedCursor.class);
         when(cursor.getName()).thenReturn("cursor");
-        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursor);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursor, null);
         dispatcher.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
         verify(topic, atLeast(1)).getBrokerService();
     }
@@ -296,7 +296,7 @@ public class PersistentTopicTest {
         ManagedCursor cursor = mock(ManagedCursor.class);
         when(cursor.getName()).thenReturn("cursor");
         PersistentDispatcherSingleActiveConsumer dispatcher = new PersistentDispatcherSingleActiveConsumer(cursor,
-                SubType.Exclusive, 1, topic);
+                SubType.Exclusive, 1, topic, null);
         Consumer consumer = mock(Consumer.class);
         dispatcher.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), consumer);
         verify(topic, atLeast(1)).getBrokerService();


### PR DESCRIPTION
### Motivation

As discussed in #4062, there is a back and forth between the dispatcher and the consumer when passing the messages. The key points are:

 * We need to filter the entries we got from storage for various reasons, like: 
   - Checksum and metadata corruption
   - Delays 
   - Internal markers not meant for consumers
* Consumer needs to know the batch size for each entry
* We want to de-serialize the message metadata protobuf just once

With this PR, the dispatcher will do the filter and it will prefill a the batch sizes for each entry. Consumer will just see the filtered list.