### PR TITLE
Fix server type in kerberos

### DIFF
--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/PulsarSaslClient.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/PulsarSaslClient.java
@@ -52,9 +52,10 @@ public class PulsarSaslClient {
     public PulsarSaslClient(String serverHostname, String serverType, Subject subject) throws SaslException {
         checkArgument(subject != null, "Cannot create SASL client with NULL JAAS subject");
         checkArgument(!Strings.isNullOrEmpty(serverHostname), "Cannot create SASL client with NUll server name");
-        checkArgument(serverType.equalsIgnoreCase(SaslConstants.SASL_BROKER_PROTOCOL) ||
-                serverType.equalsIgnoreCase(SaslConstants.SASL_PROXY_PROTOCOL),
-            "Server type [" + serverType + "] invalid, should be broker or proxy");
+        if (!serverType.equals(SaslConstants.SASL_BROKER_PROTOCOL) && !serverType
+                                                                           .equals(SaslConstants.SASL_PROXY_PROTOCOL)) {
+            log.warn("The server type {} is not recommended", serverType);
+        }
 
         String serverPrincipal = serverType.toLowerCase() + "/" + serverHostname;
         this.clientSubject = subject;


### PR DESCRIPTION
## Motivation 

Currently, In Pulsar Kerberos authentication, The server type part of pulsar node principle is hard coded as "broker" and "proxy". The expected principle for pulsar nodes would be like "broker/brokera.host.name@your.com" or "proxy/proxyb.host.name@your.com". 

But some times, user may want to re-use existing principle like "u-service/host.name@some.com", to test and play around, then "u-service" will not match service type of "broker" or "proxy", and the authentication will be rejected.
This change is to remove the check of "broker" or "proxy" service type check.

## Modifaction

Remove the check of "broker" or "proxy" service type check. 