### PR TITLE
expose getLastMessageId method in ConsumerImpl

### DIFF
--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
@@ -158,4 +158,11 @@ public class ConsumerV1Impl implements Consumer {
         return consumer.unsubscribeAsync();
     }
 
+    public MessageId getLastMessageId() throws PulsarClientException {
+        return consumer.getLastMessageId();
+    }
+
+    public CompletableFuture<MessageId> getLastMessageIdAsync() {
+        return consumer.getLastMessageIdAsync();
+    }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -368,6 +368,20 @@ public interface Consumer<T> extends Closeable {
     CompletableFuture<Void> seekAsync(long timestamp);
 
     /**
+     * Get the last message id available available for consume.
+     *
+     * @return the last message id.
+     */
+    MessageId getLastMessageId() throws PulsarClientException;
+
+    /**
+     * Get the last message id available available for consume.
+     *
+     * @return a future that can be used to track the completion of the operation.
+     */
+    CompletableFuture<MessageId> getLastMessageIdAsync();
+
+    /**
      * @return Whether the consumer is connected to the broker
      */
     boolean isConnected();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -133,9 +133,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return internalReceiveAsync();
     }
 
-    abstract protected Message<T> internalReceive() throws PulsarClientException;
+    protected abstract Message<T> internalReceive() throws PulsarClientException;
 
-    abstract protected CompletableFuture<Message<T>> internalReceiveAsync();
+    protected abstract CompletableFuture<Message<T>> internalReceiveAsync();
 
     @Override
     public Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException {
@@ -165,7 +165,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return internalReceive(timeout, unit);
     }
 
-    abstract protected Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException;
+    protected abstract Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException;
 
     @Override
     public void acknowledge(Message<?> message) throws PulsarClientException {
@@ -241,7 +241,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         negativeAcknowledge(message.getMessageId());
     }
 
-    abstract protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
+    protected abstract CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
                                                              Map<String,Long> properties);
 
     @Override
