### PR TITLE
fix minor issue when cleaning up subscriptions for functions

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -346,7 +346,7 @@ public class FunctionActioner {
                                                             List<Map<String, String>> existingConsumers = Collections.emptyList();
                                                             try {
                                                                 TopicStats stats = pulsarAdmin.topics().getStats(topic);
-                                                                SubscriptionStats sub = stats.subscriptions.get(InstanceUtils.getDefaultSubscriptionName(details));
+                                                                SubscriptionStats sub = stats.subscriptions.get(subscriptionName);
                                                                 if (sub != null) {
                                                                     existingConsumers = sub.consumers.stream()
                                                                             .map(consumerStats -> consumerStats.metadata)


### PR DESCRIPTION

### Motivation

The subscription named used to print out connected consumers for debugging purposes is not always correct

