### PR TITLE
[pulsar-client] Client stats on partitioned topics missing some aggregated values

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerStatTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
 
+import static java.util.UUID.randomUUID;
 import static org.apache.pulsar.client.api.SimpleProducerConsumerStatTest.validatingLogInfo;
 import static org.testng.Assert.*;
 
@@ -84,9 +85,10 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
             MessageRoutingMode messageRoutingMode
     ) throws Exception {
         log.info("-- Starting {} test --", methodName);
+        String randomTopicName = "persistent://my-property/tp1/my-ns/my-topic1"+ randomUUID().toString();
         pulsarClient = newPulsarClient(lookupUrl, intervalInSecs);
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic1")
+                .topic(randomTopicName)
                 .subscriptionName("my-subscriber-name")
                 .receiverQueueSize(10);
 
@@ -98,7 +100,7 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
 
         Consumer<byte[]> consumer = consumerBuilder.subscribe();
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic1")
+                .topic(randomTopicName)
                 .messageRoutingMode(messageRoutingMode);
         if (batchMessageDelayMs != 0) {
             producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
@@ -141,9 +143,10 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
             MessageRoutingMode messageRoutingMode
     ) throws Exception {
         log.info("-- Starting {} test --", methodName);
+        String randomTopicName = "persistent://my-property/tp1/my-ns/my-topic2"+ randomUUID().toString();
         pulsarClient = newPulsarClient(lookupUrl, intervalInSecs);
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic2")
+                .topic(randomTopicName)
                 .subscriptionName("my-subscriber-name")
                 .receiverQueueSize(10);
         if (ackTimeoutSec > 0) {
@@ -153,7 +156,7 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
         Consumer<byte[]> consumer = consumerBuilder.subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic2")
+                .topic(randomTopicName)
                 .messageRoutingMode(messageRoutingMode);
         if (batchMessageDelayMs != 0) {
             producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
@@ -207,9 +210,10 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
             int intervalInSecs,
             MessageRoutingMode messageRoutingMode) throws Exception {
         log.info("-- Starting {} test --", methodName);
+        String randomTopicName = "persistent://my-property/tp1/my-ns/my-topic2"+ randomUUID().toString();
         pulsarClient = newPulsarClient(lookupUrl, intervalInSecs);
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic2")
+                .topic(randomTopicName)
                 .subscriptionName("my-subscriber-name")
                 .receiverQueueSize(10);
         if (ackTimeoutSec > 0) {
@@ -219,7 +223,7 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
         Consumer<byte[]> consumer = consumerBuilder.subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic2")
+                .topic(randomTopicName)
                 .messageRoutingMode(messageRoutingMode);
         if (batchMessageDelayMs != 0) {
             producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
@@ -274,8 +278,8 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
         int numMessages = 100;
         final CountDownLatch latch = new CountDownLatch(numMessages);
-
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/tp1/my-ns/my-topic3")
+        String randomTopicName = "persistent://my-property/tp1/my-ns/my-topic3"+ randomUUID().toString();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(randomTopicName)
                 .subscriptionName("my-subscriber-name").ackTimeout(100, TimeUnit.SECONDS)
                 .receiverQueueSize(10)
                 .messageListener((consumer1, msg) -> {
@@ -287,7 +291,7 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
                 }).subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic3")
+                .topic(randomTopicName)
                 .messageRoutingMode(messageRoutingMode);
         if (batchMessageDelayMs != 0) {
             producerBuilder.enableBatching(true)
@@ -323,12 +327,12 @@ public class PartitionedProducerConsumerStatTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch")
     public void testSendTimeout(int batchMessageDelayMs, MessageRoutingMode messageRoutingMode) throws Exception {
         log.info("-- Starting {} test --", methodName);
-
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/tp1/my-ns/my-topic5")
+        String randomTopicName = "persistent://my-property/tp1/my-ns/my-topic4"+ randomUUID().toString();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(randomTopicName)
                 .subscriptionName("my-subscriber-name").receiverQueueSize(10).subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/tp1/my-ns/my-topic5")
+                .topic(randomTopicName)
                 .sendTimeout(1, TimeUnit.SECONDS)
                 .messageRoutingMode(messageRoutingMode);
         if (batchMessageDelayMs != 0) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
@@ -107,4 +107,5 @@ public interface ProducerStats extends Serializable {
      */
     long getTotalAcksReceived();
 
+    double[] getLatencyPctValues();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsDisabled.java
@@ -89,6 +89,11 @@ public class ProducerStatsDisabled implements ProducerStatsRecorder {
     }
 
     @Override
+    public double[] getLatencyPctValues() {
+        return new double[0];
+    }
+
+    @Override
     public double getSendMsgsRate() {
         return 0;
     }


### PR DESCRIPTION
Fixes #4432 

### Motivation
In `ProducerStatsRecorderImpl.updateCumulativeStats`,it doesn't aggregate  some aggregated values. We should return a cumulative value for the multi-partition.

### Modifications

The "parent" producer of a partitioned topic should have fully populated aggregated stats from all its "children" producers

### Verifying this change

This change added tests and can be verified as follows:
  - Added integration tests for  missing aggregated values (org.apache.pulsar.client.api.PartitionedProducerConsumerStatTest)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / `no`)
  - The public API: (yes / `no`)
  - The schema: (yes / `no` / don't know)
  - The default values of configurations: (yes / `no`)
  - The wire protocol: (yes / `no`)
  - The rest endpoints: (yes / `no`)
  - The admin cli options: (yes / `no`)
  - Anything that affects deployment: (yes / `no` / don't know)
