### PR TITLE
[hotfix][minor]Remove tenant/namespace/name from sources and functions REST endpoints

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -91,16 +91,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "  The size of the system resources allowed by the function runtime. The resources include: cpu, ram, disk.  \n" +
                             "className  \n" +
                             "  The class name of functions.  \n" +
-                            "tenant  \n" +
-                            "  The tenant of functions.  \n" +
-                            "namespace  \n" +
-                            "  The namespace of functions.  \n" +
-                            "name  \n" +
-                            "  The name of functions.  \n" +
                             "customSchemaInputs  \n" +
-                            "  The map of input topics to Schema class names (The customSchemaInputs is JSON string).  \n" +
+                            "  The map of input topics to Schema class names (specified as a JSON object).  \n" +
                             "customSerdeInputs  \n" +
-                            "  The map of input topics to SerDe class names (The customSerdeInputs is JSON string).  \n" +
+                            "  The map of input topics to SerDe class names (specified as a JSON object).  \n" +
                             "deadLetterTopic  \n" +
                             "  Messages that are not processed successfully are sent to `deadLetterTopic`.  \n" +
                             "runtimeFlags  \n" +
@@ -108,7 +102,8 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "fqfn  \n" +
                             "  The Fully Qualified Function Name (FQFN) for the function.  \n" +
                             "inputSpecs  \n" +
-                            "  A generalized way of specifying inputs.  \n" +
+                            "   The map of input topics to its consumer configuration, each configuration has schema of " +
+                            "   {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \n" +
                             "inputs  \n" +
                             "  The input topic or topics (multiple topics can be specified as a comma-separated list) of functions.  \n" +
                             "jar  \n" +
@@ -144,10 +139,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "  The message timeout in milliseconds.  \n" +
                             "topicsPattern  \n" +
                             "  The topic pattern to consume from a list of topics under a namespace that match the pattern." +
-                            "  [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a " +
-                            "  pattern in --custom-serde-inputs (supported for java fun only)  \n" +
+                            "  [input] and [topic-pattern] are mutually exclusive. Add SerDe class name for a " +
+                            "  pattern in customSerdeInputs (supported for java fun only)  \n" +
                             "userConfig  \n" +
-                            "  User-defined config key/values  \n" +
+                            "  A map of user-defined configurations (specified as a JSON object).  \n" +
                             "secrets  \n" +
                             "  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that" +
                             "  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the" +
@@ -203,16 +198,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "  The size of the system resources allowed by the function runtime. The resources include: cpu, ram, disk.  \n" +
                             "className  \n" +
                             "  The class name of functions.  \n" +
-                            "tenant  \n" +
-                            "  The tenant of functions.  \n" +
-                            "namespace  \n" +
-                            "  The namespace of functions.  \n" +
-                            "name  \n" +
-                            "  The name of functions.  \n" +
                             "customSchemaInputs  \n" +
-                            "  The map of input topics to Schema class names (The customSchemaInputs is JSON string).  \n" +
+                            "  The map of input topics to Schema class names (specified as a JSON object).  \n" +
                             "customSerdeInputs  \n" +
-                            "  The map of input topics to SerDe class names (The customSerdeInputs is JSON string).  \n" +
+                            "  The map of input topics to SerDe class names (specified as a JSON object).  \n" +
                             "deadLetterTopic  \n" +
                             "  Messages that are not processed successfully are sent to `deadLetterTopic`.  \n" +
                             "runtimeFlags  \n" +
@@ -220,7 +209,8 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "fqfn  \n" +
                             "  The Fully Qualified Function Name (FQFN) for the function.  \n" +
                             "inputSpecs  \n" +
-                            "  A generalized way of specifying inputs.  \n" +
+                            "   The map of input topics to its consumer configuration, each configuration has schema of " +
+                            "   {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \n" +
                             "inputs  \n" +
                             "  The input topic or topics (multiple topics can be specified as a comma-separated list) of functions.  \n" +
                             "jar  \n" +
@@ -256,10 +246,10 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
                             "  The message timeout in milliseconds.  \n" +
                             "topicsPattern  \n" +
                             "  The topic pattern to consume from a list of topics under a namespace that match the pattern." +
-                            "  [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a " +
-                            "  pattern in --custom-serde-inputs (supported for java fun only)  \n" +
+                            "  [input] and [topicsPattern] are mutually exclusive. Add SerDe class name for a " +
+                            "  pattern in customSerdeInputs (supported for java fun only)  \n" +
                             "userConfig  \n" +
-                            "  User-defined config key/values  \n" +
+                            "  A map of user-defined configurations (specified as a JSON object).  \n" +
                             "secrets  \n" +
                             "  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that" +
                             "  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the" +

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
@@ -82,12 +82,6 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
             final @FormDataParam("url") String functionPkgUrl,
             @ApiParam(
                     value = "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \n" +
-                            "tenant  \n" +
-                            "  The tenant of source.  \n" +
-                            "namespace  \n" +
-                            "  The namespace of source.  \n" +
-                            "name  \n" +
-                            "  The name of source.  \n" +
                             "classname  \n" +
                             "  The source's class name if archive is file-url-path (file://).  \n" +
                             "topicName  \n" +
@@ -163,12 +157,6 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
             final @FormDataParam("url") String functionPkgUrl,
             @ApiParam(
                     value = "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \n" +
-                            "tenant  \n" +
-                            "  The tenant of source.  \n" +
-                            "namespace  \n" +
-                            "  The namespace of source.  \n" +
-                            "name  \n" +
-                            "  The name of source.  \n" +
                             "classname  \n" +
                             "  The source's class name if archive is file-url-path (file://).  \n" +
                             "topicName  \n" +


### PR DESCRIPTION
`Tenant`, `namespace` and `sourceName` already appear in `PathParam` and shouldn't be a part of `sourceConfigJson`.