### PR TITLE
[doc] Add code samples for Protobuf and Avro schemas in java documentation

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -594,29 +594,26 @@ The following schema formats are currently available for Java:
         .create();
   ```
 
-* JSON schemas can be created for POJOs using the `JSONSchema` class. Here's an example:
+* JSON schemas can be created for POJOs using `Schema.JSON`. Here's an example:
 
   ```java
-  Schema<MyPojo> pojoSchema = JSONSchema.of(MyPojo.class);
-  Producer<MyPojo> pojoProducer = client.newProducer(pojoSchema)
+  Producer<MyPojo> pojoProducer = client.newProducer(Schema.JSON(MyPojo.class))
         .topic("some-pojo-topic")
         .create();
   ```
 
-* Protobuf schemas can be generate using the `ProtobufSchema` class. The following example shows how to create the Protobuf schema and use it to instantiate a new producer:
+* Protobuf schemas can be generate using `Schema.PROTOBUF`. The following example shows how to create the Protobuf schema and use it to instantiate a new producer:
 
   ```java
-  Schema<MyProtobuf> protobufSchema = ProtobufSchema.of(MyProtobuf.class);
-  Producer<MyProtobuf> protobufProducer = client.newProducer(protobufSchema)
+  Producer<MyProtobuf> protobufProducer = client.newProducer(Schema.PROTOBUF(MyProtobuf.class))
         .topic("some-protobuf-topic")
         .create();
   ```
 
-* Avro schemas can be defined with the help of the `AvroSchema` class. The next code snippet demonstrates the creation and usage of the Avro schema:
+* Avro schemas can be defined with the help of `Schema.AVRO`. The next code snippet demonstrates the creation and usage of the Avro schema:
   
   ```java
-  Schema<MyAvro> avroSchema = AvroSchema.of(MyAvro.class);
-  Producer<MyAvro> avroProducer = client.newProducer(avroSchema)
+  Producer<MyAvro> avroProducer = client.newProducer(Schema.AVRO(MyAvro.class))
         .topic("some-avro-topic")
         .create();
   ```

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -593,12 +593,31 @@ The following schema formats are currently available for Java:
         .topic("some-string-topic")
         .create();
   ```
+
 * JSON schemas can be created for POJOs using the `JSONSchema` class. Here's an example:
 
   ```java
   Schema<MyPojo> pojoSchema = JSONSchema.of(MyPojo.class);
   Producer<MyPojo> pojoProducer = client.newProducer(pojoSchema)
         .topic("some-pojo-topic")
+        .create();
+  ```
+
+* Protobuf schemas can be generate using the `ProtobufSchema` class. The following example shows how to create the Protobuf schema and use it to instantiate a new producer:
+
+  ```java
+  Schema<MyProtobuf> protobufSchema = ProtobufSchema.of(MyProtobuf.class);
+  Producer<MyProtobuf> protobufProducer = client.newProducer(protobufSchema)
+        .topic("some-protobuf-topic")
+        .create();
+  ```
+
+* Avro schemas can be defined with the help of the `AvroSchema` class. The next code snippet demonstrates the creation and usage of the Avro schema:
+  
+  ```java
+  Schema<MyAvro> avroSchema = AvroSchema.of(MyAvro.class);
+  Producer<MyAvro> avroProducer = client.newProducer(avroSchema)
+        .topic("some-avro-topic")
         .create();
   ```
 


### PR DESCRIPTION
### Motivation

We could not find Java examples which would include Avro and Protobuf schemas, but from the other [documentation page](https://pulsar.apache.org/docs/en/concepts-schema-registry/) it was clear that Pulsar supports them.

### Modification

Two code snippets (one for Protobuf and the other one for Avro) were added to the [Schema example](https://pulsar.apache.org/docs/en/client-libraries-java/#schemas) chapter.
