### PR TITLE
[pulsar-client] fix protobuf dependency with shaded pulsar-client

### DIFF
--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -116,6 +116,8 @@
                   <include>commons-*:*</include>
                   <include>io.swagger:*</include>
 
+                  <include>org.apache.pulsar:protobuf-shaded</include>
+                  <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>org.apache.bookkeeper:circe-checksum</include>
                   <include>com.yahoo.datasketches:sketches-core</include>


### PR DESCRIPTION
### Motivation

Right now, pulsar-client doesn't include classes of `pulsar::protobuf-shaded` and because of that it throws below runtime error

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/pulsar/shaded/com/google/protobuf/v241/UninitializedMessageException
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
	at java.lang.Class.getConstructor0(Class.java:3075)
	at java.lang.Class.getConstructor(Class.java:1825)
	at org.apache.pulsar.client.internal.ReflectionUtils.getConstructor(ReflectionUtils.java:52)
	at org.apache.pulsar.client.internal.DefaultImplementation.<clinit>(DefaultImplementation.java:55)
	at org.apache.pulsar.client.api.Schema.<clinit>(Schema.java:117)
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.shaded.com.google.protobuf.v241.UninitializedMessageException
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 11 more
```