### PR TITLE
Allow resource overcommitting when running functions in Kubernetes

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -129,6 +129,12 @@ processContainerFactory:
 #  extraFunctionDependenciesDir:
 #  # Additional memory padding added on top of the memory requested by the function per on a per instance basis
 #  percentMemoryPadding: 10
+#  # The ratio cpu request and cpu limit to be set for a function/source/sink.
+#  # The formula for cpu request is cpuRequest = userRequestCpu / cpuOverCommitRatio
+#  cpuOverCommitRatio: 1.0
+#  # The ratio memory request and memory limit to be set for a function/source/sink.
+#  # The formula for memory request is memoryRequest = userRequestMemory / memoryOverCommitRatio
+#  memoryOverCommitRatio: 1.0
 
 ## A set of the minimum amount of resources functions must request.
 ## Support for this depends on function runtime.

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
@@ -76,6 +76,8 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         private String changeConfigMap;
         private String changeConfigMapNamespace;
         private int percentMemoryPadding;
+        private double cpuOverCommitRatio;
+        private double memoryOverCommitRatio;
     }
     private final KubernetesInfo kubernetesInfo;
     private final Boolean submittingInsidePod;
@@ -108,6 +110,8 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
                                     String extraDependenciesDir,
                                     Map<String, String> customLabels,
                                     int percentMemoryPadding,
+                                    double cpuOverCommitRatio,
+                                    double memoryOverCommitRatio,
                                     String pulsarServiceUri,
                                     String pulsarAdminUri,
                                     String stateStorageServiceUri,
@@ -158,6 +162,8 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         this.kubernetesInfo.setChangeConfigMap(changeConfigMap);
         this.kubernetesInfo.setChangeConfigMapNamespace(changeConfigMapNamespace);
         this.kubernetesInfo.setPercentMemoryPadding(percentMemoryPadding);
+        this.kubernetesInfo.setCpuOverCommitRatio(cpuOverCommitRatio);
+        this.kubernetesInfo.setMemoryOverCommitRatio(memoryOverCommitRatio);
         this.submittingInsidePod = submittingInsidePod;
         this.installUserCodeDependencies = installUserCodeDependencies;
         this.customLabels = customLabels;
@@ -230,6 +236,8 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             secretsProviderConfigurator,
             expectedMetricsCollectionInterval,
             this.kubernetesInfo.getPercentMemoryPadding(),
+            this.kubernetesInfo.getCpuOverCommitRatio(),
+            this.kubernetesInfo.getMemoryOverCommitRatio(),
             getAuthProvider(),
             authenticationEnabled);
     }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
@@ -135,6 +135,8 @@ public class KubernetesRuntimeFactoryTest {
             extraDepsDir,
             null,
                 0,
+                1.0,
+                1.0,
                 pulsarServiceUrl,
             pulsarAdminUrl,
             stateStorageServiceUrl,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -149,7 +149,8 @@ public class KubernetesRuntimeTest {
         }
     }
 
-    KubernetesRuntimeFactory createKubernetesRuntimeFactory(String extraDepsDir, int percentMemoryPadding) throws Exception {
+    KubernetesRuntimeFactory createKubernetesRuntimeFactory(String extraDepsDir, int percentMemoryPadding,
+                                                            double cpuOverCommitRatio, double memoryOverCommitRatio) throws Exception {
         KubernetesRuntimeFactory factory = spy(new KubernetesRuntimeFactory(
             null,
             null,
@@ -163,6 +164,8 @@ public class KubernetesRuntimeTest {
             extraDepsDir,
             null,
                 percentMemoryPadding,
+                cpuOverCommitRatio,
+                memoryOverCommitRatio,
                 pulsarServiceUrl,
             pulsarAdminUrl,
             stateStorageServiceUrl,
@@ -222,7 +225,7 @@ public class KubernetesRuntimeTest {
     }
 
     private void verifyRamPadding(int percentMemoryPadding, long ram, long expectedRamWithPadding) throws Exception {
-        factory = createKubernetesRuntimeFactory(null, percentMemoryPadding);
+        factory = createKubernetesRuntimeFactory(null, percentMemoryPadding, 1.0, 1.0);
         InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, true);
 
         KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, 30l);
@@ -240,7 +243,7 @@ public class KubernetesRuntimeTest {
     public void testJavaConstructor() throws Exception {
         InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, false);
 
-        factory = createKubernetesRuntimeFactory(null, 10);
+        factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0);
 
         verifyJavaInstance(config, pulsarRootDir + "/instances/deps", false);
     }
@@ -249,7 +252,7 @@ public class KubernetesRuntimeTest {
     public void testJavaConstructorWithSecrets() throws Exception {
         InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, true);
 
-        factory = createKubernetesRuntimeFactory(null, 10);
+        factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0);
 
         verifyJavaInstance(config, pulsarRootDir + "/instances/deps", true);
     }
@@ -260,9 +263,35 @@ public class KubernetesRuntimeTest {
 
         String extraDepsDir = "/path/to/deps/dir";
 
-        factory = createKubernetesRuntimeFactory(extraDepsDir, 10);
+        factory = createKubernetesRuntimeFactory(extraDepsDir, 10, 1.0, 1.0);
 
         verifyJavaInstance(config, extraDepsDir, false);
+    }
+
+    @Test
+    public void testOverCommit() throws Exception {
+        testOverCommit(1.0, 1.0);
+        testOverCommit(2.0, 1.0);
+        testOverCommit(1.0, 2.0);
+        testOverCommit(1.5, 1.5);
+    }
+
+    public void testOverCommit(double cpuOverCommitRatio, double memoryOverCommitRatio) throws Exception {
+
+        InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, false);
+        factory = createKubernetesRuntimeFactory(null, 10, cpuOverCommitRatio, memoryOverCommitRatio);
+        KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, 30l);
+        List<String> args = container.getProcessArgs();
+
+        // check padding and xmx
+        long heap = Long.parseLong(args.stream().filter(s -> s.startsWith("-Xmx")).collect(Collectors.toList()).get(0).replace("-Xmx", ""));
+        V1Container containerSpec = container.getFunctionContainer(Collections.emptyList(), RESOURCES);
+        assertEquals(containerSpec.getResources().getLimits().get("memory").getNumber().longValue(), Math.round(heap + (heap * 0.1)));
+        assertEquals(containerSpec.getResources().getRequests().get("memory").getNumber().longValue(), Math.round((heap + (heap * 0.1)) / memoryOverCommitRatio));
+
+        // check cpu
+        assertEquals(containerSpec.getResources().getRequests().get("cpu").getNumber().doubleValue(), RESOURCES.getCpu() / cpuOverCommitRatio);
+        assertEquals(containerSpec.getResources().getLimits().get("cpu").getNumber().doubleValue(), RESOURCES.getCpu());
     }
 
 
