### PR TITLE
[Issue 4441][client]Deduce ClientConfigurationData.isUseTls from protocol

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -77,7 +77,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     public boolean isUseTls() {
         if (useTls)
             return true;
-        if (this.getServiceUrl().startsWith("pulsar+ssl") || this.getServiceUrl().startsWith("https")) {
+        if (getServiceUrl() != null && (this.getServiceUrl().startsWith("pulsar+ssl") || this.getServiceUrl().startsWith("https"))) {
             this.useTls = true;
             return true;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -74,6 +74,16 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private long defaultBackoffIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
     private long maxBackoffIntervalNanos = TimeUnit.SECONDS.toNanos(30);
 
+    public boolean isUseTls() {
+        if (useTls)
+            return true;
+        if (this.getServiceUrl().startsWith("pulsar+ssl") || this.getServiceUrl().startsWith("https")) {
+            this.useTls = true;
+            return true;
+        }
+        return false;
+    }
+
     public ClientConfigurationData clone() {
         try {
             return (ClientConfigurationData) super.clone();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
@@ -66,7 +66,7 @@ public class BuildersTest {
         assertEquals(builder.conf.getServiceUrl(), "pulsar://service:6650");
 
         builder = (ClientBuilderImpl)PulsarClient.builder().serviceUrl("pulsar+ssl://service:6650").enableTls(false);
-        assertEquals(builder.conf.isUseTls(), false);
+        assertEquals(builder.conf.isUseTls(), true);
         assertEquals(builder.conf.getServiceUrl(), "pulsar+ssl://service:6650");
     }
 }


### PR DESCRIPTION
### Motivation
There are two ways of instantiating a java client and both should behave in similar ways. As of now, PulsarClient.builder assumes tls enabled if the pulsar+ssl or https is used in the service url. In fact, the builder marks enableTls() as deprecated.

ClientConfigurationData.java lags a bit that way. It does not enable tls if pulsar+ssl or https is used in service url.

### Modifications
Deduce tls from protocol