### PR TITLE
Remove pulsar-client-api from shaded jar

### DIFF
--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -98,7 +98,6 @@
                 <includes>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
-                  <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>


### PR DESCRIPTION
The split package issue has been properly fixed with https://github.com/apache/pulsar/pull/4445 so there is no need for workarounds anymore. This PR removes the previously added workaround as merged by https://github.com/apache/pulsar/pull/4257 which was to include the pulsar-client-api jar in the pulsar-client-all shaded artifact.