### PR TITLE
[pulsar-broker] add topic-name in log on topic unloading failure

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1003,9 +1003,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     public void removeTopicFromCache(String topic) {
+        TopicName topicName = null;
+        NamespaceBundle namespaceBundle = null;
         try {
-            TopicName topicName = TopicName.get(topic);
-            NamespaceBundle namespaceBundle = pulsar.getNamespaceService().getBundle(topicName);
+            topicName = TopicName.get(topic);
+            namespaceBundle = pulsar.getNamespaceService().getBundle(topicName);
             checkArgument(namespaceBundle instanceof NamespaceBundle);
 
             String bundleName = namespaceBundle.toString();
@@ -1030,7 +1032,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 }
             }
         } catch (Exception e) {
-            log.warn("Got exception when retrieving bundle name during removeTopicFromCache", e);
+            log.warn("Got exception when retrieving bundle name {} for topic {} during removeTopicFromCache", topicName,
+                    namespaceBundle, e);
         }
 
         topics.remove(topic);


### PR DESCRIPTION
### Motivation

broker sees NPE while unloading topic but it doesn't log topic name in it so, logging topic name and bundle name help in below failure
```
00:13:57.422 [bookkeeper-ml-workers-OrderedExecutor-0-0] WARN  org.apache.pulsar.broker.service.BrokerService - Got exception when retrieving bundle name during removeTopicFromCache
java.lang.NullPointerException: null
        at org.apache.pulsar.broker.service.BrokerService.removeTopicFromCache(BrokerService.java:1009) ~[pulsar-broker-2.4.0-SNAPSHOT.jar:2.4.0-SNAPSHOT]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic$5.closeFailed(PersistentTopic.java:935) ~[pulsar-broker-2.4.0-SNAPSHOT.jar:2.4.0-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.lambda$closeAllCursors$14(ManagedLedgerImpl.java:1171) ~[managed-ledger-original-2.4.0-SNAPSHOT.jar:2.4.0-SNAPSHOT]
        at java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:870) ~[?:1.8.0_181]
        at java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:852) ~[?:1.8.0_181]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_181]
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962) ~[?:1.8.0_181]
```