### PR TITLE
[Transaction][Buffer]make the transaction index to store in the ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -23,6 +23,7 @@ import com.google.common.base.Predicate;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
@@ -587,4 +588,22 @@ public interface ManagedCursor {
      */
     void setThrottleMarkDelete(double throttleMarkDelete);
 
+    /**
+     * Add entry to the cursor ledger.
+     *
+     * @param entry
+     *          the added entry
+     * @param callback
+     *          callback object returning the added entry position
+     * @param ctx
+     *          opaque context
+     */
+    void asyncAddEntry(byte[] entry, AsyncCallbacks.AddEntryCallback callback, Object ctx);
+
+    /**
+     * Get the cursor current using ledger.
+     *
+     * @return the current ledger
+     */
+    LedgerHandle getCurrentCursorLedger();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Position.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Position.java
@@ -32,4 +32,12 @@ public interface Position {
      * @return the position of the next logical entry
      */
     Position getNext();
+
+    /**
+     * Get the position of the entry previous to this one. The returned position might point to a non-existing, or not-yet
+     * existing entry
+     *
+     * @return the position of the previous logical entry
+     */
+    Position getPrev();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2581,5 +2581,25 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
+    @Override
+    public void asyncAddEntry(byte[] entry, AsyncCallbacks.AddEntryCallback callback, Object ctx) {
+        cursorLedger.asyncAddEntry(entry, (rc, lh, entryId, addCtx) -> {
+            if (rc == BKException.Code.OK) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Add entry to cursor {} ledger id: {}, entyr id: {}", ledger.getName(), name,
+                              lh.getId(), entryId);
+                }
+                callback.addComplete(new PositionImpl(lh.getId(), entryId), addCtx);
+            } else {
+                callback.addFailed(createManagedLedgerException(rc), addCtx);
+            }
+        }, ctx);
+    }
+
+    @Override
+    public LedgerHandle getCurrentCursorLedger() {
+        return cursorLedger;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(ManagedCursorImpl.class);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -75,6 +75,14 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
         return PositionImpl.get(ledgerId, entryId + 1);
     }
 
