### PR TITLE
Add pulsar-io-influxdb to distribution.

### DIFF
--- a/distribution/io/src/assemble/io.xml
+++ b/distribution/io/src/assemble/io.xml
@@ -66,5 +66,6 @@
     <file><source>${basedir}/../../pulsar-io/mongo/target/pulsar-io-mongo-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/debezium/mysql/target/pulsar-io-debezium-mysql-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/debezium/postgres/target/pulsar-io-debezium-postgres-${project.version}.nar</source></file>
+    <file><source>${basedir}/../../pulsar-io/influxdb/target/pulsar-io-influxdb-${project.version}.nar</source></file>
   </files>
 </assembly>

--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -94,5 +94,11 @@ module.exports = [
         longName: 'Twitter Firehose',
         type: 'Source',
         link: 'https://developer.twitter.com/en/docs'
+    },
+    {
+        name: 'influxdb',
+        longName: 'InfluxDB',
+        type: 'Source',
+        link: 'https://www.influxdata.com/products/influxdb-overview/'
     }
 ]


### PR DESCRIPTION
### Motivation

pulsar-io-influxdb have not be distribute in 2.4.0, so add it to the distribution and distribute it in 2.4.1
