### PR TITLE
[Issue 4636][pulsar-dashboard] Count distinct bundles

### DIFF
--- a/dashboard/django/stats/views.py
+++ b/dashboard/django/stats/views.py
@@ -230,7 +230,7 @@ def brokers_cluster(request, cluster_name):
                 )
 
     brokers = brokers.annotate(
-        numBundles       = Count('topic__bundle'),
+        numBundles       = Count('topic__bundle', True),
         numTopics        = Count('topic'),
         numProducers     = Sum('topic__producerCount'),
         numSubscriptions = Sum('topic__subscriptionCount'),


### PR DESCRIPTION
Fixes #4636 

### Motivation


When looking at the Brokers page on the dashboard the number of bundles equalled the number of topics meaning 1 topic per bundle. This is incorrect. 

### Modifications

When counting the number of bundles set the distinct parameter to True.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation

### Before this fix
![WrongBundleCount](https://user-images.githubusercontent.com/48561471/60341926-fd505800-99a7-11e9-8fbe-15cb786039ed.png)
### After this fix
![FixedBundleCount](https://user-images.githubusercontent.com/48561471/60342053-55875a00-99a8-11e9-90f1-a9e5d655bcba.png)
