### PR TITLE
Support max message size for cpp and go client

### DIFF
--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -113,6 +113,8 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
         }
     } else {
         LOG_DEBUG("Connection not ready for batch message container.")
+        batchMessageCallBack(ResultNotConnected, messagesContainerListPtr_, nullptr);
+        clear();
     }
 
     Message msg;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -111,6 +111,8 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
             clear();
             return;
         }
+    } else {
+        LOG_DEBUG("Connection not ready for batch message container.")
     }
 
     Message msg;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -115,6 +115,7 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
         LOG_DEBUG("Connection not ready for batch message container.")
         batchMessageCallBack(ResultNotConnected, messagesContainerListPtr_, nullptr);
         clear();
+        return;
     }
 
     Message msg;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -113,9 +113,13 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
         }
     } else {
         LOG_DEBUG("Connection not ready for batch message container.")
-        batchMessageCallBack(ResultNotConnected, messagesContainerListPtr_, nullptr);
-        clear();
-        return;
+        if (impl_->payload.readableBytes() > Commands::DefaultMaxMessageSize) {
+            // At this point the compressed batch is above the overall MaxMessageSize. There
+            // can only 1 single message in the batch at this point.
+            batchMessageCallBack(ResultMessageTooBig, messagesContainerListPtr_, nullptr);
+            clear();
+            return;
+        }
     }
 
     Message msg;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -102,7 +102,7 @@ void BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
     producer_.encryptMessage(impl_->metadata, impl_->payload, encryptedPayload);
     impl_->payload = encryptedPayload;
 
