### PR TITLE
Update readme for setting up protobuf 2.6.0 on mac.

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -130,15 +130,8 @@ brew install openssl
 export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
 export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
-# For Protobuf 2.6.0
-brew install boost boost-python log4cxx jsoncpp
-
-git clone https://github.com/google/protobuf.git
-cd protobuf
-git checkout v2.6.0
-./configure CC=clang CXX=clang++ CXXFLAGS='-std=c++11 -stdlib=libc++ -O3 -g' LDFLAGS='-stdlib=libc++' LIBS="-lc++ -lc++abi"
-make -j 4
-sudo make install
+# For Protobuf
+brew install protobuf boost boost-python log4cxx jsoncpp
 
 # For gtest
 cd $HOME

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -130,9 +130,15 @@ brew install openssl
 export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
 export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
-# For Protobuf
-brew tap homebrew/versions
-brew install protobuf260 boost boost-python log4cxx jsoncpp
+# For Protobuf 2.6.0
+brew install boost boost-python log4cxx jsoncpp
+
+git clone https://github.com/google/protobuf.git
+cd protobuf
+git checkout v2.6.0
+./configure CC=clang CXX=clang++ CXXFLAGS='-std=c++11 -stdlib=libc++ -O3 -g' LDFLAGS='-stdlib=libc++' LIBS="-lc++ -lc++abi"
+make -j 4
+sudo make install
 
 # For gtest
 cd $HOME

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -28,10 +28,10 @@ globalZookeeperServers=
 # Configuration Store connection string
 configurationStoreServers=
 
-brokerServicePort=6650
+brokerServicePort=8885
 
 # Port to use to server HTTP request
-webServicePort=8080
+webServicePort=8765
 
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -28,10 +28,10 @@ globalZookeeperServers=
 # Configuration Store connection string
 configurationStoreServers=
 
-brokerServicePort=8885
+brokerServicePort=6650
 
 # Port to use to server HTTP request
-webServicePort=8765
+webServicePort=8080
 
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0


### PR DESCRIPTION
Instruction in cpp client readme on installing protobuf2.6 in outdated. 
Updated with steps I've recently tried and worked.

Also in readme it says use tests/standalone.conf as configuration to start a pulsar service in standalone mode to run cpp tests locally, but port setting in the config file doesn't match the ports the cpp test cases try to connect.
Updated to ports the test cases expecting.

There is a test case using a client-ras.pem file, it's probably the same one used for java tests, but I'm not sure where to put that key so the cpp test case can load it. Try to put it under tests/ but doesn't work.
Can someone help adding that public key? Thanks!