### PR TITLE
Expose acknowledgment flushing capabilities at the consumer level

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -255,6 +255,13 @@ public interface Consumer<T> extends Closeable {
      * @return a future that can be used to track the completion of the operation
      */
     CompletableFuture<Void> acknowledgeCumulativeAsync(MessageId messageId);
+    
+    /**
+     * Flush all batched acknowledgements and wait until all acknowledgments have been persisted.
+     * 
+     * Flush acks returns immediately if batching of acks is disabled.
+     */
+    void flushAcknowledgements();
 
     /**
      * Get statistics for the consumer.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -260,8 +260,16 @@ public interface Consumer<T> extends Closeable {
      * Flush all batched acknowledgements and wait until all acknowledgments have been persisted.
      * 
      * Flush acks returns immediately if batching of acks is disabled.
+     * @throws PulsarClientException 
      */
-    void flushAcknowledgements();
+    void flushAcknowledgements() throws PulsarClientException;
+    
+    /**
+     * Asynchronously flush all batched acknowledgements.
+     * 
+     * @return a future that can be used to track the completion of the operation.
+     */
+    CompletableFuture<Void> flushAcknowledgementsAsync();
 
     /**
      * Get statistics for the consumer.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -236,7 +236,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return doAcknowledge(messageId, AckType.Cumulative, Collections.emptyMap());
     }
 
-	@Override
+    @Override
     public void negativeAcknowledge(Message<?> message) {
         negativeAcknowledge(message.getMessageId());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -237,6 +237,22 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     @Override
+    public void flushAcknowledgements() throws PulsarClientException {
+    	try {
+    		flushAcknowledgementsAsync().get();
+    	} catch (Exception e) {
+    		throw PulsarClientException.unwrap(e);
+    	}
+    }
+    
+    @Override
+    public CompletableFuture<Void> flushAcknowledgementsAsync() {
+    	return doFlushAcknowledgements();
+    }
+    
+    abstract protected CompletableFuture<Void> doFlushAcknowledgements();
+    
+    @Override
     public void negativeAcknowledge(Message<?> message) {
         negativeAcknowledge(message.getMessageId());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -236,7 +236,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return doAcknowledge(messageId, AckType.Cumulative, Collections.emptyMap());
     }
 
-    @Override
+	@Override
     public void negativeAcknowledge(Message<?> message) {
         negativeAcknowledge(message.getMessageId());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -481,9 +481,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
     
     @Override
-    public void flushAcknowledgements() {
+    protected CompletableFuture<Void> doFlushAcknowledgements() {
     	acknowledgmentsGroupingTracker.flush();
+    	return CompletableFuture.completedFuture(null);
     }
+
 
     @Override
     public void connectionOpened(final ClientCnx cnx) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -479,6 +479,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         // Ensure the message is not redelivered for ack-timeout, since we did receive an "ack"
         unAckedMessageTracker.remove(messageId);
     }
+    
+    @Override
+    public void flushAcknowledgements() {
+    	acknowledgmentsGroupingTracker.flush();
+    }
 
     @Override
     public void connectionOpened(final ClientCnx cnx) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -423,10 +423,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
     
     @Override
-    public void flushAcknowledgements() {
+    protected CompletableFuture<Void> doFlushAcknowledgements() {
     	for (ConsumerImpl<T> consumer : consumers.values()) {
     		consumer.flushAcknowledgements();
     	}
+    	return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -421,6 +421,13 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         ConsumerImpl<T> consumer = consumers.get(topicMessageId.getTopicPartitionName());
         consumer.negativeAcknowledge(topicMessageId.getInnerMessageId());
     }
+    
+    @Override
+    public void flushAcknowledgements() {
+    	for (ConsumerImpl<T> consumer : consumers.values()) {
+    		consumer.flushAcknowledgements();
+    	}
+    }
 
     @Override
     public CompletableFuture<Void> unsubscribeAsync() {


### PR DESCRIPTION
### Motivation

In a checkpoint-based system, in which a system waits to send acknowledgements to the Pulsar server until it reaches a checkpoint, it should be able to know that all acknowledgements were sent off at the end of the checkpoint without sacrificing performance. Currently, acknowledgements are by default batched, which improves network performance. To guarantee the above, one would have to disable batching. These changes provide that guarantee without sacrificing network performance.

### Modifications

Added API call to the consumer for flushing pending batched acknowledgments. Added implementations in ConsumerImpl.java and MultiTopicsConsumerImpl.java.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
        - Add flushAcknowledgements() to consumer API
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
