### PR TITLE
[Hot fix][pulsar-client-admin] InterruptedException shouldn't be swallowed by Pulsar-client-admin silently

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
@@ -57,7 +57,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -77,7 +77,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -110,7 +110,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -143,7 +143,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -176,7 +176,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -195,7 +195,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -226,7 +226,7 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -134,7 +134,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -200,7 +200,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -212,7 +212,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
     
@@ -239,7 +239,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -259,7 +259,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -297,7 +297,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -322,7 +322,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -342,7 +342,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -361,7 +361,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -394,7 +394,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -427,7 +427,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -460,7 +460,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -494,7 +494,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -532,7 +532,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -565,7 +565,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -585,7 +585,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -605,7 +605,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -625,7 +625,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -646,7 +646,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -693,7 +693,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 
@@ -969,7 +969,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e.getCause());
+            throw new PulsarAdminException(e);
         }
     }
 


### PR DESCRIPTION
### Motivation

Currently, in `TopicsImpl`, when an InterruptedException `ie` occurs, it would be caught and throw a `PulsarAdminException` with `ie.cause()`, which in turn is `null` and meaningless to the caller why Pulsar fails.

### Modifications

Change from `throw new PulsarAdminException(e.getCause())` to `throw new PulsarAdminException(e)`.

This change is already covered by existing tests
