### PR TITLE
Fixed the default port for https and http in admin client

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
@@ -52,8 +52,8 @@ public class ServiceURI {
 
     private static final int BINARY_PORT = 6650;
     private static final int BINARY_TLS_PORT = 6651;
-    private static final int HTTP_PORT = 8080;
-    private static final int HTTPS_PORT = 8443;
+    private static final int HTTP_PORT = 80;
+    private static final int HTTPS_PORT = 443;
 
     /**
      * Create a service uri instance from a uri string.

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
@@ -184,7 +184,7 @@ public class ServiceURITest {
 
     @Test
     public void testMultipleHostsWithoutHttpsPorts() {
-        String serviceUri = "https://host1, host2,host3/path/to/namespace";
+        String serviceUri = "https://host1,host2,host3/path/to/namespace";
         assertServiceUri(
             serviceUri,
             "https",

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
@@ -178,19 +178,19 @@ public class ServiceURITest {
             "http",
             new String[0],
             null,
-            new String[] { "host1:8080", "host2:8080", "host3:8080" },
+            new String[] { "host1:80", "host2:80", "host3:80" },
             "/path/to/namespace");
     }
 
     @Test
     public void testMultipleHostsWithoutHttpsPorts() {
-        String serviceUri = "https://host1,host2,host3/path/to/namespace";
+        String serviceUri = "https://host1, host2,host3/path/to/namespace";
         assertServiceUri(
             serviceUri,
             "https",
             new String[0],
             null,
-            new String[] { "host1:8443", "host2:8443", "host3:8443" },
+            new String[] { "host1:443", "host2:443", "host3:443" },
             "/path/to/namespace");
     }
 


### PR DESCRIPTION
### Motivation

After #3249, the client is not able to use the correct default port for https, switching instead to the non-default of 8443. 

This makes it very difficult and confusing to use standard ports for the service.