### PR TITLE
[pulsar-broker] fix ConcurrentModificationException while load-report serialization

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.Maps;
 
 
 /**
@@ -94,7 +95,7 @@ public class LocalBrokerData extends JSONWritable implements LoadManagerReport {
         this.webServiceUrlTls = webServiceUrlTls;
         this.pulsarServiceUrl = pulsarServiceUrl;
         this.pulsarServiceUrlTls = pulsarServiceUrlTls;
-        lastStats = new HashMap<>();
+        lastStats = Maps.newConcurrentMap();
         lastUpdate = System.currentTimeMillis();
         cpu = new ResourceUsage();
         memory = new ResourceUsage();


### PR DESCRIPTION
### Motivation

Load-balancer fails to write load-report due to below exception `java.util.ConcurrentModificationException) (through reference chain: org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData["lastStats"])` which happens due to `lastStats` field into `LocalBrokerData` that is being modified and access from different threads.

```
01:24:23.044 [pulsar-load-manager-4-1] WARN  org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl - Error writing broker data on ZooKeeper: {}
com.fasterxml.jackson.databind.JsonMappingException: (was java.util.ConcurrentModificationException) (through reference chain: org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData["lastStats"])
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:394) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:353) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:316) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:727) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3905) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsBytes(ObjectMapper.java:3243) ~[jackson-databind-2.9.7.jar:2.9.7]
        at org.apache.pulsar.policies.data.loadbalancer.JSONWritable.getJsonBytes(JSONWritable.java:39) ~[pulsar-common-2.2.jar:2.2]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.writeBrokerDataOnZooKeeper(ModularLoadManagerImpl.java:859) [pulsar-broker-2.2.jar:2.2]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.writeLoadReportOnZookeeper(ModularLoadManagerWrapper.java:110) [pulsar-broker-2.2.jar:2.2]
        at org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask.run(LoadReportUpdaterTask.java:41) [pulsar-broker-2.2.jar:2.2]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_181]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_181]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_181]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_181]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.22.Final.jar:4.1.22.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442) ~[?:1.8.0_181]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1476) ~[?:1.8.0_181]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1474) ~[?:1.8.0_181]
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeOptionalFields(MapSerializer.java:740) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:635) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:33) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:727) ~[jackson-databind-2.9.7.jar:2.9.7]
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:719) ~[jackson-databind-2.9.7.jar:2.9.7]
        ... 17 more
```

### Modification

making `lastStats` concurrentHashMap will fix `ConcurrentModificationException`