### PR TITLE
[pulsar-client-tools] Remove redundant command usage when authentication exception

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -123,7 +123,6 @@ public class PulsarClientTool {
             } catch (UnsupportedAuthenticationException exp) {
                 System.out.println("Failed to load an authentication plugin");
                 exp.printStackTrace();
-                commandParser.usage();
                 return -1;
             }
 


### PR DESCRIPTION
### Motivation

It is redundant to print command usage when auth failed throwing `UnsupportedAuthenticationException` since the script usage may be correct.