### PR TITLE
Remove failed stale producer from the connection

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -668,7 +668,7 @@ public class ServerCnx extends PulsarHandler {
                                     error = ServerError.ServiceNotReady;
                                 }else {
                                     error = getErrorCode(existingConsumerFuture);
-                                    consumers.remove(consumerId, consumerFuture);
+                                    consumers.remove(consumerId);
                                 }
                                 ctx.writeAndFlush(Commands.newError(requestId, error,
                                         "Consumer is already present on the connection"));
@@ -863,7 +863,8 @@ public class ServerCnx extends PulsarHandler {
                                     error = ServerError.ServiceNotReady;
                                 }else {
                                     error = getErrorCode(existingProducerFuture);
-                                    producers.remove(producerId, producerFuture);
+                                    // remove producer with producerId as it's already completed with exception
+                                    producers.remove(producerId);
                                 }
                                 log.warn("[{}][{}] Producer with id {} is already present on the connection", remoteAddress,
                                         producerId, topicName);


### PR DESCRIPTION
### Motivation

As described in #4138, broker tries to clean up stale failed-producer from the connection however, while cleaning up producer-future, it tries to remove newly created producer-future rather old-failed producer because of that broker still gives below error

```
17:22:00.700 [pulsar-io-21-26] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:1111][453] Producer with id persistent://prop/cluster/ns/topic is already present on the connection
```