### PR TITLE
[Integeration-test]Fix integration-test failed when execute pip3 install pulsar_client

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -54,9 +54,7 @@ RUN apt-get update \
 # Install python3.5.6
 RUN curl -O -L https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz
 RUN tar -zxvf Python-3.5.6.tgz
-RUN cd Python-3.5.6
-RUN ./configure --enable-optimizations
-RUN make altinstall
+RUN cd Python-3.5.6 && ./configure --enable-optimizations && make altinstall
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python2.7 get-pip.py

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -46,7 +46,6 @@ RUN apt-get update \
      && apt-get install -y netcat dnsutils \
                  python2.7 python-setuptools \
                  python3-setuptools \
-                 build-essential checkinstall \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
                  curl \
      && apt-get clean \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -45,15 +45,24 @@ COPY --from=pulsar /pulsar /pulsar
 RUN apt-get update \
      && apt-get install -y netcat dnsutils \
                  python2.7 python-setuptools \
-                 python3 python3-setuptools \
+                 python3-setuptools \
+                 build-essential checkinstall \
+                 libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
                  curl \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
+# Install python3.5.6
+RUN curl -O -L https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz
+RUN tar -zxvf Python-3.5.6.tgz
+RUN cd Python-3.5.6
+RUN ./configure --enable-optimizations
+RUN make altinstall
+
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python2.7 get-pip.py
 RUN pip install kazoo pyyaml
-RUN python3 get-pip.py
+RUN python3.5 get-pip.py
 
 ADD target/python-client/ /pulsar/pulsar-client
 RUN /pulsar/bin/install-pulsar-client-27.sh

--- a/docker/pulsar/scripts/install-pulsar-client-35.sh
+++ b/docker/pulsar/scripts/install-pulsar-client-35.sh
@@ -21,4 +21,4 @@
 set -x
 
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep cp35)
-pip3 install /pulsar/pulsar-client/${WHEEL_FILE}
+pip3.5 install /pulsar/pulsar-client/${WHEEL_FILE}


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/4748#issuecomment-512670185

### Motivation
When installing the pulsar-client-2.5.0 using the image openjdk:8-jdk-slim, for Debian 10 systems, python3.7 will be installed when `apt-get install python3` is executed. When installing the client using pip3, the following exception will be thrown
```
cat /etc/issue
Debian GNU/Linux 10 \n \l

root@40fdedf3f3c3:/# python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>

root@40fdedf3f3c3:/# pip3 install pulsar_client-2.5.0-cp35-cp35m-manylinux1_x86_64.whl
ERROR: pulsar_client-2.5.0-cp35-cp35m-manylinux1_x86_64.whl is not a supported wheel on this platform.
```

### Modification

Install Use pip3.5 instead of pip3.


