### PR TITLE
[pulsar-client-tools] Print the exception message when authentication failed to create

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -122,6 +122,7 @@ public class PulsarClientTool {
                                      // it will default to the values passed in by the constructor
             } catch (UnsupportedAuthenticationException exp) {
                 System.out.println("Failed to load an authentication plugin");
+                exp.printStackTrace();
                 commandParser.usage();
                 return -1;
             }


### PR DESCRIPTION
### Motivation

It would be better to print stack trace when `authentication` init throws exception in order to specify a cause.