### PR TITLE
[Issue 4347] ClientAPI ReaderBuilder.loadConf() not working

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -96,7 +96,9 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
 
     @Override
     public ReaderBuilder<T> loadConf(Map<String, Object> config) {
+        MessageId startMessageId = conf.getStartMessageId();
         conf = ConfigurationDataUtils.loadData(config, conf, ReaderConfigurationData.class);
+        conf.setStartMessageId(startMessageId);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.conf;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -31,6 +32,8 @@ import lombok.Data;
 public class ReaderConfigurationData<T> implements Serializable, Cloneable {
 
     private String topicName;
+
+    @JsonIgnore
     private MessageId startMessageId;
 
     private int receiverQueueSize = 1000;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
@@ -21,7 +21,12 @@ package org.apache.pulsar.client.impl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.testng.annotations.Test;
 
 public class BuildersTest {
@@ -68,5 +73,28 @@ public class BuildersTest {
         builder = (ClientBuilderImpl)PulsarClient.builder().serviceUrl("pulsar+ssl://service:6650").enableTls(false);
         assertEquals(builder.conf.isUseTls(), false);
         assertEquals(builder.conf.getServiceUrl(), "pulsar+ssl://service:6650");
+    }
+
+    @Test
+    public void readerBuilderLoadConfTest() throws Exception {
+        PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
+        String topicName = "test_src";
+        MessageId messageId = new MessageIdImpl(1, 2, 3);
+        Map<String, Object> config = new HashMap<>();
+        config.put("topicName", topicName);
+        config.put("receiverQueueSize", 2000);
+        ReaderBuilderImpl<byte[]> builder = (ReaderBuilderImpl<byte[]>) client.newReader()
+            .startMessageId(messageId)
+            .loadConf(config);
+
+        Class<?> clazz = builder.getClass();
+        Field conf = clazz.getDeclaredField("conf");
+        conf.setAccessible(true);
+        Object obj = conf.get(builder);
+        assertTrue(obj instanceof ReaderConfigurationData);
+        if (obj instanceof ReaderConfigurationData) {
+            assertEquals(((ReaderConfigurationData) obj).getTopicName(), topicName);
+            assertEquals(((ReaderConfigurationData) obj).getStartMessageId(), messageId);
+        }
     }
 }


### PR DESCRIPTION
*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #4347 

### Motivation

`MessageId` is a interface, not support `mapper.readValue()` from `conf.set("startMessageId", new MessageIdImpl()) `.  
If support,  modify code to `mapper.forType(MessageIdImpl.class)` or use jackson annotation 
```java
@JsonTypeInfo(
  use = JsonTypeInfo.Id, 
  include = JsonTypeInfo.As.PROPERTY, 
  property = "type")
@JsonSubTypes({ 
  @Type(value = MessageIdImpl.class), 
  @Type(value = BatchMessageIdImpl.class) ,
  @Type(value = TopicMessageIdImpl.class) 
})
public interface MessageId
```
so I thank use `@JsonIgnore` then `builder.startMessageId()` is the easiest solution.

### Modifications

1. @JsonIgnore startMessageId
2. conf.setStartMessageId()

### Verifying this change

- [✔️ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
