### PR TITLE
Issue #4638 : Update Kafka connect-api to version 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>
     <aerospike-client.version>4.1.11</aerospike-client.version>
-    <kafka-client.version>0.10.2.1</kafka-client.version>
+    <kafka-client.version>2.3.0</kafka-client.version>
     <rabbitmq-client.version>5.1.1</rabbitmq-client.version>
     <aws-sdk.version>1.11.297</aws-sdk.version>
     <avro.version>1.8.2</avro.version>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
@@ -308,6 +309,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public void subscribe(Pattern pattern) {
+        throw new UnsupportedOperationException("Cannot subscribe with topic name pattern");
+    }
+
+    @Override
     public void unsubscribe() {
         consumers.values().forEach(c -> {
             try {
@@ -386,6 +392,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         }
     }
 
+    @Override
+    public ConsumerRecords<K, V> poll(Duration duration) {
+        return poll(duration.toMillis());
+    }
+
     @SuppressWarnings("unchecked")
     private K getKey(String topic, Message<byte[]> msg) {
         if (!msg.hasKey()) {
@@ -411,12 +422,22 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public void commitSync(Duration duration) {
+        commitSync();
+    }
+
+    @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
         try {
             doCommitOffsets(offsets).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> map, Duration duration) {
+        commitSync(map);
     }
 
     @Override
@@ -517,6 +538,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public void seek(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
+        seek(topicPartition, offsetAndMetadata.offset());
+    }
+
+    @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
@@ -571,6 +597,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         return unpolledPartitions.contains(partition) ? 0 : offset;
     }
 
+    @Override
+    public long position(TopicPartition topicPartition, Duration duration) {
+        return position(topicPartition);
+    }
+
     private SubscriptionInitialPosition resetOffsets(final TopicPartition partition) {
     	log.info("Resetting partition {} and seeking to {} position", partition, strategy);
         if (strategy == SubscriptionInitialPosition.Earliest) {
@@ -587,6 +618,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public OffsetAndMetadata committed(TopicPartition topicPartition, Duration duration) {
+        return committed(topicPartition);
+    }
+
+    @Override
     public Map<MetricName, ? extends Metric> metrics() {
         throw new UnsupportedOperationException();
     }
@@ -597,7 +633,17 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public List<PartitionInfo> partitionsFor(String s, Duration duration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<String, List<PartitionInfo>> listTopics() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(Duration duration) {
         throw new UnsupportedOperationException();
     }
 
@@ -622,12 +668,27 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     }
 
     @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> map, Duration duration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
         throw new UnsupportedOperationException();
     }
 
     @Override
+    public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> collection, Duration duration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> collection, Duration duration) {
         throw new UnsupportedOperationException();
     }
 
@@ -649,6 +710,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void close(Duration duration) {
+        close(duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaProducerInterceptorWrapper.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaProducerInterceptorWrapper.java
@@ -141,10 +141,10 @@ public class KafkaProducerInterceptorWrapper<K, V> implements ProducerIntercepto
             partitionID = getPartitionID(messageMetadataBuilder);
             TopicPartition topicPartition = new TopicPartition(topic, Integer.parseInt(partitionID));
             kafkaProducerInterceptor.onAcknowledgement(new RecordMetadata(topicPartition,
-                                                                -1,
-                                                                -1,
+                                                                -1L,
+                                                                -1L,
                                                                 messageMetadataBuilder.getEventTime(),
-                                                                -1,
+                                                                -1L,
                                                                 message.getKeyBytes().length,
                                                                 message.getValue().length), new Exception(exception));
         } catch (NumberFormatException e) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -105,7 +105,8 @@ public class KafkaConnectSource implements Source<KeyValue<byte[], byte[]>> {
         valueConverter.configure(config, false);
 
         offsetStore = new PulsarOffsetBackingStore();
-        offsetStore.configure(new PulsarKafkaWorkerConfig(stringConfig));
+        PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(stringConfig);
+        offsetStore.configure(pulsarKafkaWorkerConfig);
         offsetStore.start();
 
         offsetReader = new OffsetStorageReaderImpl(
@@ -121,7 +122,7 @@ public class KafkaConnectSource implements Source<KeyValue<byte[], byte[]>> {
             valueConverter
         );
 
-        sourceTaskContext = new PulsarIOSourceTaskContext(offsetReader);
+        sourceTaskContext = new PulsarIOSourceTaskContext(offsetReader, pulsarKafkaWorkerConfig);
 
         sourceTask.initialize(sourceTaskContext);
         sourceTask.start(stringConfig);

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarIOSourceTaskContext.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarIOSourceTaskContext.java
@@ -21,12 +21,21 @@ package org.apache.pulsar.io.kafka.connect;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
+import java.util.Map;
+
 class PulsarIOSourceTaskContext implements SourceTaskContext {
 
     private final OffsetStorageReader reader;
+    private final PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig;
 
-    PulsarIOSourceTaskContext(OffsetStorageReader reader) {
+    PulsarIOSourceTaskContext(OffsetStorageReader reader, PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig) {
         this.reader = reader;
+        this.pulsarKafkaWorkerConfig = pulsarKafkaWorkerConfig;
+    }
+
+    @Override
+    public Map<String, String> configs() {
+        return pulsarKafkaWorkerConfig.originalsStrings();
     }
 
     @Override

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -67,6 +67,7 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
         config.put(FileStreamSourceConnector.TOPIC_CONFIG, topicName);
         tempFile = File.createTempFile("some-file-name", null);
         config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsoluteFile().toString());
+        config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG, String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE));
 
     }
 

--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -130,7 +130,6 @@ Properties:
 | `acks`                                  | Ignored   | Durability and quorum writes are configured at the namespace level            |
 | `auto.offset.reset`                     | Yes       | Will have a default value of `latest` if user does not give specific setting. |
 | `batch.size`                            | Ignored   |                                                                               |
-| `block.on.buffer.full`                  | Yes       | If true it will block producer, otherwise an error is returned.                          |
 | `bootstrap.servers`                     | Yes       |                                 |
 | `buffer.memory`                         | Ignored   |                                                                               |
 | `client.id`                             | Ignored   |                                                                               |


### PR DESCRIPTION
Upgrade Kafka connect-api to version 2.3.0 in order to fix an "Unexpected exception" at startup when using Postgres Debezium connector with a nullable "Postgis.Geometry" column.
