### PR TITLE
[hotfix] enable get boolean schema in AutoConsumeSchema

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -96,6 +96,8 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
                 return FloatSchema.of();
             case DOUBLE:
                 return DoubleSchema.of();
+            case BOOLEAN:
+                return BooleanSchema.of();
             case BYTES:
                 return BytesSchema.of();
             case DATE:


### PR DESCRIPTION
BooleanSchema has been left out in `AutoConsumeSchema#getSchema(SchemaInfo)`.
