### PR TITLE
[pulsar-broker] support secondary bookie isolation group at namespace

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -756,12 +756,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Enable bookie secondary-isolation group if bookkeeperClientIsolationGroups doesn't have enough bookie available."
                 )
     private String bookkeeperClientSecondaryIsolationGroups;
-    @FieldContext(
-            category = CATEGORY_STORAGE_BK,
-            required = false,
-            doc = "Minimum bookies that should be available as part of bookkeeperClientIsolationGroups \n\n"
-                + "else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.")
-    private int bookkeeperClientMinAvailableBookiesInIsolationGroups = 0;
     @FieldContext(category = CATEGORY_STORAGE_BK, doc = "Enable/disable having read operations for a ledger to be sticky to "
             + "a single bookie.\n" +
             "If this flag is enabled, the client will use one single bookie (by " +

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -124,8 +124,6 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
                     conf.getBookkeeperClientIsolationGroups());
             bkConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                     conf.getBookkeeperClientSecondaryIsolationGroups());
-            bkConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.MIN_AVAILABLE_PRIMARY_ISOLATED_BOOKIE,
-                    conf.getBookkeeperClientMinAvailableBookiesInIsolationGroups());
             if (bkConf.getProperty(ZooKeeperCache.ZK_CACHE_INSTANCE) == null) {
                 ZooKeeperCache zkc = new ZooKeeperCache(zkClient, conf.getZooKeeperOperationTimeoutSeconds()) {
                 };

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
@@ -552,13 +553,13 @@ public class Namespaces extends NamespacesBase {
     }
 
     @POST
-    @Path("/{property}/{cluster}/{namespace}/persistence/bookieAffinity/{bookieAffinityGroup}")
+    @Path("/{property}/{cluster}/{namespace}/persistence/bookieAffinity")
     @ApiOperation(hidden = true, value = "Set the bookie-affinity-group to namespace-local policy.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
     public void setBookieAffinityGroup(@PathParam("property") String property, @PathParam("cluster") String cluster,
-            @PathParam("namespace") String namespace, @PathParam("bookieAffinityGroup") String bookieAffinityGroup) {
+            @PathParam("namespace") String namespace, BookieAffinityGroupData bookieAffinityGroup) {
         validateNamespaceName(property, cluster, namespace);
         internalSetBookieAffinityGroup(bookieAffinityGroup);
     }
@@ -569,7 +570,7 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
-    public String getBookieAffinityGroup(@PathParam("property") String property,
+    public BookieAffinityGroupData getBookieAffinityGroup(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
         return internalGetBookieAffinityGroup();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
@@ -492,13 +493,13 @@ public class Namespaces extends NamespacesBase {
     }
 
     @POST
-    @Path("/{tenant}/{namespace}/persistence/bookieAffinity/{bookieAffinityGroup}")
+    @Path("/{tenant}/{namespace}/persistence/bookieAffinity")
     @ApiOperation(value = "Set the bookie-affinity-group to namespace-persistent policy.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
     public void setBookieAffinityGroup(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
-            @PathParam("bookieAffinityGroup") String bookieAffinityGroup) {
+            BookieAffinityGroupData bookieAffinityGroup) {
         validateNamespaceName(tenant, namespace);
         internalSetBookieAffinityGroup(bookieAffinityGroup);
     }
@@ -509,7 +510,7 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
-    public String getBookieAffinityGroup(@PathParam("property") String property,
+    public BookieAffinityGroupData getBookieAffinityGroup(@PathParam("property") String property,
             @PathParam("namespace") String namespace) {
         validateNamespaceName(property, namespace);
         return internalGetBookieAffinityGroup();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -746,12 +746,14 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             managedLedgerConfig.setEnsembleSize(persistencePolicies.getBookkeeperEnsemble());
             managedLedgerConfig.setWriteQuorumSize(persistencePolicies.getBookkeeperWriteQuorum());
             managedLedgerConfig.setAckQuorumSize(persistencePolicies.getBookkeeperAckQuorum());
-            if (localPolicies.isPresent() && StringUtils.isNotBlank(localPolicies.get().bookkeeperAffinityGroup)) {
+            if (localPolicies.isPresent() && localPolicies.get().bookieAffinityGroup != null) {
                 managedLedgerConfig
                         .setBookKeeperEnsemblePlacementPolicyClassName(ZkIsolatedBookieEnsemblePlacementPolicy.class);
                 Map<String, Object> properties = Maps.newHashMap();
                 properties.put(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS,
-                        localPolicies.get().bookkeeperAffinityGroup);
+                        localPolicies.get().bookieAffinityGroup.bookkeeperAffinityGroupPrimary);
+                properties.put(ZkIsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
+                        localPolicies.get().bookieAffinityGroup.bookkeeperAffinityGroupSecondary);
                 managedLedgerConfig.setBookKeeperEnsemblePlacementPolicyProperties(properties);
             }
             managedLedgerConfig.setThrottleMarkDelete(persistencePolicies.getManagedLedgerMaxMarkDeleteRate());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -52,6 +53,8 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException.BrokerPersistenceException;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -173,13 +176,19 @@ public class BrokerBookieIsolationTest {
         admin.namespaces().createNamespace(ns2);
         admin.namespaces().createNamespace(ns3);
         admin.namespaces().createNamespace(ns4);
-        admin.namespaces().setBookieAffinityGroup(ns2, tenantNamespaceIsolationGroups);
-        admin.namespaces().setBookieAffinityGroup(ns3, tenantNamespaceIsolationGroups);
-        admin.namespaces().setBookieAffinityGroup(ns4, tenantNamespaceIsolationGroups);
+        admin.namespaces().setBookieAffinityGroup(ns2,
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
+        admin.namespaces().setBookieAffinityGroup(ns3,
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
+        admin.namespaces().setBookieAffinityGroup(ns4,
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
 
-        assertEquals(admin.namespaces().getBookieAffinityGroup(ns2), tenantNamespaceIsolationGroups);
-        assertEquals(admin.namespaces().getBookieAffinityGroup(ns3), tenantNamespaceIsolationGroups);
-        assertEquals(admin.namespaces().getBookieAffinityGroup(ns4), tenantNamespaceIsolationGroups);
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns2),
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns3),
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns4),
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroups, null));
 
         try {
             admin.namespaces().getBookieAffinityGroup(ns1);
@@ -230,10 +239,137 @@ public class BrokerBookieIsolationTest {
 
         // broker should create only 1 bk-client and factory per isolation-group
         assertEquals(bkPlacementPolicyToBkClientMap.size(), 1);
-        Class<? extends EnsemblePlacementPolicy> clazz = bkPlacementPolicyToBkClientMap.keySet().iterator().next()
-                .getPolicyClass();
-        System.out.println(clazz);
+    }
 
+    /**
+     * It verifies that "ZkIsolatedBookieEnsemblePlacementPolicy" considers secondary affinity-group if primary group
+     * doesn't have enough non-faulty bookies.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testBookieIsilationWithSecondaryGroup() throws Exception {
+
+        final String tenant1 = "tenant1";
+        final String cluster = "use";
+        final String ns1 = String.format("%s/%s/%s", tenant1, cluster, "ns1");
+        final String ns2 = String.format("%s/%s/%s", tenant1, cluster, "ns2");
+        final String ns3 = String.format("%s/%s/%s", tenant1, cluster, "ns3");
+        final String ns4 = String.format("%s/%s/%s", tenant1, cluster, "ns4");
+        final int totalPublish = 100;
+
+        final String brokerBookkeeperClientIsolationGroups = "default-group";
+        final String tenantNamespaceIsolationGroupsPrimary = "tenant1-isolation-primary";
+        final String tenantNamespaceIsolationGroupsSecondary = "tenant1-isolation=secondary";
+
+        BookieServer[] bookies = bkEnsemble.getBookies();
+        ZooKeeper zkClient = bkEnsemble.getZkClient();
+
+        Set<BookieSocketAddress> defaultBookies = Sets.newHashSet(bookies[0].getLocalAddress(),
+                bookies[1].getLocalAddress());
+        Set<BookieSocketAddress> isolatedBookies = Sets.newHashSet(bookies[2].getLocalAddress(),
+                bookies[3].getLocalAddress());
+
+        setDefaultIsolationGroup(brokerBookkeeperClientIsolationGroups, zkClient, defaultBookies);
+        // primary group empty
+        setDefaultIsolationGroup(tenantNamespaceIsolationGroupsPrimary, zkClient, Sets.newHashSet());
+        setDefaultIsolationGroup(tenantNamespaceIsolationGroupsSecondary, zkClient, isolatedBookies);
+
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+        config.setClusterName(cluster);
+        config.setWebServicePort(Optional.of(PRIMARY_BROKER_WEBSERVICE_PORT));
+        config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
+        config.setBrokerServicePort(Optional.of(PRIMARY_BROKER_PORT));
+        config.setAdvertisedAddress("localhost");
+        config.setBookkeeperClientIsolationGroups(brokerBookkeeperClientIsolationGroups);
+
+        config.setManagedLedgerDefaultEnsembleSize(2);
+        config.setManagedLedgerDefaultWriteQuorum(2);
+        config.setManagedLedgerDefaultAckQuorum(2);
+
+        int totalEntriesPerLedger = 20;
+        int totalLedgers = totalPublish / totalEntriesPerLedger;
+        config.setManagedLedgerMaxEntriesPerLedger(totalEntriesPerLedger);
+        config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        pulsarService = new PulsarService(config);
+        pulsarService.start();
+
+        URL brokerUrl = new URL("http://127.0.0.1" + ":" + PRIMARY_BROKER_WEBSERVICE_PORT);
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).build();
+
+        ClusterData clusterData = new ClusterData(pulsarService.getWebServiceAddress());
+        admin.clusters().createCluster(cluster, clusterData);
+        TenantInfo tenantInfo = new TenantInfo(null, Sets.newHashSet(cluster));
+        admin.tenants().createTenant(tenant1, tenantInfo);
+        admin.namespaces().createNamespace(ns1);
+        admin.namespaces().createNamespace(ns2);
+        admin.namespaces().createNamespace(ns3);
+        admin.namespaces().createNamespace(ns4);
+        admin.namespaces().setBookieAffinityGroup(ns2, new BookieAffinityGroupData(
+                tenantNamespaceIsolationGroupsPrimary, tenantNamespaceIsolationGroupsSecondary));
+        admin.namespaces().setBookieAffinityGroup(ns3, new BookieAffinityGroupData(
+                tenantNamespaceIsolationGroupsPrimary, tenantNamespaceIsolationGroupsSecondary));
+        admin.namespaces().setBookieAffinityGroup(ns4,
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroupsPrimary, null));
+
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns2), new BookieAffinityGroupData(
+                tenantNamespaceIsolationGroupsPrimary, tenantNamespaceIsolationGroupsSecondary));
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns3), new BookieAffinityGroupData(
+                tenantNamespaceIsolationGroupsPrimary, tenantNamespaceIsolationGroupsSecondary));
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns4),
+                new BookieAffinityGroupData(tenantNamespaceIsolationGroupsPrimary, null));
+
+        try {
+            admin.namespaces().getBookieAffinityGroup(ns1);
+        } catch (PulsarAdminException.NotFoundException e) {
+            // Ok
+        }
+
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(brokerUrl.toString())
+                .statsInterval(-1, TimeUnit.SECONDS).build();
+
+        PersistentTopic topic1 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns1, "topic1", totalPublish);
+        PersistentTopic topic2 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns2, "topic1", totalPublish);
+        PersistentTopic topic3 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns3, "topic1", totalPublish);
+
+        Bookie bookie1 = bookies[0].getBookie();
+        Field ledgerManagerField = Bookie.class.getDeclaredField("ledgerManager");
+        ledgerManagerField.setAccessible(true);
+        LedgerManager ledgerManager = (LedgerManager) ledgerManagerField.get(bookie1);
+
+        // namespace: ns1
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) topic1.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), defaultBookies);
+
+        // namespace: ns2
+        ml = (ManagedLedgerImpl) topic2.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), isolatedBookies);
+
+        // namespace: ns3
+        ml = (ManagedLedgerImpl) topic3.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), isolatedBookies);
+
+        ManagedLedgerClientFactory mlFactory = pulsarService.getManagedLedgerClientFactory();
+        Map<EnsemblePlacementPolicyConfig, BookKeeper> bkPlacementPolicyToBkClientMap = mlFactory
+                .getBkEnsemblePolicyToBookKeeperMap();
+
+        // broker should create only 1 bk-client and factory per isolation-group
+        assertEquals(bkPlacementPolicyToBkClientMap.size(), 1);
+
+        // ns4 doesn't have secondary group so, publish should fail
+        try {
+            PersistentTopic topic4 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns4, "topic1", 1);
+            fail("should have failed due to not enough non-faulty bookie");
+        } catch (BrokerPersistenceException e) {
+            // Ok..
+        }
     }
 
     private void assertAffinityBookies(LedgerManager ledgerManager, List<LedgerInfo> ledgers1,
@@ -257,7 +393,7 @@ public class BrokerBookieIsolationTest {
                 .subscribe();
         consumer.close();
 
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName).sendTimeout(5, TimeUnit.SECONDS);
 
         Producer<byte[]> producer = producerBuilder.create();
         for (int i = 0; i < totalPublish; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -269,10 +269,12 @@ public class BrokerBookieIsolationTest {
                 bookies[1].getLocalAddress());
         Set<BookieSocketAddress> isolatedBookies = Sets.newHashSet(bookies[2].getLocalAddress(),
                 bookies[3].getLocalAddress());
+        Set<BookieSocketAddress> downedBookies = Sets.newHashSet(new BookieSocketAddress("1.1.1.1:1111"),
+                new BookieSocketAddress("1.1.1.1:1112"));
 
         setDefaultIsolationGroup(brokerBookkeeperClientIsolationGroups, zkClient, defaultBookies);
         // primary group empty
-        setDefaultIsolationGroup(tenantNamespaceIsolationGroupsPrimary, zkClient, Sets.newHashSet());
+        setDefaultIsolationGroup(tenantNamespaceIsolationGroupsPrimary, zkClient, downedBookies);
         setDefaultIsolationGroup(tenantNamespaceIsolationGroupsSecondary, zkClient, isolatedBookies);
 
         ServiceConfiguration config = new ServiceConfiguration();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
@@ -761,9 +762,28 @@ public interface Namespaces {
      */
     PersistencePolicies getPersistence(String namespace) throws PulsarAdminException;
 
-    void setBookieAffinityGroup(String namespace, String bookieAffinityGroup) throws PulsarAdminException;
+    /**
+     * Set bookie affinity group for a namespace to isolate namespace write to bookies that are part of given affinity
+     * group.
+     * 
+     * @param namespace
+     *            namespace name
+     * @param bookieAffinityGroup
+     *            bookie affinity group
+     * @throws PulsarAdminException
+     */
+    void setBookieAffinityGroup(String namespace, BookieAffinityGroupData bookieAffinityGroup)
+            throws PulsarAdminException;
+    
 
-    String getBookieAffinityGroup(String namespace) throws PulsarAdminException;
+    /**
+     * Get bookie affinity group configured for a namespace.
+     * 
+     * @param namespace
+     * @return
+     * @throws PulsarAdminException
+     */
+    BookieAffinityGroupData getBookieAffinityGroup(String namespace) throws PulsarAdminException;
 
     /**
      * Set the retention configuration for all the topics on a namespace.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
@@ -404,22 +405,22 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void setBookieAffinityGroup(String namespace, String bookieAffinityGroup) throws PulsarAdminException {
+    public void setBookieAffinityGroup(String namespace, BookieAffinityGroupData bookieAffinityGroup) throws PulsarAdminException {
         try {
             NamespaceName ns = NamespaceName.get(namespace);
-            WebTarget path = namespacePath(ns, "persistence", "bookieAffinity", bookieAffinityGroup);
-            request(path).post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+            WebTarget path = namespacePath(ns, "persistence", "bookieAffinity");
+            request(path).post(Entity.entity(bookieAffinityGroup, MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }
     }
 
     @Override
-    public String getBookieAffinityGroup(String namespace) throws PulsarAdminException {
+    public BookieAffinityGroupData getBookieAffinityGroup(String namespace) throws PulsarAdminException {
         try {
             NamespaceName ns = NamespaceName.get(namespace);
             WebTarget path = namespacePath(ns, "persistence", "bookieAffinity");
-            return request(path).get(String.class);
+            return request(path).get(BookieAffinityGroupData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -280,8 +281,10 @@ public class PulsarAdminToolTest {
         namespaces.run(split("get-clusters myprop/clust/ns1"));
         verify(mockNamespaces).getNamespaceReplicationClusters("myprop/clust/ns1");
 
-        namespaces.run(split("set-bookie-affinity-group myprop/clust/ns1 --group test"));
-        verify(mockNamespaces).setBookieAffinityGroup("myprop/clust/ns1", "test");
+        namespaces
+                .run(split("set-bookie-affinity-group myprop/clust/ns1 --primary-group test1 --secondary-group test2"));
+        verify(mockNamespaces).setBookieAffinityGroup("myprop/clust/ns1",
+                new BookieAffinityGroupData("test1", "test2"));
         
         namespaces.run(split("get-bookie-affinity-group myprop/clust/ns1"));
         verify(mockNamespaces).getBookieAffinityGroup("myprop/clust/ns1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -431,7 +431,7 @@ public class CmdNamespaces extends CmdBase {
                 "-pg" }, description = "Bookie-affinity primary-groups (comma separated) name where namespace messages should be written", required = true)
         private String bookieAffinityGroupNamePrimary;
         @Parameter(names = { "--secondary-group",
-                "-sg" }, description = "Bookie-affinity secondary-group (comma separated) name where namespace messages should be written", required = true)
+                "-sg" }, description = "Bookie-affinity secondary-group (comma separated) name where namespace messages should be written", required = false)
         private String bookieAffinityGroupNameSecondary;
 
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
@@ -426,15 +427,19 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--group",
-                "-g" }, description = "Bookie-affinity group name where namespace messages should be written", required = true)
-        private String bookieAffinityGroupName;
+        @Parameter(names = { "--primary-group",
+                "-pg" }, description = "Bookie-affinity primary-groups (comma separated) name where namespace messages should be written", required = true)
+        private String bookieAffinityGroupNamePrimary;
+        @Parameter(names = { "--secondary-group",
+                "-sg" }, description = "Bookie-affinity secondary-group (comma separated) name where namespace messages should be written", required = true)
+        private String bookieAffinityGroupNameSecondary;
 
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            admin.namespaces().setBookieAffinityGroup(namespace, bookieAffinityGroupName);
+            admin.namespaces().setBookieAffinityGroup(namespace,
+                    new BookieAffinityGroupData(bookieAffinityGroupNamePrimary, bookieAffinityGroupNameSecondary));
         }
     }
     

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookieAffinityGroupData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookieAffinityGroupData.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import com.google.common.base.Objects;
+
+public class BookieAffinityGroupData {
+
+    public String bookkeeperAffinityGroupPrimary;
+    public String bookkeeperAffinityGroupSecondary;
+
+    public BookieAffinityGroupData() {
+    }
+
+    public BookieAffinityGroupData(String bookkeeperAffinityGroupPrimary, String bookkeeperAffinityGroupSecondary) {
+        this.bookkeeperAffinityGroupPrimary = bookkeeperAffinityGroupPrimary;
+        this.bookkeeperAffinityGroupSecondary = bookkeeperAffinityGroupSecondary;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(bookkeeperAffinityGroupPrimary, bookkeeperAffinityGroupSecondary);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BookieAffinityGroupData) {
+            BookieAffinityGroupData other = (BookieAffinityGroupData) obj;
+            return Objects.equal(bookkeeperAffinityGroupPrimary, other.bookkeeperAffinityGroupPrimary)
+                    && Objects.equal(bookkeeperAffinityGroupSecondary, other.bookkeeperAffinityGroupSecondary);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("bookkeeperAffinityGroupPrimary=%s bookkeeperAffinityGroupSecondary=%s",
+                bookkeeperAffinityGroupPrimary, bookkeeperAffinityGroupSecondary);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
@@ -25,7 +25,7 @@ import com.google.common.base.Objects;
 public class LocalPolicies {
 
     public BundlesData bundles;
-    public String bookkeeperAffinityGroup;
+    public BookieAffinityGroupData bookieAffinityGroup;
 
     public LocalPolicies() {
         bundles = defaultBundle();
@@ -33,7 +33,7 @@ public class LocalPolicies {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(bundles, bookkeeperAffinityGroup);
+        return Objects.hashCode(bundles, bookieAffinityGroup);
     }
 
     @Override
@@ -41,7 +41,7 @@ public class LocalPolicies {
         if (obj instanceof LocalPolicies) {
             LocalPolicies other = (LocalPolicies) obj;
             return Objects.equal(bundles, other.bundles)
-                    && Objects.equal(bookkeeperAffinityGroup, other.bookkeeperAffinityGroup);
+                    && Objects.equal(bookieAffinityGroup, other.bookieAffinityGroup);
         }
         return false;
     }

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
@@ -390,7 +390,6 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         });
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS, secondaryIsolatedGroup);
-        bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.MIN_AVAILABLE_PRIMARY_ISOLATED_BOOKIE, 2);
         isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
                 NullStatsLogger.INSTANCE);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
@@ -436,7 +435,6 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                 secondaryIsolatedGroup);
-        bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.MIN_AVAILABLE_PRIMARY_ISOLATED_BOOKIE, 2);
         isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
                 NullStatsLogger.INSTANCE);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);


### PR DESCRIPTION
### Motivation
with #4261, broker supports secondary bk-isolation group. Now, namespace level bookie-isolation can also have secondary isolation group to fallback if primary isolation group doesn't have enough bookies available.

### Modification
- rest api change to accept bookieAffinityGroup data and cli/admin-client can pass the expected data.
- bk-client can receive both primary and secondary isolation groups to create ensemble for ledgers of the namespace topics.

