### PR TITLE
Renamed C++ logger enum names to avoid conflicts with compiler macros

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Logger.h
+++ b/pulsar-client-cpp/include/pulsar/Logger.h
@@ -28,10 +28,10 @@ class PULSAR_PUBLIC Logger {
    public:
     enum Level
     {
-        DEBUG = 0,
-        INFO = 1,
-        WARN = 2,
-        ERROR = 3
+        LEVEL_DEBUG = 0,
+        LEVEL_INFO = 1,
+        LEVEL_WARN = 2,
+        LEVEL_ERROR = 3
     };
 
     virtual ~Logger() {}

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -46,40 +46,40 @@ namespace pulsar {
         return ptr;                                                                              \
     }
 
-#define LOG_DEBUG(message)                                                 \
+#define LOG_DEBUG(message)                                                      \
+    {                                                                           \
+        if (PULSAR_UNLIKELY(logger()->isEnabled(pulsar::Logger:LEVEL_DEBUG))) { \
+            std::stringstream ss;                                               \
+            ss << message;                                                      \
+            logger()->log(pulsar::Logger::LEVEL_DEBUG, __LINE__, ss.str());     \
+        }                                                                       \
+    }
+
+#define LOG_INFO(message)                                                  \
     {                                                                      \
-        if (PULSAR_UNLIKELY(logger()->isEnabled(pulsar::Logger::DEBUG))) { \
+        if (logger()->isEnabled(pulsar::Logger::LEVEL_INFO)) {             \
             std::stringstream ss;                                          \
             ss << message;                                                 \
-            logger()->log(pulsar::Logger::LEVEL_DEBUG, __LINE__, ss.str());      \
+            logger()->log(pulsar::Logger::LEVEL_INFO, __LINE__, ss.str()); \
         }                                                                  \
     }
 
-#define LOG_INFO(message)                                            \
-    {                                                                \
-        if (logger()->isEnabled(pulsar::Logger::LEVEL_INFO)) {             \
-            std::stringstream ss;                                    \
-            ss << message;                                           \
-            logger()->log(pulsar::Logger::INFO, __LINE__, ss.str()); \
-        }                                                            \
-    }
-
-#define LOG_WARN(message)                                            \
-    {                                                                \
+#define LOG_WARN(message)                                                  \
+    {                                                                      \
         if (logger()->isEnabled(pulsar::Logger::LEVEL_WARN)) {             \
-            std::stringstream ss;                                    \
-            ss << message;                                           \
+            std::stringstream ss;                                          \
+            ss << message;                                                 \
             logger()->log(pulsar::Logger::LEVEL_WARN, __LINE__, ss.str()); \
-        }                                                            \
+        }                                                                  \
     }
 
-#define LOG_ERROR(message)                                            \
-    {                                                                 \
-        if (logger()->isEnabled(pulsar::Logger::ERROR)) {             \
-            std::stringstream ss;                                     \
-            ss << message;                                            \
+#define LOG_ERROR(message)                                                  \
+    {                                                                       \
+        if (logger()->isEnabled(pulsar::Logger::LEVEL_ERROR)) {             \
+            std::stringstream ss;                                           \
+            ss << message;                                                  \
             logger()->log(pulsar::Logger::LEVEL_ERROR, __LINE__, ss.str()); \
-        }                                                             \
+        }                                                                   \
     }
 
 class PULSAR_PUBLIC LogUtils {

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -46,13 +46,13 @@ namespace pulsar {
         return ptr;                                                                              \
     }
 
-#define LOG_DEBUG(message)                                                      \
-    {                                                                           \
-        if (PULSAR_UNLIKELY(logger()->isEnabled(pulsar::Logger:LEVEL_DEBUG))) { \
-            std::stringstream ss;                                               \
-            ss << message;                                                      \
-            logger()->log(pulsar::Logger::LEVEL_DEBUG, __LINE__, ss.str());     \
-        }                                                                       \
+#define LOG_DEBUG(message)                                                       \
+    {                                                                            \
+        if (PULSAR_UNLIKELY(logger()->isEnabled(pulsar::Logger::LEVEL_DEBUG))) { \
+            std::stringstream ss;                                                \
+            ss << message;                                                       \
+            logger()->log(pulsar::Logger::LEVEL_DEBUG, __LINE__, ss.str());      \
+        }                                                                        \
     }
 
 #define LOG_INFO(message)                                                  \

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -51,13 +51,13 @@ namespace pulsar {
         if (PULSAR_UNLIKELY(logger()->isEnabled(pulsar::Logger::DEBUG))) { \
             std::stringstream ss;                                          \
             ss << message;                                                 \
-            logger()->log(pulsar::Logger::DEBUG, __LINE__, ss.str());      \
+            logger()->log(pulsar::Logger::LEVEL_DEBUG, __LINE__, ss.str());      \
         }                                                                  \
     }
 
 #define LOG_INFO(message)                                            \
     {                                                                \
-        if (logger()->isEnabled(pulsar::Logger::INFO)) {             \
+        if (logger()->isEnabled(pulsar::Logger::LEVEL_INFO)) {             \
             std::stringstream ss;                                    \
             ss << message;                                           \
             logger()->log(pulsar::Logger::INFO, __LINE__, ss.str()); \
@@ -66,10 +66,10 @@ namespace pulsar {
 
 #define LOG_WARN(message)                                            \
     {                                                                \
-        if (logger()->isEnabled(pulsar::Logger::WARN)) {             \
+        if (logger()->isEnabled(pulsar::Logger::LEVEL_WARN)) {             \
             std::stringstream ss;                                    \
             ss << message;                                           \
-            logger()->log(pulsar::Logger::WARN, __LINE__, ss.str()); \
+            logger()->log(pulsar::Logger::LEVEL_WARN, __LINE__, ss.str()); \
         }                                                            \
     }
 
@@ -78,7 +78,7 @@ namespace pulsar {
         if (logger()->isEnabled(pulsar::Logger::ERROR)) {             \
             std::stringstream ss;                                     \
             ss << message;                                            \
-            logger()->log(pulsar::Logger::ERROR, __LINE__, ss.str()); \
+            logger()->log(pulsar::Logger::LEVEL_ERROR, __LINE__, ss.str()); \
         }                                                             \
     }
 

--- a/pulsar-client-cpp/lib/MessageCrypto.cc
+++ b/pulsar-client-cpp/lib/MessageCrypto.cc
@@ -147,7 +147,7 @@ Result MessageCrypto::addPublicKeyCipher(std::set<std::string>& keyNames,
 
     // Generate data key
     RAND_bytes(dataKey_.get(), dataKeyLen_);
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string dataKeyStr(reinterpret_cast<char*>(dataKey_.get()), dataKeyLen_);
         std::string strHex = stringToHex(dataKeyStr, dataKeyStr.size());
         LOG_DEBUG(logCtx_ << "Generated Data key " << strHex);
@@ -203,7 +203,7 @@ Result MessageCrypto::addPublicKeyCipher(const std::string& keyName, const Crypt
     // Add a new entry or replace existing entry, if one is present.
     encryptedDataKeyMap_[keyName] = eki;
 
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string strHex = stringToHex(encryptedKeyStr, encryptedKeyStr.size());
         LOG_DEBUG(logCtx_ << " Data key encrypted for key " << keyName
                           << ". Encrypted key size = " << encryptedKeyStr.size() << ", value = " << strHex);
@@ -253,7 +253,7 @@ bool MessageCrypto::encrypt(std::set<std::string>& encKeys, const CryptoKeyReade
         proto::EncryptionKeys* encKeys = proto::EncryptionKeys().New();
         encKeys->set_key(keyName);
         encKeys->set_value(keyInfo->getKey());
-        if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+        if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
             std::string strHex = stringToHex(keyInfo->getKey(), keyInfo->getKey().size());
             LOG_DEBUG(logCtx_ << " Encrypted data key added for key " << keyName << ". Encrypted key size = "
                               << keyInfo->getKey().size() << ", value = " << strHex);
@@ -323,7 +323,7 @@ bool MessageCrypto::encrypt(std::set<std::string>& encKeys, const CryptoKeyReade
         return false;
     }
     encryptedPayload.bytesWritten(tagLen_);
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string strPayloadHex = stringToHex(payload.data(), payload.readableBytes());
         std::string strHex = stringToHex(encryptedPayload.data(), encryptedPayload.readableBytes());
         LOG_DEBUG(logCtx_ << " Original size = " << payload.readableBytes() << ", value = " << strPayloadHex
@@ -376,7 +376,7 @@ bool MessageCrypto::decryptDataKey(const std::string& keyName, const std::string
     std::string keyDigestStr(reinterpret_cast<char*>(keyDigest), digestLen);
     std::string dataKeyStr(reinterpret_cast<char*>(dataKey_.get()), dataKeyLen_);
     dataKeyCache_[keyDigestStr] = make_pair(dataKeyStr, boost::posix_time::second_clock::universal_time());
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string strHex = stringToHex(dataKeyStr, dataKeyStr.size());
         LOG_DEBUG(logCtx_ << "Data key for key " << keyName << " decrypted. Decrypted data key is "
                           << strHex);
@@ -395,7 +395,7 @@ bool MessageCrypto::decryptData(const std::string& dataKeySecret, const proto::M
 
     EVP_CIPHER_CTX* cipherCtx = NULL;
     decryptedPayload = SharedBuffer::allocate(payload.readableBytes() + EVP_MAX_BLOCK_LENGTH + tagLen_);
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string strHex = stringToHex(payload.data(), payload.readableBytes());
         LOG_DEBUG(logCtx_ << "Attempting to decrypt data with encrypted size " << payload.readableBytes()
                           << ", data = " << strHex);
@@ -443,7 +443,7 @@ bool MessageCrypto::decryptData(const std::string& dataKeySecret, const proto::M
         return false;
     }
     decryptedPayload.bytesWritten(decLen);
-    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::DEBUG))) {
+    if (PULSAR_UNLIKELY(logger()->isEnabled(Logger::LEVEL_DEBUG))) {
         std::string strHex = stringToHex(decryptedPayload.data(), decryptedPayload.readableBytes());
         LOG_DEBUG(logCtx_ << "Data decrypted. Decrypted size = " << decryptedPayload.readableBytes()
                           << ", data = " << strHex);

--- a/pulsar-client-cpp/lib/SimpleLoggerImpl.cc
+++ b/pulsar-client-cpp/lib/SimpleLoggerImpl.cc
@@ -28,16 +28,16 @@ namespace pulsar {
 
 inline std::ostream &operator<<(std::ostream &s, Logger::Level level) {
     switch (level) {
-        case Logger::DEBUG:
+        case Logger::LEVEL_DEBUG:
             s << "DEBUG";
             break;
-        case Logger::INFO:
+        case Logger::LEVEL_INFO:
             s << "INFO ";
             break;
-        case Logger::WARN:
+        case Logger::LEVEL_WARN:
             s << "WARN ";
             break;
-        case Logger::ERROR:
+        case Logger::LEVEL_ERROR:
             s << "ERROR";
             break;
     }
@@ -51,7 +51,7 @@ class SimpleLogger : public Logger {
    public:
     SimpleLogger(const std::string &logger) : _logger(logger) {}
 
-    bool isEnabled(Level level) { return level >= Logger::INFO; }
+    bool isEnabled(Level level) { return level >= Logger::LEVEL_INFO; }
 
     void log(Level level, int line, const std::string &message) {
         std::stringstream ss;

--- a/pulsar-client-cpp/lib/c/c_ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ClientConfiguration.cc
@@ -78,7 +78,7 @@ class PulsarCLogger : public pulsar::Logger {
     PulsarCLogger(const std::string &file, pulsar_logger logger, void *ctx)
         : file_(file), logger_(logger), ctx_(ctx) {}
 
-    bool isEnabled(Level level) { return level >= pulsar::Logger::INFO; }
+    bool isEnabled(Level level) { return level >= pulsar::Logger::LEVEL_INFO; }
 
     void log(Level level, int line, const std::string &message) {
         logger_((pulsar_logger_level_t)level, file_.c_str(), line, message.c_str(), ctx_);


### PR DESCRIPTION
### Motivation

Fixes #4655 

Some compiler will have defined a macro for `DEBUG` and it will clash with the enum value name. Adding prefix to avoid the macro replacement.