### PR TITLE
[Transaction][Buffer]Add new marker to show which message belongs to transaction

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -3103,6 +3103,18 @@ public final class PulsarApi {
     // optional int32 marker_type = 20;
     boolean hasMarkerType();
     int getMarkerType();
+    
+    // optional int64 indirect_ledger_id = 21;
+    boolean hasIndirectLedgerId();
+    long getIndirectLedgerId();
+    
+    // optional uint64 txnid_least_bits = 22 [default = 0];
+    boolean hasTxnidLeastBits();
+    long getTxnidLeastBits();
+    
+    // optional uint64 txnid_most_bits = 23 [default = 0];
+    boolean hasTxnidMostBits();
+    long getTxnidMostBits();
   }
   public static final class MessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -3443,6 +3455,36 @@ public final class PulsarApi {
       return markerType_;
     }
     
+    // optional int64 indirect_ledger_id = 21;
+    public static final int INDIRECT_LEDGER_ID_FIELD_NUMBER = 21;
+    private long indirectLedgerId_;
+    public boolean hasIndirectLedgerId() {
+      return ((bitField0_ & 0x00010000) == 0x00010000);
+    }
+    public long getIndirectLedgerId() {
+      return indirectLedgerId_;
+    }
+    
+    // optional uint64 txnid_least_bits = 22 [default = 0];
+    public static final int TXNID_LEAST_BITS_FIELD_NUMBER = 22;
+    private long txnidLeastBits_;
+    public boolean hasTxnidLeastBits() {
+      return ((bitField0_ & 0x00020000) == 0x00020000);
+    }
+    public long getTxnidLeastBits() {
+      return txnidLeastBits_;
+    }
+    
+    // optional uint64 txnid_most_bits = 23 [default = 0];
+    public static final int TXNID_MOST_BITS_FIELD_NUMBER = 23;
+    private long txnidMostBits_;
+    public boolean hasTxnidMostBits() {
+      return ((bitField0_ & 0x00040000) == 0x00040000);
+    }
+    public long getTxnidMostBits() {
+      return txnidMostBits_;
+    }
+    
     private void initFields() {
       producerName_ = "";
       sequenceId_ = 0L;
@@ -3463,6 +3505,9 @@ public final class PulsarApi {
       orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
       deliverAtTime_ = 0L;
       markerType_ = 0;
+      indirectLedgerId_ = 0L;
+      txnidLeastBits_ = 0L;
+      txnidMostBits_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3562,6 +3607,15 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         output.writeInt32(20, markerType_);
       }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        output.writeInt64(21, indirectLedgerId_);
+      }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        output.writeUInt64(22, txnidLeastBits_);
+      }
+      if (((bitField0_ & 0x00040000) == 0x00040000)) {
+        output.writeUInt64(23, txnidMostBits_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -3650,6 +3704,18 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeInt32Size(20, markerType_);
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeInt64Size(21, indirectLedgerId_);
+      }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(22, txnidLeastBits_);
+      }
+      if (((bitField0_ & 0x00040000) == 0x00040000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(23, txnidMostBits_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -3802,6 +3868,12 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00020000);
         markerType_ = 0;
         bitField0_ = (bitField0_ & ~0x00040000);
+        indirectLedgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00080000);
+        txnidLeastBits_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00100000);
+        txnidMostBits_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
       
@@ -3915,6 +3987,18 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00008000;
         }
         result.markerType_ = markerType_;
+        if (((from_bitField0_ & 0x00080000) == 0x00080000)) {
+          to_bitField0_ |= 0x00010000;
+        }
+        result.indirectLedgerId_ = indirectLedgerId_;
+        if (((from_bitField0_ & 0x00100000) == 0x00100000)) {
+          to_bitField0_ |= 0x00020000;
+        }
+        result.txnidLeastBits_ = txnidLeastBits_;
+        if (((from_bitField0_ & 0x00200000) == 0x00200000)) {
+          to_bitField0_ |= 0x00040000;
+        }
+        result.txnidMostBits_ = txnidMostBits_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -3998,6 +4082,15 @@ public final class PulsarApi {
         }
         if (other.hasMarkerType()) {
           setMarkerType(other.getMarkerType());
+        }
+        if (other.hasIndirectLedgerId()) {
+          setIndirectLedgerId(other.getIndirectLedgerId());
+        }
+        if (other.hasTxnidLeastBits()) {
+          setTxnidLeastBits(other.getTxnidLeastBits());
+        }
+        if (other.hasTxnidMostBits()) {
+          setTxnidMostBits(other.getTxnidMostBits());
         }
         return this;
       }