-    if (impl_->payload.readableBytes() > Commands::MaxMessageSize) {
+    if (impl_->payload.readableBytes() > maxMessageSize) {
         // At this point the compressed batch is above the overall MaxMessageSize. There
         // can only 1 single message in the batch at this point.
         batchMessageCallBack(ResultMessageTooBig, messagesContainerListPtr_, nullptr);

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -225,9 +225,9 @@ void ClientConnection::handlePulsarConnected(const CommandConnected& cmdConnecte
     }
 
     if (cmdConnected.has_max_message_size()) {
-        LOG_DEBUG("Connection has max message size setting: "<< cmdConnected.max_message_size());
+        LOG_DEBUG("Connection has max message size setting: " << cmdConnected.max_message_size());
         maxMessageSize = cmdConnected.max_message_size();
-        LOG_DEBUG("Current max message size is: "<< maxMessageSize);
+        LOG_DEBUG("Current max message size is: " << maxMessageSize);
     }
 
     state_ = Ready;

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -131,6 +131,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
       operationsTimeout_(seconds(clientConfiguration.getOperationTimeoutSeconds())),
       authentication_(authentication),
       serverProtocolVersion_(ProtocolVersion_MIN),
+      maxMessageSize_(Commands::DefaultMaxMessageSize),
       executor_(executor),
       resolver_(executor->createTcpResolver()),
       socket_(executor->createSocket()),
@@ -226,8 +227,8 @@ void ClientConnection::handlePulsarConnected(const CommandConnected& cmdConnecte
 
     if (cmdConnected.has_max_message_size()) {
         LOG_DEBUG("Connection has max message size setting: " << cmdConnected.max_message_size());
-        maxMessageSize = cmdConnected.max_message_size();
-        LOG_DEBUG("Current max message size is: " << maxMessageSize);
+        maxMessageSize_ = cmdConnected.max_message_size();
+        LOG_DEBUG("Current max message size is: " << maxMessageSize_);
     }
 
     state_ = Ready;
@@ -1371,6 +1372,8 @@ const std::string& ClientConnection::brokerAddress() const { return physicalAddr
 const std::string& ClientConnection::cnxString() const { return cnxString_; }
 
 int ClientConnection::getServerProtocolVersion() const { return serverProtocolVersion_; }
+
+int ClientConnection::getMaxMessageSize() const { return maxMessageSize_; }
 
 Commands::ChecksumType ClientConnection::getChecksumType() const {
     return getServerProtocolVersion() >= proto::v6 ? Commands::Crc32c : Commands::None;

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -224,6 +224,12 @@ void ClientConnection::handlePulsarConnected(const CommandConnected& cmdConnecte
         return;
     }
 
+    if (cmdConnected.has_max_message_size()) {
+        LOG_DEBUG("Connection has max message size setting: "<< cmdConnected.max_message_size());
+        maxMessageSize = cmdConnected.max_message_size();
+        LOG_DEBUG("Current max message size is: "<< maxMessageSize);
+    }
+
     state_ = Ready;
     serverProtocolVersion_ = cmdConnected.protocol_version();
     connectPromise_.setValue(shared_from_this());

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -48,8 +48,6 @@ using namespace pulsar;
 
 namespace pulsar {
 
-inline int maxMessageSize = Commands::DefaultMaxMessageSize;
-
 class PulsarFriend;
 
 class ExecutorService;
@@ -147,6 +145,8 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     int getServerProtocolVersion() const;
 
+    int getMaxMessageSize() const;
+
     Commands::ChecksumType getChecksumType() const;
 
     Future<Result, BrokerConsumerStatsImpl> newConsumerStats(uint64_t consumerId, uint64_t requestId);
@@ -239,6 +239,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     TimeDuration operationsTimeout_;
     AuthenticationPtr authentication_;
     int serverProtocolVersion_;
+    int maxMessageSize_;
 
     ExecutorServicePtr executor_;
 

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -48,6 +48,8 @@ using namespace pulsar;
 
 namespace pulsar {
 
+inline int maxMessageSize = Commands::DefaultMaxMessageSize;
+
 class PulsarFriend;
 
 class ExecutorService;

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -49,7 +49,7 @@ class Commands {
     };
     enum WireFormatConstant
     {
-        MaxMessageSize = (5 * 1024 * 1024 - (10 * 1024)),
+        DefaultMaxMessageSize = (5 * 1024 * 1024 - (10 * 1024)),
         MaxFrameSize = (5 * 1024 * 1024)
     };
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -469,7 +469,8 @@ bool ConsumerImpl::uncompressMessageIfNeeded(const ClientConnectionPtr& cnx, con
             return false;
         }
     } else {
-        LOG_DEBUG("Connection not ready for Consumer - " << getConsumerId());
+        LOG_ERROR("Connection not ready for Consumer - " << getConsumerId());
+        return false;
     }
 
     if (!CompressionCodecProvider::getCodec(compressionType).decode(payload, uncompressedSize, payload)) {

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -459,7 +459,7 @@ bool ConsumerImpl::uncompressMessageIfNeeded(const ClientConnectionPtr& cnx, con
 
     uint32_t uncompressedSize = metadata.uncompressed_size();
     uint32_t payloadSize = payload.readableBytes();
-    if (payloadSize > Commands::MaxMessageSize) {
+    if (payloadSize > maxMessageSize) {
         // Uncompressed size is itself corrupted since it cannot be bigger than the MaxMessageSize
         LOG_ERROR(getName() << "Got corrupted payload message size " << payloadSize  //
                             << " at  " << msg.message_id().ledgerid() << ":" << msg.message_id().entryid());

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -359,6 +359,8 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
                 cb(ResultMessageTooBig, msg);
                 return;
             }
+        } else {
+            LOG_DEBUG("Connection not ready for producer.")
         }
     }
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -360,7 +360,9 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
                 return;
             }
         } else {
-            LOG_DEBUG("Connection not ready for producer.")
+            LOG_ERROR("Connection not ready for producer.")
+            cb(ResultUnknownError, msg);
+            return;
         }
     }
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -353,16 +353,10 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
         }
         payload = encryptedPayload;
 
-        if (cnx) {
-            if (payloadSize > cnx->getMaxMessageSize()) {
-                LOG_DEBUG(getName() << " - compressed Message payload size" << payloadSize << "cannot exceed "
-                                    << cnx->getMaxMessageSize() << " bytes");
-                cb(ResultMessageTooBig, msg);
-                return;
-            }
-        } else {
-            LOG_ERROR("Connection not ready for producer.")
-            cb(ResultUnknownError, msg);
+        if (payloadSize > keepMaxMessageSize_) {
+            LOG_DEBUG(getName() << " - compressed Message payload size" << payloadSize << "cannot exceed "
+                                << keepMaxMessageSize_ << " bytes");
+            cb(ResultMessageTooBig, msg);
             return;
         }
     }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -155,6 +155,7 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         LOG_INFO(getName() << "Created producer on broker " << cnx->cnxString());
 
         Lock lock(mutex_);
+        keepMaxMessageSize_ = cnx->getMaxMessageSize();
         cnx->registerProducer(producerId_, shared_from_this());
         producerName_ = responseData.producerName;
         schemaVersion_ = responseData.schemaVersion;

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -352,9 +352,9 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
         }
         payload = encryptedPayload;
 
-        if (payloadSize > Commands::MaxMessageSize) {
+        if (payloadSize > maxMessageSize) {
             LOG_DEBUG(getName() << " - compressed Message payload size" << payloadSize << "cannot exceed "
-                                << Commands::MaxMessageSize << " bytes");
+                                << maxMessageSize << " bytes");
             cb(ResultMessageTooBig, msg);
             return;
         }

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -63,6 +63,8 @@ class ProducerImpl : public HandlerBase,
                  const ProducerConfiguration& producerConfiguration);
     ~ProducerImpl();
 
+    int keepMaxMessageSize_;
+
     virtual const std::string& getTopic() const;
 
     virtual void sendAsync(const Message& msg, SendCallback callback);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -561,7 +561,7 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     Result result = client.createProducer(topicName, conf, producer);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
@@ -1114,7 +1114,7 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = producerFuture.get(producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);
@@ -1165,7 +1165,7 @@ TEST(BasicEndToEndTest, testBigMessageSizeBatching) {
     result = client.createProducer(topicName, conf2, producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -561,14 +561,14 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     Result result = client.createProducer(topicName, conf, producer);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::MaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
     ASSERT_EQ(ResultMessageTooBig, result);
 
     // Anything up to MaxMessageSize should be allowed
-    size = Commands::MaxMessageSize;
+    size = Commands::DefaultMaxMessageSize;
     msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
     ASSERT_EQ(ResultOk, result);
@@ -1114,7 +1114,7 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = producerFuture.get(producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::MaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);
@@ -1165,7 +1165,7 @@ TEST(BasicEndToEndTest, testBigMessageSizeBatching) {
     result = client.createProducer(topicName, conf2, producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::MaxMessageSize + 1;
+    int size = Commands::DefaultMaxMessageSize + 1;
     char *content = new char[size];
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1211,9 +1211,7 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
             oldConnections.push_back(clientConnectionPtr);
             clientConnectionPtr->close();
         }
-        if (i % 3 == 1) {
-            ASSERT_EQ(producer.send(msg), ResultNotConnected);
-        }
+        ASSERT_EQ(producer.send(msg), ResultOk);
     }
 
     std::set<std::string> receivedMsgContent;
@@ -1237,7 +1235,13 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
         receivedMsgIndex.insert(msg.getProperty(propertyName));
     }
 
-    ASSERT_EQ(receivedMsgContent.size(), 0);
+    ASSERT_EQ(receivedMsgContent.size(), 10);
+    ASSERT_EQ(receivedMsgIndex.size(), 10);
+
+    for (int i = 0; i < numOfMessages; i++) {
+        ASSERT_TRUE(receivedMsgContent.find("msg-" + std::to_string(i)) != receivedMsgContent.end());
+        ASSERT_TRUE(receivedMsgIndex.find(std::to_string(i)) != receivedMsgIndex.end());
+    }
 }
 
 TEST(BasicEndToEndTest, testRSAEncryption) {

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1211,7 +1211,9 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
             oldConnections.push_back(clientConnectionPtr);
             clientConnectionPtr->close();
         }
-        ASSERT_EQ(producer.send(msg), ResultOk);
+        if (i % 3 == 1) {
+            ASSERT_EQ(producer.send(msg), ResultNotConnected);
+        }
     }
 
     std::set<std::string> receivedMsgContent;
