### PR TITLE
[build] `docker/publish.sh` doesn't work for pulsar-all and pulsar-standalone images

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -113,6 +113,26 @@
                 </goals>
               </execution>
               <execution>
+                <id>add-no-repo-and-version</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>pulsar-all</repository>
+                  <tag>${project.version}</tag>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-no-repo-and-latest</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>pulsar-all</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+              <execution>
                 <id>tag-and-push-latest</id>
                 <goals>
                   <goal>tag</goal>

--- a/docker/pulsar-standalone/pom.xml
+++ b/docker/pulsar-standalone/pom.xml
@@ -57,6 +57,26 @@
                 </goals>
               </execution>
               <execution>
+                <id>add-no-repo-and-version</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>pulsar-standalone</repository>
+                  <tag>${project.version}</tag>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-no-repo-and-latest</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>pulsar-standalone</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+              <execution>
                 <id>tag-and-push-latest</id>
                 <goals>
                   <goal>tag</goal>


### PR DESCRIPTION

*Motivation*

pulsar-all and pulsar-standalone dont tag correct as pulsar image.
so it fails `docker/publish.sh`

*Modifications*

Tag no-repo for both latest and the release version for both pulsar-all and pulsar-standalone

*Verify this change*

After patching this change, `docker/publish.sh` works as expected.

