### PR TITLE
[Schema] Make GenericAvroRecord public

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroRecord.java
@@ -28,12 +28,12 @@ import org.apache.pulsar.client.api.schema.Field;
  * A generic avro record.
  */
 @Slf4j
-class GenericAvroRecord extends VersionedGenericRecord {
+public class GenericAvroRecord extends VersionedGenericRecord {
 
     private final org.apache.avro.Schema schema;
     private final org.apache.avro.generic.GenericRecord record;
 
-    GenericAvroRecord(byte[] schemaVersion,
+    public GenericAvroRecord(byte[] schemaVersion,
                       org.apache.avro.Schema schema,
                       List<Field> fields,
                       org.apache.avro.generic.GenericRecord record) {
@@ -61,7 +61,7 @@ class GenericAvroRecord extends VersionedGenericRecord {
         }
     }
 
-    org.apache.avro.generic.GenericRecord getAvroRecord() {
+    public org.apache.avro.generic.GenericRecord getAvroRecord() {
         return record;
     }
 


### PR DESCRIPTION
### Motivation

If I construct an Avro record in my application and want to send it to Pulsar as a typed message, currently I can only rebuild it with `Schema.generic` and `newRecordBuilder`. To make the situation worse, when I want to construct an Avro record with `record` type in `map`'s value, it's not possible through the `SchemaBuilder` way.

Pulsar's `GenericAvroRecord` is just a thin wrapper over Avro's GenericRecord, it will be much easier to use to just make `GenericAvroRecord` with its method/constructor public.

### Modifications

Make `GenericAvroRecord` with its method/constructor public

### Does this pull request potentially affect one of the following parts:

  - The public API: yes

