### PR TITLE
[pulsar-websocket]Completing log parameters

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -137,13 +137,13 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
 
     public void close(WebSocketError error) {
         log.warn("[{}] Closing WebSocket session for topic {} - code: [{}], reason: [{}]",
-                getSession().getRemoteAddress(), topic, error);
+                getSession().getRemoteAddress(), topic, error.getCode(), error.getDescription());
         getSession().close(error.getCode(), error.getDescription());
     }
 
     public void close(WebSocketError error, String message) {
         log.warn("[{}] Closing WebSocket session for topic {} - code: [{}], reason: [{}]",
-                getSession().getRemoteAddress(), topic, error, message);
+                getSession().getRemoteAddress(), topic, error.getCode(), error.getDescription() + ": " + message);
         getSession().close(error.getCode(), error.getDescription() + ": " + message);
     }
 


### PR DESCRIPTION
**Describe the bug**
Number of placeholder and arguments mismatch in log message.
eg:
`log.warn("[{}] Closing WebSocket session for topic {} - code: [{}], reason: [{}]",
                getSession().getRemoteAddress(), topic, error);`

Fix issue for incorrect log parameters (#4304 ) 