### PR TITLE
[doc] Update admin part for Pulsar Functions

### DIFF
--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -1,29 +1,28 @@
 ---
 id: functions-runtime
 title: Configure Functions runtime
-sidebar_label: Configure Functions runtime
+sidebar_label: Admin: Configure Functions runtime
 ---
+This guide is used for administrator. 
 
-Currently, Pulsar Functions support the following three methods to run functions.
+Pulsar Functions support the following methods to run functions.
 
 - *Thread*: Invoke functions in threads in Functions Worker.
 - *Process*: Invoke functions in processes forked by Functions Worker.
 - *Kubernetes*: Submit functions as Kubernetes StatefulSets by Functions Worker.
 
 ## Configure thread runtime
-
-*Thread* runtime is easy to configure. In most cases, you don't need to configure anything. You can customize the thread group name with the following settings:
+It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
 threadContainerFactory:
   threadGroupName: "Your Function Container Group"
 ```
 
-*Thread* runtime only supports Java language.
+*Thread* runtime is only supported in Java function.
 
 ## Configure process runtime
-
-Similar as *Thread* runtime, you don't need to configure anything special when enabling *Process* runtime.
+When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
 processContainerFactory:
@@ -37,7 +36,7 @@ processContainerFactory:
   extraFunctionDependenciesDir:
 ```
 
-Currently Pulsar supports running Java, Python, and Go Functions in process runtime mode.
+*Process* runtime is supported in Java, Python, and Go functions.
 
 ## Configure Kubernetes runtime
 

--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -1,8 +1,9 @@
 ---
 id: functions-worker
 title: Deploy and manage functions worker
-sidebar_label: Functions Worker
+sidebar_label: Admin: Pulsar Functions Worker
 ---
+This guide is used for administrator. 
 
 Pulsar `functions-worker` is a logic component to run Pulsar Functions in cluster mode. Two options are available, and you can select either of the two options based on your requirements. 
 - [run with brokers](#run-Functions-worker-with-brokers)


### PR DESCRIPTION
Master Issue: #4554

### Motivation
As proposed in #4554, refine the admin(Setup part). Due to the limitation of website framework, we can add admin for the sidebar display to make it clear and reduce heading level.
I do not change much of the two files, so we can just use them in both old and new Pulsar Functions docs.

### Modifications
1. Add lead in sentence at the beginning: "This guide is used for administrator. "
2. Add "Admin" for the sidebar_label.
3. Refine language parts of "configure runtime".