### PR TITLE
[pulsar-client] add async-http-client properties to shaded client

### DIFF
--- a/pulsar-client/src/main/resources/ahc.properties
+++ b/pulsar-client/src/main/resources/ahc.properties
@@ -69,3 +69,5 @@ org.apache.pulsar.shade.org.asynchttpclient.shutdownQuietPeriod=2000
 org.apache.pulsar.shade.org.asynchttpclient.shutdownTimeout=15000
 org.apache.pulsar.shade.org.asynchttpclient.useNativeTransport=false
 org.apache.pulsar.shade.org.asynchttpclient.ioThreadsCount=0
+org.apache.pulsar.shade.org.asynchttpclient.acquireFreeChannelTimeout=0
+org.apache.pulsar.shade.org.org.asynchttpclient.enableWebSocketCompression=true


### PR DESCRIPTION
### Motivation
Add required async-http-client properties for shaded pulsar-client. 
it fails with below error error without this config
```
Exception in thread "main" java.lang.NumberFormatException: null
  at java.lang.Integer.parseInt(Integer.java:542)
  at java.lang.Integer.parseInt(Integer.java:615)
  at org.apache.pulsar.shade.org.asynchttpclient.config.AsyncHttpClientConfigHelper$Config.getInt(AsyncHttpClientConfigHelper.java:85)
  at org.apache.pulsar.shade.org.asynchttpclient.config.AsyncHttpClientConfigDefaults.default AcquireFreeChannelTimeout(AsyncHttpClientConfigDefaults.java:68)
  at org.apache.pulsar.shade.org.asynchttpclient.DefaultAsyncHttpClientConfig$Builder.<init>(DefaultAsyncHttpClientConfig.java:599)
```
