### PR TITLE
Fix bug of key_shared subscription(Message cannot be dispatched while a consumer crash)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeStickyKeyConsumerSelector.java
@@ -92,9 +92,10 @@ public class HashRangeStickyKeyConsumerSelector implements StickyKeyConsumerSele
         Integer removeRange = consumerRange.get(consumer);
         if (removeRange != null) {
             if (removeRange == rangeSize && rangeMap.size() > 1) {
-                Consumer lowerConsumer = rangeMap.lowerEntry(removeRange).getValue();
-                rangeMap.put(removeRange, lowerConsumer);
-                consumerRange.put(lowerConsumer, removeRange);
+                Map.Entry<Integer, Consumer> lowerEntry = rangeMap.lowerEntry(removeRange);
+                rangeMap.put(removeRange, lowerEntry.getValue());
+                rangeMap.remove(lowerEntry.getKey());
+                consumerRange.put(lowerEntry.getValue(), removeRange);
             } else {
                 rangeMap.remove(removeRange);
                 consumerRange.remove(consumer);


### PR DESCRIPTION
### Motivation

**Describe the bug**
Use key_shared subscription, while a consumer crash, message cannot be dispatched correctly.

**To Reproduce**
1. start consumer1
2. start consumer2
3. start consumer3
4. send message
5. close consumer1
6. close consumer2

**Expected behavior**
Messages can also be received in full.

**Actual behavior**
Unable to receive part of messages that the range originally responsible for consumer2.

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)