### PR TITLE
[pulsar-broker] fix NPE at managed-ledger when fetch reader internal-stats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -231,7 +231,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public Map<String, Long> getProperties() {
-        return lastMarkDeleteEntry.properties;
+        return lastMarkDeleteEntry != null ? lastMarkDeleteEntry.properties : Collections.emptyMap();
     }
 
     /**


### PR DESCRIPTION
### Motivation

Broker throws NPE when pulsar-admin tries to fetch stats-internal for topic with reader.

```
Caused by: java.lang.NullPointerException
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getProperties(ManagedCursorImpl.java:234) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$getInternalStats$48(PersistentTopic.java:1461) ~[classes/:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:1.8.0_92]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.getInternalStats(PersistentTopic.java:1446) ~[classes/:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalGetInternalStats(PersistentTopicsBase.java:621) ~[classes/:?]
	at org.apache.pulsar.broker.admin.v2.PersistentTopics.getInternalStats(PersistentTopics.java:430) ~[classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_92]
```