### PR TITLE
remove duplicate dependency in pom

### DIFF
--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -40,12 +40,12 @@
       <artifactId>pulsar-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
-  
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -101,11 +101,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-annotations</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
remove duplicate dependency in pom, which will cause error when `mvn apache-rat:check`
       
```
...
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.swagger:swagger-annotations:jar -> duplicate declaration of version (?) @ org.apache.pulsar:pulsar-common:[unknown-version], /Users/jia/ws/code/pulsar/pulsar-common/pom.xml, line 106, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.

```