### PR TITLE
add get message method in Record interface

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Record.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Record.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.functions.api;
 
+import org.apache.pulsar.client.api.Message;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -102,6 +104,10 @@ public interface Record<T> {
      * @return The topic this message should be written to
      */
     default Optional<String> getDestinationTopic() {
+        return Optional.empty();
+    }
+
+    default Optional<Message<T>> getMessage() {
         return Optional.empty();
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
@@ -106,4 +106,9 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
     public void fail() {
         this.failFunction.run();
     }
+
+    @Override
+    public Optional<Message<T>> getMessage() {
+        return Optional.of(message);
+    }
 }


### PR DESCRIPTION
### Motivation

Currently there is not way for users to the attributes of the underlying Message received.

This simple addition that allows users to do this for Function and WindowFunction

This is a cleaner and simpler approach IMO compared to 

https://github.com/apache/pulsar/pull/4313