### PR TITLE
[conf]minorCompactionInterval should be greater than gcWaitTime

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -498,6 +498,7 @@ majorCompactionThreshold=0.5
 
 # Interval to run major compaction, in seconds
 # If it is set to less than zero, the major compaction is disabled.
+# Note: should be greater than gcWaitTime.
 majorCompactionInterval=86400
 
 # Throttle compaction by bytes or by entries.

--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -475,6 +475,7 @@ minorCompactionThreshold=0.2
 
 # Interval to run minor compaction, in seconds
 # If it is set to less than zero, the minor compaction is disabled.
+# Note: should be greater than gcWaitTime.
 minorCompactionInterval=3600
 
 # Set the maximum number of entries which can be compacted without flushing.


### PR DESCRIPTION
### Motivation

Fixes #4558

### Modifications

Add more instructions to note that minorCompactionInterval should be greater than gcWaitTime.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
