### PR TITLE
[pulsar-client] NPE in UnAckedMessageTrackerDisabled#size (#4535)

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -55,6 +55,11 @@ public class UnAckedMessageTracker implements Closeable {
         }
 
         @Override
+        long size() {
+            return 0;
+        }
+
+        @Override
         public boolean add(MessageId m) {
             return true;
         }


### PR DESCRIPTION
*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #4535

### Modifications

* If ackTimeout is not set, UnAckedMessageTracker is a disabled method.We can get a default value. Such as 0.*

### Verifying this change

This change added tests and can be verified as follows:

  - *Extended integration test for recovery in UnAckedMessageTrackerDisabled#size*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

