### PR TITLE
Merge Request for #4809: provide a convenient method for C++ client producer batch container

### DIFF
--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -158,11 +158,6 @@ void BatchMessageContainer::batchMessageCallBack(Result r, MessageContainerListP
     for (size_t i = 0; i < batch_size; i++) {
         messagesContainerListPtr->operator[](i).callBack(r);
     }
-    // for (MessageContainerList::iterator iter = messagesContainerListPtr->begin();
-    //      iter != messagesContainerListPtr->end(); iter++) {
-    //     // callback(result, message)
-    //     iter->sendCallback_(r, iter->message_);
-    // }
     if (flushCallback) {
         flushCallback(ResultOk);
     }

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -154,11 +154,15 @@ void BatchMessageContainer::batchMessageCallBack(Result r, MessageContainerListP
     }
     LOG_DEBUG("BatchMessageContainer::batchMessageCallBack called with [Result = "
               << r << "] [numOfMessages = " << messagesContainerListPtr->size() << "]");
-    for (MessageContainerList::iterator iter = messagesContainerListPtr->begin();
-         iter != messagesContainerListPtr->end(); iter++) {
-        // callback(result, message)
-        iter->sendCallback_(r, iter->message_);
+    size_t batch_size = messagesContainerListPtr->size();
+    for (size_t i = 0; i < batch_size; i++) {
+        messagesContainerListPtr->operator[](i).callBack(r);
     }
+    // for (MessageContainerList::iterator iter = messagesContainerListPtr->begin();
+    //      iter != messagesContainerListPtr->end(); iter++) {
+    //     // callback(result, message)
+    //     iter->sendCallback_(r, iter->message_);
+    // }
     if (flushCallback) {
         flushCallback(ResultOk);
     }

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -49,7 +49,7 @@ class BatchMessageContainer {
             : message_(message), sendCallback_(sendCallback) {}
         Message message_;
         SendCallback sendCallback_;
-        void callBack(const pulsar::Result& r){ sendCallback_(r, message_); }
+        void callBack(const pulsar::Result& r) { sendCallback_(r, message_); }
     };
     typedef std::vector<MessageContainer> MessageContainerList;
     typedef std::shared_ptr<MessageContainerList> MessageContainerListPtr;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -49,6 +49,7 @@ class BatchMessageContainer {
             : message_(message), sendCallback_(sendCallback) {}
         Message message_;
         SendCallback sendCallback_;
+        void callBack(pulsar::Result r) { sendCallback_(r, message_); }
     };
     typedef std::vector<MessageContainer> MessageContainerList;
     typedef std::shared_ptr<MessageContainerList> MessageContainerListPtr;

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -49,7 +49,7 @@ class BatchMessageContainer {
             : message_(message), sendCallback_(sendCallback) {}
         Message message_;
         SendCallback sendCallback_;
-        void callBack(pulsar::Result r) { sendCallback_(r, message_); }
+        void callBack(const pulsar::Result& r){ sendCallback_(r, message_); }
     };
     typedef std::vector<MessageContainer> MessageContainerList;
     typedef std::shared_ptr<MessageContainerList> MessageContainerListPtr;


### PR DESCRIPTION
provide a convenient method for C++ client producer batch container https://github.com/apache/pulsar/issues/4809

Formally the container element must be used like the following way:
`MessageContainerList::iterator iter = messagesContainerListPtr->begin();`
`iter->sendCallback_(r, iter->message_);`
There are totally 3 reference operation steps inside:

1. Reference an exact element of MessageContainer explicitly from outside by iteration operator;
2. Reference the `sendCallback_` function pointer of said MessageContainer element explicitly from outside;
3. Reference the `message_` member of said MessageContainer element explicitly from outside;

Besides,  there is only one incoming variable say `Result r` is given from outside; 

In an ideal design, a user of `MessageContainer` should not have to know exactly the existence of `MessageContainer::sendCallback_` or `MessageContainer::message_`, what they exactly are, either how to use them.  Organize those stuff in a right way, should be the responsibility of struct `MessageContainer` itself.

So a reasonable convenient invoking method should be like:
`MessageContainerList::iterator iter = messagesContainerListPtr->begin();`
`iter->callBack(r);`

And said `MessageContainer::callBack` function shall be implemented like below:
`void callBack(const pulsar::Result& r) { sendCallback_(r, message_); }`

Obviously, said convenient method is also an efficient one.

Moreover, use a more efficient iteration method while going through the MessageContainerList; 
From some benchmark test result in my local environment, such "for iteration based a fixed-length", will be 5 times faster than the STL::iterator operator way. 

Refer to the change on BatchMessageContainer.cc, please.
