### PR TITLE
Add separate config for function worker authentication in broker config

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1208,6 +1208,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean functionsWorkerEnabled = false;
 
+    @FieldContext(
+        category = CATEGORY_FUNCTIONS,
+        doc = "Enable function worker authentication"
+    )
+    private boolean functionWorkerAuthenticationEnabled = false;
+
     /**** --- Broker Web Stats --- ****/
     @FieldContext(
         category = CATEGORY_METRICS,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -178,8 +178,8 @@ public class PulsarBrokerStarter {
                     "c-" + brokerConfig.getClusterName()
                         + "-fw-" + hostname
                         + "-" + workerConfig.getWorkerPort());
-                // inherit broker authorization setting
-                workerConfig.setAuthenticationEnabled(brokerConfig.isAuthenticationEnabled());
+
+                workerConfig.setAuthenticationEnabled(brokerConfig.isFunctionWorkerAuthenticationEnabled());
                 workerConfig.setAuthenticationProviders(brokerConfig.getAuthenticationProviders());
 
                 workerConfig.setAuthorizationEnabled(brokerConfig.isAuthorizationEnabled());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -297,8 +297,8 @@ public class PulsarStandalone implements AutoCloseable {
                 "c-" + config.getClusterName()
                     + "-fw-" + hostname
                     + "-" + workerConfig.getWorkerPort());
-            // inherit broker authorization setting
-            workerConfig.setAuthenticationEnabled(config.isAuthenticationEnabled());
+
+            workerConfig.setAuthenticationEnabled(config.isFunctionWorkerAuthenticationEnabled());
             workerConfig.setAuthenticationProviders(config.getAuthenticationProviders());
 
             workerConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());


### PR DESCRIPTION
Currently, If function worker runs in broker, function worker inherit broker authentication setting `isAuthenticationEnabled`.
In this way, broker authentication and worker authentication have the same config, they will both be set to same value(enable or disable). 

It would be good to provide a separate config in broker, so user could have a choice to enable broker authentication and  function worker authentication as they wanted. 
e.g. disable broker authentication, while enable only function worker authentication; 
or inversely disable function worker authentication, while enable broker authentication.

This also helps to isolate authentication configs. e.g. if function worker authentication config issue and caused error starting function worker, use could disable function worker authentication, and not cause PulsarBrokerStarter failed to start.