### PR TITLE
Issue 4469: add function worker client auth config in standalone

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -307,6 +307,9 @@ public class PulsarStandalone implements AutoCloseable {
             workerConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
             workerConfig.setZooKeeperOperationTimeoutSeconds(config.getZooKeeperOperationTimeoutSeconds());
 
+            workerConfig.setUseTls(config.isTlsEnabled());
+            workerConfig.setTlsHostnameVerificationEnable(false);
+
             workerConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
             workerConfig.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -307,6 +307,9 @@ public class PulsarStandalone implements AutoCloseable {
             workerConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
             workerConfig.setZooKeeperOperationTimeoutSeconds(config.getZooKeeperOperationTimeoutSeconds());
 
+            workerConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
+            workerConfig.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
+
             // client in worker will use this config to authenticate with broker
             workerConfig.setClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
             workerConfig.setClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -288,7 +288,7 @@ public class PulsarStandalone implements AutoCloseable {
             } else if (workerConfig.getStateStorageServiceUrl() == null) {
                 workerConfig.setStateStorageServiceUrl("bk://127.0.0.1:" + this.getStreamStoragePort());
             }
-            
+
             String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                 config.getAdvertisedAddress());
             workerConfig.setWorkerHostname(hostname);
@@ -306,6 +306,10 @@ public class PulsarStandalone implements AutoCloseable {
             workerConfig.setConfigurationStoreServers(config.getConfigurationStoreServers());
             workerConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
             workerConfig.setZooKeeperOperationTimeoutSeconds(config.getZooKeeperOperationTimeoutSeconds());
+
+            // client in worker will use this config to authenticate with broker
+            workerConfig.setClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
+            workerConfig.setClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
 
             // inherit super users
             workerConfig.setSuperUserRoles(config.getSuperUserRoles());


### PR DESCRIPTION
Fixes #4469 

### Motivation

when it is setting to use token authn, standalone pulsar will failed to start because of function worker authentication fail.

It happens like this:
standalone will start function WorkerService, then WorkerService will create a pulsar client to create topics. But this pulsar client in worker could not get properly configuration, and caused failure when it connects to server, which has authn enabled.

### Modifications

add authn related configs, so user could config the Client in worker, and make it work.
