### PR TITLE
Merge Request for #4808: TYPO in C++ client producer method for processing failure case

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -256,7 +256,7 @@ void ProducerImpl::failPendingMessages(Result result) {
     }
 
     // this function can handle null pointer
-    BatchMessageContainer::batchMessageCallBack(ResultTimeout, messageContainerListPtr, NULL);
+    BatchMessageContainer::batchMessageCallBack(result, messageContainerListPtr, NULL);
 }
 
 void ProducerImpl::resendMessages(ClientConnectionPtr cnx) {


### PR DESCRIPTION
Definitely this is a typo. This method is dealing the Failed Message with the GIVEN result, but not a CERTAIN result.

### Contribution Checklist
  
https://github.com/apache/pulsar/issues/4808 : TYPO in C++ client producer method for processing failure case

