### PR TITLE
FIX Key_Shared dispatch ordering of message redelivery.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -467,7 +467,7 @@ public interface ManagedCursor {
             throws InterruptedException, ManagedLedgerException;
 
     /**
-     * Read the specified set of positions from ManagedLedger.
+     * Read the specified set of positions from ManagedLedger without ordering.
      *
      * @param positions
      *            set of positions to read
@@ -480,6 +480,23 @@ public interface ManagedCursor {
      */
     Set<? extends Position> asyncReplayEntries(
         Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx);
+
+    /**
+     * Read the specified set of positions from ManagedLedger.
+     *
+     * @param positions
+     *            set of positions to read
+     * @param callback
+     *            callback object returning the list of entries
+     * @param ctx
+     *            opaque context
+     * @param sortEntries
+     *            callback with sorted entry list.
+     * @return skipped positions
+     *              set of positions which are already deleted/acknowledged and skipped while replaying them
+     */
+    Set<? extends Position> asyncReplayEntries(
+            Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx, boolean sortEntries);
 
     /**
      * Close the cursor and releases the associated resources.

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -238,6 +238,11 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
+        public Set<? extends Position> asyncReplayEntries(Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx, boolean sortEntries) {
+            return Sets.newConcurrentHashSet();
+        }
+
+        @Override
         public List<Entry> readEntriesOrWait(int numberOfEntriesToRead)
                 throws InterruptedException, ManagedLedgerException {
             return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  */
-public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMultipleConsumers implements Dispatcher, ReadEntriesCallback {
+public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMultipleConsumers implements Dispatcher, ReadEntriesCallback {
 
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
@@ -297,8 +297,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
                 }
 
                 havePendingReplayRead = true;
-                Set<? extends Position> deletedMessages = cursor.asyncReplayEntries(messagesToReplayNow, this,
-                        ReadType.Replay);
+                Set<? extends Position> deletedMessages = asyncReplayEntries(messagesToReplayNow);
                 // clear already acked positions from replay bucket
 
                 deletedMessages.forEach(position -> messagesToReplay.remove(((PositionImpl) position).getLedgerId(),
@@ -327,6 +326,10 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
                 log.debug("[{}] Consumer buffer is full, pause reading", name);
             }
         }
+    }
+
+    protected Set<? extends Position> asyncReplayEntries(Set<? extends Position> positions) {
+        return cursor.asyncReplayEntries(positions, this, ReadType.Replay);
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -25,10 +25,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
@@ -159,6 +161,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     @Override
     public SubType getType() {
         return SubType.Key_Shared;
+    }
+
+    @Override
+    protected Set<? extends Position> asyncReplayEntries(Set<? extends Position> positions) {
+        return cursor.asyncReplayEntries(positions, this, ReadType.Replay, true);
     }
 
     private byte[] peekStickyKey(ByteBuf metadataAndPayload) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -396,6 +396,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             int redeliveryCount = check.getValue() / 2;
             log.info("[{}] Consumer wait for {} messages redelivery ...", redeliveryCount);
             // messages not acked, test redelivery
+            lastMessageForKey = new HashMap<>();
             for (int i = 0; i < redeliveryCount; i++) {
                 Message<Integer> message = check.getKey().receive();
                 received++;
@@ -403,6 +404,14 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 String key = message.hasOrderingKey() ? new String(message.getOrderingKey()) : message.getKey();
                 log.info("[{}] Receive redeliver message key: {} value: {} messageId: {}",
                         check.getKey().getConsumerName(), key, message.getValue(), message.getMessageId());
+                // check redelivery messages is order by key
+                if (lastMessageForKey.get(key) == null) {
+                    Assert.assertNotNull(message);
+                } else {
+                    Assert.assertTrue(message.getValue()
+                            .compareTo(lastMessageForKey.get(key).getValue()) > 0);
+                }
+                lastMessageForKey.put(key, message);
             }
             Message noMessages = null;
             try {


### PR DESCRIPTION
### Motivation

Ensure redelivery messages is ordered dispatch by key in Key_Shared subscription.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