@@ -4151,6 +4244,21 @@ public final class PulsarApi {
             case 160: {
               bitField0_ |= 0x00040000;
               markerType_ = input.readInt32();
+              break;
+            }
+            case 168: {
+              bitField0_ |= 0x00080000;
+              indirectLedgerId_ = input.readInt64();
+              break;
+            }
+            case 176: {
+              bitField0_ |= 0x00100000;
+              txnidLeastBits_ = input.readUInt64();
+              break;
+            }
+            case 184: {
+              bitField0_ |= 0x00200000;
+              txnidMostBits_ = input.readUInt64();
               break;
             }
           }
@@ -4797,6 +4905,69 @@ public final class PulsarApi {
       public Builder clearMarkerType() {
         bitField0_ = (bitField0_ & ~0x00040000);
         markerType_ = 0;
+        
+        return this;
+      }
+      
+      // optional int64 indirect_ledger_id = 21;
+      private long indirectLedgerId_ ;
+      public boolean hasIndirectLedgerId() {
+        return ((bitField0_ & 0x00080000) == 0x00080000);
+      }
+      public long getIndirectLedgerId() {
+        return indirectLedgerId_;
+      }
+      public Builder setIndirectLedgerId(long value) {
+        bitField0_ |= 0x00080000;
+        indirectLedgerId_ = value;
+        
+        return this;
+      }
+      public Builder clearIndirectLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00080000);
+        indirectLedgerId_ = 0L;
+        
+        return this;
+      }
+      
+      // optional uint64 txnid_least_bits = 22 [default = 0];
+      private long txnidLeastBits_ ;
+      public boolean hasTxnidLeastBits() {
+        return ((bitField0_ & 0x00100000) == 0x00100000);
+      }
+      public long getTxnidLeastBits() {
+        return txnidLeastBits_;
+      }
+      public Builder setTxnidLeastBits(long value) {
+        bitField0_ |= 0x00100000;
+        txnidLeastBits_ = value;
+        
+        return this;
+      }
+      public Builder clearTxnidLeastBits() {
+        bitField0_ = (bitField0_ & ~0x00100000);
+        txnidLeastBits_ = 0L;
+        
+        return this;
+      }
+      
+      // optional uint64 txnid_most_bits = 23 [default = 0];
+      private long txnidMostBits_ ;
+      public boolean hasTxnidMostBits() {
+        return ((bitField0_ & 0x00200000) == 0x00200000);
+      }
+      public long getTxnidMostBits() {
+        return txnidMostBits_;
+      }
+      public Builder setTxnidMostBits(long value) {
+        bitField0_ |= 0x00200000;
+        txnidMostBits_ = value;
+        
+        return this;
+      }
+      public Builder clearTxnidMostBits() {
+        bitField0_ = (bitField0_ & ~0x00200000);
+        txnidMostBits_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -3104,10 +3104,6 @@ public final class PulsarApi {
     boolean hasMarkerType();
     int getMarkerType();
     
-    // optional int64 indirect_ledger_id = 21;
-    boolean hasIndirectLedgerId();
-    long getIndirectLedgerId();
-    
     // optional uint64 txnid_least_bits = 22 [default = 0];
     boolean hasTxnidLeastBits();
     long getTxnidLeastBits();
@@ -3455,21 +3451,11 @@ public final class PulsarApi {
       return markerType_;
     }
     
-    // optional int64 indirect_ledger_id = 21;
-    public static final int INDIRECT_LEDGER_ID_FIELD_NUMBER = 21;
-    private long indirectLedgerId_;
-    public boolean hasIndirectLedgerId() {
-      return ((bitField0_ & 0x00010000) == 0x00010000);
-    }
-    public long getIndirectLedgerId() {
-      return indirectLedgerId_;
-    }
-    
     // optional uint64 txnid_least_bits = 22 [default = 0];
     public static final int TXNID_LEAST_BITS_FIELD_NUMBER = 22;
     private long txnidLeastBits_;
     public boolean hasTxnidLeastBits() {
-      return ((bitField0_ & 0x00020000) == 0x00020000);
+      return ((bitField0_ & 0x00010000) == 0x00010000);
     }
     public long getTxnidLeastBits() {
       return txnidLeastBits_;
@@ -3479,7 +3465,7 @@ public final class PulsarApi {
     public static final int TXNID_MOST_BITS_FIELD_NUMBER = 23;
     private long txnidMostBits_;
     public boolean hasTxnidMostBits() {
-      return ((bitField0_ & 0x00040000) == 0x00040000);
+      return ((bitField0_ & 0x00020000) == 0x00020000);
     }
     public long getTxnidMostBits() {
       return txnidMostBits_;
@@ -3505,7 +3491,6 @@ public final class PulsarApi {
       orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
       deliverAtTime_ = 0L;
       markerType_ = 0;
-      indirectLedgerId_ = 0L;
       txnidLeastBits_ = 0L;
       txnidMostBits_ = 0L;
     }
@@ -3608,12 +3593,9 @@ public final class PulsarApi {
         output.writeInt32(20, markerType_);
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
-        output.writeInt64(21, indirectLedgerId_);
-      }
-      if (((bitField0_ & 0x00020000) == 0x00020000)) {
         output.writeUInt64(22, txnidLeastBits_);
       }
-      if (((bitField0_ & 0x00040000) == 0x00040000)) {
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
         output.writeUInt64(23, txnidMostBits_);
       }
     }
@@ -3707,13 +3689,9 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeInt64Size(21, indirectLedgerId_);
-      }
-      if (((bitField0_ & 0x00020000) == 0x00020000)) {
-        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(22, txnidLeastBits_);
       }
-      if (((bitField0_ & 0x00040000) == 0x00040000)) {
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(23, txnidMostBits_);
       }
@@ -3868,12 +3846,10 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00020000);
         markerType_ = 0;
         bitField0_ = (bitField0_ & ~0x00040000);
-        indirectLedgerId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00080000);
         txnidLeastBits_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00100000);
