### PR TITLE
fix cluster_url which may be set as a list

### DIFF
--- a/dashboard/django/collector.py
+++ b/dashboard/django/collector.py
@@ -355,6 +355,8 @@ def fetch_stats():
         if cluster_name == 'global': continue
 
         cluster_url = get(args.serviceUrl, '/admin/v2/clusters/' + cluster_name)['serviceUrl']
+        if cluster_url.find(',')>=0:
+                cluster_url = cluster_url.split(',')[0]
         logger.info('Cluster:{} -> {}'.format(cluster_name, cluster_url))
         cluster, created = Cluster.objects.get_or_create(name=cluster_name)
         if cluster_url != cluster.serviceUrl:

--- a/dashboard/django/collector.py
+++ b/dashboard/django/collector.py
@@ -32,6 +32,7 @@ from django.utils.dateparse import parse_datetime
 from django.db import connection
 import time
 import argparse
+import random
 
 current_milli_time = lambda: int(round(time.time() * 1000))
 logger = logging.getLogger(__name__)
@@ -356,7 +357,14 @@ def fetch_stats():
 
         cluster_url = get(args.serviceUrl, '/admin/v2/clusters/' + cluster_name)['serviceUrl']
         if cluster_url.find(',')>=0:
-                cluster_url = cluster_url.split(',')[0]
+            cluster_url_list = cluster_url.split(',')
+            index = random.randint(0,len(cluster_url_list)-1)
+            if index==0:
+                cluster_url = cluster_url_list[index]
+            else:
+                protocol = ("https://" if(cluster_url.find("https")>=0) else "http://")
+                cluster_url = protocol+cluster_url_list[index]
+
         logger.info('Cluster:{} -> {}'.format(cluster_name, cluster_url))
         cluster, created = Cluster.objects.get_or_create(name=cluster_name)
         if cluster_url != cluster.serviceUrl:


### PR DESCRIPTION
### Motivation

If the service_url is set to **http://{server-1}:8080,{server-2}:8080,{server-3}:8080** when **initialize-cluster-metadata**, the cluster_url will be "{server-1}:8080,{server-2}:8080,{server-3}:8080".
And the string "{server-1}:8080,{server-2}:8080,{server-3}:8080" isn't a standard url.
