### PR TITLE
[Integration tests]Fix integration test

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -46,12 +46,14 @@ RUN apt-get update \
      && apt-get install -y netcat dnsutils \
                  python2.7 python-setuptools \
                  python3 python3-setuptools \
+                 curl \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-RUN easy_install pip
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python2.7 get-pip.py
 RUN pip install kazoo pyyaml
-RUN easy_install3 pip
+RUN python3 get-pip.py
 
 ADD target/python-client/ /pulsar/pulsar-client
 RUN /pulsar/bin/install-pulsar-client-27.sh


### PR DESCRIPTION

### Motivation
There is a problem with the current installation of pip when running the integration tests.
Therefore, install pip using the officially recommended method.

### Modifications

Modify the pip installation method, refer to https://pip.pypa.io/en/stable/installing/

### Verifying this change

Local integration test passed

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