+        bitField0_ = (bitField0_ & ~0x00080000);
         txnidMostBits_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00200000);
+        bitField0_ = (bitField0_ & ~0x00100000);
         return this;
       }
       
@@ -3990,13 +3966,9 @@ public final class PulsarApi {
         if (((from_bitField0_ & 0x00080000) == 0x00080000)) {
           to_bitField0_ |= 0x00010000;
         }
-        result.indirectLedgerId_ = indirectLedgerId_;
+        result.txnidLeastBits_ = txnidLeastBits_;
         if (((from_bitField0_ & 0x00100000) == 0x00100000)) {
           to_bitField0_ |= 0x00020000;
-        }
-        result.txnidLeastBits_ = txnidLeastBits_;
-        if (((from_bitField0_ & 0x00200000) == 0x00200000)) {
-          to_bitField0_ |= 0x00040000;
         }
         result.txnidMostBits_ = txnidMostBits_;
         result.bitField0_ = to_bitField0_;
@@ -4082,9 +4054,6 @@ public final class PulsarApi {
         }
         if (other.hasMarkerType()) {
           setMarkerType(other.getMarkerType());
-        }
-        if (other.hasIndirectLedgerId()) {
-          setIndirectLedgerId(other.getIndirectLedgerId());
         }
         if (other.hasTxnidLeastBits()) {
           setTxnidLeastBits(other.getTxnidLeastBits());
@@ -4246,18 +4215,13 @@ public final class PulsarApi {
               markerType_ = input.readInt32();
               break;
             }
-            case 168: {
-              bitField0_ |= 0x00080000;
-              indirectLedgerId_ = input.readInt64();
-              break;
-            }
             case 176: {
-              bitField0_ |= 0x00100000;
+              bitField0_ |= 0x00080000;
               txnidLeastBits_ = input.readUInt64();
               break;
             }
             case 184: {
-              bitField0_ |= 0x00200000;
+              bitField0_ |= 0x00100000;
               txnidMostBits_ = input.readUInt64();
               break;
             }
@@ -4909,43 +4873,22 @@ public final class PulsarApi {
         return this;
       }
       
-      // optional int64 indirect_ledger_id = 21;
-      private long indirectLedgerId_ ;
-      public boolean hasIndirectLedgerId() {
-        return ((bitField0_ & 0x00080000) == 0x00080000);
-      }
-      public long getIndirectLedgerId() {
-        return indirectLedgerId_;
-      }
-      public Builder setIndirectLedgerId(long value) {
-        bitField0_ |= 0x00080000;
-        indirectLedgerId_ = value;
-        
-        return this;
-      }
-      public Builder clearIndirectLedgerId() {
-        bitField0_ = (bitField0_ & ~0x00080000);
-        indirectLedgerId_ = 0L;
-        
-        return this;
-      }
-      
       // optional uint64 txnid_least_bits = 22 [default = 0];
       private long txnidLeastBits_ ;
       public boolean hasTxnidLeastBits() {
-        return ((bitField0_ & 0x00100000) == 0x00100000);
+        return ((bitField0_ & 0x00080000) == 0x00080000);
       }
       public long getTxnidLeastBits() {
         return txnidLeastBits_;
       }
       public Builder setTxnidLeastBits(long value) {
-        bitField0_ |= 0x00100000;
+        bitField0_ |= 0x00080000;
         txnidLeastBits_ = value;
         
         return this;
       }
       public Builder clearTxnidLeastBits() {
-        bitField0_ = (bitField0_ & ~0x00100000);
+        bitField0_ = (bitField0_ & ~0x00080000);
         txnidLeastBits_ = 0L;
         
         return this;
@@ -4954,19 +4897,19 @@ public final class PulsarApi {
       // optional uint64 txnid_most_bits = 23 [default = 0];
       private long txnidMostBits_ ;
       public boolean hasTxnidMostBits() {
-        return ((bitField0_ & 0x00200000) == 0x00200000);
+        return ((bitField0_ & 0x00100000) == 0x00100000);
       }
       public long getTxnidMostBits() {
         return txnidMostBits_;
       }
       public Builder setTxnidMostBits(long value) {
-        bitField0_ |= 0x00200000;
+        bitField0_ |= 0x00100000;
         txnidMostBits_ = value;
         
         return this;
       }
       public Builder clearTxnidMostBits() {
-        bitField0_ = (bitField0_ & ~0x00200000);
+        bitField0_ = (bitField0_ & ~0x00100000);
         txnidMostBits_ = 0L;
         
         return this;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarMarkers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarMarkers.java
@@ -15,9 +15,8 @@ public final class PulsarMarkers {
     REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE(2, 11),
     REPLICATED_SUBSCRIPTION_SNAPSHOT(3, 12),
     REPLICATED_SUBSCRIPTION_UPDATE(4, 13),
-    TXN_DATA(5, 20),
-    TXN_COMMIT(6, 21),
-    TXN_ABORT(7, 22),
+    TXN_COMMIT(5, 20),
+    TXN_ABORT(6, 21),
     ;
     
     public static final int UNKNOWN_MARKER_VALUE = 0;
@@ -25,9 +24,8 @@ public final class PulsarMarkers {
     public static final int REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE_VALUE = 11;
     public static final int REPLICATED_SUBSCRIPTION_SNAPSHOT_VALUE = 12;
     public static final int REPLICATED_SUBSCRIPTION_UPDATE_VALUE = 13;
-    public static final int TXN_DATA_VALUE = 20;
-    public static final int TXN_COMMIT_VALUE = 21;
-    public static final int TXN_ABORT_VALUE = 22;
+    public static final int TXN_COMMIT_VALUE = 20;
+    public static final int TXN_ABORT_VALUE = 21;
     
     
     public final int getNumber() { return value; }
@@ -39,9 +37,8 @@ public final class PulsarMarkers {
         case 11: return REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE;
         case 12: return REPLICATED_SUBSCRIPTION_SNAPSHOT;
         case 13: return REPLICATED_SUBSCRIPTION_UPDATE;
-        case 20: return TXN_DATA;
-        case 21: return TXN_COMMIT;
-        case 22: return TXN_ABORT;
+        case 20: return TXN_COMMIT;
+        case 21: return TXN_ABORT;
         default: return null;
       }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarMarkers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarMarkers.java
@@ -15,6 +15,9 @@ public final class PulsarMarkers {
     REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE(2, 11),
     REPLICATED_SUBSCRIPTION_SNAPSHOT(3, 12),
     REPLICATED_SUBSCRIPTION_UPDATE(4, 13),
+    TXN_DATA(5, 20),
+    TXN_COMMIT(6, 21),
+    TXN_ABORT(7, 22),
     ;
     
     public static final int UNKNOWN_MARKER_VALUE = 0;
@@ -22,6 +25,9 @@ public final class PulsarMarkers {
     public static final int REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE_VALUE = 11;
     public static final int REPLICATED_SUBSCRIPTION_SNAPSHOT_VALUE = 12;
     public static final int REPLICATED_SUBSCRIPTION_UPDATE_VALUE = 13;
+    public static final int TXN_DATA_VALUE = 20;
+    public static final int TXN_COMMIT_VALUE = 21;
+    public static final int TXN_ABORT_VALUE = 22;
     
     
     public final int getNumber() { return value; }
@@ -33,6 +39,9 @@ public final class PulsarMarkers {
         case 11: return REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE;
         case 12: return REPLICATED_SUBSCRIPTION_SNAPSHOT;
         case 13: return REPLICATED_SUBSCRIPTION_UPDATE;
+        case 20: return TXN_DATA;
+        case 21: return TXN_COMMIT;
+        case 22: return TXN_ABORT;
         default: return null;
       }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
@@ -261,9 +261,9 @@ public class Markers {
                && msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE;
     }
 
-    public static ByteBuf newTxnCommitMarker(long sequenceId, long indirectLedgerId, long txnMostBits,
+    public static ByteBuf newTxnCommitMarker(long sequenceId, long txnMostBits,
                                              long txnLeastBits) {
-        return newTxnMarker(MarkerType.TXN_COMMIT, sequenceId, indirectLedgerId, txnMostBits, txnLeastBits);
+        return newTxnMarker(MarkerType.TXN_COMMIT, sequenceId, txnMostBits, txnLeastBits);
     }
 
     public static boolean isTxnAbortMarker(MessageMetadata msgMetadata) {
@@ -272,19 +272,18 @@ public class Markers {
                && msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE;
     }
 
-    public static ByteBuf newTxnAbortMarker(long sequenceId, long indirectLedgerId, long txnMostBits,
+    public static ByteBuf newTxnAbortMarker(long sequenceId, long txnMostBits,
                                             long txnLeastBits) {
-        return newTxnMarker(MarkerType.TXN_ABORT, sequenceId, indirectLedgerId, txnMostBits, txnLeastBits);
+        return newTxnMarker(MarkerType.TXN_ABORT, sequenceId, txnMostBits, txnLeastBits);
     }
 
-    private static ByteBuf newTxnMarker(MarkerType markerType, long sequenceId, long indirectLedgerId, long txnMostBits,
+    private static ByteBuf newTxnMarker(MarkerType markerType, long sequenceId, long txnMostBits,
                                         long txnLeastBits) {
         MessageMetadata.Builder msgMetadataBuilder = MessageMetadata.newBuilder();
         msgMetadataBuilder.setPublishTime(System.currentTimeMillis());
         msgMetadataBuilder.setProducerName("pulsar.txn.marker");
         msgMetadataBuilder.setSequenceId(sequenceId);
         msgMetadataBuilder.setMarkerType(markerType.getNumber());
-        msgMetadataBuilder.setIndirectLedgerId(indirectLedgerId);
         msgMetadataBuilder.setTxnidMostBits(txnMostBits);
         msgMetadataBuilder.setTxnidLeastBits(txnLeastBits);
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 
 import lombok.SneakyThrows;

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -123,6 +123,11 @@ message MessageMetadata {
     // internal metadata instead of application published data.
     // Markers will generally not be propagated back to clients
     optional int32 marker_type = 20;
+
+	// transaction related message info
+	optional int64 indirect_ledger_id = 21;
+	optional uint64 txnid_least_bits = 22 [default = 0];
+	optional uint64 txnid_most_bits = 23 [default = 0];
 }
 
 message SingleMessageMetadata {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -125,7 +125,6 @@ message MessageMetadata {
     optional int32 marker_type = 20;
 
 	// transaction related message info
-	optional int64 indirect_ledger_id = 21;
 	optional uint64 txnid_least_bits = 22 [default = 0];
 	optional uint64 txnid_most_bits = 23 [default = 0];
 }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -124,9 +124,9 @@ message MessageMetadata {
     // Markers will generally not be propagated back to clients
     optional int32 marker_type = 20;
 
-	// transaction related message info
-	optional uint64 txnid_least_bits = 22 [default = 0];
-	optional uint64 txnid_most_bits = 23 [default = 0];
+    // transaction related message info
+    optional uint64 txnid_least_bits = 22 [default = 0];
+    optional uint64 txnid_most_bits = 23 [default = 0];
 }
 
 message SingleMessageMetadata {

--- a/pulsar-common/src/main/proto/PulsarMarkers.proto
+++ b/pulsar-common/src/main/proto/PulsarMarkers.proto
@@ -32,6 +32,9 @@ enum MarkerType {
     REPLICATED_SUBSCRIPTION_UPDATE            = 13;
 
     // Next markers start at 20
+    TXN_DATA = 20;
+    TXN_COMMIT = 21;
+    TXN_ABORT = 22;
 }
 
 /// --- Replicated subscriptions ---

--- a/pulsar-common/src/main/proto/PulsarMarkers.proto
+++ b/pulsar-common/src/main/proto/PulsarMarkers.proto
@@ -32,9 +32,8 @@ enum MarkerType {
     REPLICATED_SUBSCRIPTION_UPDATE            = 13;
 
     // Next markers start at 20
-    TXN_DATA = 20;
-    TXN_COMMIT = 21;
-    TXN_ABORT = 22;
+    TXN_COMMIT = 20;
+    TXN_ABORT = 21;
 }
 
 /// --- Replicated subscriptions ---

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
@@ -119,17 +119,15 @@ public class MarkersTest {
     @Test
     public void testTxnCommitMarker() {
         long sequenceId = 1L;
-        long indirectLedgerId = 0L;
         long mostBits = 1234L;
         long leastBits = 2345L;
 
-        ByteBuf buf = Markers.newTxnCommitMarker(sequenceId, indirectLedgerId, mostBits, leastBits);
+        ByteBuf buf = Markers.newTxnCommitMarker(sequenceId, mostBits, leastBits);
 
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(buf);
 
         assertEquals(msgMetadata.getMarkerType(), PulsarMarkers.MarkerType.TXN_COMMIT_VALUE);
         assertEquals(msgMetadata.getSequenceId(), sequenceId);
-        assertEquals(msgMetadata.getIndirectLedgerId(), indirectLedgerId);
         assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
         assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
     }
@@ -137,17 +135,15 @@ public class MarkersTest {
     @Test
     public void testTxnAbortMarker() {
         long sequenceId = 1L;
-        long indirectLedgerId = 0L;
         long mostBits = 1234L;
         long leastBits = 2345L;
 
-        ByteBuf buf = Markers.newTxnAbortMarker(sequenceId, indirectLedgerId, mostBits, leastBits);
+        ByteBuf buf = Markers.newTxnAbortMarker(sequenceId, mostBits, leastBits);
 
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(buf);
 
         assertEquals(msgMetadata.getMarkerType(), PulsarMarkers.MarkerType.TXN_ABORT_VALUE);
         assertEquals(msgMetadata.getSequenceId(), sequenceId);
-        assertEquals(msgMetadata.getIndirectLedgerId(), indirectLedgerId);
         assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
         assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.api.proto.PulsarMarkers;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshot;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshotRequest;
@@ -113,6 +114,42 @@ public class MarkersTest {
         assertEquals(snapshot.getClusters(1).getCluster(), "us-east");
         assertEquals(snapshot.getClusters(1).getMessageId().getLedgerId(), 10);
         assertEquals(snapshot.getClusters(1).getMessageId().getEntryId(), 11);
+    }
+
+    @Test
+    public void testTxnCommitMarker() {
+        long sequenceId = 1L;
+        long indirectLedgerId = 0L;
+        long mostBits = 1234L;
+        long leastBits = 2345L;
+
+        ByteBuf buf = Markers.newTxnCommitMarker(sequenceId, indirectLedgerId, mostBits, leastBits);
+
+        MessageMetadata msgMetadata = Commands.parseMessageMetadata(buf);
+
+        assertEquals(msgMetadata.getMarkerType(), PulsarMarkers.MarkerType.TXN_COMMIT_VALUE);
+        assertEquals(msgMetadata.getSequenceId(), sequenceId);
+        assertEquals(msgMetadata.getIndirectLedgerId(), indirectLedgerId);
+        assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
+        assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
+    }
+
+    @Test
+    public void testTxnAbortMarker() {
+        long sequenceId = 1L;
+        long indirectLedgerId = 0L;
+        long mostBits = 1234L;
+        long leastBits = 2345L;
+
+        ByteBuf buf = Markers.newTxnAbortMarker(sequenceId, indirectLedgerId, mostBits, leastBits);
+
+        MessageMetadata msgMetadata = Commands.parseMessageMetadata(buf);
+
+        assertEquals(msgMetadata.getMarkerType(), PulsarMarkers.MarkerType.TXN_ABORT_VALUE);
+        assertEquals(msgMetadata.getSequenceId(), sequenceId);
+        assertEquals(msgMetadata.getIndirectLedgerId(), indirectLedgerId);
+        assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
+        assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
     }
 
 }


### PR DESCRIPTION

*Motivation*

Add new message type in the transaction including data and commit and abort maker in the transaction log.

*Modifications*

Add three new types of transaction messages.
TXN_DATA is the normal message of the transaction.
TXN_COMMIT is the commit marker of the transaction.
TXN_ABORT is the abort marker of the transaction.
