### PR TITLE
Merge Request for #4808: TYPO in C++ client producer method for processing failure case, and add corresponding unit test case.

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -256,7 +256,7 @@ void ProducerImpl::failPendingMessages(Result result) {
     }
 
     // this function can handle null pointer
-    BatchMessageContainer::batchMessageCallBack(ResultTimeout, messageContainerListPtr, NULL);
+    BatchMessageContainer::batchMessageCallBack(result, messageContainerListPtr, NULL);
 }
 
 void ProducerImpl::resendMessages(ClientConnectionPtr cnx) {

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -919,7 +919,7 @@ TEST(BatchMessageTest, testPartitionedTopics) {
     ASSERT_EQ(i, numOfMessages - globalPublishCountQueueFull);
 }
 
-TEST(ProducerTest, producerFailureResult) {
+TEST(BatchMessageTest, producerFailureResult) {
     std::string testName = std::to_string(epochTime) + "testCumulativeAck";
 
     ClientConfiguration clientConfig;

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -56,6 +56,11 @@ class PulsarFriend {
         return *producerImpl;
     }
 
+    static void producerFailMessages(Producer producer, Result result) {
+        ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
+        producerImpl->failPendingMessages(result);
+    }
+
     static ConsumerImpl& getConsumerImpl(Consumer consumer) {
         ConsumerImpl* consumerImpl = static_cast<ConsumerImpl*>(consumer.impl_.get());
         return *consumerImpl;


### PR DESCRIPTION
Definitely, this is a typo. This method is dealing with the Failed Message with the GIVEN result, but not a CERTAIN result.

Contribution Checklist
#4808 : TYPO in C++ client producer method for processing failure case
Add c++ client producer failure message unit test case.

UT passed:

BatchMessageTest