### PR TITLE
[issue 4589] Fix redelivered message logic of partition topic

### DIFF
--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -365,6 +365,7 @@ void PartitionedConsumerImpl::messageReceived(Consumer consumer, const Message& 
         }
         messages_.push(msg);
         if (messageListener_) {
+            unAckedMessageTrackerPtr_->add(msg.getMessageId());
             listenerExecutor_->postWork(
                 std::bind(&PartitionedConsumerImpl::internalListener, shared_from_this(), consumer));
         }

--- a/pulsar-client-go/pulsar/c_consumer.go
+++ b/pulsar-client-go/pulsar/c_consumer.go
@@ -211,7 +211,7 @@ func subscribeAsync(client *client, options ConsumerOptions, schema Schema, call
 		C._pulsar_client_subscribe_multi_topics_async(client.ptr, (**C.char)(cArray), C.int(len(options.Topics)),
 			subName, conf, callbackPtr)
 
-		for idx, _ := range options.Topics {
+		for idx := range options.Topics {
 			C.free(unsafe.Pointer(a[idx]))
 		}
 

--- a/pulsar-client-go/pulsar/c_error.go
+++ b/pulsar-client-go/pulsar/c_error.go
@@ -42,7 +42,7 @@ type Error struct {
 
 func newError(result C.pulsar_result, msg string) error {
 	return &Error{
-		msg:    fmt.Sprintf("%s: %s", msg, C.GoString(C.pulsar_result_str(result))),
+		msg:    fmt.Sprintf("%s: %v", msg, C.GoString(C.pulsar_result_str(result))),
 		result: Result(result),
 	}
 }


### PR DESCRIPTION
Fixes #4589

### Motivation

When using Partition-topic, the logic of redeliver messages will not be triggered when the time of `ackTimeout` arrives.

This is because the `unAckedMessageTrackerPtr_->add(msg.getMessageId())` is not call in the listener handling of partitioned topic in cpp code
