### PR TITLE
[pulsar-io-jdbc] no action set as insert

### DIFF
--- a/pulsar-io/jdbc/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/pulsar-io/jdbc/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -182,18 +182,29 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
                 // bind each record value
                 for (Record<T> record : swapList) {
                     String action = record.getProperties().get(ACTION);
-                    if (action != null && action.equals(DELETE)) {
-                        bindValue(deleteStatment, record, action);
-                        count += 1;
-                        deleteStatment.execute();
-                    } else if (action != null && action.equals(UPDATE)) {
-                        bindValue(updateStatment, record, action);
-                        count += 1;
-                        updateStatment.execute();
-                    } else if (action != null && action.equals(INSERT)){
-                        bindValue(insertStatement, record, action);
-                        count += 1;
-                        insertStatement.execute();
+                    if (action == null) {
+                        action = INSERT;
+                    }
+                    switch (action) {
+                        case DELETE:
+                            bindValue(deleteStatment, record, action);
+                            count += 1;
+                            deleteStatment.execute();
+                            break;
+                        case UPDATE:
+                            bindValue(updateStatment, record, action);
+                            count += 1;
+                            updateStatment.execute();
+                            break;
+                        case INSERT:
+                            bindValue(insertStatement, record, action);
+                            count += 1;
+                            insertStatement.execute();
+                            break;
+                        default:
+                            String msg = String.format("Unsupported action %s, can be one of %s, or not set which indicate %s",
+                                                       action, Arrays.asList(INSERT, UPDATE, DELETE), INSERT);
+                            throw new IllegalArgumentException(msg);
                     }
                 }
                 connection.commit();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

jdbc sink treat all record as INSERT before #4358 , now it requires an indispensable action property which seems to be a break change, and we can deal records without any action property as INSERT.

### Modifications

treat action not set as INSERT action like before.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *TestInsertAction*.

This change added tests and can be verified as follows: *TestNoAction*

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
