### PR TITLE
[pulsar-client-cpp] Make it possible to compile binary statically linked with log4cxx

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -71,7 +71,7 @@ if (LINK_STATIC)
     if (USE_LOG4CXX)
         if (LOG4CXX_USE_DYNAMIC_LIBS)
             find_library(LOG4CXX_LIBRARY_PATH log4cxx)
-        elseif (LOG4CXX_USE_DYNAMIC_LIBS)
+        else ()
             find_library(LOG4CXX_LIBRARY_PATH NAMES liblog4cxx.a)
 
             # Libraries needed by log4cxx to link statically with


### PR DESCRIPTION
### Motivation

`LOG4CXX_USE_DYNAMIC_LIBS` has been added by https://github.com/apache/pulsar/pull/3503 as an option when building C++ client. However, log4cxx seems to be not linked statically even if `LOG4CXX_USE_DYNAMIC_LIBS=OFF` is specified. This is because there is a mistake in `CMakeLists.txt`.

### Modifications

Fixed the conditional branch in `CMakeLists.txt` as follows:
```
if (LOG4CXX_USE_DYNAMIC_LIBS)
    ...
endif (LOG4CXX_USE_DYNAMIC_LIBS)
    ...
endif (LOG4CXX_USE_DYNAMIC_LIBS)
```
↓
```
if (LOG4CXX_USE_DYNAMIC_LIBS)
    ...
else ()
    ...
endif (LOG4CXX_USE_DYNAMIC_LIBS)
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.