### PR TITLE
[Issue 4564] Replace the functions worker's hard-coded localhost

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -161,13 +161,12 @@ public class PulsarBrokerStarter {
                 }
                 // worker talks to local broker
                 boolean useTls = workerConfig.isUseTls();
-                String localhost = "127.0.0.1";
                 String pulsarServiceUrl = useTls
-                        ? PulsarService.brokerUrlTls(localhost, brokerConfig.getBrokerServicePortTls().get())
-                        : PulsarService.brokerUrl(localhost, brokerConfig.getBrokerServicePort().get());
+                        ? PulsarService.brokerUrlTls(brokerConfig)
+                        : PulsarService.brokerUrl(brokerConfig);
                 String webServiceUrl = useTls
-                        ? PulsarService.webAddressTls(localhost, brokerConfig.getWebServicePortTls().get())
-                        : PulsarService.webAddress(localhost, brokerConfig.getWebServicePort().get());
+                        ? PulsarService.webAddressTls(brokerConfig)
+                        : PulsarService.webAddress(brokerConfig);
                 workerConfig.setPulsarServiceUrl(pulsarServiceUrl);
                 workerConfig.setPulsarWebServiceUrl(webServiceUrl);
                 String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -273,13 +273,12 @@ public class PulsarStandalone implements AutoCloseable {
             }
             // worker talks to local broker
             boolean useTls = workerConfig.isUseTls();
-            String localhost = "127.0.0.1";
             String pulsarServiceUrl = useTls
-                    ? PulsarService.brokerUrlTls(localhost, config.getBrokerServicePortTls().get())
-                    : PulsarService.brokerUrl(localhost, config.getBrokerServicePort().get());
+                    ? PulsarService.brokerUrlTls(config)
+                    : PulsarService.brokerUrl(config);
             String webServiceUrl = useTls
-                    ? PulsarService.webAddressTls(localhost, config.getWebServicePortTls().get())
-                    : PulsarService.webAddress(localhost, config.getWebServicePort().get());
+                    ? PulsarService.webAddressTls(config)
+                    : PulsarService.webAddress(config);
             workerConfig.setPulsarServiceUrl(pulsarServiceUrl);
             workerConfig.setPulsarWebServiceUrl(webServiceUrl);
             if (this.isNoStreamStorage()) {


### PR DESCRIPTION
### Motivation

Fixes #4564

### Modifications

The internal-client that function worker created currently uses hard-coded `127.0.0.1` to auth with broker, however the kdc would reject the request using principal which contains `localhost`, therefore, we should replace it.