### PR TITLE
[Issue 4489] [Schema-AVRO] Unable to encode POJO class with byte[] fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka-client.version>0.10.2.1</kafka-client.version>
     <rabbitmq-client.version>5.1.1</rabbitmq-client.version>
     <aws-sdk.version>1.11.297</aws-sdk.version>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.0</avro.version>
     <joda.version>2.10.1</joda.version>
     <jclouds.version>2.1.1</jclouds.version>
     <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import io.netty.buffer.Unpooled;
@@ -44,7 +45,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import avro.shaded.com.google.common.collect.Lists;
 
 public class MessageParserTest extends MockedPulsarServiceBaseTest {
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.schema;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Conversions;
+import org.apache.avro.data.JodaTimeConversions;
 import org.apache.avro.data.TimeConversions;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -49,23 +50,23 @@ public class AvroSchema<T> extends StructSchema<T> {
 
             reflectDataAllowNull.addLogicalTypeConversion(new Conversions.DecimalConversion());
             reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.DateConversion());
-            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.LossyTimeMicrosConversion());
-            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.LossyTimestampMicrosConversion());
+            reflectDataAllowNull.addLogicalTypeConversion(new JodaTimeConversions.LossyTimeMicrosConversion());
+            reflectDataAllowNull.addLogicalTypeConversion(new JodaTimeConversions.LossyTimestampMicrosConversion());
             reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
             reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampConversion());
-            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimeConversion());
+            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+            reflectDataAllowNull.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
 
             ReflectData reflectDataNotAllowNull = ReflectData.get();
 
             reflectDataNotAllowNull.addLogicalTypeConversion(new Conversions.DecimalConversion());
             reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.DateConversion());
-            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampConversion());
-            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.LossyTimeMicrosConversion());
-            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.LossyTimestampMicrosConversion());
+            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+            reflectDataNotAllowNull.addLogicalTypeConversion(new JodaTimeConversions.LossyTimeMicrosConversion());
+            reflectDataNotAllowNull.addLogicalTypeConversion(new JodaTimeConversions.LossyTimestampMicrosConversion());
             reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
             reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimeConversion());
+            reflectDataNotAllowNull.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
         } catch (Throwable t) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Avro logical types are not available. If you are going to use avro logical types, " +

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -27,8 +27,10 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.fail;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Arrays;
-import java.util.Date;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -50,8 +52,6 @@ import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Foo;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 import org.joda.time.chrono.ISOChronology;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -290,9 +290,9 @@ public class AvroSchemaTest {
     NasaMission nasaMission = NasaMission.newBuilder()
         .setId(1001)
         .setName("one")
-        .setCreateYear(new LocalDate(new Date().getTime()))
-        .setCreateTime(new LocalTime(new Date().getTime()))
-        .setCreateTimestamp(new DateTime(new Date().getTime()))
+        .setCreateYear(LocalDate.now())
+        .setCreateTime(LocalTime.now())
+        .setCreateTimestamp(Instant.now())
         .build();
 
     byte[] bytes = avroSchema.encode(nasaMission);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
@@ -20,7 +20,6 @@
 package org.apache.pulsar.proxy.server;
 
 
-import avro.shaded.com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -28,6 +27,7 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import java.util.ArrayList;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.raw.MessageParser;
 import org.apache.pulsar.common.api.raw.RawMessage;
@@ -88,7 +88,7 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
         PulsarApi.BaseCommand cmd = null;
         PulsarApi.BaseCommand.Builder cmdBuilder = null;
         TopicName topicName ;
-        List<RawMessage> messages = Lists.newArrayList();
+        List<RawMessage> messages = new ArrayList();
         ByteBuf buffer = (ByteBuf)(msg);
 
         try {


### PR DESCRIPTION
### Motivation

Fixes #4489

### Modifications

1. upgrade avro.version to 1.9.0
2. https://issues.apache.org/jira/browse/AVRO-1401

### Verifying this change

Example run ok:
```java
import lombok.Data;
import org.apache.pulsar.client.api.Producer;
import org.apache.pulsar.client.api.PulsarClient;
import org.apache.pulsar.client.api.Schema;

public class ProduceExample {
    public static void main(String[] args) throws Exception {
      try (PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build()) {
        Schema schema = Schema.AVRO(Foo.class);

        Producer producer = client.newProducer(schema).topic("test_src").create();

        producer.send(new Foo("12".getBytes(), true));
      }

      System.out.println("producer msg end ...");
    }

  @Data
  static class Foo {
    private byte[] bs;
    private boolean b;
    public Foo() {
    }
    public Foo(byte[] bs, boolean b) {
      this.bs = bs;
      this.b = b;
    }
  }
}
```

```java
import org.apache.pulsar.client.api.Consumer;
import org.apache.pulsar.client.api.Message;
import org.apache.pulsar.client.api.PulsarClient;
import org.apache.pulsar.client.api.Schema;
import org.apache.spark.streaming.receiver.example.ProduceExample.Foo;

public class ConsumerExample {
  public static void main(String[] args) throws Exception {
    try (PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build()) {
      Schema sa = Schema.AVRO(ProduceExample.Foo.class);
      Consumer consumer = client.newConsumer(sa).topic("test_src").subscriptionName("test").subscribe();
      Message receive = consumer.receive();
      Object value = receive.getValue();
      if (value instanceof ProduceExample.Foo) {
        ProduceExample.Foo foo = (Foo) value;
        System.out.println(new String(foo.getBs()));
        System.out.println(foo.isB());
      }
    }
  }

}
```

stdout:
```shell
log4j:WARN No appenders could be found for logger (io.netty.util.internal.logging.InternalLoggerFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
12
true

Process finished with exit code 0
```


