### PR TITLE
shade additional dependencies in java-instance.jar

### DIFF
--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -262,6 +262,10 @@
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.validation</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>javax.activation</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.activation</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>io.prometheus</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.prometheus</shadedPattern>
                 </relocation>

--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -118,80 +118,264 @@
               </filters>
               <relocations>
                 <relocation>
+                  <pattern>com.typesafe.netty</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.typesafe.netty</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.google</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.grpc</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.grpc</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.bookkeeper</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.squareup</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.squareup</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>okio</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.okio</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.inferred</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.inferred</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.jboss</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.jboss</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.beust</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.beust</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>net.jodah</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.net.jodah</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.yaml</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.yaml</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.glassfish</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.glassfish</shadedPattern>
-                </relocation>
-                  <relocation>
-                  <pattern>com.yahoo</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.yahoo</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.http</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.jute</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.jute</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.servlet</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.servlet</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.junit</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.junit</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>junit</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.junit</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.jodah</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.net.jodah</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.lz4</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.lz4</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.reactivestreams</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.reactivestreams</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.commons</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.jvnet</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.jvnet</shadedPattern>
+                  <pattern>io.swagger</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.swagger</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.yaml</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.yaml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.jctools</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.jctools</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.squareup.okhttp</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.squareup.okhttp</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.grpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.joda</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.joda</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.ws.rs</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.ws.rs</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.kubernetes</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.kubernetes</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.opencensus</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.opencensus</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.eclipse</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.eclipse</shadedPattern>
+                  <pattern>net.jpountz</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.net.jpountz</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.aspectj</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.aspectj</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-configuration</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-configuration</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.tukaani</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.tukaani</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.github</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.github</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-io</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-io</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.distributedlog</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.distributedlog</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.fasterxml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.inferred</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.inferred</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.bookkeeper</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.bookkeeper</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.bookkeeper</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>dlshade</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.dlshade</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.jackson</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.codehaus.jackson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.java.dev.jna</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.net.java.dev.jna</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.curator</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.curator</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.validation</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.validation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.prometheus</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.prometheus</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.zookeeper</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.zookeeper</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.jsonwebtoken</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.jsonwebtoken</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-codec</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-codec</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.thoughtworks.paranamer</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.thoughtworks.paranamer</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.mojo</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.codehaus.mojo</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.github.luben</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.github.luben</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jline</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.jline</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-logging</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-logging</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.bouncycastle</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.bouncycastle</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.xerial.snappy</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.xerial.snappy</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.checkerframework</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.yetus</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.yetus</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-cli</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-cli</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>commons-lang</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.commons-lang</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.squareup.okio</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.squareup.okio</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.rocksdb</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.rocksdb</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.objenesis</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.objenesis</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.eclipse.jetty</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.eclipse.jetty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.avro</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.avro</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>avro.shaded</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.avo.shaded</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.yahoo</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.beust</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.beust</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.hamcrest</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.hamcrest</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>aj.org</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.aj.org</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.scurrilous</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.com.scurrilous</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>okio</pattern>
+                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.okio</shadedPattern>
                 </relocation>
                 <!--
                     asynchttpclient can only be shaded to be under `org.apache.pulsar.shade`
@@ -202,24 +386,12 @@
                   <pattern>org.asynchttpclient</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.bouncycastle</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.bouncycastle</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>jersey</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.jersey</shadedPattern>
-                </relocation>
                 <!-- DONT ever shade log4j, otherwise logging won't work anymore in running functions in process mode
                 <relocation>
                   <pattern>org.apache.logging</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.logging</shadedPattern>
                 </relocation>
                 -->
-                <relocation>
-                  <pattern>javassist</pattern>
-                  <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javassist</shadedPattern>
-                </relocation>
               </relocations>
             </configuration>
           </execution>


### PR DESCRIPTION
### Motivation

Some dependencies are not shaded in the java-instance.jar.  Probably leaked into the JAR via other dependencies.

