### PR TITLE
Fixed C++ client lookup over HTTP on standalone

### DIFF
--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -314,10 +314,13 @@ LookupDataResultPtr HTTPLookupService::parseLookupData(const std::string &json) 
         return LookupDataResultPtr();
     }
 
-    const std::string brokerUrlTls = root.get<std::string>("brokerUrlTls", defaultNotFoundString);
+    std::string brokerUrlTls = root.get<std::string>("brokerUrlTls", defaultNotFoundString);
     if (brokerUrlTls == defaultNotFoundString) {
-        LOG_ERROR("malformed json! - brokerUrlTls not present" << json);
-        return LookupDataResultPtr();
+        brokerUrlTls = root.get<std::string>("brokerUrlSsl", defaultNotFoundString);
+        if (brokerUrlTls == defaultNotFoundString) {
+            LOG_ERROR("malformed json! - brokerUrlTls not present" << json);
+            return LookupDataResultPtr();
+        }
     }
 
     LookupDataResultPtr lookupDataResultPtr = std::make_shared<LookupDataResult>();


### PR DESCRIPTION
### Motivation

C++ client (plus Python and Go) are getting error when using the HTTP based service URL (as opposed to the "pulsar://") if the broker has not set the TLS service URL in the response.