### PR TITLE
Increase timeout for replicator tests setup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -47,13 +47,13 @@ import com.google.common.collect.Sets;
 public class PeerReplicatorTest extends ReplicatorTestBase {
 
     @Override
-    @BeforeClass
+    @BeforeClass(timeOut = 300000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass
+    @AfterClass(timeOut = 300000)
     void shutdown() throws Exception {
         super.shutdown();
     }
@@ -178,11 +178,11 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         }, 5, 100);
         assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), peerClusters);
     }
-	
+
     /**
      * Removing local cluster from the replication-cluster should make sure that bundle should not be loaded by the
      * cluster even if owner broker doesn't receive the watch to avoid lookup-conflict between peer-cluster.
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut = 10000)
@@ -192,7 +192,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         admin1.clusters().updatePeerClusterNames("r1", null);
         admin1.clusters().updatePeerClusterNames("r2", null);
         admin1.clusters().updatePeerClusterNames("r3", null);
-        
+
         final String serviceUrl = pulsar3.getBrokerServiceUrl();
         final String namespace1 = "pulsar/global/peer-change-repl-ns";
         admin1.namespaces().createNamespace(namespace1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -45,13 +45,13 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
     }
 
     @Override
-    @BeforeClass(timeOut = 60000)
+    @BeforeClass(timeOut = 300000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass(timeOut = 60000)
+    @AfterClass(timeOut = 300000)
     void shutdown() throws Exception {
         super.shutdown();
     }
@@ -59,7 +59,7 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
     /**
      * If local cluster is removed from the global namespace then all topics under that namespace should be deleted from
      * the cluster.
-     * 
+     *
      * @throws Exception
      */
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -54,13 +54,13 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     }
 
     @Override
-    @BeforeClass(timeOut = 30000)
+    @BeforeClass(timeOut = 300000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass(timeOut = 30000)
+    @AfterClass(timeOut = 300000)
     void shutdown() throws Exception {
         super.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -99,13 +99,13 @@ public class ReplicatorTest extends ReplicatorTestBase {
     }
 
     @Override
-    @BeforeClass(timeOut = 30000)
+    @BeforeClass(timeOut = 300000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass(timeOut = 30000)
+    @AfterClass(timeOut = 300000)
     void shutdown() throws Exception {
         super.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
@@ -33,7 +33,7 @@ import org.testng.collections.Lists;
 public class ReplicatorTlsTest extends ReplicatorTestBase {
 
     @Override
-    @BeforeClass
+    @BeforeClass(timeOut = 300000)
     void setup() throws Exception {
         config1.setBrokerClientTlsEnabled(true);
         config2.setBrokerClientTlsEnabled(true);
@@ -42,7 +42,7 @@ public class ReplicatorTlsTest extends ReplicatorTestBase {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(timeOut = 300000)
     void shutdown() throws Exception {
         super.shutdown();
     }


### PR DESCRIPTION
### Motivation

In many cases, replicator tests are intermittently failing for timeout on the setup phase. In some of these tests, the timeout is set to 30 seconds. This time might not be enough on the Jenkins, since it takes ~15 secs on a local run.

Increasing all timeouts to 5mins for replicator tests.