### PR TITLE
Update concepts-messaging.md

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -220,11 +220,17 @@ PulsarClient pulsarClient = // Instantiate Pulsar client object
 
 // Subscribe to all topics in a namespace
 Pattern allTopicsInNamespace = Pattern.compile("persistent://public/default/.*");
-Consumer allTopicsConsumer = pulsarClient.subscribe(allTopicsInNamespace, "subscription-1");
+Consumer allTopicsConsumer = pulsarClient.newConsumer()
+                .topicsPattern(allTopicsInNamespace)
+                .subscriptionName("subscription-1")
+                .subscribe();
 
 // Subscribe to a subsets of topics in a namespace, based on regex
 Pattern someTopicsInNamespace = Pattern.compile("persistent://public/default/foo.*");
-Consumer someTopicsConsumer = pulsarClient.subscribe(someTopicsInNamespace, "subscription-1");
+Consumer someTopicsConsumer = pulsarClient.newConsumer()
+                .topicsPattern(someTopicsInNamespace)
+                .subscriptionName("subscription-1")
+                .subscribe();
 ```
 
 For code examples, see:
@@ -316,17 +322,24 @@ Producers and consumers can connect to non-persistent topics in the same way as 
 Here's an example [Java consumer](client-libraries-java.md#consumers) for a non-persistent topic:
 
 ```java
-PulsarClient client = PulsarClient.create("pulsar://localhost:6650");
+PulsarClient client = PulsarClient.builder()
+        .serviceUrl("pulsar://localhost:6650")
+        .build();
 String npTopic = "non-persistent://public/default/my-topic";
 String subscriptionName = "my-subscription-name";
 
-Consumer consumer = client.subscribe(npTopic, subscriptionName);
+Consumer consumer = client.newConsumer()
+        .topic(npTopic)
+        .subscriptionName(subscriptionName)
+        .subscribe();
 ```
 
 Here's an example [Java producer](client-libraries-java.md#producer) for the same non-persistent topic:
 
 ```java
-Producer producer = client.createProducer(npTopic);
+Producer producer = client.newProducer()
+                .topic(npTopic)
+                .create();
 ```
 
 ## Message retention and expiry

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -220,14 +220,14 @@ PulsarClient pulsarClient = // Instantiate Pulsar client object
 
 // Subscribe to all topics in a namespace
 Pattern allTopicsInNamespace = Pattern.compile("persistent://public/default/.*");
-Consumer allTopicsConsumer = pulsarClient.newConsumer()
+Consumer<byte[]> allTopicsConsumer = pulsarClient.newConsumer()
                 .topicsPattern(allTopicsInNamespace)
                 .subscriptionName("subscription-1")
                 .subscribe();
 
 // Subscribe to a subsets of topics in a namespace, based on regex
 Pattern someTopicsInNamespace = Pattern.compile("persistent://public/default/foo.*");
-Consumer someTopicsConsumer = pulsarClient.newConsumer()
+Consumer<byte[]> someTopicsConsumer = pulsarClient.newConsumer()
                 .topicsPattern(someTopicsInNamespace)
                 .subscriptionName("subscription-1")
                 .subscribe();
@@ -328,7 +328,7 @@ PulsarClient client = PulsarClient.builder()
 String npTopic = "non-persistent://public/default/my-topic";
 String subscriptionName = "my-subscription-name";
 
-Consumer consumer = client.newConsumer()
+Consumer<byte[]> consumer = client.newConsumer()
         .topic(npTopic)
         .subscriptionName(subscriptionName)
         .subscribe();
@@ -337,7 +337,7 @@ Consumer consumer = client.newConsumer()
 Here's an example [Java producer](client-libraries-java.md#producer) for the same non-persistent topic:
 
 ```java
-Producer producer = client.newProducer()
+Producer<byte[]> producer = client.newProducer()
                 .topic(npTopic)
                 .create();
 ```


### PR DESCRIPTION
Since the  #1089，the interface 'org.apache.pulsar.client.api.PulsarClient' has supported builder for consumer and producer.
And,int the #3272, some deprecated client API have been removed including 'public static PulsarClient create(String serviceUrl)','Consumer<byte[]> subscribe(String topic, String subscription)' and 'Producer<byte[]> createProducer(String topic)'.

So, I modified the example with the current version of the interface.