### PR TITLE
fix: add anonymous role to proxy configuration

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -253,6 +253,12 @@ public class ProxyConfiguration implements PulsarConfiguration {
     )
     private boolean tlsEnabledWithBroker = false;
 
+    @FieldContext(
+            category = CATEGORY_AUTHORIZATION,
+            doc = "When this parameter is not empty, unauthenticated users perform as anonymousUserRole"
+    )
+    private String anonymousUserRole = null;
+
     /***** --- TLS --- ****/
 
     @Deprecated


### PR DESCRIPTION
### Motivation

Currently there is not configuration in proxy for anonymousUserRole.  We need to have it in order for anonymous roles to be able to be used when running a proxy