@@ -1235,13 +1237,7 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
         receivedMsgIndex.insert(msg.getProperty(propertyName));
     }
 
-    ASSERT_EQ(receivedMsgContent.size(), 10);
-    ASSERT_EQ(receivedMsgIndex.size(), 10);
-
-    for (int i = 0; i < numOfMessages; i++) {
-        ASSERT_TRUE(receivedMsgContent.find("msg-" + std::to_string(i)) != receivedMsgContent.end());
-        ASSERT_TRUE(receivedMsgIndex.find(std::to_string(i)) != receivedMsgIndex.end());
-    }
+    ASSERT_EQ(receivedMsgContent.size(), 0);
 }
 
 TEST(BasicEndToEndTest, testRSAEncryption) {

--- a/pulsar-client-go/go.mod
+++ b/pulsar-client-go/go.mod
@@ -2,7 +2,6 @@ module github.com/apache/pulsar/pulsar-client-go
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/alecthomas/jsonschema v0.0.0-20190122210438-a6952de1bbe6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1

--- a/pulsar-client-go/go.sum
+++ b/pulsar-client-go/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/alecthomas/jsonschema v0.0.0-20190122210438-a6952de1bbe6 h1:xadBCbc8D9mmkaNfCsEBHbIoCjbayJXJNsY1JjPjNio=
-github.com/alecthomas/jsonschema v0.0.0-20190122210438-a6952de1bbe6/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

support max message size for cpp and go client.

test code use go-client as follows:

```
func main() {
	client, err := pulsar.NewClient(pulsar.ClientOptions{
		URL:       "pulsar://localhost:6650",
		IOThreads: 5,
	})

	if err != nil {
		log.Fatal(err)
	}

	defer client.Close()

	producer, err := client.CreateProducer(pulsar.ProducerOptions{
		Topic:           "my-topic",
		CompressionType: pulsar.NoCompression,
		//Batching: false,
	})
	if err != nil {
		log.Fatal(err)
	}

	defer producer.Close()

	ctx := context.Background()
	buf := make([]byte, 10*1024*1024)
	arrays := [1024*1024*7 - 10*1024 - 1]byte{} // 7MB
	buf = arrays[:]

	producer.SendAsync(ctx, pulsar.ProducerMessage{
		Payload: buf,
	}, func(producerMessage pulsar.ProducerMessage, e error) {
		fmt.Print("send complete. err=", e)
	})
}
```

add standalone.conf:

```
maxMessageSize=10485760 (10*1024*1024)

nettyMaxFrameSizeBytes=10496000 (10*1024*1024 + 10*1024)
```

output as follow:

```
2019/05/23 15:37:56.108 c_client.go:68: [info] INFO  | ConnectionPool:72 | Created connection for pulsar://localhost:6650
2019/05/23 15:37:56.111 c_client.go:68: [info] INFO  | ClientConnection:313 | [127.0.0.1:60601 -> 127.0.0.1:6650] Connected to broker
2019/05/23 15:37:56.113 c_client.go:68: [info] INFO  | ClientConnection:228 | Connection has max message size setting: 10485760
2019/05/23 15:37:56.113 c_client.go:68: [info] INFO  | ClientConnection:230 | Connection has max message size setting: 10485760
2019/05/23 15:37:56.117 c_client.go:68: [info] INFO  | BatchMessageContainer:43 | { BatchContainer [size = 0] [batchSizeInBytes_ = 0] [maxAllowedMessageBatchSizeInBytes_ = 131072] [maxAllowedNumMessagesInBatch_ = 1000] [topicName = persistent://public/default/my-topic-1] [producerName_ = ] [batchSizeInBytes_ = 0] [numberOfBatchesSent = 0] [averageBatchSize = 0]} BatchMessageContainer constructed
2019/05/23 15:37:56.118 c_client.go:68: [info] INFO  | HandlerBase:52 | [persistent://public/default/my-topic-1, ] Getting connection from pool
2019/05/23 15:37:56.124 c_client.go:68: [info] INFO  | ConnectionPool:72 | Created connection for pulsar://ranxiaolong:6650
2019/05/23 15:37:56.126 c_client.go:68: [info] INFO  | ClientConnection:315 | [127.0.0.1:60602 -> 127.0.0.1:6650] Connected to broker through proxy. Logical broker: pulsar://ranxiaolong:6650
2019/05/23 15:37:56.128 c_client.go:68: [info] INFO  | ClientConnection:228 | Connection has max message size setting: 10485760
2019/05/23 15:37:56.517 c_client.go:68: [info] INFO  | ProducerImpl:155 | [persistent://public/default/my-topic-1, ] Created producer on broker [127.0.0.1:60602 -> 127.0.0.1:6650] 

2019/05/23 15:37:56.567 c_client.go:68: [info] INFO  | ProducerImpl:448 | send message Message(prod=standalone-96-2, seq=0, publish_time=1558597076544, payload_size=7329812, msg_id=(-1,-1,-1,-1), props={})
2019/05/23 15:37:56.567 c_client.go:68: [info] INFO  | ProducerImpl:460 | [persistent://public/default/my-topic-1, standalone-96-2] Sending msg immediately - seq: 0
2019/05/23 15:37:56.569 c_client.go:68: [info] INFO  | ProducerImpl:496 | [persistent://public/default/my-topic-1, standalone-96-2] Closing producer for topic persistent://public/default/my-topic-1
send complete. err= [<nil>]
2019/05/23 15:37:56.639 c_client.go:68: [info] INFO  | ProducerImpl:534 | [persistent://public/default/my-topic-1, standalone-96-2] Closed producer
2019/05/23 15:37:56.640 c_client.go:68: [info] INFO  | ClientImpl:479 | Closing Pulsar client
```
