### PR TITLE
[cpp client] fix set_schema_info logic

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -89,7 +89,7 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_consumer_type(
 PULSAR_PUBLIC pulsar_consumer_type
 pulsar_consumer_configuration_get_consumer_type(pulsar_consumer_configuration_t *consumer_configuration);
 
-void pulsar_consumer_configuration_set_schema_info(pulsar_consumer_configuration_t *consumer_configuration,
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_schema_info(pulsar_consumer_configuration_t *consumer_configuration,
                                                    pulsar_schema_type schemaType, const char *name,
                                                    const char *schema, pulsar_string_map_t *properties);
 

--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -89,9 +89,9 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_consumer_type(
 PULSAR_PUBLIC pulsar_consumer_type
 pulsar_consumer_configuration_get_consumer_type(pulsar_consumer_configuration_t *consumer_configuration);
 
-PULSAR_PUBLIC void pulsar_consumer_configuration_set_schema_info(pulsar_consumer_configuration_t *consumer_configuration,
-                                                   pulsar_schema_type schemaType, const char *name,
-                                                   const char *schema, pulsar_string_map_t *properties);
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_schema_info(
+    pulsar_consumer_configuration_t *consumer_configuration, pulsar_schema_type schemaType, const char *name,
+    const char *schema, pulsar_string_map_t *properties);
 
 /**
  * A message listener enables your application to configure how to process


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

When we are verifying DEB and RPM, executing `go build .` fails with the following error:

```
[root@0a71d4a4fdfe consumer]# go build .
# github.com/apache/pulsar/pulsar-client-go/pulsar
/tmp/go-build921222889/b049/_x003.o: In function `_cgo_cf55d0d7869c_Cfunc_pulsar_consumer_configuration_set_schema_info':
/tmp/go-build/cgo-gcc-prolog:292: undefined reference to `pulsar_consumer_configuration_set_schema_info'
collect2: error: ld returned 1 exit status
```

The problem is that the `pulsar_consumer_configuration_set_schema_info` function is not public, and the function is not found in the built rpm or deb package. The pull request will fix it.