### PR TITLE
Feature - reset cursor on Reader to current position

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -618,7 +618,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 future.completeExceptionally(e);
             }
         }).exceptionally(ex -> {
-            log.warn("[{}] Failed to create subscription for {}: ", topic, subscriptionName, ex.getMessage());
+            log.warn("[{}] Failed to create subscription: {} error: {}", topic, subscriptionName, ex.getMessage());
             USAGE_COUNT_UPDATER.decrementAndGet(PersistentTopic.this);
             future.completeExceptionally(new PersistenceException(ex));
             return null;
@@ -678,11 +678,10 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (msgId instanceof BatchMessageIdImpl) {
                 // When the start message is relative to a batch, we need to take one step back on the previous message,
                 // because the "batch" might not have been consumed in its entirety.
-                // The client will then be able to discard the first messages in the batch.
-                if (((BatchMessageIdImpl) msgId).getBatchIndex() >= 0) {
-                    entryId = msgId.getEntryId() - 1;
-                }
+                // The client will then be able to discard the first messages if needed.
+                entryId = msgId.getEntryId() - 1;
             }
+
             Position startPosition = new PositionImpl(ledgerId, entryId);
             ManagedCursor cursor = null;
             try {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -108,6 +108,7 @@ public interface ReaderBuilder<T> extends Cloneable {
 
     /**
      * The initial reader positioning is done by specifying a message id. The options are:
+     * <p>
      * <ul>
      * <li>{@link MessageId#earliest}: Start reading from the earliest message available in the topic</li>
      * <li>{@link MessageId#latest}: Start reading from end of the topic. The first message read will be the one
@@ -116,11 +117,22 @@ public interface ReaderBuilder<T> extends Cloneable {
      * immediately <b>*after*</b> the specified message</li>
      * </ul>
      *
+     * <p>
+     * If the first message <b>*after*</b> the specified message is not the desired behaviour, use
+     * {@link ReaderBuilder#startMessageIdInclusive()}.
+     *
      * @param startMessageId the message id where the reader will be initially positioned on
      * @return the reader builder instance
      */
     ReaderBuilder<T> startMessageId(MessageId startMessageId);
-    // TODO: Add java-doc
+
+    /**
+     * Set the reader to include the given position of {@link ReaderBuilder#startMessageId(MessageId)}
+     * <p>
+     * This configuration option also applies for any cursor reset operation like {@link Reader#seek(MessageId)}.
+     *
+     * @return the reader builder instance
+     */
     ReaderBuilder<T> startMessageIdInclusive();
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -120,6 +120,8 @@ public interface ReaderBuilder<T> extends Cloneable {
      * @return the reader builder instance
      */
     ReaderBuilder<T> startMessageId(MessageId startMessageId);
+    // TODO: Add java-doc
+    ReaderBuilder<T> startMessageIdInclusive();
 
     /**
      * Sets a {@link ReaderListener} for the reader

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -113,6 +113,12 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     }
 
     @Override
+    public ReaderBuilder<T> startMessageIdInclusive() {
+        conf.setResetIncludeHead(true);
+        return this;
+    }
+
+    @Override
     public ReaderBuilder<T> readerListener(ReaderListener<T> readerListener) {
         conf.setReaderListener(readerListener);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -49,8 +49,13 @@ public class ReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
+
         if (readerConfiguration.getReaderName() != null) {
             consumerConfiguration.setConsumerName(readerConfiguration.getReaderName());
+        }
+
+        if (readerConfiguration.isResetIncludeHead()) {
+            consumerConfiguration.setResetIncludeHead(true);
         }
 
         if (readerConfiguration.getReaderListener() != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -102,6 +102,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private boolean replicateSubscriptionState = false;
 
+    private boolean resetIncludeHead = false;
+
     @JsonIgnore
     public String getSingleTopic() {
         checkArgument(topicNames.size() == 1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -44,6 +44,7 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 
     private boolean readCompacted = false;
+    private boolean resetIncludeHead = false;
 
     @SuppressWarnings("unchecked")
     public ReaderConfigurationData<T> clone() {


### PR DESCRIPTION
*Motivation*

There are some cases in which is it useful to be able to include current
position of message when reset of cursor was made.

This was reported by a `vvy` on slack, no issue has been created to track this.

*Modifications*

  - Add startMessageIdInclusive() to support include current position of
    reset on ReaderBuilder.
  - Add resetIncludeHead field for Reader and Consumer Configuration Data
  - Fix position of cursor for non durable consumer.
  - Improve discard if statement for batch enable mode.
  - Add discard if statement for batch disable mode.
  - Add test case to assert the start of specific message id at the expected
    position with data provider scenarios:
      A. Batch enable and start inclusive enable.
      B. Batch enable and start inclusive disable.
      C. Batch disable and start inclusive enable.
      D. Batch disable and start inclusive disable.