### PR TITLE
[pulsar-admin] update dynamic config with escape char

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -617,6 +617,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_AUTHORIZATION,
+        dynamic = true,
         doc = "Role names that are treated as `super-user`, meaning they will be able to"
             + " do all admin operations and publish/consume from all topics"
     )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -468,6 +468,17 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         } catch (Exception e) {
             assertTrue(e instanceof PreconditionFailedException);
         }
+        
+        // (4) try to update dynamic-field with special char "/" and "%"
+        String user1 = "test/test%&$*/^";
+        String user2 = "user2/password";
+        final String configValue = user1 + "," + user2;
+        admin.brokers().updateDynamicConfiguration("superUserRoles", configValue);
+        String storedValue = admin.brokers().getAllDynamicConfigurations().get("superUserRoles");
+        assertEquals(configValue, storedValue);
+        retryStrategically((test) -> pulsar.getConfiguration().getSuperUserRoles().size() == 2, 5, 200);
+        assertTrue(pulsar.getConfiguration().getSuperUserRoles().contains(user1));
+        assertTrue(pulsar.getConfiguration().getSuperUserRoles().contains(user2));
 
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
+import org.apache.pulsar.common.util.Codec;
 
 public class BrokersImpl extends BaseResource implements Brokers {
     private final WebTarget adminBrokers;
@@ -65,7 +66,8 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public void updateDynamicConfiguration(String configName, String configValue) throws PulsarAdminException {
         try {
-            request(adminBrokers.path("/configuration/").path(configName).path(configValue)).post(Entity.json(""),
+            String value = Codec.encode(configValue);
+            request(adminBrokers.path("/configuration/").path(configName).path(value)).post(Entity.json(""),
                     ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);


### PR DESCRIPTION
### Motivation
Right now, cms-admin can not update dynamic configuration with escape character like "/$%". It fixes the issue. also made superUser-role dynamic as user sometimes wants to update super-suer role dynamically.