### PR TITLE
[go function] fix: go function should parse conf content first

### DIFF
--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -102,7 +102,7 @@ func (c *Conf) GetConf() *Conf {
 
 	confFileExists = fileExists(confFilePath)
 
-	if (confContent == "" && (confFilePath == "" || !confFileExists){
+	if confContent == "" && (confFilePath == "" || !confFileExists) {
 		log.Errorf("no yaml file or conf content provided")
 		return nil
 	}

--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -80,14 +80,34 @@ var (
 	confContent  string
 )
 
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
 func (c *Conf) GetConf() *Conf {
+	var confFileExists = false
 	flag.Parse()
 
 	if help {
 		flag.Usage()
 	}
 
-	if confFilePath != "" {
+	confFileExists = fileExists(confFilePath)
+
+	if (confContent == "" && (confFilePath == "" || !confFileExists){
+		log.Errorf("no yaml file or conf content provided")
+		return nil
+	}
+
+	if confFileExists {
 		yamlFile, err := ioutil.ReadFile(confFilePath)
 		if err != nil {
 			log.Errorf("not found conf file, err:%s", err.Error())
@@ -107,6 +127,7 @@ func (c *Conf) GetConf() *Conf {
 			return nil
 		}
 	}
+
 	return c
 }
 

--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -85,7 +85,7 @@ func fileExists(path string) bool {
 		return false
 	}
 	_, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil || os.IsNotExist(err) {
 		return false
 	}
 

--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -80,43 +80,26 @@ var (
 	confContent  string
 )
 
-func fileExists(path string) bool {
-	if path == "" {
-		return false
-	}
-	_, err := os.Stat(path)
-	if err != nil || os.IsNotExist(err) {
-		return false
-	}
-
-	return true
-}
-
 func (c *Conf) GetConf() *Conf {
-	var confFileExists = false
 	flag.Parse()
 
 	if help {
 		flag.Usage()
 	}
 
-	confFileExists = fileExists(confFilePath)
-
-	if confContent == "" && (confFilePath == "" || !confFileExists) {
+	if confContent == "" && confFilePath == "" {
 		log.Errorf("no yaml file or conf content provided")
 		return nil
 	}
 
-	if confFileExists {
+	if confFilePath != "" {
 		yamlFile, err := ioutil.ReadFile(confFilePath)
-		if err != nil {
-			log.Errorf("not found conf file, err:%s", err.Error())
-			return nil
-		}
-		err = yaml.Unmarshal(yamlFile, c)
-		if err != nil {
-			log.Errorf("unmarshal yaml file error:%s", err.Error())
-			return nil
+		if err == nil {
+			err = yaml.Unmarshal(yamlFile, c)
+			if err != nil {
+				log.Errorf("unmarshal yaml file error:%s", err.Error())
+				return nil
+			}
 		}
 	}
 

--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -100,8 +100,11 @@ func (c *Conf) GetConf() *Conf {
 				log.Errorf("unmarshal yaml file error:%s", err.Error())
 				return nil
 			}
-		} else if (err != nil || os.IsNotExist(err)) && confContent == "" {
-			log.Errorf("not found conf file, err:%s", err.Error())
+		} else if err != nil && os.IsNotExist(err) && confContent == "" {
+			log.Errorf("conf file not found, no config content provided, err:%s", err.Error())
+			return nil
+		} else if err != nil && !os.IsNotExist(err) {
+			log.Errorf("load conf file failed, err:%s", err.Error())
 			return nil
 		}
 	}

--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -100,6 +100,9 @@ func (c *Conf) GetConf() *Conf {
 				log.Errorf("unmarshal yaml file error:%s", err.Error())
 				return nil
 			}
+		} else if (err != nil || os.IsNotExist(err)) && confContent == "" {
+			log.Errorf("not found conf file, err:%s", err.Error())
+			return nil
 		}
 	}
 


### PR DESCRIPTION
### Motivation

`pulsar-function-go/conf` package apply `instance-conf-path` with default value `HOME_PATH+github.com/apache/pulsar/pulsar-function-go/conf/conf.yaml`, once function deployed, the running node may not have the yaml conf file exist, then go function will panic with `not found conf file` error. 

This PR changed the logic of config parsing, parse `confContent` first, then parse `confFilePath` if `confContent` empty. 
