### PR TITLE
[pulsar-io]Fix localrun start failed

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -124,16 +124,9 @@ public class PulsarAdminTool {
             PulsarAdmin admin = adminFactory.apply(adminBuilder);
             for (Map.Entry<String, Class<?>> c : commandMap.entrySet()) {
                 if (admin != null) {
-                    // To remain backwards compatibility for "source" and "sink" commands
-                    // TODO eventually remove this
-                    if (c.getKey().equals("sources") || c.getKey().equals("source")) {
-                        jcommander.addCommand("sources", c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin), "source");
-                    } else if (c.getKey().equals("sinks") || c.getKey().equals("sink")) {
-                        jcommander.addCommand("sinks", c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin), "sink");
-                    } else {
-                        // Other mode, all components are initialized.
-                        jcommander.addCommand(c.getKey(), c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin));
-                    }
+                    addCommand(c, admin);
+                } else {
+                    addCommand(c, admin);
                 }
             }
         } catch (Exception e) {
@@ -145,6 +138,21 @@ public class PulsarAdminTool {
             }
             System.err.println(cause.getClass() + ": " + cause.getMessage());
             System.exit(1);
+        }
+    }
+
+    private void addCommand(Map.Entry<String, Class<?>> c, PulsarAdmin admin) throws Exception {
+        if (c.getKey().equals("sources") || c.getKey().equals("source")) {
+            jcommander.addCommand("sources", c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin), "source");
+        } else if (c.getKey().equals("sinks") || c.getKey().equals("sink")) {
+            jcommander.addCommand("sinks", c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin), "sink");
+        } else if (c.getKey().equals("functions")) {
+            jcommander.addCommand(c.getKey(), c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin));
+        } else {
+            if (admin != null) {
+                // Other mode, all components are initialized.
+                jcommander.addCommand(c.getKey(), c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin));
+            }
         }
     }
 
@@ -205,7 +213,7 @@ public class PulsarAdminTool {
             } else if (cmd.equals("sink")) {
                 cmd = "sinks";
             }
-
+            System.out.println(jcommander.getCommands());
             JCommander obj = jcommander.getCommands().get(cmd);
             CmdBase cmdObj = (CmdBase) obj.getObjects().get(0);
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -123,11 +123,7 @@ public class PulsarAdminTool {
             adminBuilder.authentication(authPluginClassName, authParams);
             PulsarAdmin admin = adminFactory.apply(adminBuilder);
             for (Map.Entry<String, Class<?>> c : commandMap.entrySet()) {
-                if (admin != null) {
-                    addCommand(c, admin);
-                } else {
-                    addCommand(c, admin);
-                }
+                addCommand(c, admin);
             }
         } catch (Exception e) {
             Throwable cause;
@@ -213,7 +209,6 @@ public class PulsarAdminTool {
             } else if (cmd.equals("sink")) {
                 cmd = "sinks";
             }
-            System.out.println(jcommander.getCommands());
             JCommander obj = jcommander.getCommands().get(cmd);
             CmdBase cmdObj = (CmdBase) obj.getObjects().get(0);
 


### PR DESCRIPTION

### Motivation

Start function with the following command:
reverse.py

```
def process(input):
    return input[::-1]
```
```
bin/pulsar-admin functions localrun --py reverse.py --classname reverse --inputs persistent://public/default/my-topic --output persistent://public/default/test --tenant public --namespace default --name reverse
```
Report error:
```
Exception in thread "main" java.lang.NullPointerException
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:218)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:262)
```

### Modifications

Fix localrun of sink, source and function

### Verifying this change
Test pass

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
