### PR TITLE
Upgrade version of maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1364,7 +1364,7 @@ flexible messaging model and an intuitive client API.</description>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.21.0</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Motivation

Ugrade to latest version of Maven surefire plugin for executing tests. Current version supports java 9-12. 

Also, it might be helpful to check for a better handling of these errors:
```
org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```