### PR TITLE
Add missed serialization schema argument for PulsarOutputFormat 

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
@@ -37,7 +37,9 @@ public class PulsarOutputFormat<T> extends BasePulsarOutputFormat<T> {
         this.serializationSchema = serializationSchema;
     }
 
-    public PulsarOutputFormat(ClientConfigurationData clientConfigurationData, ProducerConfigurationData producerConfigurationData) {
+    public PulsarOutputFormat(final ClientConfigurationData clientConfigurationData,
+                              final ProducerConfigurationData producerConfigurationData,
+                              final SerializationSchema<T> serializationSchema) {
         super(clientConfigurationData, producerConfigurationData);
         Preconditions.checkNotNull(serializationSchema, "serializationSchema cannot be null.");
         this.serializationSchema = serializationSchema;

--- a/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormatTest.java
@@ -72,7 +72,7 @@ public class PulsarOutputFormatTest {
                 .topicName("testTopic")
                 .build();
 
-        new PulsarOutputFormat(clientConf, producerConf);
+        new PulsarOutputFormat(clientConf, producerConf, text -> text.toString().getBytes());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -85,7 +85,7 @@ public class PulsarOutputFormatTest {
                 .topicName(null)
                 .build();
 
-        new PulsarOutputFormat(clientConf, producerConf);
+        new PulsarOutputFormat(clientConf, producerConf, text -> text.toString().getBytes());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -98,7 +98,7 @@ public class PulsarOutputFormatTest {
                 .topicName(StringUtils.EMPTY)
                 .build();
 
-        new PulsarOutputFormat(clientConf, producerConf);
+        new PulsarOutputFormat(clientConf, producerConf, text -> text.toString().getBytes());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -111,7 +111,18 @@ public class PulsarOutputFormatTest {
                 .topicName("testTopic")
                 .build();
 
-        new PulsarOutputFormat(clientConf, producerConf);
+        new PulsarOutputFormat(clientConf, producerConf, text -> text.toString().getBytes());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testPulsarOutputFormatConstructorV2WhenSerializationSchemaIsNull() {
+        ClientConfigurationData clientConf = ClientConfigurationData.builder()
+                .serviceUrl("testServiceUrl")
+                .build();
+        ProducerConfigurationData producerConf = ProducerConfigurationData.builder()
+                .topicName("testTopic")
+                .build();
+        new PulsarOutputFormat(clientConf, producerConf, null);
     }
 
     @Test


### PR DESCRIPTION
The constructor of PulsarOutputFormat expects a serializationSchema passed in otherwise it's member serializationSchema will be assigned by itself. 