### PR TITLE
[pulsar-ml] handle race condition between timeout-task and add-call complete

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -228,6 +228,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private static final AtomicLongFieldUpdater<ManagedLedgerImpl> READ_OP_COUNT_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ManagedLedgerImpl.class, "readOpCount");
     private volatile long readOpCount = 0;
+    protected static final AtomicLongFieldUpdater<ManagedLedgerImpl> ADD_OP_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(ManagedLedgerImpl.class, "addOpCount");
+    private volatile long addOpCount = 0;
 
     private final long backloggedCursorThresholdEntries;
 
@@ -3084,7 +3087,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             if (isTimedOut) {
                 log.error("Failed to add entry for ledger {} in time-out {} sec",
                         (opAddEntry.ledger != null ? opAddEntry.ledger.getId() : -1), timeoutSec);
-                opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, opAddEntry.ctx);
+                opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, opAddEntry.addOpCount);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3080,12 +3080,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         OpAddEntry opAddEntry = pendingAddEntries.peek();
         if (opAddEntry != null) {
             boolean isTimedOut = opAddEntry.lastInitTime != -1
-                    && TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - opAddEntry.lastInitTime) >= timeoutSec
-                    && opAddEntry.completed == FALSE;
+                    && TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - opAddEntry.lastInitTime) >= timeoutSec;
             if (isTimedOut) {
                 log.error("Failed to add entry for ledger {} in time-out {} sec",
                         (opAddEntry.ledger != null ? opAddEntry.ledger.getId() : -1), timeoutSec);
-                opAddEntry.handleAddFailure(opAddEntry.ledger);
+                opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, opAddEntry.ctx);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -24,9 +24,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -38,8 +37,6 @@ import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.TRUE;
-import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.FALSE;
 
 /**
  * Handles the life-cycle of an addEntry() operation.
@@ -53,9 +50,9 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     @SuppressWarnings("unused")
     private volatile AddEntryCallback callback;
     Object ctx;
-    private volatile Object ctxForCallbackComplete;
-    private static final AtomicReferenceFieldUpdater<OpAddEntry, Object> CTX_FOR_CALLBACK_COMPLETE = AtomicReferenceFieldUpdater
-            .newUpdater(OpAddEntry.class, Object.class, "ctxForCallbackComplete");
+    volatile long addOpCount;
+    private static final AtomicLongFieldUpdater<OpAddEntry> ADD_OP_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(OpAddEntry.class, "addOpCount");
     private boolean closeWhenDone;
     private long startTime;
     volatile long lastInitTime;
@@ -74,7 +71,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         op.dataLength = data.readableBytes();
         op.callback = callback;
         op.ctx = ctx;
-        op.ctxForCallbackComplete = ctx;
+        op.addOpCount = ManagedLedgerImpl.ADD_OP_COUNT_UPDATER.incrementAndGet(ml);
         op.closeWhenDone = false;
         op.entryId = -1;
         op.startTime = System.nanoTime();
@@ -97,9 +94,9 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         ByteBuf duplicateBuffer = data.retainedDuplicate();
 
         // internally asyncAddEntry() will take the ownership of the buffer and release it at the end
-        this.ctxForCallbackComplete = ctx;
-        this.lastInitTime = System.nanoTime();
-        ledger.asyncAddEntry(duplicateBuffer, this, ctx);
+        addOpCount = ManagedLedgerImpl.ADD_OP_COUNT_UPDATER.incrementAndGet(ml);;
+        lastInitTime = System.nanoTime();
+        ledger.asyncAddEntry(duplicateBuffer, this, addOpCount);
     }
 
     public void failed(ManagedLedgerException e) {
@@ -118,7 +115,6 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         }
         checkArgument(ledger.getId() == lh.getId(), "ledgerId %s doesn't match with acked ledgerId %s", ledger.getId(),
                 lh.getId());
-        checkArgument(this.ctx == ctx);
         
         if (!checkAndCompleteOp(ctx)) {
             // means callback might have been completed by different thread (timeout task thread).. so do nothing
@@ -210,16 +206,16 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
      * @return true if task is not already completed else returns false.
      */
     private boolean checkAndCompleteOp(Object ctx) {
-        if (ctx != null && !CTX_FOR_CALLBACK_COMPLETE.compareAndSet(this, ctx, null)) {
-            log.info("Add-entry already completed for {}-{}", this.ledger != null ? this.ledger.getId() : -1,
-                    this.entryId);
-            return false;
+        long addOpCount = (ctx != null && ctx instanceof Long) ? (long) ctx : -1;
+        if (addOpCount != -1 && ADD_OP_COUNT_UPDATER.compareAndSet(this, this.addOpCount, -1)) {
+            return true;
         }
-        return true;
+        log.info("Add-entry already completed for {}-{}", ledger != null ? ledger.getId() : -1, entryId);
+        return false;
     }
 
     void handleAddTimeoutFailure(final LedgerHandle ledger, Object ctx) {
-        if (!checkAndCompleteOp(ctx)) {
+        if (checkAndCompleteOp(ctx)) {
             this.handleAddFailure(ledger);
         }
     }
@@ -261,7 +257,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         dataLength = -1;
         callback = null;
         ctx = null;
-        ctxForCallbackComplete = null;
+        addOpCount = -1;
         closeWhenDone = false;
         entryId = -1;
         startTime = -1;


### PR DESCRIPTION
### Motivation
Broker has addEntry operation-timeout task which can timeout Add-entry operation if it's not completed in configured time. So, addEntry operation can be completed by timeout-task or normal bk-client thread. This PR makes sure that addEntry task can be completed atomically by one thread only.