+    @Override
+    public Position getPrev() {
+        if (entryId < 0) {
+            return PositionImpl.get(ledgerId, entryId);
+        }
+        return PositionImpl.get(ledgerId, entryId - 1);
+    }
+
     /**
      * String representation of virtual cursor - LedgerId:EntryId.
      */

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
@@ -302,6 +303,16 @@ public class ManagedCursorContainerTest {
 
         @Override
         public void setThrottleMarkDelete(double throttleMarkDelete) {
+        }
+
+        @Override
+        public void asyncAddEntry(byte[] entry, AsyncCallbacks.AddEntryCallback callback, Object ctx) {
+
+        }
+
+        @Override
+        public LedgerHandle getCurrentCursorLedger() {
+            return null;
         }
 
         @Override

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/exceptions/TransactionIndexRecoveringError.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/exceptions/TransactionIndexRecoveringError.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/exceptions/TransactionIndexRecoveringError.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/exceptions/TransactionIndexRecoveringError.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.transaction.buffer.exceptions;
+
+/**
+ * Exception is when recovering transaction index.
+ */
+public class TransactionIndexRecoveringError extends TransactionBufferException {
+    private static final long serialVersionUID = 0L;
+
+    public TransactionIndexRecoveringError(String message) {
+        super(message);
+    }
+}

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/DataFormat.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/DataFormat.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.transaction.buffer.impl;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.transaction.buffer.TransactionMeta;
+import org.apache.pulsar.transaction.impl.common.TxnID;
+import org.apache.pulsar.transaction.impl.common.TxnStatus;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredEntryInfo;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredPosition;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredStatus;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredTxn;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredTxnID;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredTxnMeta;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredTxnStatus;
+
+/**
+ * Data format used to format index snapshot entry.
+ */
+public class DataFormat {
+    static StoredTxn parseStoredTxn(byte[] data) {
+        try {
+            return StoredTxn.parseFrom(data);
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static StoredTxn startStore(Position bufferPosition) {
+        return StoredTxn.newBuilder().setPosition(buildPosition(bufferPosition))
+                        .setStoredStatus(StoredStatus.START).build();
+    }
+    static StoredTxn middleStore(Position startPosition, TransactionMetaImpl meta) {
+        return StoredTxn.newBuilder().setStoredStatus(StoredStatus.MIDDLE)
+                        .setPosition(buildPosition(startPosition)).setTxnMeta(buildStoredTxnMeta(meta)).build();
+    }
+
+    static StoredTxn endStore(Position startPosition) {
+        return StoredTxn.newBuilder().setStoredStatus(StoredStatus.END)
+                        .setPosition(buildPosition(startPosition)).build();
+    }
+
+    static TransactionMeta parseToTransactionMeta(byte[] data) {
+        StoredTxn storedTxn = parseStoredTxn(data);
+        return recoverMeta(storedTxn.getTxnMeta());
+    }
+
+    private static StoredPosition buildPosition(Position position) {
+        PositionImpl newPosition = (PositionImpl) position;
+        return StoredPosition.newBuilder().setLedgerId(newPosition.getLedgerId()).setEntryId(newPosition.getEntryId())
+                             .build();
+    }
+
+    static Position recoverPosition(StoredPosition position) {
+        return new PositionImpl(position.getLedgerId(), position.getEntryId());
+    }
+
+    private static StoredTxnMeta buildStoredTxnMeta(TransactionMetaImpl meta) {
+        return StoredTxnMeta.newBuilder().setTxnId(buildTxnId(meta.getTxnID()))
+                            .setStatus(buildTxnStatus(meta.getTxnStatus()))
+                            .addAllEntryInfo(buildEntryInfoList(meta.getEntries()))
+                            .setCommittedLedger(meta.getCommittedAtLedgerId())
+                            .setCommittedEntry(meta.getCommittedAtEntryId()).build();
+    }
+
+    static TransactionMetaImpl recoverMeta(StoredTxnMeta meta) {
+        return new TransactionMetaImpl(recoverTxnId(meta.getTxnId()), recoverEntries(meta.getEntryInfoList()),
+                                       recoverStatus(meta.getStatus()), meta.getCommittedLedger(),
+                                       meta.getCommittedEntry());
+    }
+
+    private static StoredTxnID buildTxnId(TxnID txnID) {
+        return StoredTxnID.newBuilder().setLeastSigBits(txnID.getLeastSigBits()).setMostSigBits(txnID.getMostSigBits())
+                          .build();
+    }
+
+    private static TxnID recoverTxnId(StoredTxnID txnID) {
+        return new TxnID(txnID.getMostSigBits(), txnID.getLeastSigBits());
+    }
+
+    private static List<StoredEntryInfo> buildEntryInfoList(SortedMap<Long, Position> entries) {
+        return entries.entrySet().stream()
+                      .map(entry -> StoredEntryInfo.newBuilder()
+                                                   .setPosition(buildPosition(entry.getValue()))
+                                                   .setSequenceId(entry.getKey())
+                                                   .build())
+                      .collect(Collectors.toList());
+    }
+    @Builder
+    @Getter
+    final static class EntryInfo {
+        long sequenceId;
+        Position position;
+    }
+
+    private static SortedMap<Long, Position> recoverEntries(List<StoredEntryInfo> entries) {
+        Map<Long, Position> index = entries.stream().map(
+            storedEntryInfo -> EntryInfo.builder().sequenceId(storedEntryInfo.getSequenceId())
+                                        .position(recoverPosition(storedEntryInfo.getPosition())).build())
+                                           .collect(Collectors.toMap(EntryInfo::getSequenceId, EntryInfo::getPosition));
+        return new TreeMap<>(index);
+    }
+
+    private static StoredTxnStatus buildTxnStatus(TxnStatus status) {
+        return StoredTxnStatus.valueOf(status.name());
+    }
+
+    private static TxnStatus recoverStatus(StoredTxnStatus storedStatus) {
+        return TxnStatus.valueOf(storedStatus.name());
+    }
+}

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -51,8 +51,6 @@ import org.apache.pulsar.transaction.impl.common.TxnID;
 @Slf4j
 public class PersistentTransactionBuffer extends PersistentTopic implements TransactionBuffer {
 
-    static final String TXN_CURSOR_NAME = "pulsar.transaction";
-
     private TransactionCursor txnCursor;
     private ManagedCursor retentionCursor;
 

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -51,6 +51,8 @@ import org.apache.pulsar.transaction.impl.common.TxnID;
 @Slf4j
 public class PersistentTransactionBuffer extends PersistentTopic implements TransactionBuffer {
 
+    static final String TXN_CURSOR_NAME = "pulsar.transaction";
+
     private TransactionCursor txnCursor;
     private ManagedCursor retentionCursor;
 
@@ -80,9 +82,9 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
     }
 
     public PersistentTransactionBuffer(String topic, ManagedLedger ledger, BrokerService brokerService)
-        throws BrokerServiceException.NamingException, ManagedLedgerException {
+        throws BrokerServiceException.NamingException, ManagedLedgerException, InterruptedException {
         super(topic, ledger, brokerService);
-        this.txnCursor = new TransactionCursorImpl();
+        this.txnCursor = new TransactionCursorImpl(ledger);
         this.retentionCursor = ledger.newNonDurableCursor(PositionImpl.earliest);
     }
 

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -73,7 +73,8 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
 
     private CompletableFuture<List<TransactionEntry>> readEntry(SortedMap<Long, Position> entries) {
         CompletableFuture<List<TransactionEntry>> readFuture = new CompletableFuture<>();
-        List<TransactionEntry> txnEntries = new ArrayList<>(entries.size()); List<CompletableFuture<Void>> futures = new ArrayList<>();
+        List<TransactionEntry> txnEntries = new ArrayList<>(entries.size());
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (Map.Entry<Long, Position> longPositionEntry : entries.entrySet()) {
             CompletableFuture<Void> tmpFuture = new CompletableFuture<>();
             readEntry(longPositionEntry.getValue()).whenComplete((entry, throwable) -> {

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -73,9 +73,7 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
 
     private CompletableFuture<List<TransactionEntry>> readEntry(SortedMap<Long, Position> entries) {
         CompletableFuture<List<TransactionEntry>> readFuture = new CompletableFuture<>();
-        List<TransactionEntry> txnEntries = new ArrayList<>(entries.size());
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
-
+        List<TransactionEntry> txnEntries = new ArrayList<>(entries.size()); List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (Map.Entry<Long, Position> longPositionEntry : entries.entrySet()) {
             CompletableFuture<Void> tmpFuture = new CompletableFuture<>();
             readEntry(longPositionEntry.getValue()).whenComplete((entry, throwable) -> {

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionCursorImpl.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionCursorImpl.java
@@ -18,29 +18,111 @@
  */
 package org.apache.pulsar.transaction.buffer.impl;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarMarkers;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.Markers;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.transaction.buffer.TransactionCursor;
 import org.apache.pulsar.transaction.buffer.TransactionMeta;
 import org.apache.pulsar.transaction.buffer.exceptions.NoTxnsCommittedAtLedgerException;
+import org.apache.pulsar.transaction.buffer.exceptions.TransactionIndexRecoveringError;
 import org.apache.pulsar.transaction.buffer.exceptions.TransactionNotFoundException;
 import org.apache.pulsar.transaction.impl.common.TxnID;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats.StoredTxn;
 
+@Slf4j
 public class TransactionCursorImpl implements TransactionCursor {
 
+    private final ManagedLedger txnLog;
+    private volatile AtomicReference<ManagedCursor> indexCursor = new AtomicReference<>();
 
     private final ConcurrentMap<TxnID, TransactionMetaImpl> txnIndex;
     private final Map<Long, Set<TxnID>> committedLedgerTxnIndex;
 
-    TransactionCursorImpl() {
+    TransactionCursorImpl(ManagedLedger ledger) throws InterruptedException {
         this.txnIndex = new ConcurrentHashMap<>();
         this.committedLedgerTxnIndex = new TreeMap<>();
+        this.txnLog = ledger;
+        initializeTransactionCursor();
+    }
+
+    @VisibleForTesting
+    void addToTxnIndex(TransactionMetaImpl meta) {
+        txnIndex.putIfAbsent(meta.id(), meta);
+    }
+
+    @VisibleForTesting
+    void addToCommittedLedgerTxnIndex(long ledgerId, TxnID txnID) {
+        committedLedgerTxnIndex.computeIfAbsent(ledgerId, ledger -> new HashSet<>()).add(txnID);
+    }
+
+    @VisibleForTesting
+    TransactionMetaImpl findInIndex(TxnID txnID) {
+        return txnIndex.get(txnID);
+    }
+
+    @VisibleForTesting
+    LedgerHandle getCursorLedger() {
+        return indexCursor.get().getCurrentCursorLedger();
+    }
+
+    private void initializeTransactionCursor() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        txnLog.asyncOpenCursor(PersistentTransactionBuffer.TXN_CURSOR_NAME, new AsyncCallbacks.OpenCursorCallback() {
+            @Override
+            public void openCursorComplete(ManagedCursor cursor, Object ctx) {
+                cursor.setAlwaysInactive();
+                indexCursor.compareAndSet(null, cursor);
+                recover().whenComplete((ignore, error) -> {
+                    if (error != null) {
+                        log.error("Failed to recover the transaction index");
+                    } else {
+                        log.info("Succeed to recover the transaction index.");
+                    }
+                    latch.countDown();
+                });
+            }
+
+            @Override
+            public void openCursorFailed(ManagedLedgerException exception, Object ctx) {
+                log.error("Failed to open the transaction index cursor to recover transaction index", exception);
+                latch.countDown();
+            }
+        }, null);
+
+        latch.await();
     }
 
     @Override
@@ -55,10 +137,7 @@ public class TransactionCursorImpl implements TransactionCursor {
             }
 
             TransactionMetaImpl newMeta = new TransactionMetaImpl(txnID);
-            TransactionMeta oldMeta = txnIndex.putIfAbsent(txnID, newMeta);
-            if (null != oldMeta) {
-                meta = oldMeta;
-            } else {
+            TransactionMeta oldMeta = txnIndex.putIfAbsent(txnID, newMeta); if (null != oldMeta) { meta = oldMeta; } else {
                 meta = newMeta;
             }
         }
@@ -122,5 +201,378 @@ public class TransactionCursorImpl implements TransactionCursor {
         }
 
         return removeFuture;
+    }
+
+    // Take a snapshot for all indexes. We can persist the transaction meta because the indexes can be rebuilt by it.
+    // a. Create a begin block and put the current transaction log position into it.
+    // b. Create the middle  block to store the transaction meta  and the snapshot start position.
+    // c. Create the end block to say the snapshot is ending and put the sanpshot start position to get the number of
+    //    snapshot blocks  when recovering.
+    public CompletableFuture<Void> takeSnapshot(Position txnBufferPosition) {
+        return startSnapshot(txnBufferPosition)
+            .thenCompose(position -> indexSnapshot(position, txnIndex.values()))
+            .thenCompose(position -> endSnapshot(position));
+    }
+
+    private CompletableFuture<Position> startSnapshot(Position position) {
+        return record(DataFormat.startStore(position));
+    }
+
+    private CompletableFuture<Position> indexSnapshot(Position startSnapshotPos,
+                                               Collection<TransactionMetaImpl> snapshotsMeta) {
+        List<CompletableFuture<Position>> snapshot =
+            snapshotsMeta.stream()
+                         .map(meta -> record(DataFormat.middleStore(startSnapshotPos, (TransactionMetaImpl) meta)))
+                         .collect(Collectors.toList());
+
+        return FutureUtil.waitForAll(snapshot).thenApply(ignore -> startSnapshotPos);
+    }
+
+    private CompletableFuture<Void> endSnapshot(Position startPos) {
+        return record(DataFormat.endStore(startPos)).thenApply(position -> null);
+    }
+
+    private CompletableFuture<Position> record(StoredTxn storedTxn) {
+        CompletableFuture<Position> recordFuture = new CompletableFuture<>();
+
+        indexCursor.get().asyncAddEntry(storedTxn.toByteArray(), new AsyncCallbacks.AddEntryCallback() {
+            @Override
+            public void addComplete(Position position, Object ctx) {
+                if (log.isDebugEnabled()) {
+                    log.info("Success to record the txn [{} - {}:{}] at [{}]", storedTxn.getStoredStatus(),
+                             storedTxn.getTxnMeta().getTxnId().getMostSigBits(),
+                             storedTxn.getTxnMeta().getTxnId().getLeastSigBits(), position);
+                }
+                recordFuture.complete(position);
+            }
+
+            @Override
+            public void addFailed(ManagedLedgerException exception, Object ctx) {
+                if (log.isDebugEnabled()) {
+                    log.info("Failed to record the txn [{} : {}:{}]", storedTxn.getStoredStatus(),
+                             storedTxn.getTxnMeta().getTxnId().getMostSigBits(),
+                             storedTxn.getTxnMeta().getTxnId().getLeastSigBits());
+                }
+                recordFuture.completeExceptionally(exception);
+            }
+        }, null);
+
+        return recordFuture;
+    }
+
+    // Recover the index.
+    // i. Read the last entry of the transaction cursor ledger.
+    //      a. If the end entry is the beginning of the snapshot, move backward and recover the index by c.
+    //      b. If the end entry in the middle of the snapshot, get teh snapshot beginning position, recover the index
+    //         by a.
+    //      c. If the end entry is the ending of the snapshot, get the snapshot beginning position, recover it by the
+    //         middle  entries.
+    public CompletableFuture<Void> recover() {
+        CompletableFuture<Void> recoverFuture = new CompletableFuture<>();
+
+        LedgerHandle lh = indexCursor.get().getCurrentCursorLedger();
+        long ledgerId = lh.getId();
+        long entryId = lh.getLastAddConfirmed();
+        PositionImpl currentPosition = PositionImpl.get(ledgerId, entryId);
+
+        readSpecifiedPosEntry(currentPosition)
+            .thenApply(entry -> new PersistentTxnIndexSnapshot(entry.getData()))
+            .whenComplete((snapshot, throwable) -> {
+                if (throwable != null) {
+                    recoverFuture.completeExceptionally(throwable);
+                } else {
+                    if (snapshot.status == null) {
+                        recoverFuture.complete(null);
+                    }else {
+                        switch (snapshot.status) {
+                            case START:
+                                recoverFromStart(currentPosition).whenComplete((ignore, error) -> {
+                                    checkComplete(error, recoverFuture);
+                                });
+                                break;
+                            case MIDDLE:
+                                recoverFromMiddle(snapshot).whenComplete((ignore, error) -> {
+                                    checkComplete(error, recoverFuture);
+                                });
+                                break;
+                            case END:
+                                recoverFromEnd(snapshot).whenComplete((ignore, error) -> {
+                                    checkComplete(error, recoverFuture);
+                                });
+                        }
+                    }
+                }
+            });
+
+        return recoverFuture;
+    }
+
+    private void checkComplete(Throwable error, CompletableFuture<Void> future) {
+        if (error != null) {
+            future.completeExceptionally(error);
+        } else {
+            future.complete(null);
+        }
+    }
+
+    @Getter
+    final static class PersistentTxnIndexSnapshot {
+        enum SnapshotStatus  {
+            START,
+            MIDDLE,
+            END,
+        }
+
+        SnapshotStatus status;
+        // If the status is START, the position is the position which is the transaction log doing snapshot.
+        //  If the status is others, the position is the snapshot beginning position on the cursor ledger.
+        Position position;
+        TransactionMetaImpl meta;
+
+        PersistentTxnIndexSnapshot(byte[] entry) {
+            StoredTxn txn = DataFormat.parseStoredTxn(entry);
+            switch (txn.getStoredStatus()) {
+                case START:
+                    this.status = SnapshotStatus.START;
+                    break;
+                case MIDDLE:
+                    this.status = SnapshotStatus.MIDDLE;
+                    break;
+                case END:
+                    this.status = SnapshotStatus.END;
+                    break;
+            }
+            this.meta = DataFormat.recoverMeta(txn.getTxnMeta());
+            this.position = DataFormat.recoverPosition(txn.getPosition());
+        }
+
+    }
+
+    private CompletableFuture<Void> recoverFromStart(Position currentPosition) {
+        return readPrevEntry(currentPosition)
+                   .thenApply(entry -> new PersistentTxnIndexSnapshot(entry.getData()))
+                   .thenCompose(this::recoverFromEnd);
+
+    }
+
+    private CompletableFuture<Entry> readPrevEntry(Position position) {
+        PositionImpl currentPos = (PositionImpl) position;
+        if (currentPos.getEntryId() == 0) {
+            return FutureUtil.failedFuture(
+                new TransactionIndexRecoveringError("Not found the prev position of the current position " + position));
+        }
+
+        PositionImpl prevPosition = PositionImpl.get(currentPos.getLedgerId(), currentPos.getEntryId() - 1);
+        return readSpecifiedPosEntry(prevPosition);
+    }
+
+    private CompletableFuture<Void> recoverFromMiddle(PersistentTxnIndexSnapshot snapshot) {
+        return readSpecifiedPosEntry(snapshot.position)
+                   .thenApply(entry -> new PersistentTxnIndexSnapshot(entry.getData()))
+                   .thenCompose(startBlock -> recoverFromStart(snapshot.position));
+
+    }
+
+    private CompletableFuture<Entry> readSpecifiedPosEntry(Position position) {
+        CompletableFuture<Entry> readFuture = new CompletableFuture<>();
+
+        PositionImpl readPos = (PositionImpl) position;
+        LedgerHandle ledger = indexCursor.get().getCurrentCursorLedger();
+
+        ledger.asyncReadEntries(readPos.getEntryId(), readPos.getEntryId(), (rc, handle, entries, ctx) -> {
+            if (rc != BKException.Code.OK) {
+                readFuture.completeExceptionally(BKException.create(rc));
+            } else {
+                if (entries.hasMoreElements()) {
+                    LedgerEntry ledgerEntry = entries.nextElement();
+                    EntryImpl entry = EntryImpl.create(ledgerEntry.getLedgerId(), ledgerEntry.getEntryId(),
+                                                       ledgerEntry.getEntry());
+
+                    readFuture.complete(entry);
+                } else {
+                    readFuture.completeExceptionally(new NoSuchElementException(
+                        "No such entry " + readPos.getEntryId() + " in ledger " + handle.getId()));
+                }
+            }
+        }, null);
+
+        return readFuture;
+    }
+
+    private CompletableFuture<Void> recoverFromEnd(PersistentTxnIndexSnapshot snapshot) {
+        return recoverFromLedger(snapshot);
+    }
+
+    private CompletableFuture<Void> recoverFromLedger(PersistentTxnIndexSnapshot snapshot) {
+        return readEntryFromCursorLedger(snapshot.position, indexCursor.get().getCurrentCursorLedger())
+            .thenApply(entries ->
+                           entries.stream()
+                                  .map(entry -> new PersistentTxnIndexSnapshot(entry.getData()))
+                                  .filter(tmpSnapshot ->
+                                              !tmpSnapshot.getStatus()
+                                                         .equals(PersistentTxnIndexSnapshot.SnapshotStatus.END))
+                                  .collect(Collectors.toList()))
+            .thenCompose(snapshots -> rebuildIndex(snapshots))
+            .thenCompose(beginning -> replayTxnLogEntries(beginning.position));
+    }
+
+    private CompletableFuture<PersistentTxnIndexSnapshot> rebuildIndex(List<PersistentTxnIndexSnapshot> snapshots) {
+        List<CompletableFuture<Void>> rebuildFutre = new ArrayList<>();
+
+        snapshots.stream()
+                 .filter(snapshot -> snapshot.getStatus().equals(PersistentTxnIndexSnapshot.SnapshotStatus.MIDDLE))
+                 .map(snapshot -> snapshot.getMeta())
+                 .forEach(transactionMeta -> rebuildFutre.add(rebuildIndexByEntry(transactionMeta)));
+
+        return FutureUtil.waitForAll(rebuildFutre).thenCompose(ignore -> findStart(snapshots));
+    }
+
+    private CompletableFuture<PersistentTxnIndexSnapshot> findStart(List<PersistentTxnIndexSnapshot> snapshots) {
+        List<PersistentTxnIndexSnapshot> beginning = snapshots.stream()
+                 .filter(snapshot -> snapshot.getStatus().equals(PersistentTxnIndexSnapshot.SnapshotStatus.START))
+                 .collect(Collectors.toList());
+
+        if (beginning.size() != 1 || beginning.get(0) == null) {
+            return FutureUtil.failedFuture(new TransactionIndexRecoveringError(
+                "Found more than one START when recovering transaction index on cursor ledger: "
+                + indexCursor.get().getCurrentCursorLedger().getId()));
+        }
+
+        return CompletableFuture.completedFuture(beginning.get(0));
+    }
+
+    private CompletableFuture<Void> rebuildIndexByEntry(TransactionMetaImpl meta) {
+        // add to transaction index
+        txnIndex.putIfAbsent(meta.id(), meta);
+
+        // add to committed ledger transaction index
+        synchronized (committedLedgerTxnIndex) {
+            if (meta.isCommitted()) {
+                addTxnToCommittedIndex(meta.id(), meta.committedAtLedgerId());
+            }
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private CompletableFuture<List<Entry>> readEntryFromCursorLedger(Position startSnapshotPos,
+                                                                     LedgerHandle cursorLedger) {
+        CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
+        PositionImpl startPos = (PositionImpl) startSnapshotPos;
+        long startEntryId = startPos.getEntryId();
+        long endEntryId = cursorLedger.getLastAddConfirmed();
+
+        cursorLedger.asyncReadEntries(startEntryId, endEntryId, (rc, handle, entries, ctx) -> {
+            if (rc != BKException.Code.OK) {
+                readFuture.completeExceptionally(BKException.create(rc));
+            } else {
+                if (entries.hasMoreElements()) {
+                    List<Entry> entryList = Collections.list(entries)
+                                                       .stream()
+                                                       .map(ledgerEntry -> EntryImpl.create(ledgerEntry.getLedgerId()
+                                                           , ledgerEntry.getEntryId(), ledgerEntry.getEntry()))
+                                                       .collect(Collectors.toList());
+                    readFuture.complete(entryList);
+                } else {
+                    readFuture.completeExceptionally(new NoSuchElementException(
+                        "No more entry can read from ledger: " + handle.getId() + ", entry: " + startEntryId));
+                }
+            }
+        }, null);
+
+        return readFuture;
+    }
+
+    private CompletableFuture<List<Entry>> readEntryFromLedger(Position startSnapshotPos, ManagedLedger managedLedger) {
+        CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
+
+        List<CompletableFuture<Void>> readAllEntryFuture = new ArrayList<>();
+        List<Entry> entryList = new ArrayList<>();
+        ManagedLedger cursorLedger = managedLedger;
+        ManagedCursor readCursor = null;
+        try {
+            readCursor = cursorLedger.newNonDurableCursor(startSnapshotPos);
+
+            while (readCursor.hasMoreEntries()) {
+                CompletableFuture<Void> readEntries = new CompletableFuture<>();
+                readCursor.asyncReadEntries(100, new AsyncCallbacks.ReadEntriesCallback() {
+                    @Override
+                    public void readEntriesComplete(List<Entry> entries, Object ctx) {
+                        synchronized (entryList) {
+                            entryList.addAll(entries);
+                        }
+                        readEntries.complete(null);
+                    }
+
+                    @Override
+                    public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+                        readEntries.completeExceptionally(exception);
+                    }
+                }, null);
+                readAllEntryFuture.add(readEntries);
+            }
+
+            FutureUtil.waitForAll(readAllEntryFuture).whenComplete((ignore, error) -> {
+                if (error != null) {
+                    readFuture.completeExceptionally(error);
+                } else {
+                    readFuture.complete(entryList);
+                }
+            });
+
+        } catch (ManagedLedgerException e) {
+            readFuture.completeExceptionally(e);
+        } finally {
+            if (readCursor != null) {
+                readCursor.asyncClose(new AsyncCallbacks.CloseCallback() {
+                    @Override
+                    public void closeComplete(Object ctx) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Cursor for recovering the transaction index is closed");
+                        }
+                    }
+
+                    @Override
+                    public void closeFailed(ManagedLedgerException exception, Object ctx) {
+                        log.error("Failed close the cursor for recovering the transaction index.", exception);
+                    }
+                }, null);
+            }
+        }
+        return readFuture;
+    }
+
+    // Replay all messages from the previous snapshot position on the transaction log.
+    private CompletableFuture<Void> replayTxnLogEntries(Position position) {
+        return readEntryFromLedger(position, txnLog).thenAccept(entries -> entries.forEach(this::replayEntry));
+    }
+
+    private CompletableFuture<Void> replayEntry(Entry entry) {
+        PulsarApi.MessageMetadata messageMetadata = Commands.parseMessageMetadata(entry.getDataBuffer());
+
+        TxnID txnID = new TxnID(messageMetadata.getTxnidMostBits(), messageMetadata.getTxnidLeastBits());
+        long sequenceId = messageMetadata.getSequenceId();
+
+        switch (messageMetadata.getMarkerType()) {
+            case PulsarMarkers.MarkerType.TXN_COMMIT_VALUE:
+                return replayCommitMarker(txnID, entry);
+            case PulsarMarkers.MarkerType.TXN_ABORT_VALUE:
+                return abortTxn(txnID);
+            default:
+                return getTxnMeta(txnID, true)
+                           .thenCompose(meta -> meta.appendEntry(sequenceId, entry.getPosition()));
+        }
+    }
+
+    private CompletableFuture<Void> replayCommitMarker(TxnID txnID, Entry entry) {
+        try {
+            PulsarMarkers.TxnCommitMarker marker = Markers.parseCommitMarker(entry.getDataBuffer());
+            long committedLedger = marker.getMessageId().getLedgerId();
+            long committedEntry = marker.getMessageId().getEntryId();
+
+            return commitTxn(committedLedger, committedEntry, txnID, entry.getPosition());
+        } catch (IOException e) {
+            return FutureUtil.failedFuture(e);
+        }
     }
 }

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionCursorImpl.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionCursorImpl.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +136,10 @@ public class TransactionCursorImpl implements TransactionCursor {
             }
 
             TransactionMetaImpl newMeta = new TransactionMetaImpl(txnID);
-            TransactionMeta oldMeta = txnIndex.putIfAbsent(txnID, newMeta); if (null != oldMeta) { meta = oldMeta; } else {
+            TransactionMeta oldMeta = txnIndex.putIfAbsent(txnID, newMeta);
+            if (null != oldMeta) {
+                meta = oldMeta;
+            } else {
                 meta = newMeta;
             }
         }
@@ -283,7 +285,7 @@ public class TransactionCursorImpl implements TransactionCursor {
                 } else {
                     if (snapshot.status == null) {
                         recoverFuture.complete(null);
-                    }else {
+                    } else {
                         switch (snapshot.status) {
                             case START:
                                 recoverFromStart(currentPosition).whenComplete((ignore, error) -> {

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionMetaImpl.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionMetaImpl.java
@@ -24,7 +24,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.transaction.buffer.TransactionMeta;

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionMetaImpl.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/TransactionMetaImpl.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.transaction.buffer.TransactionMeta;
 import org.apache.pulsar.transaction.buffer.exceptions.EndOfTransactionException;
@@ -31,6 +34,8 @@ import org.apache.pulsar.transaction.buffer.exceptions.UnexpectedTxnStatusExcept
 import org.apache.pulsar.transaction.impl.common.TxnID;
 import org.apache.pulsar.transaction.impl.common.TxnStatus;
 
+@AllArgsConstructor
+@Getter
 public class TransactionMetaImpl implements TransactionMeta {
 
     private final TxnID txnID;
@@ -160,4 +165,9 @@ public class TransactionMetaImpl implements TransactionMeta {
         }
         return true;
     }
+
+    public boolean isCommitted() {
+        return committedAtLedgerId != -1L && committedAtEntryId != -1L;
+    }
+
 }

--- a/pulsar-transaction/buffer/src/main/proto/TransactionBufferDataFormats.proto
+++ b/pulsar-transaction/buffer/src/main/proto/TransactionBufferDataFormats.proto
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+
+option java_package = "org.apache.pulsar.transaction.proto";
+option optimize_for = LITE_RUNTIME;
+
+message StoredTxnID {
+    int64 mostSigBits = 1;
+    int64 leastSigBits = 2;
+}
+
+enum StoredTxnStatus {
+    OPEN = 0;
+    COMMITTING = 1;
+    COMMITTED = 2;
+    ABORTING = 3;
+    ABORTED = 4;
+}
+
+message StoredPosition {
+    int64 ledger_id = 1;
+    int64 entry_id = 2;
+}
+
+message StoredEntryInfo {
+    StoredPosition position = 1;
+    int64 sequenceId = 2;
+}
+
+message StoredTxnMeta {
+    StoredTxnID txn_id = 1;
+    repeated StoredEntryInfo entry_info = 2;
+    StoredTxnStatus status = 3;
+    int64 committed_ledger = 4;
+    int64 committed_entry = 5;
+}
+
+enum StoredStatus {
+    START   = 0; // the index log start marker
+    MIDDLE  = 1; // index log
+    END     = 2; // the index log end marker
+}
+
+message StoredTxn {
+    StoredStatus stored_status = 1;
+    StoredPosition position= 2;
+    StoredTxnMeta txn_meta = 3;
+}
+
+enum MarkerStatus {
+    COMMIT = 0;
+    ABORT = 1;
+}
+
+message Marker {
+    StoredTxnID txn_id = 1;
+    int64 committed_ledger = 2;
+    int64 committed_entry = 3;
+    MarkerStatus status = 4;
+}

--- a/pulsar-transaction/buffer/src/main/proto/TransactionBufferDataFormats.proto
+++ b/pulsar-transaction/buffer/src/main/proto/TransactionBufferDataFormats.proto
@@ -52,14 +52,14 @@ message StoredTxnMeta {
     int64 committed_entry = 5;
 }
 
-enum StoredStatus {
+enum StoredSnapshotStatus {
     START   = 0; // the index log start marker
     MIDDLE  = 1; // index log
     END     = 2; // the index log end marker
 }
 
-message StoredTxn {
-    StoredStatus stored_status = 1;
+message StoredTxnIndexEntry {
+    StoredSnapshotStatus stored_status = 1;
     StoredPosition position= 2;
     StoredTxnMeta txn_meta = 3;
 }

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.transaction.buffer.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.mockito.ArgumentMatchers.endsWith;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.transaction.buffer.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.pulsar.transaction.buffer.TransactionMeta;
+import org.apache.pulsar.transaction.impl.common.TxnID;
+import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats;
+import org.testng.annotations.Test;
+
+public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
+
+    private Random randomGenerator = new Random(System.currentTimeMillis());
+
+    @Test
+    public void testTakeSnapshot() throws ManagedLedgerException, InterruptedException, ExecutionException,
+                                          BKException {
+        ManagedLedger txnlog = factory.open("test_takesnapshot");
+        TransactionCursorImpl cursor = new TransactionCursorImpl(txnlog);
+        List<TransactionMetaImpl> metaList = createExampleData(20);
+        metaList.forEach(cursor::addToTxnIndex);
+        List<TxnID> txnIDList = metaList.stream().map(TransactionMetaImpl::getTxnID).collect(Collectors.toList());
+        cursor.takeSnapshot(PositionImpl.get(-1L, -1L)).get();
+
+        LedgerHandle readLedger = cursor.getCursorLedger();
+        assertEquals(readLedger.getLastAddConfirmed(), 22);
+
+        Enumeration<LedgerEntry> entryList = readLedger.readEntries(0, readLedger.getLastAddConfirmed());
+
+        int count = -1;
+        while (entryList.hasMoreElements()) {
+            if (count == -1) {
+                entryList.nextElement();
+                count++;
+                continue;
+            }
+            LedgerEntry ledgerEntry = entryList.nextElement();
+            byte[] data = ledgerEntry.getEntry();
+            TransactionBufferDataFormats.StoredTxn txn = DataFormat.parseStoredTxn(data);
+            if (count == 0) {
+                assertEquals(txn.getStoredStatus(), TransactionBufferDataFormats.StoredStatus.START);
+                assertEquals(txn.getPosition().getLedgerId(), -1L);
+                assertEquals(txn.getPosition().getEntryId(), -1L);
+                count++;
+                continue;
+            }
+
+            if (count == metaList.size() + 1) {
+                assertEquals(txn.getStoredStatus(), TransactionBufferDataFormats.StoredStatus.END);
+                assertEquals(txn.getPosition().getLedgerId(), readLedger.getId());
+                assertEquals(txn.getPosition().getEntryId(), 1);
+                count++;
+                continue;
+            }
+            assertEquals(txn.getStoredStatus(), TransactionBufferDataFormats.StoredStatus.MIDDLE);
+            assertEquals(txn.getPosition().getLedgerId(), readLedger.getId());
+            assertEquals(txn.getPosition().getEntryId(), 1);
+            TransactionMetaImpl meta = (TransactionMetaImpl) DataFormat.parseToTransactionMeta(data);
+            assertTrue(txnIDList.remove(meta.getTxnID()));
+            count++;
+        }
+    }
+
+    @Test
+    public void testRecoverTxnIndex()
+        throws ManagedLedgerException, InterruptedException, BKException, ExecutionException {
+        ManagedLedger txnLog = factory.open("test_recover_txnindex");
+        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLog);
+
+        LedgerHandle write = cursor.getCursorLedger();
+        List<TransactionMetaImpl> metaList = createExampleData(10);
+        for (TransactionMetaImpl transactionMeta : metaList) {
+            TransactionMeta meta = cursor.findInIndex(transactionMeta.getTxnID());
+            assertNull(meta);
+        }
+
+        writeExampleDataToLedger(write, metaList);
+
+        cursor.recover().get();
+
+        for (TransactionMetaImpl transactionMeta : metaList) {
+            TransactionMeta meta = cursor.findInIndex(transactionMeta.getTxnID());
+            assertEquals(((TransactionMetaImpl) meta).getTxnID(), transactionMeta.getTxnID());
+        }
+    }
+
+    private void writeExampleDataToLedger(LedgerHandle ledgerHandle, List<TransactionMetaImpl> metaList)
+        throws BKException, InterruptedException {
+        TransactionBufferDataFormats.StoredTxn startStore = DataFormat.startStore(PositionImpl.get(-1, -1));
+        long startEntryId = ledgerHandle.addEntry(startStore.toByteArray());
+
+        PositionImpl startPos = PositionImpl.get(ledgerHandle.getId(), startEntryId);
+        for (TransactionMetaImpl meta : metaList) {
+            TransactionBufferDataFormats.StoredTxn middleStore = DataFormat.middleStore(startPos, meta);
+            ledgerHandle.addEntry(middleStore.toByteArray());
+        }
+
+        TransactionBufferDataFormats.StoredTxn endStore = DataFormat.endStore(startPos);
+        ledgerHandle.addEntry(endStore.toByteArray());
+    }
+
+    private List<TransactionMetaImpl> createExampleData(int num) {
+        List<TransactionMetaImpl> metaList = new ArrayList<>(num);
+        for (int i = 0; i < 20; i++) {
+            long mostBits = randomGenerator.nextInt(1000);
+            long leastBits = randomGenerator.nextInt(1000);
+            TxnID txnID = new TxnID(mostBits, leastBits);
+            TransactionMetaImpl meta = new TransactionMetaImpl(txnID);
+            metaList.add(meta);
+        }
+        return metaList;
+    }
+
+}

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -52,6 +52,8 @@ import org.apache.pulsar.transaction.buffer.TransactionMeta;
 import org.apache.pulsar.transaction.buffer.exceptions.TransactionNotFoundException;
 import org.apache.pulsar.transaction.impl.common.TxnID;
 import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
@@ -113,9 +115,11 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     //      c. verify the transaction index
     @Test
     public void testRecoverNormalTxnIndex() throws Exception {
-        ManagedLedger txnLog = factory.open("test_recover_txnindex");
-        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLog).get();
 
+        ManagedLedger txnLog = factory.open("test_recover_txnindex");
+        Logger logger = LoggerFactory.getLogger(TransactionCursorImpl.class);
+
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLog).get();
         LedgerHandle write = cursor.getCursorLedger();
         List<TransactionMetaImpl> metaList = createExampleData(10);
         for (TransactionMetaImpl transactionMeta : metaList) {

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -62,7 +62,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     public void testTakeSnapshot() throws ManagedLedgerException, InterruptedException, ExecutionException,
                                           BKException {
         ManagedLedger txnlog = factory.open("test_takesnapshot");
-        TransactionCursorImpl cursor = new TransactionCursorImpl(txnlog);
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnlog).get();
         List<TransactionMetaImpl> metaList = createExampleData(20);
         metaList.forEach(cursor::addToTxnIndex);
         List<TxnID> txnIDList = metaList.stream().map(TransactionMetaImpl::getTxnID).collect(Collectors.toList());
@@ -114,7 +114,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     @Test
     public void testRecoverNormalTxnIndex() throws Exception {
         ManagedLedger txnLog = factory.open("test_recover_txnindex");
-        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLog);
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLog).get();
 
         LedgerHandle write = cursor.getCursorLedger();
         List<TransactionMetaImpl> metaList = createExampleData(10);
@@ -142,7 +142,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     public void testRecoverTxnIndexFromTxnLog1() throws ManagedLedgerException, InterruptedException,
                                                        ExecutionException {
         ManagedLedger txnLedger = factory.open("test_recover1");
-        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLedger).get();
         long committedAtLedgerId = 1234L;
         long committedAtEntryId = 2345L;
         long mostBits = randomGenerator.nextInt(1000);
@@ -182,7 +182,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     @Test
     public void testRecoverTxnIndexFromTxnLog2() throws Exception {
         ManagedLedger txnLedger = factory.open("test_recover2");
-        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLedger).get();
         long committedAtLedgerId = randomGenerator.nextInt(1000);
         long committedAtEntryId = randomGenerator.nextInt(1000);
 
@@ -232,7 +232,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
     @Test
     public void testRecoverTxnIndexFromTxnLog3() throws Exception {
         ManagedLedger txnLedger = factory.open("test_recover3");
-        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+        TransactionCursorImpl cursor = TransactionCursorImpl.createTransactionCursor(txnLedger).get();
 
         long committedAtLedgerId = randomGenerator.nextInt(1000);
         long committedAtEntryId = randomGenerator.nextInt(1000);

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -118,16 +118,16 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
 
     private void writeExampleDataToLedger(LedgerHandle ledgerHandle, List<TransactionMetaImpl> metaList)
         throws BKException, InterruptedException {
-        TransactionBufferDataFormats.StoredTxn startStore = DataFormat.startStore(PositionImpl.get(-1, -1));
+        TransactionBufferDataFormats.StoredTxn startStore = DataFormat.newSnapshotStartEntry(PositionImpl.get(-1, -1));
         long startEntryId = ledgerHandle.addEntry(startStore.toByteArray());
 
         PositionImpl startPos = PositionImpl.get(ledgerHandle.getId(), startEntryId);
         for (TransactionMetaImpl meta : metaList) {
-            TransactionBufferDataFormats.StoredTxn middleStore = DataFormat.middleStore(startPos, meta);
+            TransactionBufferDataFormats.StoredTxn middleStore = DataFormat.newSnapshotMiddleEntry(startPos, meta);
             ledgerHandle.addEntry(middleStore.toByteArray());
         }
 
-        TransactionBufferDataFormats.StoredTxn endStore = DataFormat.endStore(startPos);
+        TransactionBufferDataFormats.StoredTxn endStore = DataFormat.newSnapshotEndEntry(startPos);
         ledgerHandle.addEntry(endStore.toByteArray());
     }
 

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTxnIndexTest.java
@@ -18,24 +18,38 @@
  */
 package org.apache.pulsar.transaction.buffer.impl;
 
+import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarMarkers;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.transaction.buffer.TransactionMeta;
+import org.apache.pulsar.transaction.buffer.exceptions.TransactionNotFoundException;
 import org.apache.pulsar.transaction.impl.common.TxnID;
 import org.apache.pulsar.transaction.proto.TransactionBufferDataFormats;
 import org.testng.annotations.Test;
@@ -93,9 +107,12 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
         }
     }
 
+    // test the recover as this flow:
+    //      a. write some snapshot messages in the cursor ledger
+    //      b. execute the recover logic to recover the transaction index
+    //      c. verify the transaction index
     @Test
-    public void testRecoverTxnIndex()
-        throws ManagedLedgerException, InterruptedException, BKException, ExecutionException {
+    public void testRecoverNormalTxnIndex() throws Exception {
         ManagedLedger txnLog = factory.open("test_recover_txnindex");
         TransactionCursorImpl cursor = new TransactionCursorImpl(txnLog);
 
@@ -106,7 +123,7 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
             assertNull(meta);
         }
 
-        writeExampleDataToLedger(write, metaList);
+        writeExampleDataToLedger(write, metaList, PositionImpl.earliest);
 
         cursor.recover().get();
 
@@ -116,25 +133,222 @@ public class PersistentTxnIndexTest extends MockedBookKeeperTestCase {
         }
     }
 
-    private void writeExampleDataToLedger(LedgerHandle ledgerHandle, List<TransactionMetaImpl> metaList)
-        throws BKException, InterruptedException {
-        TransactionBufferDataFormats.StoredTxnIndexEntry startStore = DataFormat.newSnapshotStartEntry(PositionImpl.get(-1,
-                                                                                                                -1));
-        long startEntryId = ledgerHandle.addEntry(startStore.toByteArray());
+    // test the  recover as this flow:
+    //      a. write some transaction messages in the transaction log
+    //      b. no snapshot messages in the cursor ledger
+    //      c. make recover the transaction index from the cursor ledger failed
+    //      d. should recover from the transaction log
+    @Test
+    public void testRecoverTxnIndexFromTxnLog1() throws ManagedLedgerException, InterruptedException,
+                                                       ExecutionException {
+        ManagedLedger txnLedger = factory.open("test_recover1");
+        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+        long committedAtLedgerId = 1234L;
+        long committedAtEntryId = 2345L;
+        long mostBits = randomGenerator.nextInt(1000);
+        long leastBits = randomGenerator.nextInt(1000);
+        TxnID txnID = new TxnID(mostBits, leastBits);
+        List<Position> positionList = generateNormalDataInTxnLog(txnID, txnLedger, committedAtLedgerId,
+                                                                 committedAtEntryId, 0, true, false);
 
-        PositionImpl startPos = PositionImpl.get(ledgerHandle.getId(), startEntryId);
-        for (TransactionMetaImpl meta : metaList) {
-            TransactionBufferDataFormats.StoredTxnIndexEntry middleStore = DataFormat.newSnapshotMiddleEntry(startPos, meta);
-            ledgerHandle.addEntry(middleStore.toByteArray());
+        assertEquals(positionList.size(), 11);
+
+        try {
+            cursor.getTxnMeta(txnID, false).get();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof TransactionNotFoundException);
         }
 
-        TransactionBufferDataFormats.StoredTxnIndexEntry endStore = DataFormat.newSnapshotEndEntry(startPos);
+        cursor.recover().get();
+
+        TransactionMetaImpl meta = (TransactionMetaImpl) cursor.getTxnMeta(txnID, false).get();
+        SortedMap<Long, Position> entries = meta.getEntries();
+
+        assertEquals(entries.size(), 10);
+        int count = 0;
+        for (Map.Entry<Long, Position> longPositionEntry : entries.entrySet()) {
+            int c = count++;
+            assertEquals(longPositionEntry.getKey().longValue(), c);
+            assertEquals(longPositionEntry.getValue(), positionList.get(c));
+        }
+    }
+
+    // test the  recover as this flow:
+    //      a. write some transaction messages in the transaction log
+    //      b. write some snapshot messages in the cursor ledger, and the position of the start snapshot point to the
+    //      last entry in the transaction log.
+    //      c. make recover the transaction index from the cursor ledger failed
+    //      d. should recover from the transaction log
+    @Test
+    public void testRecoverTxnIndexFromTxnLog2() throws Exception {
+        ManagedLedger txnLedger = factory.open("test_recover2");
+        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+        long committedAtLedgerId = randomGenerator.nextInt(1000);
+        long committedAtEntryId = randomGenerator.nextInt(1000);
+
+        long mostBits = randomGenerator.nextInt(1000);
+        long leastBits = randomGenerator.nextInt(1000);
+
+        TxnID txnID = new TxnID(mostBits, leastBits);
+        List<Position> appendOne = generateNormalDataInTxnLog(txnID, txnLedger, committedAtLedgerId,
+                                                                 committedAtEntryId, 0, false, false);
+        assertEquals(appendOne.size(), 10);
+
+        writeSnapshotStartToLedger(cursor.getCursorLedger(), appendOne.get(3));
+
+        try {
+            cursor.getTxnMeta(txnID, false).get();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof TransactionNotFoundException);
+        }
+
+        List<Position> appendTwo = generateNormalDataInTxnLog(txnID, txnLedger, committedAtLedgerId, committedAtEntryId,
+                                                              appendOne.size(), true, false);
+        assertEquals(appendTwo.size(), 11);
+
+        cursor.recover().get();
+
+        TransactionMetaImpl meta = (TransactionMetaImpl) cursor.getTxnMeta(txnID, false).get();
+        SortedMap<Long, Position> entries = meta.getEntries();
+
+        assertEquals(entries.size(), 20);
+
+        appendOne.addAll(appendTwo);
+        int count = 0;
+        for (Map.Entry<Long, Position> longPositionEntry : entries.entrySet()) {
+            int c = count++;
+            assertEquals(longPositionEntry.getKey().longValue(), c);
+            assertEquals(longPositionEntry.getValue(), appendOne.get(c));
+        }
+
+    }
+
+    // test the recover as this flow:
+    //      a. write some transaction messages in the transaction log
+    //      b. write some snapshot messages in the cursor ledger, and the position of the start snapshot point  to
+    //      the middle entry in the transaction log
+    //      c. the transaction index should recover from snapshot and then replay all entries in the transaction
+    //      log
+    @Test
+    public void testRecoverTxnIndexFromTxnLog3() throws Exception {
+        ManagedLedger txnLedger = factory.open("test_recover3");
+        TransactionCursorImpl cursor = new TransactionCursorImpl(txnLedger);
+
+        long committedAtLedgerId = randomGenerator.nextInt(1000);
+        long committedAtEntryId = randomGenerator.nextInt(1000);
+
+        long mostBits = randomGenerator.nextInt(1000);
+        long leastBits = randomGenerator.nextInt(1000);
+
+        TxnID txnID = new TxnID(mostBits, leastBits);
+        List<Position> appendOne = generateNormalDataInTxnLog(txnID, txnLedger, committedAtLedgerId, committedAtEntryId,
+                                                              0, false, false);
+        assertEquals(appendOne.size(), 10);
+
+        List<TransactionMetaImpl> metaList = createExampleData(10);
+        writeExampleDataToLedger(cursor.getCursorLedger(), metaList, appendOne.get(5));
+
+        cursor.recover().get();
+
+        TransactionMetaImpl meta = (TransactionMetaImpl) cursor.getTxnMeta(txnID, false).get();
+        SortedMap<Long, Position> entries = meta.getEntries();
+
+        // there only have 10 entries in the txnID,
+        assertEquals(entries.size(), 5);
+        int count = 5;
+        for (Map.Entry<Long, Position> longPositionEntry : entries.entrySet()) {
+            int c = count++;
+            assertEquals(longPositionEntry.getKey().longValue(), c);
+            assertEquals(longPositionEntry.getValue(), appendOne.get(c));
+        }
+
+        for (TransactionMetaImpl transactionMeta : metaList) {
+            try {
+                cursor.getTxnMeta(transactionMeta.getTxnID(), false).get();
+            } catch (Exception e) {
+                fail("Should not have any error");
+            }
+        }
+    }
+
+    private List<Position> generateNormalDataInTxnLog(TxnID txnID, ManagedLedger ledger, long commitAtLedgerId,
+                                                     long commitAtEntryId, long sequenceBase, boolean commit,
+                                                      boolean abort)
+        throws ManagedLedgerException, InterruptedException {
+        List<Position> positions = new ArrayList<>();
+        List<ByteBuf> messages = generateMessageMetaData(txnID, 10, commitAtLedgerId, commitAtEntryId, sequenceBase,
+                                                         commit, abort);
+        for (ByteBuf message : messages) {
+            Position position = ledger.addEntry(message.array());
+            positions.add(position);
+        }
+
+        return positions;
+    }
+
+    private List<ByteBuf> generateMessageMetaData(TxnID txnID, int numMessage, long commitAtLedgerId,
+                                                  long commitAtEntryId, long sequenceBase, boolean commit,
+                                                  boolean abort) {
+        List<ByteBuf> txnMessage = new ArrayList<>();
+
+        IntStream.range(0, numMessage).forEach(i -> {
+            PulsarApi.MessageMetadata.Builder messageBuilder = PulsarApi.MessageMetadata.newBuilder();
+            messageBuilder.setTxnidMostBits(txnID.getMostSigBits());
+            messageBuilder.setTxnidLeastBits(txnID.getLeastSigBits());
+            messageBuilder.setSequenceId(i + sequenceBase);
+            messageBuilder.setProducerName(txnID.toString());
+            messageBuilder.setPublishTime(System.currentTimeMillis());
+            PulsarApi.MessageMetadata messageMetadata = messageBuilder.build();
+            ByteBuf payload = Unpooled.copiedBuffer("message-" + i + sequenceBase, StandardCharsets.UTF_8);
+            ByteBuf byteBuf = serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, messageMetadata, payload);
+
+            txnMessage.add(byteBuf);
+            messageBuilder.recycle();
+            messageMetadata.recycle();
+        });
+
+        if (commit) {
+            PulsarMarkers.MessageIdData messageIdData = PulsarMarkers.MessageIdData.newBuilder()
+                                                                                   .setLedgerId(commitAtLedgerId)
+                                                                                   .setEntryId(commitAtEntryId).build();
+            ByteBuf commitMarker = Markers.newTxnCommitMarker(numMessage, txnID.getMostSigBits(), txnID.getLeastSigBits(),
+                                                              messageIdData);
+            txnMessage.add(commitMarker);
+        }
+
+        return txnMessage;
+    }
+
+    private Position writeSnapshotStartToLedger(LedgerHandle ledgerHandle, Position position) throws Exception {
+        TransactionBufferDataFormats.StoredTxnIndexEntry startStore = DataFormat.newSnapshotStartEntry(position);
+        long entryId = ledgerHandle.addEntry(startStore.toByteArray());
+        return PositionImpl.get(ledgerHandle.getId(), entryId);
+    }
+
+    private void writeSnapshotMiddleToLedger(LedgerHandle ledgerHandle, Position position,
+                                             List<TransactionMetaImpl> metaList) throws Exception {
+        for (TransactionMetaImpl meta : metaList) {
+            TransactionBufferDataFormats.StoredTxnIndexEntry middleStore = DataFormat
+                                                                               .newSnapshotMiddleEntry(position, meta);
+            ledgerHandle.addEntry(middleStore.toByteArray());
+        }
+    }
+
+    private void writeSnapshotEndToLedger(LedgerHandle ledgerHandle, Position position) throws Exception {
+        TransactionBufferDataFormats.StoredTxnIndexEntry endStore = DataFormat.newSnapshotEndEntry(position);
         ledgerHandle.addEntry(endStore.toByteArray());
+    }
+
+    private void writeExampleDataToLedger(LedgerHandle ledgerHandle, List<TransactionMetaImpl> metaList,
+                                          Position position) throws Exception {
+        Position startPos = writeSnapshotStartToLedger(ledgerHandle, position);
+        writeSnapshotMiddleToLedger(ledgerHandle, startPos, metaList);
+        writeSnapshotEndToLedger(ledgerHandle, startPos);
     }
 
     private List<TransactionMetaImpl> createExampleData(int num) {
         List<TransactionMetaImpl> metaList = new ArrayList<>(num);
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < num; i++) {
             long mostBits = randomGenerator.nextInt(1000);
             long leastBits = randomGenerator.nextInt(1000);
             TxnID txnID = new TxnID(mostBits, leastBits);


### PR DESCRIPTION
---
*Motivation*

Currently, the transaciton index is in memory. When the broker restart all indexes will be discarded. We need a mechanism to recover the index.

*Modifications*

Make the transaction index store in the cursor ledger.
