### PR TITLE
[Dashboard] requests should respect no_proxy env variable

### DIFF
--- a/dashboard/django/collector.py
+++ b/dashboard/django/collector.py
@@ -461,7 +461,7 @@ if __name__ == "__main__":
         logger.info(http_headers)
 
     global http_proxyes
-    http_proxyes = {}
+    http_proxyes = { "no_proxy": os.getenv("NO_PROXY", "") }
     if args.proxy:
         http_proxyes['http'] = args.proxy
         http_proxyes['https'] = args.proxy


### PR DESCRIPTION
If you want to specify a no_proxy variable in your dockerfile or docker-compose.yml, then this little fix respects the variable in get-requests. Otherwise the proxies could break your docker namespace lookup.

### Motivation

I try to run pulsar and dashboard in a docker-compose.yml, but my http_proxies broke the service-namespace lookup. So i had to exlude the service-name from the proxy, but the dashboard ignores the no_proxy variable.

### Modifications

Added os.getenv["NO_PROXY"] to http_proxyes.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes
