### PR TITLE
Use versioned path for reference docs

### DIFF
--- a/pulsar-client-cpp/Doxyfile
+++ b/pulsar-client-cpp/Doxyfile
@@ -77,7 +77,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../generated-site/api/cpp
+OUTPUT_DIRECTORY       = ../target/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -18,17 +18,21 @@
 # under the License.
 #
 
-set -x -e
-
 ROOT_DIR=$(git rev-parse --show-toplevel)
 VERSION=`${ROOT_DIR}/src/get-project-version.py`
-DOXYGEN=doxygen
 
-mkdir -p $ROOT_DIR/generated-site/api/cpp
+set -x -e
 
-(
-  cd $ROOT_DIR/pulsar-client-cpp
-  $DOXYGEN Doxyfile
-)
+${ROOT_DIR}/site2/tools/generate-api-docs.sh
+cd ${ROOT_DIR}/site2/website
+yarn
+yarn write-translations
+yarn run crowdin-upload
+yarn run crowdin-download
+yarn build
 
-mv $ROOT_DIR/target/doxygen/html $ROOT_DIR/generated-site/api/cpp/${VERSION}
+node ./scripts/replace.js
+
+rm -rf ${ROOT_DIR}/generated-site/content
+mkdir -p ${ROOT_DIR}/generated-site/content
+cp -R ./build/pulsar/* ${ROOT_DIR}/generated-site/content

--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -44,4 +44,4 @@ CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 
 DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -e CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID} -e CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY} -v $ROOT_DIR:/pulsar $IMAGE"
 
-$DOCKER_CMD bash -l -c '/pulsar/site2/tools/generate-api-docs.sh && cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && rm -rf /pulsar/generated-site/content && mkdir -p /pulsar/generated-site/content && cp -R ./build/pulsar/* /pulsar/generated-site/content'
+$DOCKER_CMD bash -l -c 'cd /pulsar && /pulsar/site2/tools/build-site.sh'

--- a/site2/tools/generate-api-docs.sh
+++ b/site2/tools/generate-api-docs.sh
@@ -18,7 +18,17 @@
 # under the License.
 #
 
+SCRIPT_DIR=`dirname "$0"`
+cd $SCRIPT_DIR
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION=`${ROOT_DIR}/src/get-project-version.py`
+
 set -x -e
+
+cd ${ROOT_DIR}
+mkdir -p site2/website/static/swagger/${VERSION}
+cp pulsar-broker/target/docs/*.json site2/website/static/swagger/${VERSION}/
 
 SCRIPT_DIR=`dirname "$0"`
 

--- a/site2/tools/javadoc-gen.sh
+++ b/site2/tools/javadoc-gen.sh
@@ -20,6 +20,7 @@
 
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION=`${ROOT_DIR}/src/get-project-version.py`
 DEST_DIR=$ROOT_DIR/generated-site
 JDK_COMMON_PKGS=java.lang:java.util:java.util.concurrent:java.nio:java.net:java.io
 
@@ -32,7 +33,7 @@ JDK_COMMON_PKGS=java.lang:java.util:java.util.concurrent:java.nio:java.net:java.
     -windowtitle "Pulsar Client Java API" \
     -doctitle "Pulsar Client Java API" \
     -overview site/javadoc/client.html \
-    -d $DEST_DIR/api/client \
+    -d $DEST_DIR/api/client/${VERSION}/ \
     -subpackages org.apache.pulsar.client.api \
     -noqualifier $JDK_COMMON_PKGS \
     -notimestamp \
@@ -45,7 +46,7 @@ JDK_COMMON_PKGS=java.lang:java.util:java.util.concurrent:java.nio:java.net:java.
     -windowtitle "Pulsar Admin Java API" \
     -doctitle "Pulsar Admin Java API" \
     -overview site/javadoc/admin.html \
-    -d $DEST_DIR/api/admin \
+    -d $DEST_DIR/api/admin/${VERSION}/ \
     -noqualifier $JDK_COMMON_PKGS \
     -notimestamp \
     -Xdoclint:none \
@@ -58,7 +59,7 @@ JDK_COMMON_PKGS=java.lang:java.util:java.util.concurrent:java.nio:java.net:java.
     -windowtitle "Pulsar Functions Java SDK" \
     -doctitle "Pulsar Functions Java SDK" \
     -overview site/javadoc/pulsar-functions.html \
-    -d $DEST_DIR/api/pulsar-functions \
+    -d $DEST_DIR/api/pulsar-functions/${VERSION}/ \
     -noqualifier $JDK_COMMON_PKGS \
     -notimestamp \
     -Xdoclint:none \

--- a/site2/tools/python-doc-gen.sh
+++ b/site2/tools/python-doc-gen.sh
@@ -21,6 +21,7 @@
 set -xe
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION=`${ROOT_DIR}/src/get-project-version.py`
 
 # Make sure the Python client lib is installed
 # so that Pdoc can import the module
@@ -36,8 +37,9 @@ pip install six
 pip install fastavro
 pip install certifi
 
-DESTINATION=$ROOT_DIR/generated-site/api/python
-rm -fr $DESTINATION/{index.html,functions,pulsar}
+DESTINATION=$ROOT_DIR/generated-site/api/python/${VERSION}
+rm -fr $DESTINATION
+mkdir -p $DESTINATION
 PYTHONPATH=$ROOT_DIR/pulsar-client-cpp/python pdoc pulsar \
   --html \
   --html-dir $DESTINATION


### PR DESCRIPTION
### Motivation

For reference docs (Javadocs, Doxygen, Pdoc and Swagger) we should use version tags. This will make easy to check the documentation for a particular version of Pulsar client.

Additionally, some the reference docs are currently broken (not updating in the website). 

Note: this change only address the 1st part, generating the docs with the version in the URL. It will leave untouched the current docs. 
The next step will be to change the link to point to the versioned docs.