### PR TITLE
Removed joda-time test dependency from pulsar-client

### DIFF
--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -142,11 +142,6 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation

Joda-time dependency is already included as `provided` dependency. Having it as a `test` dependency, overrides the `provided` scope.