### PR TITLE
Issue 4456: add sasl-client jar into server distribution

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -60,6 +60,12 @@
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-auth-sasl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/site2/docs/security-kerberos.md
+++ b/site2/docs/security-kerberos.md
@@ -127,7 +127,17 @@ Make sure that the keytabs configured in the `pulsar_jaas.conf` file and kdc ser
 
 ### Kerberos configuration for clients
 
-In client, we need to configure the authentication type to use `AuthenticationSasl`, and also provide the authentication parameters to it. 
+In client application, include `pulsar-client-auth-sasl` in your project dependency.
+
+```
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-auth-sasl</artifactId>
+      <version>${pulsar.version}</version>
+    </dependency>
+```
+
+configure the authentication type to use `AuthenticationSasl`, and also provide the authentication parameters to it. 
 
 There are 2 parameters needed: 
 - `saslJaasClientSectionName` is corresponding to the section in JAAS configuration file for client; 


### PR DESCRIPTION
Fixes #4456

### Motivation
sometimes, user may use sasl client directly, e.g. use cli command bin/pulsar-client, and if sasl-client not included in, it may meet error of `class not found`