### PR TITLE
[] [site2/docs] python api reader interface example

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.apache.pulsar</groupId>
   <artifactId>buildtools</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.4.0</version>
   <packaging>jar</packaging>
   <name>Pulsar Build Tools</name>
 

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>../docker</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distribution/offloaders/pom.xml
+++ b/distribution/offloaders/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distribution/server/src/assemble/src.xml
+++ b/distribution/server/src/assemble/src.xml
@@ -38,6 +38,8 @@
         <include>**/pom.xml</include>
         <include>**/src/**</include>
         <include>**/pulsar-client-cpp/**</include>
+        <include>**/pulsar-client-go/**</include>
+        <include>**/pulsar-function-go/**</include>
         <include>**/conf/**</include>
         <include>**/bin/**</include>
         <include>**/*.txt</include>

--- a/distribution/server/src/assemble/src.xml
+++ b/distribution/server/src/assemble/src.xml
@@ -78,6 +78,7 @@
         <exclude>**/python/dist/**</exclude>
         <exclude>**/pulsar-client-cpp/pkg/rpm/RPMS/**</exclude>
         <exclude>**/pulsar-client-cpp/pkg/rpm/SOURCES/**</exclude>
+        <exclude>**/pulsar-client-cpp/pkg/deb/BUILD/**</exclude>
         <exclude>**/python/wheelhouse/**</exclude>
         <exclude>**/python/MANIFEST</exclude>
         <exclude>**/*.egg-info/**</exclude>

--- a/docker/grafana/pom.xml
+++ b/docker/grafana/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.pulsar</groupId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <groupId>org.apache.pulsar</groupId>
   <artifactId>docker-images</artifactId>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>pulsar-all-docker-image</artifactId>

--- a/docker/pulsar-standalone/pom.xml
+++ b/docker/pulsar-standalone/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.pulsar</groupId>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.pulsar</groupId>

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar.examples</groupId>
     <artifactId>pulsar-examples</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <groupId>org.apache.pulsar.examples</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <groupId>org.apache.pulsar.examples</groupId>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pulsar-examples</artifactId>
     <groupId>org.apache.pulsar.examples</groupId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <groupId>org.apache.pulsar.examples</groupId>

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/managed-ledger-shaded/pom.xml
+++ b/managed-ledger-shaded/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.pulsar</groupId>
   <artifactId>pulsar</artifactId>
 
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.4.0</version>
 
   <name>Pulsar</name>
   <description>Pulsar is a distributed pub-sub messaging platform with a very

--- a/pom.xml
+++ b/pom.xml
@@ -1265,7 +1265,7 @@ flexible messaging model and an intuitive client API.</description>
                  and are included in source tree for convenience -->
             <exclude>src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java</exclude>
             <exclude>src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java</exclude>
-            <exclude>src/main/java/org/apache/pulsar/common/api/proto/Markers.java</exclude>
+            <exclude>src/main/java/org/apache/pulsar/common/api/proto/PulsarMarkers.java</exclude>
             <exclude>src/main/java/org/apache/pulsar/broker/service/schema/proto/SchemaRegistryFormat.java</exclude>
             <exclude>bin/proto/MLDataFormats_pb2.py</exclude>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1296,6 +1296,12 @@ flexible messaging model and an intuitive client API.</description>
             <!-- LZ4 code is under BSD 2-clause  -->
             <exclude>pulsar-client-cpp/lib/lz4/lz4.*</exclude>
 
+            <!-- These files is go module configs -->
+            <exclude>pulsar-client-go/go.mod</exclude>
+            <exclude>pulsar-client-go/go.sum</exclude>
+            <exclude>pulsar-function-go/go.mod</exclude>
+            <exclude>pulsar-function-go/go.sum</exclude>
+
             <!-- This file is using ZLib license -->
             <exclude>pulsar-client-cpp/lib/checksum/crc32c_sw.cc</exclude>
 

--- a/protobuf-shaded/pom.xml
+++ b/protobuf-shaded/pom.xml
@@ -26,13 +26,13 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>protobuf-shaded</artifactId>
   <name>Apache Pulsar :: Protobuf shaded</name>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.4.0</version>
 
   <dependencies>
     <dependency>

--- a/pulsar-broker-auth-athenz/pom.xml
+++ b/pulsar-broker-auth-athenz/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-broker-auth-athenz</artifactId>

--- a/pulsar-broker-auth-sasl/pom.xml
+++ b/pulsar-broker-auth-sasl/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-broker-auth-sasl</artifactId>

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-broker-common</artifactId>

--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-1x-base/pom.xml
+++ b/pulsar-client-1x-base/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-1x-base/pulsar-client-1x/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-1x/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-1x-base</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-1x-base</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -89,9 +89,9 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_consumer_type(
 PULSAR_PUBLIC pulsar_consumer_type
 pulsar_consumer_configuration_get_consumer_type(pulsar_consumer_configuration_t *consumer_configuration);
 
-void pulsar_consumer_configuration_set_schema_info(pulsar_consumer_configuration_t *consumer_configuration,
-                                                   pulsar_schema_type schemaType, const char *name,
-                                                   const char *schema, pulsar_string_map_t *properties);
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_schema_info(
+    pulsar_consumer_configuration_t *consumer_configuration, pulsar_schema_type schemaType, const char *name,
+    const char *schema, pulsar_string_map_t *properties);
 
 /**
  * A message listener enables your application to configure how to process

--- a/pulsar-client-cpp/python/pkg/osx/osx-10.14/Vagrantfile
+++ b/pulsar-client-cpp/python/pkg/osx/osx-10.14/Vagrantfile
@@ -1,3 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 Vagrant.configure("2") do |config|
   config.vm.box = "apachepulsar/osx-10.14-python-dev"
   config.vm.box_version = "0.2"

--- a/pulsar-client-kafka-compat/pom.xml
+++ b/pulsar-client-kafka-compat/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-shaded/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-shaded/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-kafka-compat</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-kafka-compat</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-kafka-compat</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-flink/pom.xml
+++ b/pulsar-flink/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-functions/api-java/pom.xml
+++ b/pulsar-functions/api-java/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-api</artifactId>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-instance</artifactId>

--- a/pulsar-functions/java-examples/pom.xml
+++ b/pulsar-functions/java-examples/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-api-examples</artifactId>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-functions</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pulsar-functions/localrun/pom.xml
+++ b/pulsar-functions/localrun/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-functions</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pulsar-functions/pom.xml
+++ b/pulsar-functions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions</artifactId>

--- a/pulsar-functions/proto/pom.xml
+++ b/pulsar-functions/proto/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-functions</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-functions-proto</artifactId>

--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-runtime</artifactId>

--- a/pulsar-functions/secrets/pom.xml
+++ b/pulsar-functions/secrets/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-secrets</artifactId>

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-functions-utils</artifactId>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-io/aerospike/pom.xml
+++ b/pulsar-io/aerospike/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-aerospike</artifactId>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-io</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pulsar-io/cassandra/pom.xml
+++ b/pulsar-io/cassandra/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-cassandra</artifactId>

--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-io</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-common</artifactId>

--- a/pulsar-io/core/pom.xml
+++ b/pulsar-io/core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-core</artifactId>

--- a/pulsar-io/data-generator/pom.xml
+++ b/pulsar-io/data-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-io</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-data-generator</artifactId>

--- a/pulsar-io/debezium/core/pom.xml
+++ b/pulsar-io/debezium/core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io-debezium</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-debezium-core</artifactId>

--- a/pulsar-io/debezium/mysql/pom.xml
+++ b/pulsar-io/debezium/mysql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io-debezium</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-debezium-mysql</artifactId>

--- a/pulsar-io/debezium/pom.xml
+++ b/pulsar-io/debezium/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-debezium</artifactId>

--- a/pulsar-io/debezium/postgres/pom.xml
+++ b/pulsar-io/debezium/postgres/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io-debezium</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-debezium-postgres</artifactId>

--- a/pulsar-io/docs/pom.xml
+++ b/pulsar-io/docs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-docs</artifactId>

--- a/pulsar-io/elastic-search/pom.xml
+++ b/pulsar-io/elastic-search/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <artifactId>pulsar-io-elastic-search</artifactId>
   <name>Pulsar IO :: ElasticSearch</name>

--- a/pulsar-io/file/pom.xml
+++ b/pulsar-io/file/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-file</artifactId>

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-io</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-flume</artifactId>

--- a/pulsar-io/hbase/pom.xml
+++ b/pulsar-io/hbase/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pulsar-io</artifactId>
         <groupId>org.apache.pulsar</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>pulsar-io-hbase</artifactId>
     <name>Pulsar IO :: Hbase</name>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <artifactId>pulsar-io-hdfs2</artifactId>
   <name>Pulsar IO :: Hdfs2</name>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <artifactId>pulsar-io-hdfs3</artifactId>
   <name>Pulsar IO :: Hdfs3</name>

--- a/pulsar-io/influxdb/pom.xml
+++ b/pulsar-io/influxdb/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pulsar-io</artifactId>
         <groupId>org.apache.pulsar</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-influxdb</artifactId>

--- a/pulsar-io/jdbc/pom.xml
+++ b/pulsar-io/jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-jdbc</artifactId>

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-kafka-connect-adaptor</artifactId>

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-kafka</artifactId>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-kinesis</artifactId>

--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-io</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-mongo</artifactId>

--- a/pulsar-io/netty/pom.xml
+++ b/pulsar-io/netty/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-io</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-netty</artifactId>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io</artifactId>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-rabbitmq</artifactId>

--- a/pulsar-io/redis/pom.xml
+++ b/pulsar-io/redis/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pulsar-io</artifactId>
         <groupId>org.apache.pulsar</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-io-redis</artifactId>

--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>pulsar-io</artifactId>
         <groupId>org.apache.pulsar</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <properties>

--- a/pulsar-io/twitter/pom.xml
+++ b/pulsar-io/twitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-io</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-io-twitter</artifactId>

--- a/pulsar-log4j2-appender/pom.xml
+++ b/pulsar-log4j2-appender/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-proxy</artifactId>

--- a/pulsar-spark/pom.xml
+++ b/pulsar-spark/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-sql</artifactId>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -31,7 +31,7 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-presto-distribution</artifactId>
     <name>Pulsar SQL :: Pulsar Presto Distribution</name>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
 
     <properties>
         <presto.version>0.206</presto.version>

--- a/pulsar-sql/presto-pulsar-plugin/pom.xml
+++ b/pulsar-sql/presto-pulsar-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-sql</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-presto-connector</artifactId>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-sql</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-presto-connector-original</artifactId>

--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-transaction/buffer/pom.xml
+++ b/pulsar-transaction/buffer/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-transaction-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-transaction-buffer</artifactId>

--- a/pulsar-transaction/common/pom.xml
+++ b/pulsar-transaction/common/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-transaction-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-transaction-common</artifactId>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-transaction-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-transaction-coordinator</artifactId>

--- a/pulsar-transaction/pom.xml
+++ b/pulsar-transaction/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-transaction-parent</artifactId>

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/site/docs/latest/clients/Python.md
+++ b/site/docs/latest/clients/Python.md
@@ -110,7 +110,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -93,7 +93,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
@@ -89,7 +89,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
@@ -89,7 +89,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
@@ -89,7 +89,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
@@ -89,7 +89,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
@@ -94,7 +94,7 @@ msg_id = msg.message_id()
 reader = client.create_reader('my-topic', msg_id)
 
 while True:
-    msg = reader.receive()
+    msg = reader.read_next()
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```

--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>bc_2_0_0</artifactId>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.pulsar.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>bc_2_0_1</artifactId>

--- a/tests/docker-images/java-test-functions/pom.xml
+++ b/tests/docker-images/java-test-functions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.pulsar.tests</groupId>
         <artifactId>docker-images</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.pulsar.tests</groupId>

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.pulsar.tests</groupId>

--- a/tests/docker-images/pom.xml
+++ b/tests/docker-images/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <groupId>org.apache.pulsar.tests</groupId>
   <artifactId>docker-images</artifactId>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>integration</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
   <groupId>org.apache.pulsar.tests</groupId>
   <artifactId>tests-parent</artifactId>

--- a/tests/pulsar-kafka-compat-client-test/pom.xml
+++ b/tests/pulsar-kafka-compat-client-test/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-kafka-compat-client-test</artifactId>

--- a/tests/pulsar-spark-test/pom.xml
+++ b/tests/pulsar-spark-test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.pulsar.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>pulsar-spark-test</artifactId>

--- a/tests/pulsar-storm-test/pom.xml
+++ b/tests/pulsar-storm-test/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </parent>
 
   <artifactId>pulsar-storm-test</artifactId>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>tiered-storage-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tiered-storage/pom.xml
+++ b/tiered-storage/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
### Motivation

https://pulsar.apache.org/docs/en/client-libraries-python/#reader-interface-example
The reader interface makes use of the `read_next()` method not `retrieve()` 
The documentation is incorrect.

### Modifications

I searched for the relevant heading and changed the example code.
```bash
vim $(grep -Rl 'Reader interface example' *)
```

### Verifying this change

This change is a trivial documentation correction without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

### Documentation

  - Does this pull request introduce a new feature? NO
