### PR TITLE
[issue:4537][Go Client] Fix doc error of ProducerMessage options

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -193,7 +193,7 @@ func main() {
         producer.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {
             if err != nil { log.Fatal(err) }
 
-            fmt.Printf("Message %s succesfully published", msg.ID())
+            fmt.Printf("the %s successfully published", string(msg.Payload))
         })
     }
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Fixes #4537

### Motivation

In `ProducerMessage` struct, we didn't provide an interface to get the MessageID, but in the official documentation, we tried to get the MessageID.