@@ -254,7 +254,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     @Override
-    abstract public CompletableFuture<Void> unsubscribeAsync();
+    public abstract CompletableFuture<Void> unsubscribeAsync();
 
     @Override
     public void close() throws PulsarClientException {
@@ -266,7 +266,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     @Override
-    abstract public CompletableFuture<Void> closeAsync();
+    public abstract CompletableFuture<Void> closeAsync();
 
 
     @Override
@@ -279,7 +279,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     @Override
-    abstract public CompletableFuture<MessageId> getLastMessageIdAsync();
+    public abstract CompletableFuture<MessageId> getLastMessageIdAsync();
 
     private boolean isCumulativeAcknowledgementAllowed(SubscriptionType type) {
         return SubscriptionType.Shared != type;
@@ -305,9 +305,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return null;
     }
 
-    abstract public int getAvailablePermits();
+    public abstract int getAvailablePermits();
 
-    abstract public int numMessagesInQueue();
+    public abstract int numMessagesInQueue();
 
     public CompletableFuture<Consumer<T>> subscribeFuture() {
         return subscribeFuture;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -268,6 +268,19 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     @Override
     abstract public CompletableFuture<Void> closeAsync();
 
+
+    @Override
+    public MessageId getLastMessageId() throws PulsarClientException {
+        try {
+            return getLastMessageIdAsync().get();
+        } catch (Exception e) {
+            throw PulsarClientException.unwrap(e);
+        }
+    }
+
+    @Override
+    abstract public CompletableFuture<MessageId> getLastMessageIdAsync();
+
     private boolean isCumulativeAcknowledgementAllowed(SubscriptionType type) {
         return SubscriptionType.Shared != type;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1481,7 +1481,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
     }
 
-    CompletableFuture<MessageId> getLastMessageIdAsync() {
+    @Override
+    public CompletableFuture<MessageId> getLastMessageIdAsync() {
         if (getState() == State.Closing || getState() == State.Closed) {
             return FutureUtil
                 .failedFuture(new PulsarClientException.AlreadyClosedException("Consumer was already closed"));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiMessageIdImpl.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.Map;
+import java.util.Objects;
+import lombok.Getter;
+import org.apache.pulsar.client.api.MessageId;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+/**
+ * A MessageId implementation that contains a map of <partitionName, MessageId>.
+ * This is useful when MessageId is need for partition/multi-topics/pattern consumer.
+ * e.g. seek(), ackCumulative(), getLastMessageId().
+ */
+public class MultiMessageIdImpl implements MessageId {
+    @Getter
+    private Map<String, MessageId> map;
+
+    MultiMessageIdImpl(Map<String, MessageId> map) {
+        this.map = map;
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(map);
+    }
+
+    @Override
+    public int compareTo(MessageId o) {
+        throw new NotImplementedException();
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -19,8 +19,14 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pulsar.client.api.MessageId;
 import org.testng.annotations.Test;
 
 /**
@@ -164,4 +170,219 @@ public class MessageIdCompareToTest  {
         assertEquals(topicMessageId2.compareTo(messageIdImpl2), 0, "Expected to be equal");
     }
 
+    @Test
+    public void testMultiMessageIdEqual() {
+        // null
+        MultiMessageIdImpl null1 = new MultiMessageIdImpl(null);
+        MultiMessageIdImpl null2 = new MultiMessageIdImpl(null);
+        assertEquals(null1, null2);
+
+        // empty
+        MultiMessageIdImpl empty1 = new MultiMessageIdImpl(Collections.emptyMap());
+        MultiMessageIdImpl empty2 = new MultiMessageIdImpl(Collections.emptyMap());
+        assertEquals(empty1, empty2);
+
+        // null empty
+        assertEquals(null1, empty2);
+        assertEquals(empty2, null1);
+
+        // 1 item
+        String topic1 = "topicName1";
+        MessageIdImpl messageIdImpl1 = new MessageIdImpl(123L, 345L, 567);
+        MessageIdImpl messageIdImpl2 = new MessageIdImpl(123L, 345L, 567);
+        MessageIdImpl messageIdImpl3 = new MessageIdImpl(345L, 456L, 567);
+
+        MultiMessageIdImpl item1 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl1));
+        MultiMessageIdImpl item2 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl2));
+        assertEquals(item1, item2);
+
+        // 1 item, empty not equal
+        assertNotEquals(item1, null1);
+        assertNotEquals(null1, item1);
+
+        // key not equal
+        String topic2 = "topicName2";
+        MultiMessageIdImpl item3 = new MultiMessageIdImpl(Collections.singletonMap(topic2, messageIdImpl2));
+        assertNotEquals(item1, item3);
+        assertNotEquals(item3, item1);
+
+        // value not equal
+        MultiMessageIdImpl item4 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl3));
+        assertNotEquals(item1, item4);
+        assertNotEquals(item4, item1);
+
+        // key value not equal
+        assertNotEquals(item3, item4);
+        assertNotEquals(item4, item3);
+
+        // 2 items
+        Map<String, MessageId> map1 = Maps.newHashMap();
+        Map<String, MessageId> map2 = Maps.newHashMap();
+        map1.put(topic1, messageIdImpl1);
+        map1.put(topic2, messageIdImpl2);
+        map2.put(topic2, messageIdImpl2);
+        map2.put(topic1, messageIdImpl1);
+
+        MultiMessageIdImpl item5 = new MultiMessageIdImpl(map1);
+        MultiMessageIdImpl item6 = new MultiMessageIdImpl(map2);
+
+        assertEquals(item5, item6);
+
+        assertNotEquals(item5, null1);
+        assertNotEquals(item5, empty1);
+        assertNotEquals(item5, item1);
+        assertNotEquals(item5, item3);
+        assertNotEquals(item5, item4);
+
+        assertNotEquals(null1, item5);
+        assertNotEquals(empty1, item5);
+        assertNotEquals(item1, item5);
+        assertNotEquals(item3, item5);
+        assertNotEquals(item4, item5);
+
+        map2.put(topic1, messageIdImpl3);
+        MultiMessageIdImpl item7 = new MultiMessageIdImpl(map2);
+        assertNotEquals(item5, item7);
+        assertNotEquals(item7, item5);
+    }
+
+    @Test
+    public void testMultiMessageIdCompareto() {
+        // null
+        MultiMessageIdImpl null1 = new MultiMessageIdImpl(null);
+        MultiMessageIdImpl null2 = new MultiMessageIdImpl(null);
+        assertEquals(0, null1.compareTo(null2));
+
+        // empty
+        MultiMessageIdImpl empty1 = new MultiMessageIdImpl(Collections.emptyMap());
+        MultiMessageIdImpl empty2 = new MultiMessageIdImpl(Collections.emptyMap());
+        assertEquals(0, empty1.compareTo(empty2));
+
+        // null empty
+        assertEquals(0, null1.compareTo(empty2));
+        assertEquals(0, empty2.compareTo(null1));
+
+        // 1 item
+        String topic1 = "topicName1";
+        MessageIdImpl messageIdImpl1 = new MessageIdImpl(123L, 345L, 567);
+        MessageIdImpl messageIdImpl2 = new MessageIdImpl(123L, 345L, 567);
+        MessageIdImpl messageIdImpl3 = new MessageIdImpl(345L, 456L, 567);
+
+        MultiMessageIdImpl item1 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl1));
+        MultiMessageIdImpl item2 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl2));
+        assertEquals(0, item1.compareTo(item2));
+
+        // 1 item, empty not equal
+        try {
+            item1.compareTo(null1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+        try {
+            null1.compareTo(item1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        // key not equal
+        String topic2 = "topicName2";
+        MultiMessageIdImpl item3 = new MultiMessageIdImpl(Collections.singletonMap(topic2, messageIdImpl2));
+        try {
+            item1.compareTo(item3);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+        try {
+            item3.compareTo(item1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        // value not equal
+        MultiMessageIdImpl item4 = new MultiMessageIdImpl(Collections.singletonMap(topic1, messageIdImpl3));
+        assertTrue(item1.compareTo(item4) < 0);
+        assertTrue(item4.compareTo(item1) > 0);
+
+        // key value not equal
+        try {
+            item3.compareTo(item4);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+        try {
+            item4.compareTo(item3);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        // 2 items
+        Map<String, MessageId> map1 = Maps.newHashMap();
+        Map<String, MessageId> map2 = Maps.newHashMap();
+        map1.put(topic1, messageIdImpl1);
+        map1.put(topic2, messageIdImpl2);
+        map2.put(topic2, messageIdImpl2);
+        map2.put(topic1, messageIdImpl1);
+
+        MultiMessageIdImpl item5 = new MultiMessageIdImpl(map1);
+        MultiMessageIdImpl item6 = new MultiMessageIdImpl(map2);
+
+        assertTrue(item5.compareTo(item6) == 0);
+
+        try {
+            item5.compareTo(null1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            item5.compareTo(empty1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            item5.compareTo(item1);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            item5.compareTo(item3);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            item5.compareTo(item4);
+            fail("should throw exception for not comparable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        map2.put(topic1, messageIdImpl3);
+        MultiMessageIdImpl item7 = new MultiMessageIdImpl(map2);
+
+        assertTrue(item7.compareTo(item5) > 0);
+        assertTrue(item5.compareTo(item7) < 0);
+
+        Map<String, MessageId> map3 = Maps.newHashMap();
+        map3.put(topic1, messageIdImpl3);
+        map3.put(topic2, messageIdImpl3);
+        MultiMessageIdImpl item8 = new MultiMessageIdImpl(map3);
+        assertTrue(item8.compareTo(item5) > 0);
+        assertTrue(item8.compareTo(item7) > 0);
+
+        assertTrue(item5.compareTo(item8) < 0);
+        assertTrue(item7.compareTo(item8) < 0);
+    }
 }

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarConsumerSourceTests.java
@@ -530,6 +530,16 @@ public class PulsarConsumerSourceTests {
         @Override
         public void resume() {
         }
+
+        @Override
+        public MessageId getLastMessageId() throws PulsarClientException {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<MessageId> getLastMessageIdAsync() {
+            return null;
+        }
     }
 
     private static List<Message> createMessages(int startIndex, int numMessages) {


### PR DESCRIPTION
Fixes #4909
### Motivation

It would be good to expose method `getLastMessageId` in `ConsumerImpl` to a public method. 
eg. some times user would like to know the lag messages; or only consume messages before current time.

### Modifications

- expose method `getLastMessageId` in consumer api.
- add unit test.

### Verifying this change
Ut passed