### PR TITLE
Merge Request for #4871: change unittest code for support LLVM.

### DIFF
--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2327,7 +2327,8 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     consConfig.setConsumerType(ConsumerExclusive);
     consConfig.setReceiverQueueSize(2);
     ASSERT_FALSE(consConfig.hasMessageListener());
-    Consumer consumer[numberOfPartitions];
+    std::vector<Consumer> consumer(numberOfPartitions);
+    // Consumer consumer[numberOfPartitions];
     Result subscribeResult;
     for (int i = 0; i < numberOfPartitions; i++) {
         std::stringstream partitionedTopicName;
@@ -2539,7 +2540,8 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     consConfig.setConsumerType(ConsumerExclusive);
     consConfig.setReceiverQueueSize(2);
     ASSERT_FALSE(consConfig.hasMessageListener());
-    Consumer consumer[numberOfPartitions];
+    std::vector<Consumer> consumer(numberOfPartitions);
+    // Consumer consumer[numberOfPartitions];
     Result subscribeResult;
     for (int i = 0; i < numberOfPartitions; i++) {
         std::stringstream partitionedTopicName;

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -2328,7 +2328,6 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     consConfig.setReceiverQueueSize(2);
     ASSERT_FALSE(consConfig.hasMessageListener());
     std::vector<Consumer> consumer(numberOfPartitions);
-    // Consumer consumer[numberOfPartitions];
     Result subscribeResult;
     for (int i = 0; i < numberOfPartitions; i++) {
         std::stringstream partitionedTopicName;
@@ -2541,7 +2540,6 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     consConfig.setReceiverQueueSize(2);
     ASSERT_FALSE(consConfig.hasMessageListener());
     std::vector<Consumer> consumer(numberOfPartitions);
-    // Consumer consumer[numberOfPartitions];
     Result subscribeResult;
     for (int i = 0; i < numberOfPartitions; i++) {
         std::stringstream partitionedTopicName;


### PR DESCRIPTION
 MacOS clang/llvm compiler imcompatible code in Unit test case BasicEndToEndTest.cc 

Fixes #4871
