### PR TITLE
Fix: Messages don't get acked if there is not sink topic

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSinkDisable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSinkDisable.java
@@ -43,7 +43,7 @@ public class PulsarSinkDisable<T> implements Sink<T> {
 
     @Override
     public void write(Record<T> record) throws Exception {
-        // No-op
+        record.ack();
     }
 
 }


### PR DESCRIPTION
### Motivation

A message doesn't get automatically ACKed if there is the output topic is not set