### PR TITLE
Allows consumer retrieve the sequence id that the producer set.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -737,5 +737,69 @@ public class BatchMessageTest extends BrokerTestBase {
         producer.close();
     }
 
+    @Test(dataProvider = "containerBuilder", timeOut = 3000)
+    private void testRetrieveSequenceIdGenerated(BatcherBuilder builder) throws Exception {
+
+        int numMsgs = 10;
+        final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdGenerated-" + UUID.randomUUID();
+        final String subscriptionName = "sub-1";
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batchingMaxPublishDelay(5, TimeUnit.SECONDS).batchingMaxMessages(numMsgs).enableBatching(true)
+                .batcherBuilder(builder)
+                .create();
+
+        List<CompletableFuture<MessageId>> sendFutureList = Lists.newArrayList();
+        for (int i = 0; i < numMsgs; i++) {
+            byte[] message = ("my-message-" + i).getBytes();
+            sendFutureList.add(producer.sendAsync(message));
+        }
+        FutureUtil.waitForAll(sendFutureList).get();
+
+        for (int i = 0; i < numMsgs; i++) {
+            Message<byte[]> received = consumer.receive();
+            Assert.assertEquals(received.getSequenceId(), i);
+            consumer.acknowledge(received);
+        }
+
+        producer.close();
+        consumer.close();
+    }
+
+    @Test(dataProvider = "containerBuilder", timeOut = 3000)
+    private void testRetrieveSequenceIdSpecify(BatcherBuilder builder) throws Exception {
+
+        int numMsgs = 10;
+        final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdSpecify-" + UUID.randomUUID();
+        final String subscriptionName = "sub-1";
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batchingMaxPublishDelay(5, TimeUnit.SECONDS).batchingMaxMessages(numMsgs).enableBatching(true)
+                .batcherBuilder(builder)
+                .create();
+
+        List<CompletableFuture<MessageId>> sendFutureList = Lists.newArrayList();
+        for (int i = 0; i < numMsgs; i++) {
+            byte[] message = ("my-message-" + i).getBytes();
+            sendFutureList.add(producer.newMessage().sequenceId(i + 100).value(message).sendAsync());
+        }
+        FutureUtil.waitForAll(sendFutureList).get();
+
+        for (int i = 0; i < numMsgs; i++) {
+            Message<byte[]> received = consumer.receive();
+            Assert.assertEquals(received.getSequenceId(), i + 100);
+            consumer.acknowledge(received);
+        }
+
+        producer.close();
+        consumer.close();
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(BatchMessageTest.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -737,7 +737,7 @@ public class BatchMessageTest extends BrokerTestBase {
         producer.close();
     }
 
-    @Test(dataProvider = "containerBuilder", timeOut = 3000)
+    @Test(dataProvider = "containerBuilder")
     private void testRetrieveSequenceIdGenerated(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;
@@ -769,7 +769,7 @@ public class BatchMessageTest extends BrokerTestBase {
         consumer.close();
     }
 
-    @Test(dataProvider = "containerBuilder", timeOut = 3000)
+    @Test(dataProvider = "containerBuilder")
     private void testRetrieveSequenceIdSpecify(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -148,6 +148,10 @@ public class MessageImpl<T> implements Message<T> {
             msgMetadataBuilder.setEventTime(singleMessageMetadata.getEventTime());
         }
 
+        if (singleMessageMetadata.hasSequenceId()) {
+            msgMetadataBuilder.setSequenceId(singleMessageMetadata.getSequenceId());
+        }
+
         this.schema = schema;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -214,7 +214,6 @@ public final class PulsarApi {
     v12(12, 12),
     v13(13, 13),
     v14(14, 14),
-    v15(15, 15),
     ;
     
     public static final int v0_VALUE = 0;
@@ -232,7 +231,6 @@ public final class PulsarApi {
     public static final int v12_VALUE = 12;
     public static final int v13_VALUE = 13;
     public static final int v14_VALUE = 14;
-    public static final int v15_VALUE = 15;
     
     
     public final int getNumber() { return value; }
@@ -254,7 +252,6 @@ public final class PulsarApi {
         case 12: return v12;
         case 13: return v13;
         case 14: return v14;
-        case 15: return v15;
         default: return null;
       }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -214,6 +214,7 @@ public final class PulsarApi {
     v12(12, 12),
     v13(13, 13),
     v14(14, 14),
+    v15(15, 15),
     ;
     
     public static final int v0_VALUE = 0;
@@ -231,6 +232,7 @@ public final class PulsarApi {
     public static final int v12_VALUE = 12;
     public static final int v13_VALUE = 13;
     public static final int v14_VALUE = 14;
+    public static final int v15_VALUE = 15;
     
     
     public final int getNumber() { return value; }
@@ -252,6 +254,7 @@ public final class PulsarApi {
         case 12: return v12;
         case 13: return v13;
         case 14: return v14;
+        case 15: return v15;
         default: return null;
       }
     }
@@ -4844,6 +4847,10 @@ public final class PulsarApi {
     // optional bytes ordering_key = 7;
     boolean hasOrderingKey();
     org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString getOrderingKey();
+    
+    // optional uint64 sequence_id = 8;
+    boolean hasSequenceId();
+    long getSequenceId();
   }
   public static final class SingleMessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -4983,6 +4990,16 @@ public final class PulsarApi {
       return orderingKey_;
     }
     
+    // optional uint64 sequence_id = 8;
+    public static final int SEQUENCE_ID_FIELD_NUMBER = 8;
+    private long sequenceId_;
+    public boolean hasSequenceId() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    public long getSequenceId() {
+      return sequenceId_;
+    }
+    
     private void initFields() {
       properties_ = java.util.Collections.emptyList();
       partitionKey_ = "";
@@ -4991,6 +5008,7 @@ public final class PulsarApi {
       eventTime_ = 0L;
       partitionKeyB64Encoded_ = false;
       orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
+      sequenceId_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -5040,6 +5058,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeBytes(7, orderingKey_);
       }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeUInt64(8, sequenceId_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -5075,6 +5096,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeBytesSize(7, orderingKey_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(8, sequenceId_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -5203,6 +5228,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000020);
         orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000040);
+        sequenceId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
       
@@ -5265,6 +5292,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000020;
         }
         result.orderingKey_ = orderingKey_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.sequenceId_ = sequenceId_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -5298,6 +5329,9 @@ public final class PulsarApi {
         }
         if (other.hasOrderingKey()) {
           setOrderingKey(other.getOrderingKey());
+        }
+        if (other.hasSequenceId()) {
+          setSequenceId(other.getSequenceId());
         }
         return this;
       }
@@ -5372,6 +5406,11 @@ public final class PulsarApi {
             case 58: {
               bitField0_ |= 0x00000040;
               orderingKey_ = input.readBytes();
+              break;
+            }
+            case 64: {
+              bitField0_ |= 0x00000080;
+              sequenceId_ = input.readUInt64();
               break;
             }
           }
@@ -5609,6 +5648,27 @@ public final class PulsarApi {
       public Builder clearOrderingKey() {
         bitField0_ = (bitField0_ & ~0x00000040);
         orderingKey_ = getDefaultInstance().getOrderingKey();
+        
+        return this;
+      }
+      
+      // optional uint64 sequence_id = 8;
+      private long sequenceId_ ;
+      public boolean hasSequenceId() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      public long getSequenceId() {
+        return sequenceId_;
+      }
+      public Builder setSequenceId(long value) {
+        bitField0_ |= 0x00000080;
+        sequenceId_ = value;
+        
+        return this;
+      }
+      public Builder clearSequenceId() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        sequenceId_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1170,6 +1170,10 @@ public class Commands {
             singleMessageMetadataBuilder.setEventTime(msgBuilder.getEventTime());
         }
 
+        if (msgBuilder.hasSequenceId()) {
+            singleMessageMetadataBuilder.setSequenceId(msgBuilder.getSequenceId());
+        }
+
         try {
             return serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder, payload, batchBuffer);
         } finally {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -137,6 +137,8 @@ message SingleMessageMetadata {
 	optional bool partition_key_b64_encoded = 6 [ default = false ];
     // Specific a key to overwrite the message key which used for ordering dispatch in Key_Shared mode.
 	optional bytes ordering_key = 7;
+	// Allows consumer retrieve the sequence id that the producer set.
+	optional uint64 sequence_id = 8;
 }
 
 enum ServerError {
@@ -193,6 +195,7 @@ enum ProtocolVersion {
 	v13 = 13; // Schema-registry : added avro schema format for json
 	v14 = 14; // Add CommandAuthChallenge and CommandAuthResponse for mutual auth
 	          // Added Key_Shared subscription
+	v15 = 15; // Added sequence_id for SingleMessageMetadata, retrieve the sequence id in batch message.
 }
 
 message CommandConnect {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -195,7 +195,6 @@ enum ProtocolVersion {
 	v13 = 13; // Schema-registry : added avro schema format for json
 	v14 = 14; // Add CommandAuthChallenge and CommandAuthResponse for mutual auth
 	          // Added Key_Shared subscription
-	v15 = 15; // Added sequence_id for SingleMessageMetadata, retrieve the sequence id in batch message.
 }
 
 message CommandConnect {


### PR DESCRIPTION
Fixes #4643 

### Motivation

Allows consumer retrieve the sequence id that the producer set while enable batch producing.

### Modifications

Add sequence_id for SingleMessageMetadata in PulsarApi.proto

### Verifying this change

Added new unit tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (yes)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
