### PR TITLE
[broker] Topic loading in rest-api should time out in zooKeeperOperationTimeoutSeconds

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1343,7 +1343,7 @@ public class PersistentTopicsBase extends AdminResource {
     private Topic getTopicReference(TopicName topicName) {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
-                    .get(pulsar().getConfiguration().getZooKeeperSessionTimeoutMillis(), TimeUnit.MILLISECONDS)
+                    .get(pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)
                     .orElseThrow(() -> topicNotFoundReason(topicName));
         } catch (RestException e) {
             throw e;


### PR DESCRIPTION
### Motivation

With https://github.com/apache/pulsar/pull/4616, topic-loading in rest-api now time out in `zooKeeperSessionTimeoutMillis`. However, I think we should use `zooKeeperOperationTimeoutSeconds` rather than `zooKeeperSessionTimeoutMillis` as the timeout time, because most rest-api calls by broker time out in `zooKeeperOperationTimeoutSeconds` (cf. https://github.com/apache/pulsar/pull/4484).