### PR TITLE
Log: the number of {} is different to arguments count.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -619,7 +619,7 @@ public abstract class PulsarWebResource {
                 URI redirect = getRedirectionUrl(peerClusterData);
                 // redirect to the cluster requested
                 if (log.isDebugEnabled()) {
-                    log.debug("[{}] Redirecting the rest call to {}: cluster={}", redirect, peerClusterData);
+                    log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(),redirect, peerClusterData);
 
                 }
                 throw new WebApplicationException(Response.temporaryRedirect(redirect).build());


### PR DESCRIPTION
module: pulsar-broker 
class: org.apache.pulsar.broker.web.PulsarWebResource
error: Log the number of {} is different to arguments count.
lineNum: 622

if (log.isDebugEnabled()) {
    log.debug("[{}] Redirecting the rest call to {}: cluster={}", redirect, peerClusterData);
}
