### PR TITLE
Added delayed messages in Prometheus when using namespace-level metrics aggregation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
@@ -36,6 +36,7 @@ public class AggregatedNamespaceStats {
 
     public long storageSize;
     public long msgBacklog;
+    public long msgDelayed;
 
     long backlogSize;
     long offloadedStorageUsed;
@@ -89,6 +90,7 @@ public class AggregatedNamespaceStats {
         stats.subscriptionStats.forEach((n, as) -> {
             AggregatedSubscriptionStats subsStats =
                     subscriptionStats.computeIfAbsent(n, k -> new AggregatedSubscriptionStats());
+            msgDelayed += as.msgDelayed;
             subsStats.blockedSubscriptionOnUnackedMsgs = as.blockedSubscriptionOnUnackedMsgs;
             subsStats.msgBacklog += as.msgBacklog;
             subsStats.msgDelayed += as.msgDelayed;
@@ -116,6 +118,7 @@ public class AggregatedNamespaceStats {
 
         storageSize = 0;
         msgBacklog = 0;
+        msgDelayed = 0;
         storageWriteRate = 0;
         storageReadRate = 0;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -201,8 +201,13 @@ public class NamespaceStatsAggregator {
         metric(stream, cluster, namespace, "pulsar_throughput_out", stats.throughputOut);
 
         metric(stream, cluster, namespace, "pulsar_storage_size", stats.storageSize);
+        metric(stream, cluster, namespace, "pulsar_storage_backlog_size", stats.backlogSize);
+        metric(stream, cluster, namespace, "pulsar_storage_offloaded_size", stats.offloadedStorageUsed);
+
         metric(stream, cluster, namespace, "pulsar_storage_write_rate", stats.storageWriteRate);
         metric(stream, cluster, namespace, "pulsar_storage_read_rate", stats.storageReadRate);
+
+        metric(stream, cluster, namespace, "pulsar_subscription_delayed", stats.msgDelayed);
 
         metricWithRemoteCluster(stream, cluster, namespace, "pulsar_msg_backlog", "local", stats.msgBacklog);
 


### PR DESCRIPTION
### Motivation

Metrics for delayed messages in Prometheus are only emitted when topic-level aggregation is configured. We also need to report it when doing namespace level aggregation.