### PR TITLE
Fix typo in helm chart

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/autorecovery-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/autorecovery-deployment.yaml
@@ -73,7 +73,7 @@ spec:
                 values:
                 - {{ .Values.bookkeeper.component }}
             topologyKey: "kubernetes.io/hostname"
-      terminationGracePeriodSeconds: {{ .Values.dashboard.gracePeriod }}
+      terminationGracePeriodSeconds: {{ .Values.autoRecovery.gracePeriod }}
       initContainers:
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies


### PR DESCRIPTION
### Motivation
Incorrect value is being used in Pulsar Helm template `autorecovery-deployment.yaml`

### Modifications
Proper variable name set.

### Verifying this change
Fixed variable name is already set in `values.yaml` and `values-mini.yaml`.
This change is a trivial rework / code cleanup without any test coverage.

### Documentation
None needed.