@@ -333,7 +362,7 @@ public class KubernetesRuntimeTest {
     public void testPythonConstructor() throws Exception {
         InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.PYTHON, false);
 
-        factory = createKubernetesRuntimeFactory(null, 10);
+        factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0);
 
         verifyPythonInstance(config, pulsarRootDir + "/instances/deps", false);
     }
@@ -344,7 +373,7 @@ public class KubernetesRuntimeTest {
 
         String extraDepsDir = "/path/to/deps/dir";
 
-        factory = createKubernetesRuntimeFactory(extraDepsDir, 10);
+        factory = createKubernetesRuntimeFactory(extraDepsDir, 10, 1.0, 1.0);
 
         verifyPythonInstance(config, extraDepsDir, false);
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -399,4 +399,9 @@ public class FunctionCommon {
         }
         return TypeResolver.resolveRawArgument(funClass, loadedClass);
     }
+
+    public static double roundDecimal(double value, int places) {
+        double scale = Math.pow(10, places);
+        return Math.round(value * scale) / scale;
+    }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -166,6 +166,8 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     workerConfig.getKubernetesContainerFactory().getExtraFunctionDependenciesDir(),
                     workerConfig.getKubernetesContainerFactory().getCustomLabels(),
                     workerConfig.getKubernetesContainerFactory().getPercentMemoryPadding(),
+                    workerConfig.getKubernetesContainerFactory().getCpuOverCommitRatio(),
+                    workerConfig.getKubernetesContainerFactory().getMemoryOverCommitRatio(),
                     StringUtils.isEmpty(workerConfig.getKubernetesContainerFactory().getPulsarServiceUrl()) ? workerConfig.getPulsarServiceUrl() : workerConfig.getKubernetesContainerFactory().getPulsarServiceUrl(),
                     StringUtils.isEmpty(workerConfig.getKubernetesContainerFactory().getPulsarAdminUrl()) ? workerConfig.getPulsarWebServiceUrl() : workerConfig.getKubernetesContainerFactory().getPulsarAdminUrl(),
                     workerConfig.getStateStorageServiceUrl(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -464,6 +464,18 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
                 doc = "Additional memory padding added on top of the memory requested by the function per on a per instance basis"
         )
         private int percentMemoryPadding;
+
+        @FieldContext(
+                doc = "The ratio cpu request and cpu limit to be set for a function/source/sink." +
+                        "  The formula for cpu request is cpuRequest = userRequestCpu / cpuOverCommitRatio"
+        )
+        private double cpuOverCommitRatio = 1.0;
+
+        @FieldContext(
+                doc = "The ratio memory request and memory limit to be set for a function/source/sink." +
+                        "  The formula for memory request is memoryRequest = userRequestMemory / memoryOverCommitRatio"
+        )
+        private double memoryOverCommitRatio = 1.0;
     }
     @FieldContext(
         category = CATEGORY_FUNC_RUNTIME_MNG,


### PR DESCRIPTION
### Motivation

Currently, when running Pulsar Functions, Sources, and Sinks in Kubernetes. The resources requests and resource limits are set to the same values.  While this is ok and everything will run as it should, actual resource utilization in the cluster might be low.   To increase actual resource utilization, we need to be able to overcommit a certain amount in our clusters