### PR TITLE
Disable sticky read by default

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -447,7 +447,9 @@ bookkeeperClientMinAvailableBookiesInIsolationGroups=
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.
-bookkeeperEnableStickyReads=true
+#
+# Disable Sticy Read until {@link https://github.com/apache/bookkeeper/issues/1970} is fixed
+bookkeeperEnableStickyReads=false
 
 ### --- Managed Ledger --- ###
 


### PR DESCRIPTION
*Motivation*

2.3.x releases turn on StickyRead by default.
But StickyRead causes a lot of ArrayIndexOutOfBoundException.

See: apache/bookkeeper#1970 and apache/pulsar#3715

*Modifications*

Disable sticky read by default until the bug is fixed and a new bookkeeper version is released.

