### PR TITLE
fix dependency issue with pulsar-io-common

### DIFF
--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -40,9 +40,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-common</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 

--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.io.common;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -65,6 +65,6 @@ public class IOConfigUtils {
 
             }
         }
-        return ObjectMapperFactory.getThreadLocal().convertValue(configs, clazz);
+        return new ObjectMapper().convertValue(configs, clazz);
     }
 }


### PR DESCRIPTION

### Motivation

Can't use pulsar modules within sources/sinks/functions due to internal shading

Will cause exceptions such as

```
23:28:14.120 [tenant-ali/ns-ali/twitter-source1-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [tenant-ali/ns-ali/twitter-source1:0] Uncaught exception in Java Instance
java.lang.NoSuchMethodError: org.apache.pulsar.common.util.ObjectMapperFactory.getThreadLocal()Lcom/fasterxml/jackson/databind/ObjectMapper;
    at org.apache.pulsar.io.common.IOConfigUtils.loadWithSecrets(IOConfigUtils.java:68) ~[pulsar-io-common-2.4.0-SNAPSHOT.jar:2.4.0-SNAPSHOT]
    at org.apache.pulsar.io.common.IOConfigUtils.loadWithSecrets(IOConfigUtils.java:36) ~[pulsar-io-common-2.4.0-SNAPSHOT.jar:2.4.0-SNAPSHOT]
    at org.apache.pulsar.io.twitter.TwitterFireHose.open(TwitterFireHose.java:60) ~[pulsar-io-twitter-0.0.1.nar-unpacked/:?]
    at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:688) ~[java-instance.jar:2.4.0-streamlio-22]
    at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupJavaInstance(JavaInstanceRunnable.java:200) ~[java-instance.jar:2.4.0-streamlio-22]
    at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:230) [java-instance.jar:2.4.0-streamlio-22]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
```

