### PR TITLE
[docs] Add thread/process modes in Configure Functions runtime

### DIFF
--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -510,8 +510,3 @@ Pulsar Functions that use [Pulsar Functions SDK](#the-pulsar-functions-sdk) can 
 
 ## State storage
 Pulsar Functions use [Apache BookKeeper](https://bookkeeper.apache.org) as a state storage interface. Pulsar installation, including the local standalone installation, includes deployment of BookKeeper bookies.
-
-## Thread mode and process mode
-You can run Pulsar Functions in both thread mode and process mode. The differences of the two modes are:   
-- Thread mode: when a function runs in thread mode, it runs on the same Java virtual machine (JVM) with Functions worker.   
-- Process mode: when a function runs in process mode, it runs on the same machine that Functions worker runs.

--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -510,4 +510,3 @@ Pulsar Functions that use [Pulsar Functions SDK](#the-pulsar-functions-sdk) can 
 
 ## State storage
 Pulsar Functions use [Apache BookKeeper](https://bookkeeper.apache.org) as a state storage interface. Pulsar installation, including the local standalone installation, includes deployment of BookKeeper bookies.
-

--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -510,3 +510,8 @@ Pulsar Functions that use [Pulsar Functions SDK](#the-pulsar-functions-sdk) can 
 
 ## State storage
 Pulsar Functions use [Apache BookKeeper](https://bookkeeper.apache.org) as a state storage interface. Pulsar installation, including the local standalone installation, includes deployment of BookKeeper bookies.
+
+## Thread mode and process mode
+You can run Pulsar Functions in both thread mode and process mode. The differences of the two modes are:   
+- Thread mode: when a function runs in thread mode, it runs on the same Java virtual machine (JVM) with Functions worker.   
+- Process mode: when a function runs in process mode, it runs on the same machine that Functions worker runs.

--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -510,3 +510,4 @@ Pulsar Functions that use [Pulsar Functions SDK](#the-pulsar-functions-sdk) can 
 
 ## State storage
 Pulsar Functions use [Apache BookKeeper](https://bookkeeper.apache.org) as a state storage interface. Pulsar installation, including the local standalone installation, includes deployment of BookKeeper bookies.
+

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -11,6 +11,10 @@ Pulsar Functions support the following methods to run functions.
 - *Process*: Invoke functions in processes forked by Functions Worker.
 - *Kubernetes*: Submit functions as Kubernetes StatefulSets by Functions Worker.
 
+The differences of the thread and process modes are:   
+- Thread mode: when a function runs in thread mode, it runs on the same Java virtual machine (JVM) with Functions worker.   
+- Process mode: when a function runs in process mode, it runs on the same machine that Functions worker runs.
+
 ## Configure thread runtime
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 


### PR DESCRIPTION
Fixes #3400 

### Motivation
Fix doc issue #3400.

### Modifications
Add differences of the thread and process modes in `Configure Functions runtime` file.
