### PR TITLE
Merge Request for #4808: TYPO in C++ client producer method for processing failure case, and add corresponding unit test case.

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Producer.h
+++ b/pulsar-client-cpp/include/pulsar/Producer.h
@@ -147,6 +147,9 @@ class PULSAR_PUBLIC Producer {
     friend class PulsarWrapper;
 
     ProducerImplBasePtr impl_;
+
+    // For unit test case BatchMessageTest::producerFailureResult only
+    void producerFailMessages(Result result);
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -97,4 +97,11 @@ void Producer::flushAsync(FlushCallback callback) {
 
     impl_->flushAsync(callback);
 }
+
+void Producer::producerFailMessages(Result result) {
+    if (impl_) {
+        ProducerImpl* producerImpl = static_cast<ProducerImpl*>(impl_.get());
+        producerImpl->failPendingMessages(result);
+    }
+}
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -256,7 +256,7 @@ void ProducerImpl::failPendingMessages(Result result) {
     }
 
     // this function can handle null pointer
-    BatchMessageContainer::batchMessageCallBack(ResultTimeout, messageContainerListPtr, NULL);
+    BatchMessageContainer::batchMessageCallBack(result, messageContainerListPtr, NULL);
 }
 
 void ProducerImpl::resendMessages(ClientConnectionPtr cnx) {

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -43,6 +43,8 @@ typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
 
 class PulsarFriend;
 
+class Producer;
+
 struct OpSendMsg {
     Message msg_;
     SendCallback sendCallback_;
@@ -109,6 +111,8 @@ class ProducerImpl : public HandlerBase,
     void batchMessageTimeoutHandler(const boost::system::error_code& ec);
 
     friend class PulsarFriend;
+
+    friend class Producer;
 
     friend class BatchMessageContainer;
 

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -38,11 +38,6 @@ DECLARE_LOG_OBJECT();
 
 using namespace pulsar;
 
-void PulsarFriend::producerFailMessages(Producer producer, Result result) {
-    ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
-    producerImpl->failPendingMessages(result);
-}
-
 static int globalTestBatchMessagesCounter = 0;
 static int globalCount = 0;
 static std::string lookupUrl = "pulsar://localhost:6650";

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -919,7 +919,7 @@ TEST(BatchMessageTest, testPartitionedTopics) {
     ASSERT_EQ(i, numOfMessages - globalPublishCountQueueFull);
 }
 
-TEST(ProducerTest, producerFailureResult) {
+TEST(BatchMessageTest, producerFailureResult) {
     std::string testName = std::to_string(epochTime) + "testCumulativeAck";
 
     ClientConfiguration clientConfig;

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -38,6 +38,11 @@ DECLARE_LOG_OBJECT();
 
 using namespace pulsar;
 
+void PulsarFriend::producerFailMessages(Producer producer, Result result) {
+    ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
+    producerImpl->failPendingMessages(result);
+}
+
 static int globalTestBatchMessagesCounter = 0;
 static int globalCount = 0;
 static std::string lookupUrl = "pulsar://localhost:6650";

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -56,6 +56,11 @@ class PulsarFriend {
         return *producerImpl;
     }
 
+    static void producerFailMessages(Producer producer, Result result) {
+        ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
+        producerImpl->failPendingMessages(result);
+    }
+
     static ConsumerImpl& getConsumerImpl(Consumer consumer) {
         ConsumerImpl* consumerImpl = static_cast<ConsumerImpl*>(consumer.impl_.get());
         return *consumerImpl;

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -56,10 +56,7 @@ class PulsarFriend {
         return *producerImpl;
     }
 
-    static void producerFailMessages(Producer producer, Result result) {
-        ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
-        producerImpl->failPendingMessages(result);
-    }
+    static void producerFailMessages(Producer producer, Result result);
 
     static ConsumerImpl& getConsumerImpl(Consumer consumer) {
         ConsumerImpl* consumerImpl = static_cast<ConsumerImpl*>(consumer.impl_.get());

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -56,7 +56,9 @@ class PulsarFriend {
         return *producerImpl;
     }
 
-    static void producerFailMessages(Producer producer, Result result);
+    static void producerFailMessages(Producer producer, Result result) {
+        producer.producerFailMessages(result);
+    }
 
     static ConsumerImpl& getConsumerImpl(Consumer consumer) {
         ConsumerImpl* consumerImpl = static_cast<ConsumerImpl*>(consumer.impl_.get());


### PR DESCRIPTION
Definitely, this is a typo. This method is dealing with the Failed Message with the GIVEN result, but not a CERTAIN result.

Contribution Checklist
#4808 : TYPO in C++ client producer method for processing failure case
Add c++ client producer failure message unit test case.

UT passed:

BatchMessageTest