### PR TITLE
[pulsar-client-cpp] C++ client build fails when USE_LOG4CXX is ON

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -35,6 +35,9 @@
 #include <algorithm>
 #include <regex>
 #include <mutex>
+#ifdef USE_LOG4CXX
+#include "Log4CxxLogger.h"
+#endif
 
 DECLARE_LOG_OBJECT()
 


### PR DESCRIPTION
### Motivation

When I set `USE_LOG4CXX` to ON, C++ client build fails with the following error:
```
/tmp/apache-pulsar-2.3.2/pulsar-client-cpp/lib/ClientImpl.cc: In constructor ‘pulsar::ClientImpl::ClientImpl(const string&, const pulsar::ClientConfiguration&, bool)’:
/tmp/apache-pulsar-2.3.2/pulsar-client-cpp/lib/ClientImpl.cc:103:17: error: ‘Log4CxxLoggerFactory’ has not been declared
                 Log4CxxLoggerFactory::create(clientConfiguration_.getLogConfFilePath()));
```

This is because the header file `Log4CxxLogger.h` is not included in `ClientImpl.cc`.

### Modifications

Fixed `ClientImpl.cc` to include `Log4CxxLogger.h` only when `USE_LOG4CXX` is ON.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.