### PR TITLE
Fix C++ log level names in Log4cxxLogger

### DIFF
--- a/pulsar-client-cpp/lib/Log4cxxLogger.cc
+++ b/pulsar-client-cpp/lib/Log4cxxLogger.cc
@@ -50,13 +50,13 @@ class Log4CxxLogger : public Logger {
    private:
     static log4cxx::LevelPtr getLevel(Level level) {
         switch (level) {
-            case DEBUG:
+            case LEVEL_DEBUG:
                 return log4cxx::Level::getDebug();
-            case INFO:
+            case LEVEL_INFO:
                 return log4cxx::Level::getInfo();
-            case WARN:
+            case LEVEL_WARN:
                 return log4cxx::Level::getWarn();
-            case ERROR:
+            case LEVEL_ERROR:
                 return log4cxx::Level::getError();
         }
     }


### PR DESCRIPTION
### Motivation

If trying to build master C++ code with the `USE_LOG4CXX` flag turned ON, compilation errors occur:
```
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc: In static member function ‘static log4cxx::LevelPtr pulsar::Log4CxxLogger::getLevel(pulsar::Logger::Level)’:
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:53:18: error: ‘DEBUG’ was not declared in this scope
             case DEBUG:
                  ^
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:55:18: error: ‘INFO’ was not declared in this scope
             case INFO:
                  ^
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:57:18: error: ‘WARN’ was not declared in this scope
             case WARN:
                  ^
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:59:18: error: ‘ERROR’ was not declared in this scope
             case ERROR:
                  ^
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:52:16: error: enumeration value ‘LEVEL_DEBUG’ not handled in switch [-Werror=switch]
         switch (level) {
                ^
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:52:16: error: enumeration value ‘LEVEL_INFO’ not handled in switch [-Werror=switch]
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:52:16: error: enumeration value ‘LEVEL_WARN’ not handled in switch [-Werror=switch]
/tmp/pulsar/pulsar-client-cpp/lib/Log4cxxLogger.cc:52:16: error: enumeration value ‘LEVEL_ERROR’ not handled in switch [-Werror=switch]
cc1plus: some warnings being treated as errors
make[2]: *** [lib/CMakeFiles/pulsarStatic.dir/Log4cxxLogger.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

This is because the enum values renamed in https://github.com/apache/pulsar/pull/4664 are still used in `Log4cxxLogger.cc`.

### Modifications

Fixed the enum values used in `Log4cxxLogger.cc` by adding the prefix `LEVEL_`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.