### PR TITLE
[PIP-38] Support batch receive in java client.

### DIFF
--- a/distribution/server/licenses/LICENSE-jcip.txt
+++ b/distribution/server/licenses/LICENSE-jcip.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2005 Brian Goetz and Tim Peierls
+Released under the Creative Commons Attribution License
+  (http://creativecommons.org/licenses/by/2.5)
+Official home: http://www.jcip.net
+
+Any republication or derived work distributed in source code form
+must include this copyright and license notice.

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -576,6 +576,11 @@ Bouncy Castle License
     - org.bouncycastle-bcprov-jdk15on-1.60.jar
     - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
 
+Creative Commons Attribution License -- licenses/LICENSE-jcip.txt
+ * jcip
+    - net.jcip-jcip-annotations-1.0.jar
+    - jcip-annotations-1.0.jar
+
 ------------------------
 
 Additionaly, Netty includes code with the following licenses:

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -576,8 +576,8 @@ Bouncy Castle License
     - org.bouncycastle-bcprov-jdk15on-1.60.jar
     - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
 
-Creative Commons Attribution License -- licenses/LICENSE-jcip.txt
- * jcip
+Creative Commons Attribution License
+ * jcip -- licenses/LICENSE-jcip.txt
     - net.jcip-jcip-annotations-1.0.jar
     - jcip-annotations-1.0.jar
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -578,7 +578,7 @@ Bouncy Castle License
 
 Creative Commons Attribution License
  * Jcip -- licenses/LICENSE-jcip.txt
-    - jcip-annotations-1.0.jar
+    - net.jcip-jcip-annotations-1.0.jar
 
 ------------------------
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -577,8 +577,7 @@ Bouncy Castle License
     - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
 
 Creative Commons Attribution License
- * jcip -- licenses/LICENSE-jcip.txt
-    - net.jcip-jcip-annotations-1.0.jar
+ * Jcip -- licenses/LICENSE-jcip.txt
     - jcip-annotations-1.0.jar
 
 ------------------------

--- a/distribution/server/src/assemble/NOTICE.bin.txt
+++ b/distribution/server/src/assemble/NOTICE.bin.txt
@@ -11,6 +11,9 @@ The Apache Software Foundation (http://www.apache.org/).
 Bouncy Castle
 Copyright (c) 2000-2015 The Legion Of The Bouncy Castle Inc. (http://www.bouncycastle.org)
 
+Creative Commons Attribution
+Copyright (c) 2005 Brian Goetz and Tim Peierls
+
 JCommander
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/distribution/server/src/assemble/NOTICE.bin.txt
+++ b/distribution/server/src/assemble/NOTICE.bin.txt
@@ -11,7 +11,7 @@ The Apache Software Foundation (http://www.apache.org/).
 Bouncy Castle
 Copyright (c) 2000-2015 The Legion Of The Bouncy Castle Inc. (http://www.bouncycastle.org)
 
-Creative Commons Attribution
+Jcip
 Copyright (c) 2005 Brian Goetz and Tim Peierls
 
 JCommander

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.1.3</snappy.version>
     <hbase.version>1.4.9</hbase.version>
     <guava.version>25.1-jre</guava.version>
-    
+    <jcip.version>1.0</jcip.version>
+
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
     <disruptor.version>3.4.0</disruptor.version>
@@ -1094,6 +1095,11 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${javassist.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${jcip.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -58,54 +58,48 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                 { BatchReceivePolicy.DEFAULT_POLICY, true },
                 // Only receive timeout limitation.
                 { BatchReceivePolicy.builder()
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), true
                 },
                 // Only number of messages in a single batch receive limitation.
                 { BatchReceivePolicy.builder()
-                        .maxNumberOfMessages(10)
+                        .maxNumMessages(10)
                         .build(), true
                 },
                 // Number of messages and timeout limitation
                 { BatchReceivePolicy.builder()
-                        .maxNumberOfMessages(13)
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .maxNumMessages(13)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), true
                 },
                 // Size of messages and timeout limitation
                 { BatchReceivePolicy.builder()
-                        .maxSizeOfMessages(64)
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .maxNumBytes(64)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), true
                 },
                 // Default batch receive policy.
                 { BatchReceivePolicy.DEFAULT_POLICY, false },
                 // Only receive timeout limitation.
                 { BatchReceivePolicy.builder()
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), false
                 },
                 // Only number of messages in a single batch receive limitation.
                 { BatchReceivePolicy.builder()
-                        .maxNumberOfMessages(10)
+                        .maxNumMessages(10)
                         .build(), false
                 },
                 // Number of messages and timeout limitation
                 { BatchReceivePolicy.builder()
-                        .maxNumberOfMessages(13)
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .maxNumMessages(13)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), false
                 },
                 // Size of messages and timeout limitation
                 { BatchReceivePolicy.builder()
-                        .maxSizeOfMessages(64)
-                        .timeout(50)
-                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .maxNumBytes(64)
+                        .timeout(50, TimeUnit.MILLISECONDS)
                         .build(), false
                 }
         };

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -1,0 +1,302 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import lombok.Cleanup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "batchReceivePolicy")
+    public Object[][] batchReceivePolicyProvider() {
+        return new Object[][] {
+
+                // Default batch receive policy.
+                { BatchReceivePolicy.DEFAULT_POLICY, true },
+                // Only receive timeout limitation.
+                { BatchReceivePolicy.builder()
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), true
+                },
+                // Only number of messages in a single batch receive limitation.
+                { BatchReceivePolicy.builder()
+                        .maxNumberOfMessages(10)
+                        .build(), true
+                },
+                // Number of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumberOfMessages(13)
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), true
+                },
+                // Size of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxSizeOfMessages(64)
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), true
+                },
+                // Default batch receive policy.
+                { BatchReceivePolicy.DEFAULT_POLICY, false },
+                // Only receive timeout limitation.
+                { BatchReceivePolicy.builder()
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), false
+                },
+                // Only number of messages in a single batch receive limitation.
+                { BatchReceivePolicy.builder()
+                        .maxNumberOfMessages(10)
+                        .build(), false
+                },
+                // Number of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumberOfMessages(13)
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), false
+                },
+                // Size of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxSizeOfMessages(64)
+                        .timeout(50)
+                        .timeoutUnit(TimeUnit.MILLISECONDS)
+                        .build(), false
+                }
+        };
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-non-partition-" + UUID.randomUUID();
+        testBatchReceive(topic, batchReceivePolicy, batchProduce);
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-" + UUID.randomUUID();
+        admin.topics().createPartitionedTopic(topic, 3);
+        testBatchReceive(topic, batchReceivePolicy, batchProduce);
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testAsyncBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-non-partition-async-" + UUID.randomUUID();
+        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce);
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testAsyncBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-async-" + UUID.randomUUID();
+        admin.topics().createPartitionedTopic(topic, 3);
+        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce);
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testBatchReceiveAndRedeliveryNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-and-redelivery-non-partition-" + UUID.randomUUID();
+        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce);
+    }
+
+    @Test(dataProvider = "batchReceivePolicy")
+    public void testBatchReceiveAndRedeliveryPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receive-and-redelivery-" + UUID.randomUUID();
+        admin.topics().createPartitionedTopic(topic, 3);
+        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce);
+    }
+
+    private void testBatchReceive(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
+        if (!batchProduce) {
+            producerBuilder.enableBatching(false);
+        }
+        @Cleanup
+        Producer<String> producer = producerBuilder.create();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("s1")
+                .batchReceivePolicy(batchReceivePolicy)
+                .subscribe();
+        sendMessagesAsyncAndWait(producer, 100);
+        batchReceiveAndCheck(consumer, 100);
+    }
+
+    private void testBatchReceiveAsync(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+
+        if (batchReceivePolicy.getTimeoutMs() <= 0) {
+            return;
+        }
+
+        ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
+        if (!batchProduce) {
+            producerBuilder.enableBatching(false);
+        }
+
+        @Cleanup
+        Producer<String> producer = producerBuilder.create();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("s1")
+                .batchReceivePolicy(batchReceivePolicy)
+                .subscribe();
+
+        sendMessagesAsyncAndWait(producer, 100);
+        CountDownLatch latch = new CountDownLatch(100);
+        receiveAsync(consumer, 100, latch);
+        latch.await();
+    }
+
+    private void testBatchReceiveAndRedelivery(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce) throws Exception {
+        ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
+        if (!batchProduce) {
+            producerBuilder.enableBatching(false);
+        }
+        @Cleanup
+        Producer<String> producer = producerBuilder.create();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("s1")
+                .batchReceivePolicy(batchReceivePolicy)
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscribe();
+        sendMessagesAsyncAndWait(producer, 100);
+        batchReceiveAndRedelivery(consumer, 100);
+    }
+
+    private void receiveAsync(Consumer<String> consumer, int expected, CountDownLatch latch) {
+        consumer.batchReceiveAsync().thenAccept(messages -> {
+            if (messages != null) {
+                log.info("Received {} messages in a single batch receive.", messages.size());
+                for (Message<String> message : messages) {
+                    Assert.assertNotNull(message.getValue());
+                    log.info("Get message {} from batch", message.getValue());
+                    latch.countDown();
+                }
+                try {
+                    consumer.acknowledge(messages);
+                } catch (PulsarClientException e) {
+                    log.error("Ack message error", e);
+                }
+                if (messages.size() < expected) {
+                    EXECUTOR.execute(() -> receiveAsync(consumer, expected - messages.size(), latch));
+                } else {
+                    Assert.assertEquals(expected, 0);
+                }
+            }
+        });
+    }
+
+    private void sendMessagesAsyncAndWait(Producer<String> producer, int messages) throws Exception {
+        CountDownLatch latch = new CountDownLatch(messages);
+        for (int i = 0; i < messages; i++) {
+            String message = "my-message-" + i;
+            producer.sendAsync(message).thenAccept(messageId -> {
+                log.info("Message {} published {}", message, messageId);
+                if (messageId != null) {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+    }
+
+    private void batchReceiveAndCheck(Consumer<String> consumer, int expected) throws Exception {
+        Messages<String> messages;
+        int messageReceived = 0;
+        do {
+            messages = consumer.batchReceive();
+            if (messages != null) {
+                messageReceived += messages.size();
+                log.info("Received {} messages in a single batch receive.", messages.size());
+                for (Message<String> message : messages) {
+                    Assert.assertNotNull(message.getValue());
+                    log.info("Get message {} from batch", message.getValue());
+                }
+                consumer.acknowledge(messages);
+            }
+        } while (messageReceived < expected);
+        Assert.assertEquals(expected, messageReceived);
+    }
+
+    private void batchReceiveAndRedelivery(Consumer<String> consumer, int expected) throws Exception {
+        Messages<String> messages;
+        int messageReceived = 0;
+        do {
+            messages = consumer.batchReceive();
+            if (messages != null) {
+                messageReceived += messages.size();
+                log.info("Received {} messages in a single batch receive.", messages.size());
+                for (Message<String> message : messages) {
+                    Assert.assertNotNull(message.getValue());
+                    log.info("Get message {} from batch", message.getValue());
+                    // don't ack, test message redelivery
+                }
+            }
+        } while (messageReceived < expected);
+        Assert.assertEquals(expected, messageReceived);
+
+        do {
+            messages = consumer.batchReceive();
+            if (messages != null) {
+                messageReceived += messages.size();
+                log.info("Received {} messages in a single batch receive.", messages.size());
+                for (Message<String> message : messages) {
+                    Assert.assertNotNull(message.getValue());
+                    log.info("Get message {} from batch", message.getValue());
+                }
+            }
+            consumer.acknowledge(messages);
+        } while (messageReceived < expected * 2);
+        Assert.assertEquals(expected * 2, messageReceived);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(ConsumerBatchReceiveTest.class);
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
@@ -18,15 +18,12 @@
  */
 package org.apache.pulsar.client.api;
 
-import lombok.Builder;
-import lombok.Data;
-
 import java.util.concurrent.TimeUnit;
 
 /**
  * Configuration for message batch receive {@link Consumer#batchReceive()} {@link Consumer#batchReceiveAsync()}.
  *
- * Batch receive policy can limit the number and size of messages in a single batch, and can specify a timeout
+ * Batch receive policy can limit the number and bytes of messages in a single batch, and can specify a timeout
  * for waiting for enough messages for this batch.
  *
  * This batch receive will be completed as long as any one of the
@@ -34,52 +31,57 @@ import java.util.concurrent.TimeUnit;
  *
  * Examples:
  *
- * 1.If set maxNumberOfMessages = 10, maxSizeOfMessages = 1MB and without timeout, it
+ * 1.If set maxNumMessages = 10, maxSizeOfMessages = 1MB and without timeout, it
  * means {@link Consumer#batchReceive()} will always wait until there is enough messages.
  *
- * 2.If set maxNumberOfMessages = 0, maxSizeOfMessages = 0 and timeout = 100ms, it
+ * 2.If set maxNumberOfMessages = 0, maxNumBytes = 0 and timeout = 100ms, it
  * means {@link Consumer#batchReceive()} will waiting for 100ms whether or not there is enough messages.
  *
  * Note:
- * Must specify messages limitation(maxNumberOfMessages, maxSizeOfMessages) or wait timeout.
+ * Must specify messages limitation(maxNumMessages, maxNumBytes) or wait timeout.
  * Otherwise, {@link Messages} ingest {@link Message} will never end.
  *
  * @since 2.4.1
  */
-@Builder
-@Data
 public class BatchReceivePolicy {
 
     /**
      * Default batch receive policy
      *
      * Max number of messages: 100
-     * Max size of messages: 10MB
+     * Max number of bytes: 10MB
      * Timeout: 100ms
      */
     public static final BatchReceivePolicy DEFAULT_POLICY = new BatchReceivePolicy(
             100, 1024 * 1024 * 10, 100, TimeUnit.MILLISECONDS);
 
-    /**
-     * Max number of message for a single batch receive, 0 or negative means no limit.
-     */
-    private int maxNumberOfMessages;
+    private BatchReceivePolicy(int maxNumMessages, long maxNumBytes, int timeout, TimeUnit timeoutUnit) {
+        this.maxNumMessages = maxNumMessages;
+        this.maxNumBytes = maxNumBytes;
+        this.timeout = timeout;
+        this.timeoutUnit = timeoutUnit;
+    }
 
     /**
-     * Max size of message for a single batch receive, 0 or negative means no limit.
+     * Max number of messages for a single batch receive, 0 or negative means no limit.
      */
-    private long maxSizeOfMessages;
+    private int maxNumMessages;
 
     /**
-     * timeout for waiting for enough messages(enough number or enough size).
+     * Max bytes of messages for a single batch receive, 0 or negative means no limit.
+     */
+    private long maxNumBytes;
+
+    /**
+     * timeout for waiting for enough messages(enough number or enough bytes).
      */
     private int timeout;
     private TimeUnit timeoutUnit;
 
     public void verify() {
-        if (maxNumberOfMessages <= 0 && maxSizeOfMessages <= 0 && timeout <= 0) {
+        if (maxNumMessages <= 0 && maxNumBytes <= 0 && timeout <= 0) {
             throw new IllegalArgumentException("At least " +
-                    "one of maxNumberOfMessages, maxSizeOfMessages, timeout must be specified.");
+                    "one of maxNumMessages, maxNumBytes, timeout must be specified.");
         }
         if (timeout > 0 && timeoutUnit == null) {
             throw new IllegalArgumentException("Must set timeout unit for timeout.");
@@ -88,5 +90,71 @@ public class BatchReceivePolicy {
 
     public long getTimeoutMs() {
         return (timeout > 0 && timeoutUnit != null) ? timeoutUnit.toMillis(timeout) : 0L;
+    }
+
+    public int getMaxNumMessages() {
+        return maxNumMessages;
+    }
+
+    public long getMaxNumBytes() {
+        return maxNumBytes;
+    }
+
+    public BatchReceivePolicy setMaxNumMessages(int maxNumMessages) {
+        this.maxNumMessages = maxNumMessages;
+        return this;
+    }
+
+    public BatchReceivePolicy setMaxNumBytes(long maxNumBytes) {
+        this.maxNumBytes = maxNumBytes;
+        return this;
+    }
+
+    private BatchReceivePolicy setTimeout(int timeout, TimeUnit timeoutUnit) {
+        this.timeout = timeout;
+        this.timeoutUnit = timeoutUnit;
+        return this;
+    }
+
+    public static class Builder {
+
+        private int maxNumMessages;
+        private long maxNumBytes;
+        private int timeout;
+        private TimeUnit timeoutUnit;
+
+        public Builder maxNumMessages(int maxNumMessages) {
+            this.maxNumMessages = maxNumMessages;
+            return this;
+        }
+
+        public Builder maxNumBytes(long maxNumBytes) {
+            this.maxNumBytes = maxNumBytes;
+            return this;
+        }
+
+        public Builder timeout(int timeout, TimeUnit timeoutUnit) {
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+            return this;
+        }
+
+        public BatchReceivePolicy build() {
+            return new BatchReceivePolicy(maxNumMessages, maxNumBytes, timeout, timeoutUnit);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "BatchReceivePolicy{" +
+                "maxNumMessages=" + maxNumMessages +
+                ", maxNumBytes=" + maxNumBytes +
+                ", timeout=" + timeout +
+                ", timeoutUnit=" + timeoutUnit +
+                '}';
     }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for message batch receive {@link Consumer#batchReceive()} {@link Consumer#batchReceiveAsync()}.
+ *
+ * Batch receive policy can limit the number and size of messages in a single batch, and can specify a timeout
+ * for waiting for enough messages for this batch.
+ *
+ * This batch receive will be completed as long as any one of the
+ * conditions(has enough number of messages, has enough of size of messages, wait timeout) is met.
+ *
+ * Examples:
+ *
+ * 1.If set maxNumberOfMessages = 10, maxSizeOfMessages = 1MB and without timeout, it
+ * means {@link Consumer#batchReceive()} will always wait until there is enough messages.
+ *
+ * 2.If set maxNumberOfMessages = 0, maxSizeOfMessages = 0 and timeout = 100ms, it
+ * means {@link Consumer#batchReceive()} will waiting for 100ms whether or not there is enough messages.
+ *
+ * Note:
+ * Must specify messages limitation(maxNumberOfMessages, maxSizeOfMessages) or wait timeout.
+ * Otherwise, {@link Messages} ingest {@link Message} will never end.
+ *
+ * @since 2.4.1
+ */
+@Builder
+@Data
+public class BatchReceivePolicy {
+
+    /**
+     * Default batch receive policy
+     *
+     * Max number of messages: 100
+     * Max size of messages: 10MB
+     * Timeout: 100ms
+     */
+    public static final BatchReceivePolicy DEFAULT_POLICY = new BatchReceivePolicy(
+            100, 1024 * 1024 * 10, 100, TimeUnit.MILLISECONDS);
+
+    /**
+     * Max number of message for a single batch receive, 0 or negative means no limit.
+     */
+    private int maxNumberOfMessages;
+
+    /**
+     * Max size of message for a single batch receive, 0 or negative means no limit.
+     */
+    private long maxSizeOfMessages;
+
+    /**
+     * timeout for waiting for enough messages(enough number or enough size).
+     */
+    private int timeout;
+    private TimeUnit timeoutUnit;
+
+    public void verify() {
+        if (maxNumberOfMessages <= 0 && maxSizeOfMessages <= 0 && timeout <= 0) {
+            throw new IllegalArgumentException("At least " +
+                    "one of maxNumberOfMessages, maxSizeOfMessages, timeout must be specified.");
+        }
+        if (timeout > 0 && timeoutUnit == null) {
+            throw new IllegalArgumentException("Must set timeout unit for timeout.");
+        }
+    }
+
+    public long getTimeoutMs() {
+        return (timeout > 0 && timeoutUnit != null) ? timeoutUnit.toMillis(timeout) : 0L;
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
@@ -23,21 +23,19 @@ import java.util.concurrent.TimeUnit;
 /**
  * Configuration for message batch receive {@link Consumer#batchReceive()} {@link Consumer#batchReceiveAsync()}.
  *
- * Batch receive policy can limit the number and bytes of messages in a single batch, and can specify a timeout
+ * <p>Batch receive policy can limit the number and bytes of messages in a single batch, and can specify a timeout
  * for waiting for enough messages for this batch.
  *
- * This batch receive will be completed as long as any one of the
+ * <p>This batch receive will be completed as long as any one of the
  * conditions(has enough number of messages, has enough of size of messages, wait timeout) is met.
  *
- * Examples:
- *
+ * <p>Examples:
  * 1.If set maxNumMessages = 10, maxSizeOfMessages = 1MB and without timeout, it
  * means {@link Consumer#batchReceive()} will always wait until there is enough messages.
- *
  * 2.If set maxNumberOfMessages = 0, maxNumBytes = 0 and timeout = 100ms, it
  * means {@link Consumer#batchReceive()} will waiting for 100ms whether or not there is enough messages.
  *
- * Note:
+ * <p>Note:
  * Must specify messages limitation(maxNumMessages, maxNumBytes) or wait timeout.
  * Otherwise, {@link Messages} ingest {@link Message} will never end.
  *
@@ -46,11 +44,11 @@ import java.util.concurrent.TimeUnit;
 public class BatchReceivePolicy {
 
     /**
-     * Default batch receive policy
+     * Default batch receive policy.
      *
-     * Max number of messages: 100
+     * <p>Max number of messages: 100
      * Max number of bytes: 10MB
-     * Timeout: 100ms
+     * Timeout: 100ms<p/>
      */
     public static final BatchReceivePolicy DEFAULT_POLICY = new BatchReceivePolicy(
             -1, 10 * 1024 * 1024, 100, TimeUnit.MILLISECONDS);
@@ -80,8 +78,8 @@ public class BatchReceivePolicy {
 
     public void verify() {
         if (maxNumMessages <= 0 && maxNumBytes <= 0 && timeout <= 0) {
-            throw new IllegalArgumentException("At least " +
-                    "one of maxNumMessages, maxNumBytes, timeout must be specified.");
+            throw new IllegalArgumentException("At least "
+                    + "one of maxNumMessages, maxNumBytes, timeout must be specified.");
         }
         if (timeout > 0 && timeoutUnit == null) {
             throw new IllegalArgumentException("Must set timeout unit for timeout.");
@@ -100,6 +98,9 @@ public class BatchReceivePolicy {
         return maxNumBytes;
     }
 
+    /**
+     * Builder of BatchReceivePolicy.
+     */
     public static class Builder {
 
         private int maxNumMessages;
@@ -134,11 +135,11 @@ public class BatchReceivePolicy {
 
     @Override
     public String toString() {
-        return "BatchReceivePolicy{" +
-                "maxNumMessages=" + maxNumMessages +
-                ", maxNumBytes=" + maxNumBytes +
-                ", timeout=" + timeout +
-                ", timeoutUnit=" + timeoutUnit +
-                '}';
+        return "BatchReceivePolicy{"
+                + "maxNumMessages=" + maxNumMessages
+                + ", maxNumBytes=" + maxNumBytes
+                + ", timeout=" + timeout
+                + ", timeoutUnit=" + timeoutUnit
+                + '}';
     }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchReceivePolicy.java
@@ -53,9 +53,9 @@ public class BatchReceivePolicy {
      * Timeout: 100ms
      */
     public static final BatchReceivePolicy DEFAULT_POLICY = new BatchReceivePolicy(
-            100, 1024 * 1024 * 10, 100, TimeUnit.MILLISECONDS);
+            -1, 10 * 1024 * 1024, 100, TimeUnit.MILLISECONDS);
 
-    private BatchReceivePolicy(int maxNumMessages, long maxNumBytes, int timeout, TimeUnit timeoutUnit) {
+    private BatchReceivePolicy(int maxNumMessages, int maxNumBytes, int timeout, TimeUnit timeoutUnit) {
         this.maxNumMessages = maxNumMessages;
         this.maxNumBytes = maxNumBytes;
         this.timeout = timeout;
@@ -65,18 +65,18 @@ public class BatchReceivePolicy {
     /**
      * Max number of messages for a single batch receive, 0 or negative means no limit.
      */
-    private int maxNumMessages;
+    private final int maxNumMessages;
 
     /**
      * Max bytes of messages for a single batch receive, 0 or negative means no limit.
      */
-    private long maxNumBytes;
+    private final int maxNumBytes;
 
     /**
      * timeout for waiting for enough messages(enough number or enough bytes).
      */
-    private int timeout;
-    private TimeUnit timeoutUnit;
+    private final int timeout;
+    private final TimeUnit timeoutUnit;
 
     public void verify() {
         if (maxNumMessages <= 0 && maxNumBytes <= 0 && timeout <= 0) {
@@ -100,26 +100,10 @@ public class BatchReceivePolicy {
         return maxNumBytes;
     }
 
-    public BatchReceivePolicy setMaxNumMessages(int maxNumMessages) {
-        this.maxNumMessages = maxNumMessages;
-        return this;
-    }
-
-    public BatchReceivePolicy setMaxNumBytes(long maxNumBytes) {
-        this.maxNumBytes = maxNumBytes;
-        return this;
-    }
-
-    private BatchReceivePolicy setTimeout(int timeout, TimeUnit timeoutUnit) {
-        this.timeout = timeout;
-        this.timeoutUnit = timeoutUnit;
-        return this;
-    }
-
     public static class Builder {
 
         private int maxNumMessages;
-        private long maxNumBytes;
+        private int maxNumBytes;
         private int timeout;
         private TimeUnit timeoutUnit;
 
@@ -128,7 +112,7 @@ public class BatchReceivePolicy {
             return this;
         }
 
-        public Builder maxNumBytes(long maxNumBytes) {
+        public Builder maxNumBytes(int maxNumBytes) {
             this.maxNumBytes = maxNumBytes;
             return this;
         }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -108,7 +108,34 @@ public interface Consumer<T> extends Closeable {
     Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException;
 
     /**
-     * Acknowledge the consumption of a single message.
+     * Batch receiving messages
+     * <p>
+     * This calls blocks until has enough messages or wait timeout, more details to see {@link BatchReceivePolicy}
+     *
+     * @return messages
+     * @since 2.4.1
+     * @throws PulsarClientException
+     */
+    Messages<T> batchReceive() throws PulsarClientException;
+
+    /**
+     * Batch receiving messages
+     * <p>
+     * Retrieves messages when has enough messages or wait timeout and
+     * completes {@link CompletableFuture} with received messages.
+     * </p>
+     * <p>
+     * {@code batchReceiveAsync()} should be called subsequently once returned {@code CompletableFuture} gets complete with
+     * received messages. Else it creates <i> backlog of receive requests </i> in the application.
+     * </p>
+     * @return messages
+     * @since 2.4.1
+     * @throws PulsarClientException
+     */
+    CompletableFuture<Messages<T>> batchReceiveAsync();
+
+    /**
+     * Acknowledge the consumption of a single message
      *
      * @param message
      *            The {@code Message} to be acknowledged
@@ -126,6 +153,15 @@ public interface Consumer<T> extends Closeable {
      *             if the consumer was already closed
      */
     void acknowledge(MessageId messageId) throws PulsarClientException;
+
+    /**
+     * Acknowledge the consumption of {@link Messages}
+     *
+     * @param messages messages
+     * @throws PulsarClientException.AlreadyClosedException
+     *              if the consumer was already closed
+     */
+    void acknowledge(Messages<?> messages) throws PulsarClientException;
 
     /**
      * Acknowledge the failure to process a single message.
@@ -178,6 +214,37 @@ public interface Consumer<T> extends Closeable {
     void negativeAcknowledge(MessageId messageId);
 
     /**
+     * Acknowledge the failure to process {@link Messages}
+     * <p>
+     * When messages is "negatively acked" it will be marked for redelivery after
+     * some fixed delay. The delay is configurable when constructing the consumer
+     * with {@link ConsumerBuilder#negativeAckRedeliveryDelay(long, TimeUnit)}.
+     * <p>
+     * This call is not blocking.
+     *
+     * <p>
+     * Example of usage:
+     * <pre><code>
+     * while (true) {
+     *     Messages&lt;String&gt; msgs = consumer.batchReceive();
+     *
+     *     try {
+     *          // Process message...
+     *
+     *          consumer.acknowledge(msgs);
+     *     } catch (Throwable t) {
+     *          log.warn("Failed to process message");
+     *          consumer.negativeAcknowledge(msgs);
+     *     }
+     * }
+     * </code></pre>
+     *
+     * @param message
+     *            The {@code Message} to be acknowledged
+     */
+    void negativeAcknowledge(Messages<?> messages);
+
+    /**
      * Acknowledge the reception of all the messages in the stream up to (and including) the provided message.
      *
      * <p>This method will block until the acknowledge has been sent to the broker. After that, the messages will not be
@@ -228,6 +295,15 @@ public interface Consumer<T> extends Closeable {
      * @return a future that can be used to track the completion of the operation
      */
     CompletableFuture<Void> acknowledgeAsync(MessageId messageId);
+
+    /**
+     * Asynchronously acknowledge the consumption of {@link Messages}
+     *
+     * @param messages
+     *            The {@link Messages} to be acknowledged
+     * @return a future that can be used to track the completion of the operation
+     */
+    CompletableFuture<Void> acknowledgeAsync(Messages<?> messages);
 
     /**
      * Asynchronously Acknowledge the reception of all the messages in the stream up to (and including) the provided

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -108,9 +108,9 @@ public interface Consumer<T> extends Closeable {
     Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException;
 
     /**
-     * Batch receiving messages
-     * <p>
-     * This calls blocks until has enough messages or wait timeout, more details to see {@link BatchReceivePolicy}
+     * Batch receiving messages.
+     *
+     * <p>This calls blocks until has enough messages or wait timeout, more details to see {@link BatchReceivePolicy}.
      *
      * @return messages
      * @since 2.4.1
@@ -119,14 +119,14 @@ public interface Consumer<T> extends Closeable {
     Messages<T> batchReceive() throws PulsarClientException;
 
     /**
-     * Batch receiving messages
+     * Batch receiving messages.
      * <p>
      * Retrieves messages when has enough messages or wait timeout and
      * completes {@link CompletableFuture} with received messages.
      * </p>
      * <p>
-     * {@code batchReceiveAsync()} should be called subsequently once returned {@code CompletableFuture} gets complete with
-     * received messages. Else it creates <i> backlog of receive requests </i> in the application.
+     * {@code batchReceiveAsync()} should be called subsequently once returned {@code CompletableFuture} gets complete
+     * with received messages. Else it creates <i> backlog of receive requests </i> in the application.
      * </p>
      * @return messages
      * @since 2.4.1
@@ -135,7 +135,7 @@ public interface Consumer<T> extends Closeable {
     CompletableFuture<Messages<T>> batchReceiveAsync();
 
     /**
-     * Acknowledge the consumption of a single message
+     * Acknowledge the consumption of a single message.
      *
      * @param message
      *            The {@code Message} to be acknowledged
@@ -155,7 +155,7 @@ public interface Consumer<T> extends Closeable {
     void acknowledge(MessageId messageId) throws PulsarClientException;
 
     /**
-     * Acknowledge the consumption of {@link Messages}
+     * Acknowledge the consumption of {@link Messages}.
      *
      * @param messages messages
      * @throws PulsarClientException.AlreadyClosedException
@@ -214,16 +214,15 @@ public interface Consumer<T> extends Closeable {
     void negativeAcknowledge(MessageId messageId);
 
     /**
-     * Acknowledge the failure to process {@link Messages}
-     * <p>
-     * When messages is "negatively acked" it will be marked for redelivery after
+     * Acknowledge the failure to process {@link Messages}.
+     *
+     * <p>When messages is "negatively acked" it will be marked for redelivery after
      * some fixed delay. The delay is configurable when constructing the consumer
      * with {@link ConsumerBuilder#negativeAckRedeliveryDelay(long, TimeUnit)}.
-     * <p>
-     * This call is not blocking.
      *
-     * <p>
-     * Example of usage:
+     * <p>This call is not blocking.
+     *
+     * <p>Example of usage:
      * <pre><code>
      * while (true) {
      *     Messages&lt;String&gt; msgs = consumer.batchReceive();
@@ -239,7 +238,7 @@ public interface Consumer<T> extends Closeable {
      * }
      * </code></pre>
      *
-     * @param message
+     * @param messages
      *            The {@code Message} to be acknowledged
      */
     void negativeAcknowledge(Messages<?> messages);
@@ -297,7 +296,7 @@ public interface Consumer<T> extends Closeable {
     CompletableFuture<Void> acknowledgeAsync(MessageId messageId);
 
     /**
-     * Asynchronously acknowledge the consumption of {@link Messages}
+     * Asynchronously acknowledge the consumption of {@link Messages}.
      *
      * @param messages
      *            The {@link Messages} to be acknowledged

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -543,4 +543,20 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * @return the consumer builder instance
      */
     ConsumerBuilder<T> startMessageIdInclusive();
+
+    /**
+     * Set batch receive policy {@link BatchReceivePolicy} for consumer.
+     * By default, consumer will use {@link BatchReceivePolicy#DEFAULT_POLICY} as batch receive policy.
+     *
+     * Example:
+     * <pre>
+     * client.newConsumer().batchReceivePolicy(BatchReceivePolicy.builder()
+     *              .maxNumberOfMessages(100)
+     *              .maxSizeOfMessages(5 * 1024 * 1024)
+     *              .timeout(100)
+     *              .timeoutUnit(TimeUnit.MILLISECONDS)
+     *              .build()).subscribe();
+     * </pre>
+     */
+    ConsumerBuilder<T> batchReceivePolicy(BatchReceivePolicy batchReceivePolicy);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -553,8 +553,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * client.newConsumer().batchReceivePolicy(BatchReceivePolicy.builder()
      *              .maxNumberOfMessages(100)
      *              .maxSizeOfMessages(5 * 1024 * 1024)
-     *              .timeout(100)
-     *              .timeoutUnit(TimeUnit.MILLISECONDS)
+     *              .timeout(100, TimeUnit.MILLISECONDS)
      *              .build()).subscribe();
      * </pre>
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -551,8 +551,8 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * <p>Example:
      * <pre>
      * client.newConsumer().batchReceivePolicy(BatchReceivePolicy.builder()
-     *              .maxNumberOfMessages(100)
-     *              .maxSizeOfMessages(5 * 1024 * 1024)
+     *              .maxNumMessages(100)
+     *              .maxNumBytes(5 * 1024 * 1024)
      *              .timeout(100, TimeUnit.MILLISECONDS)
      *              .build()).subscribe();
      * </pre>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -548,7 +548,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Set batch receive policy {@link BatchReceivePolicy} for consumer.
      * By default, consumer will use {@link BatchReceivePolicy#DEFAULT_POLICY} as batch receive policy.
      *
-     * Example:
+     * <p>Example:
      * <pre>
      * client.newConsumer().batchReceivePolicy(BatchReceivePolicy.builder()
      *              .maxNumberOfMessages(100)

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
@@ -64,6 +64,11 @@ public interface ConsumerStats extends Serializable {
     long getNumReceiveFailed();
 
     /**
+     * @return Number of message batch receive failed in the last interval
+     */
+    long getNumBatchReceiveFailed();
+
+    /**
      * @return Total number of messages received by this consumer
      */
     long getTotalMsgsReceived();
@@ -77,6 +82,11 @@ public interface ConsumerStats extends Serializable {
      * @return Total number of messages receive failures
      */
     long getTotalReceivedFailed();
+
+    /**
+     * @return Total number of messages batch receive failures
+     */
+    long getTotaBatchReceivedFailed();
 
     /**
      * @return Total number of message acknowledgments sent by this consumer

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Messages.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Messages.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.List;
+
+/**
+ * A container that holds the list {@link Message} for a topic.
+ * @param <T>
+ */
+public interface Messages<T> extends Iterable<Message<T>> {
+
+    /**
+     * Get the list {@link Message}
+     */
+    List<Message<T>> getMessageList();
+
+    /**
+     * Get number of messages.
+     */
+    int size();
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Messages.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Messages.java
@@ -18,18 +18,11 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.util.List;
-
 /**
  * A container that holds the list {@link Message} for a topic.
  * @param <T>
  */
 public interface Messages<T> extends Iterable<Message<T>> {
-
-    /**
-     * Get the list {@link Message}
-     */
-    List<Message<T>> getMessageList();
 
     /**
      * Get number of messages.

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -132,6 +132,11 @@
       <artifactId>joda-time</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
     
     <!-- httpclient-hostname-verification depends on below dependencies  --> 
     <dependency>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -104,7 +104,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
         this.pendingReceives = Queues.newConcurrentLinkedQueue();
         this.schema = schema;
         this.interceptors = interceptors;
-        this.batchReceivePolicy = conf.getBatchReceivePolicy();
+        if (conf.getBatchReceivePolicy() != null) {
+            this.batchReceivePolicy = conf.getBatchReceivePolicy();
+        } else {
+            this.batchReceivePolicy = BatchReceivePolicy.DEFAULT_POLICY;
+        }
         if (batchReceivePolicy.getTimeoutMs() > 0) {
             batchReceiveTimeout = client.timer().newTimeout(this, batchReceivePolicy.getTimeoutMs(), TimeUnit.MILLISECONDS);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -123,7 +123,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
         }
         PulsarClientException exception = verifyConsumerState();
         if (exception != null) {
-            FutureUtil.failedFuture(exception);
+            return FutureUtil.failedFuture(exception);
         }
         return internalReceiveAsync();
     }
@@ -181,7 +181,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
         }
         PulsarClientException exception = verifyConsumerState();
         if (exception != null) {
-            FutureUtil.failedFuture(exception);
+            return FutureUtil.failedFuture(exception);
         }
         return internalBatchReceiveAsync();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -468,9 +468,16 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
         }
     }
 
+    protected boolean canEnqueueMessage(Message<T> message) {
+        // Default behavior, can be overridden in subclasses
+        return true;
+    }
+
     protected boolean enqueueMessageAndCheckBatchReceive(Message<T> message) {
-        incomingMessages.add(message);
-        INCOMING_MESSAGES_SIZE_UPDATER.addAndGet(this, message.getData().length);
+        if (canEnqueueMessage(message)) {
+            incomingMessages.add(message);
+            INCOMING_MESSAGES_SIZE_UPDATER.addAndGet(this, message.getData().length);
+        }
         return hasEnoughMessagesForBatchReceive();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -475,11 +475,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
     }
 
     protected boolean hasEnoughMessagesForBatchReceive() {
-        if (batchReceivePolicy.getMaxNumberOfMessages() <= 0 && batchReceivePolicy.getMaxNumberOfMessages() <= 0) {
+        if (batchReceivePolicy.getMaxNumMessages() <= 0 && batchReceivePolicy.getMaxNumMessages() <= 0) {
             return false;
         }
-        return (batchReceivePolicy.getMaxNumberOfMessages() > 0 && incomingMessages.size() >= batchReceivePolicy.getMaxNumberOfMessages())
-                || (batchReceivePolicy.getMaxSizeOfMessages() > 0 && INCOMING_MESSAGES_SIZE_UPDATER.get(this) >= batchReceivePolicy.getMaxSizeOfMessages());
+        return (batchReceivePolicy.getMaxNumMessages() > 0 && incomingMessages.size() >= batchReceivePolicy.getMaxNumMessages())
+                || (batchReceivePolicy.getMaxNumBytes() > 0 && INCOMING_MESSAGES_SIZE_UPDATER.get(this) >= batchReceivePolicy.getMaxNumBytes());
     }
 
     private PulsarClientException verifyConsumerState() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -559,10 +559,14 @@ public abstract class ConsumerBase<T> extends HandlerState implements TimerTask,
         }
     }
 
-    protected MessagesImpl<T> getReUseableMessagesImpl() {
+    protected MessagesImpl<T> getReuseableMessagesImpl() {
         MessagesImpl<T> messages = TL_MESSAGES.get();
         messages.clear();
         return messages;
+    }
+
+    protected boolean hasPendingBatchReceive() {
+        return pendingBatchReceives != null && !pendingBatchReceives.isEmpty();
     }
 
     protected abstract void completeOpBatchReceive(OpBatchReceive<T> op);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -324,8 +325,16 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+
     public ConsumerBuilder<T> startMessageIdInclusive() {
         conf.setResetIncludeHead(true);
+        return this;
+    }
+
+    public ConsumerBuilder<T> batchReceivePolicy(BatchReceivePolicy batchReceivePolicy) {
+        checkArgument(batchReceivePolicy != null, "batchReceivePolicy must not be null.");
+        batchReceivePolicy.verify();
+        conf.setBatchReceivePolicy(batchReceivePolicy);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -388,8 +388,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         try {
             lock.writeLock().lock();
             if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumberOfMessages(),
-                        batchReceivePolicy.getMaxSizeOfMessages());
+                MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumMessages(),
+                        batchReceivePolicy.getMaxNumBytes());
                 Message<T> msgPeeked = incomingMessages.peek();
                 while (msgPeeked != null && messages.canAdd(msgPeeked)) {
                     Message<T> msg = incomingMessages.poll(0L, TimeUnit.MILLISECONDS);
@@ -988,8 +988,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
 
     void notifyPendingBatchReceivedCallBack(OpBatchReceive<T> opBatchReceive) {
-        MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumberOfMessages(),
-                batchReceivePolicy.getMaxSizeOfMessages());
+        MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumMessages(),
+                batchReceivePolicy.getMaxNumBytes());
         Message<T> msgPeeked = incomingMessages.peek();
         while (msgPeeked != null && messages.canAdd(msgPeeked)) {
             Message<T> msg = null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -934,11 +934,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         });
     }
 
-    protected boolean canEnqueueMessage(Message<T> message) {
-        // Default behavior, can be overridden in subclasses
-        return true;
-    }
-
     /**
      * Notify waiting asyncReceive request with the received message
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -392,7 +392,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 pendingBatchReceives = Queues.newConcurrentLinkedQueue();
             }
             if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = getReUseableMessagesImpl();
+                MessagesImpl<T> messages = getReuseableMessagesImpl();
                 Message<T> msgPeeked = incomingMessages.peek();
                 while (msgPeeked != null && messages.canAdd(msgPeeked)) {
                     Message<T> msg = incomingMessages.poll();
@@ -881,7 +881,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (!pendingReceives.isEmpty()) {
                     notifyPendingReceivedCallback(message, null);
                 } else if (enqueueMessageAndCheckBatchReceive(message)) {
-                    if (!pendingBatchReceives.isEmpty()) {
+                    if (hasPendingBatchReceive()) {
                         notifyPendingBatchReceivedCallBack();
                     }
                 }
@@ -1069,7 +1069,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     if (!pendingReceives.isEmpty()) {
                         notifyPendingReceivedCallback(message, null);
                     } else if (enqueueMessageAndCheckBatchReceive(message)) {
-                        if (!pendingBatchReceives.isEmpty()) {
+                        if (hasPendingBatchReceive()) {
                             notifyPendingBatchReceivedCallBack();
                         }
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
@@ -41,6 +41,11 @@ public class ConsumerStatsDisabled implements ConsumerStatsRecorder {
     }
 
     @Override
+    public void incrementNumBatchReceiveFailed() {
+        // Do nothing
+    }
+
+    @Override
     public void incrementNumAcksSent(long numAcks) {
         // Do nothing
     }
@@ -76,6 +81,11 @@ public class ConsumerStatsDisabled implements ConsumerStatsRecorder {
     }
 
     @Override
+    public long getNumBatchReceiveFailed() {
+        return 0;
+    }
+
+    @Override
     public long getTotalMsgsReceived() {
         return 0;
     }
@@ -87,6 +97,11 @@ public class ConsumerStatsDisabled implements ConsumerStatsRecorder {
 
     @Override
     public long getTotalReceivedFailed() {
+        return 0;
+    }
+
+    @Override
+    public long getTotaBatchReceivedFailed() {
         return 0;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorder.java
@@ -34,6 +34,8 @@ public interface ConsumerStatsRecorder extends ConsumerStats {
 
     void incrementNumReceiveFailed();
 
+    void incrementNumBatchReceiveFailed();
+
     Optional<Timeout> getStatTimeout();
 
     void reset();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -49,11 +49,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     private final LongAdder numMsgsReceived;
     private final LongAdder numBytesReceived;
     private final LongAdder numReceiveFailed;
+    private final LongAdder numBatchReceiveFailed;
     private final LongAdder numAcksSent;
     private final LongAdder numAcksFailed;
     private final LongAdder totalMsgsReceived;
     private final LongAdder totalBytesReceived;
     private final LongAdder totalReceiveFailed;
+    private final LongAdder totalBatchReceiveFailed;
     private final LongAdder totalAcksSent;
     private final LongAdder totalAcksFailed;
 
@@ -66,11 +68,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         numMsgsReceived = new LongAdder();
         numBytesReceived = new LongAdder();
         numReceiveFailed = new LongAdder();
+        numBatchReceiveFailed = new LongAdder();
         numAcksSent = new LongAdder();
         numAcksFailed = new LongAdder();
         totalMsgsReceived = new LongAdder();
         totalBytesReceived = new LongAdder();
         totalReceiveFailed = new LongAdder();
+        totalBatchReceiveFailed = new LongAdder();
         totalAcksSent = new LongAdder();
         totalAcksFailed = new LongAdder();
     }
@@ -83,11 +87,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         numMsgsReceived = new LongAdder();
         numBytesReceived = new LongAdder();
         numReceiveFailed = new LongAdder();
+        numBatchReceiveFailed = new LongAdder();
         numAcksSent = new LongAdder();
         numAcksFailed = new LongAdder();
         totalMsgsReceived = new LongAdder();
         totalBytesReceived = new LongAdder();
         totalReceiveFailed = new LongAdder();
+        totalBatchReceiveFailed = new LongAdder();
         totalAcksSent = new LongAdder();
         totalAcksFailed = new LongAdder();
         init(conf);
@@ -116,12 +122,14 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                 long currentNumMsgsReceived = numMsgsReceived.sumThenReset();
                 long currentNumBytesReceived = numBytesReceived.sumThenReset();
                 long currentNumReceiveFailed = numReceiveFailed.sumThenReset();
+                long currentNumBatchReceiveFailed = numBatchReceiveFailed.sumThenReset();
                 long currentNumAcksSent = numAcksSent.sumThenReset();
                 long currentNumAcksFailed = numAcksFailed.sumThenReset();
 
                 totalMsgsReceived.add(currentNumMsgsReceived);
                 totalBytesReceived.add(currentNumBytesReceived);
                 totalReceiveFailed.add(currentNumReceiveFailed);
+                totalBatchReceiveFailed.add(currentNumBatchReceiveFailed);
                 totalAcksSent.add(currentNumAcksSent);
                 totalAcksFailed.add(currentNumAcksFailed);
 
@@ -133,12 +141,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                     log.info(
                             "[{}] [{}] [{}] Prefetched messages: {} --- "
                                     + "Consume throughput received: {} msgs/s --- {} Mbit/s --- "
-                                    + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- " + "Failed acks: {}",
+                                    + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- batch messages: {} ---"
+                                    + "Failed acks: {}",
                             consumer.getTopic(), consumer.getSubscription(), consumer.consumerName,
                             consumer.incomingMessages.size(), THROUGHPUT_FORMAT.format(receivedMsgsRate),
                             THROUGHPUT_FORMAT.format(receivedBytesRate * 8 / 1024 / 1024),
                             THROUGHPUT_FORMAT.format(currentNumAcksSent / elapsed), currentNumReceiveFailed,
-                            currentNumAcksFailed);
+                            currentNumBatchReceiveFailed, currentNumAcksFailed);
                 }
             } catch (Exception e) {
                 log.error("[{}] [{}] [{}]: {}", consumer.getTopic(), consumer.subscription, consumer.consumerName,
@@ -177,6 +186,11 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     }
 
     @Override
+    public void incrementNumBatchReceiveFailed() {
+        numBatchReceiveFailed.increment();
+    }
+
+    @Override
     public Optional<Timeout> getStatTimeout() {
         return Optional.ofNullable(statTimeout);
     }
@@ -186,11 +200,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         numMsgsReceived.reset();
         numBytesReceived.reset();
         numReceiveFailed.reset();
+        numBatchReceiveFailed.reset();
         numAcksSent.reset();
         numAcksFailed.reset();
         totalMsgsReceived.reset();
         totalBytesReceived.reset();
         totalReceiveFailed.reset();
+        totalBatchReceiveFailed.reset();
         totalAcksSent.reset();
         totalAcksFailed.reset();
     }
@@ -203,11 +219,13 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         numMsgsReceived.add(stats.getNumMsgsReceived());
         numBytesReceived.add(stats.getNumBytesReceived());
         numReceiveFailed.add(stats.getNumReceiveFailed());
+        numBatchReceiveFailed.add(stats.getNumBatchReceiveFailed());
         numAcksSent.add(stats.getNumAcksSent());
         numAcksFailed.add(stats.getNumAcksFailed());
         totalMsgsReceived.add(stats.getTotalMsgsReceived());
         totalBytesReceived.add(stats.getTotalBytesReceived());
         totalReceiveFailed.add(stats.getTotalReceivedFailed());
+        totalBatchReceiveFailed.add(stats.getTotaBatchReceivedFailed());
         totalAcksSent.add(stats.getTotalAcksSent());
         totalAcksFailed.add(stats.getTotalAcksFailed());
     }
@@ -232,6 +250,11 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         return numReceiveFailed.longValue();
     }
 
+    @Override
+    public long getNumBatchReceiveFailed() {
+        return numBatchReceiveFailed.longValue();
+    }
+
     public long getTotalMsgsReceived() {
         return totalMsgsReceived.longValue();
     }
@@ -242,6 +265,11 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
 
     public long getTotalReceivedFailed() {
         return totalReceiveFailed.longValue();
+    }
+
+    @Override
+    public long getTotaBatchReceivedFailed() {
+        return totalBatchReceiveFailed.longValue();
     }
 
     public long getTotalAcksSent() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -19,14 +19,15 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.base.Preconditions;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+@NotThreadSafe
 public class MessagesImpl<T> implements Messages<T> {
 
     private List<Message<T>> messageList;
@@ -62,17 +63,18 @@ public class MessagesImpl<T> implements Messages<T> {
     }
 
     @Override
-    public List<Message<T>> getMessageList() {
-        return messageList == null ? Collections.emptyList() : Collections.unmodifiableList(messageList);
+    public int size() {
+        return messageList.size();
     }
 
-    @Override
-    public int size() {
-        return getMessageList().size();
+    public void clear() {
+        this.currentNumberOfMessages = 0;
+        this.currentSizeOfMessages = 0;
+        this.messageList.clear();
     }
 
     @Override
     public Iterator<Message<T>> iterator() {
-        return  getMessageList().iterator();
+        return  messageList.iterator();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import com.google.common.base.Preconditions;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Messages;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class MessagesImpl<T> implements Messages<T> {
+
+    private List<Message<T>> messageList;
+
+    private final int maxNumberOfMessages;
+    private final long maxSizeOfMessages;
+
+    private int currentNumberOfMessages;
+    private long currentSizeOfMessages;
+
+    protected MessagesImpl(int maxNumberOfMessages, long maxSizeOfMessages) {
+        this.maxNumberOfMessages = maxNumberOfMessages;
+        this.maxSizeOfMessages = maxSizeOfMessages;
+        messageList = maxNumberOfMessages > 0 ? new ArrayList<>(maxNumberOfMessages) : new ArrayList<>();
+    }
+
+    protected boolean canAdd(Message<T> message) {
+        if (maxNumberOfMessages <= 0 && maxSizeOfMessages <= 0) {
+            return true;
+        }
+        return (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 <= maxNumberOfMessages)
+                || (maxSizeOfMessages > 0 && currentSizeOfMessages + message.getData().length <= maxSizeOfMessages);
+    }
+
+    protected void add(Message<T> message) {
+        if (message == null) {
+            return;
+        }
+        Preconditions.checkArgument(canAdd(message), "No more space to add messages.");
+        currentNumberOfMessages ++;
+        currentSizeOfMessages += message.getData().length;
+        messageList.add(message);
+    }
+
+    @Override
+    public List<Message<T>> getMessageList() {
+        return messageList == null ? Collections.emptyList() : Collections.unmodifiableList(messageList);
+    }
+
+    @Override
+    public int size() {
+        return getMessageList().size();
+    }
+
+    @Override
+    public Iterator<Message<T>> iterator() {
+        return  getMessageList().iterator();
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -321,8 +321,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
 
     void notifyPendingBatchReceivedCallBack(OpBatchReceive<T> opBatchReceive) {
-        MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumberOfMessages(),
-                batchReceivePolicy.getMaxSizeOfMessages());
+        MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumMessages(),
+                batchReceivePolicy.getMaxNumBytes());
         Message<T> msgPeeked = incomingMessages.peek();
         while (msgPeeked != null && messages.canAdd(msgPeeked)) {
             Message<T> msg = null;
@@ -416,8 +416,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         try {
             lock.writeLock().lock();
             if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumberOfMessages(),
-                        batchReceivePolicy.getMaxSizeOfMessages());
+                MessagesImpl<T> messages = new MessagesImpl<>(batchReceivePolicy.getMaxNumMessages(),
+                        batchReceivePolicy.getMaxNumBytes());
                 Message<T> msgPeeked = incomingMessages.peek();
                 while (msgPeeked != null && messages.canAdd(msgPeeked)) {
                     Message<T> msg = incomingMessages.poll(0L, TimeUnit.MILLISECONDS);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -280,7 +280,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 unAckedMessageTracker.add(topicMessage.getMessageId());
                 listenerExecutor.execute(() -> receivedFuture.complete(topicMessage));
             } else if (enqueueMessageAndCheckBatchReceive(topicMessage)) {
-                if (!pendingBatchReceives.isEmpty()) {
+                if (hasPendingBatchReceive()) {
                     notifyPendingBatchReceivedCallBack();
                 }
             }
@@ -421,7 +421,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 pendingBatchReceives = Queues.newConcurrentLinkedQueue();
             }
             if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = getReUseableMessagesImpl();
+                MessagesImpl<T> messages = getReuseableMessagesImpl();
                 Message<T> msgPeeked = incomingMessages.peek();
                 while (msgPeeked != null && messages.canAdd(msgPeeked)) {
                     Message<T> msg = incomingMessages.poll();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -32,9 +32,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.CryptoKeyReader;
@@ -97,6 +97,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private RegexSubscriptionMode regexSubscriptionMode = RegexSubscriptionMode.PersistentOnly;
 
     private DeadLetterPolicy deadLetterPolicy;
+
+    private BatchReceivePolicy batchReceivePolicy = BatchReceivePolicy.DEFAULT_POLICY;
 
     private boolean autoUpdatePartitions = true;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -99,7 +99,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private DeadLetterPolicy deadLetterPolicy;
 
     @JsonIgnore
-    private BatchReceivePolicy batchReceivePolicy = BatchReceivePolicy.DEFAULT_POLICY;
+    private BatchReceivePolicy batchReceivePolicy;
 
     private boolean autoUpdatePartitions = true;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -98,6 +98,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private DeadLetterPolicy deadLetterPolicy;
 
+    @JsonIgnore
     private BatchReceivePolicy batchReceivePolicy = BatchReceivePolicy.DEFAULT_POLICY;
 
     private boolean autoUpdatePartitions = true;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -241,6 +241,21 @@ public class ConsumerBuilderImplTest {
         consumerBuilderImpl.patternAutoDiscoveryPeriod(-1);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenBatchReceivePolicyIsNull() {
+        consumerBuilderImpl.batchReceivePolicy(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenBatchReceivePolicyIsNotValid() {
+        consumerBuilderImpl.batchReceivePolicy(BatchReceivePolicy.builder()
+                .maxNumberOfMessages(0)
+                .maxSizeOfMessages(0)
+                .timeout(0)
+                .timeoutUnit(TimeUnit.MILLISECONDS)
+                .build());
+    }
+
     @Test
     public void testConsumerBuilderImplWhenNumericPropertiesAreValid() {
         consumerBuilderImpl.negativeAckRedeliveryDelay(1, TimeUnit.MILLISECONDS);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -249,10 +249,9 @@ public class ConsumerBuilderImplTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenBatchReceivePolicyIsNotValid() {
         consumerBuilderImpl.batchReceivePolicy(BatchReceivePolicy.builder()
-                .maxNumberOfMessages(0)
-                .maxSizeOfMessages(0)
-                .timeout(0)
-                .timeoutUnit(TimeUnit.MILLISECONDS)
+                .maxNumMessages(0)
+                .maxNumBytes(0)
+                .timeout(0, TimeUnit.MILLISECONDS)
                 .build());
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import io.netty.util.Timer;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -57,6 +58,7 @@ public class ConsumerImplTest {
         clientConf.setOperationTimeoutMs(100);
         clientConf.setStatsIntervalSeconds(0);
         when(client.getConfiguration()).thenReturn(clientConf);
+        when(client.timer()).thenReturn(mock(Timer.class));
 
         consumerConf.setSubscriptionName("test-sub");
         consumer = ConsumerImpl.newConsumerImpl(client, topic, consumerConf,

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -420,6 +421,16 @@ public class PulsarConsumerSourceTests {
         }
 
         @Override
+        public Messages<byte[]> batchReceive() throws PulsarClientException {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<Messages<byte[]>> batchReceiveAsync() {
+            return null;
+        }
+
+        @Override
         public void acknowledge(Message<?> message) throws PulsarClientException {
 
         }
@@ -430,11 +441,21 @@ public class PulsarConsumerSourceTests {
         }
 
         @Override
+        public void acknowledge(Messages<?> messages) throws PulsarClientException {
+
+        }
+
+        @Override
         public void negativeAcknowledge(Message<?> message) {
         }
 
         @Override
         public void negativeAcknowledge(MessageId messageId) {
+        }
+
+        @Override
+        public void negativeAcknowledge(Messages<?> messages) {
+
         }
 
         @Override
@@ -456,6 +477,11 @@ public class PulsarConsumerSourceTests {
         public CompletableFuture<Void> acknowledgeAsync(MessageId messageId) {
             acknowledgedIds.put(messageId, messageId);
             return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> acknowledgeAsync(Messages<?> messages) {
+            return null;
         }
 
         @Override

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -554,7 +554,7 @@ Bouncy Castle License
     - bcpkix-jdk15on-1.60.jar
     - bcprov-jdk15on-1.60.jar
 
-Creative Commons Attribution License -- licenses/LICENSE-jcip.txt
- * jcip
+Creative Commons Attribution License
+ * jcip -- licenses/LICENSE-jcip.txt
     - net.jcip-jcip-annotations-1.0.jar
     - jcip-annotations-1.0.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -555,6 +555,5 @@ Bouncy Castle License
     - bcprov-jdk15on-1.60.jar
 
 Creative Commons Attribution License
- * jcip -- licenses/LICENSE-jcip.txt
-    - net.jcip-jcip-annotations-1.0.jar
+ * Jcip -- licenses/LICENSE-jcip.txt
     - jcip-annotations-1.0.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -553,3 +553,8 @@ Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
     - bcpkix-jdk15on-1.60.jar
     - bcprov-jdk15on-1.60.jar
+
+Creative Commons Attribution License -- licenses/LICENSE-jcip.txt
+ * jcip
+    - net.jcip-jcip-annotations-1.0.jar
+    - jcip-annotations-1.0.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -556,4 +556,4 @@ Bouncy Castle License
 
 Creative Commons Attribution License
  * Jcip -- licenses/LICENSE-jcip.txt
-    - net.jcip-jcip-annotations-1.0.jar
+    - jcip-annotations-1.0.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -556,4 +556,4 @@ Bouncy Castle License
 
 Creative Commons Attribution License
  * Jcip -- licenses/LICENSE-jcip.txt
-    - jcip-annotations-1.0.jar
+    - net.jcip-jcip-annotations-1.0.jar

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -344,11 +344,20 @@ consumer.acknowledge(messages)
 > Consumer consumer = client.newConsumer()
 >         .topic("my-topic")
 >         .subscriptionName("my-subscription")
->   			.batchReceivePolicy(BatchReceivePolicy.builder()
->                         .maxNumberOfMessages(100)
->                         .timeout(200, TimeUnit.MILLISECONDS)
->                         .build())
+>         .batchReceivePolicy(BatchReceivePolicy.builder()
+>              .maxNumMessages(100)
+>              .maxNumBytes(1024 * 1024)
+>              .timeout(200, TimeUnit.MILLISECONDS)
+>              .build())
 >         .subscribe();
+> ```
+> And the default batch receive policy is:
+> ```java
+> BatchReceivePolicy.builder()
+>     .maxNumMessage(-1)
+>     .maxNumBytes(10 * 1024 * 1024)
+>     .timeout(100, TimeUnit.MILLISECONDS)
+>     .build();
 > ```
 
 ### Multi-topic subscriptions

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -336,9 +336,9 @@ consumer.acknowledge(messages)
 
 > Note:
 >
-> Batch receive policy can limit the number and size of messages in a single batch, and can specify a timeout for waiting for enough messages.
+> Batch receive policy can limit the number and bytes of messages in a single batch, and can specify a timeout for waiting for enough messages.
 >
-> The batch receive will be completed as long as any one of the conditions(has enough number of messages, has enough of size of messages, wait timeout) is met.
+> The batch receive will be completed as long as any one of the conditions(has enough number of messages, has enough of bytes of messages, wait timeout) is met.
 >
 > ```java
 > Consumer consumer = client.newConsumer()
@@ -346,8 +346,7 @@ consumer.acknowledge(messages)
 >         .subscriptionName("my-subscription")
 >   			.batchReceivePolicy(BatchReceivePolicy.builder()
 >                         .maxNumberOfMessages(100)
->                         .timeout(200)
->                         .timeoutUnit(TimeUnit.MILLISECONDS)
+>                         .timeout(200, TimeUnit.MILLISECONDS)
 >                         .build())
 >         .subscribe();
 > ```

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -320,6 +320,38 @@ CompletableFuture<Message> asyncMessage = consumer.receiveAsync();
 
 Async receive operations return a {@inject: javadoc:Message:/client/org/apache/pulsar/client/api/Message} wrapped inside of a [`CompletableFuture`](http://www.baeldung.com/java-completablefuture).
 
+### Batch receive
+
+Use `batchReceive` can receive multiple messages for each calls. 
+
+Here's an example:
+
+```java
+Messages messages = consumer.batchReceive();
+for (message in messages) {
+  // do something
+}
+consumer.acknowledge(messages)
+```
+
+> Note:
+>
+> Batch receive policy can limit the number and size of messages in a single batch, and can specify a timeout for waiting for enough messages.
+>
+> The batch receive will be completed as long as any one of the conditions(has enough number of messages, has enough of size of messages, wait timeout) is met.
+>
+> ```java
+> Consumer consumer = client.newConsumer()
+>         .topic("my-topic")
+>         .subscriptionName("my-subscription")
+>   			.batchReceivePolicy(BatchReceivePolicy.builder()
+>                         .maxNumberOfMessages(100)
+>                         .timeout(200)
+>                         .timeoutUnit(TimeUnit.MILLISECONDS)
+>                         .build())
+>         .subscribe();
+> ```
+
 ### Multi-topic subscriptions
 
 In addition to subscribing a consumer to a single Pulsar topic, you can also subscribe to multiple topics simultaneously using [multi-topic subscriptions](concepts-messaging.md#multi-topic-subscriptions). To use multi-topic subscriptions you can supply either a regular expression (regex) or a `List` of topics. If you select topics via regex, all topics must be within the same Pulsar namespace.

--- a/src/check-binary-license
+++ b/src/check-binary-license
@@ -110,7 +110,7 @@ done
 for J in $LICENSEJARS; do
     echo "$JARS" | grep -q $J
     if [ $? != 0 ]; then
-        echo $J mentioned in LICENSE, but not bundled
+        echo $J mentioned in lib/presto/LICENSE, but not bundled
         EXIT=2
     fi
 done


### PR DESCRIPTION
### Motivation

Support messages batch receiving, some application scenarios can be made simpler. Users often increase application throughput through batch operations. For example, batch insert or update database.

At present, we provide the ability to receive a single message. If users want to take advantage of batch operating advantages, need to implement a message collector him self. So this proposal aims to provide a universal interface and mechanism for batch receiving messages.

For example:
```
Messages messages = consumer.batchReceive();
insertToDB(messages);
consumer.acknowledge(messages);
```

### Verifying this change

Added new UT to verify this change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs and JavaDocs)
