### PR TITLE
[pulsar-client] fix pulsar-client-shade fails with async-http client request

### DIFF
--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -66,6 +66,15 @@
                   <includes>**/ProtobufSchema.class</includes>
                   <outputDirectory>${project.build.directory}/classes</outputDirectory>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.pulsar</groupId>
+                  <artifactId>pulsar-client-original</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/ahc.properties</includes>
+                  <outputDirectory>${project.build.directory}/classes/org/asynchttpclient/config</outputDirectory>
+                </artifactItem>
               </artifactItems>
 
 


### PR DESCRIPTION
### Motivation

Right now, pulsar-client-shaded artifact is broken for http-lookup because with recent async-http-client version: https://github.com/AsyncHttpClient/async-http-client/issues/1546
> custom ahc.properties must be in org.asynchttpclient.config package, not at classpath root.


Now, pulsar-client-shaded doesn't have `ahc.properties` into `org.asynchttpclient.config` and because of that async-http-client init fails with below exception
```
Exception in thread "main" java.lang.NumberFormatException: null
  at java.lang.Integer.parseInt(Integer.java:542)
  at java.lang.Integer.parseInt(Integer.java:615)
  at org.apache.pulsar.shade.org.asynchttpclient.config.AsyncHttpClientConfigHelper$Config.getInt(AsyncHttpClientConfigHelper.java:85)
  at org.apache.pulsar.shade.org.asynchttpclient.config.AsyncHttpClientConfigDefaults.defaultMaxRedirects(AsyncHttpClientConfigDefaults.java:68)
  at org.apache.pulsar.shade.org.asynchttpclient.DefaultAsyncHttpClientConfig$Builder.<init>(DefaultAsyncHttpClientConfig.java:599)
  at org.apache.pulsar.client.impl.HttpClient.<init>(HttpClient.java:75)
  at org.apache.pulsar.client.impl.HttpClient.<init>(HttpClient.java:60)
  at org.apache.pulsar.client.impl.HttpLookupService.<init>(HttpLookupService.java:47)
  at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:97)
  at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:110)
  at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:84)
  at org.apache.pulsar.client.api.PulsarClient.create(PulsarClient.java:58)
  at org.apache.pulsar.client.api.PulsarClient.create(PulsarClient.java:43)
  at client_java.client_java.PulsarV2Example2.publishAndSubscribeOnCMSV2(PulsarV2Example2.java:31)
  at client_java.client_java.PulsarV2Example2.main(PulsarV2Example2.java:24)
```