### PR TITLE
fix: set go function package executable

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -242,6 +242,11 @@ public class FunctionActioner {
         } finally {
             tempPkgFile.delete();
         }
+
+        if(details.getRuntime() == Function.FunctionDetails.Runtime.GO && !pkgFile.canExecute()) {
+            pkgFile.setExecutable(true);
+            log.info("Golang function package file {} is set to executable", pkgFile);
+        }
     }
 
     private void cleanupFunctionFiles(FunctionRuntimeInfo functionRuntimeInfo) {


### PR DESCRIPTION
### Motivation

Currently golang function needs to be compiled before deploy to pulsar, so the executable permission is required when function package is downloaded to local node from bookkeeper. This PR is intent to make golang function package executable after download from bookkeeper, to make sure the function is ok to run.