### PR TITLE
Update admin-api-overview.md

### DIFF
--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -50,43 +50,39 @@ You can find documentation for the REST API exposed by Pulsar [brokers](referenc
 
 ### Java admin client
 
-To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, specifying a URL for a Pulsar [broker](reference-terminology.md#broker) and a {@inject: javadoc:ClientConfiguration:/admin/org/apache/pulsar/client/admin/ClientConfiguration}. Here's a minimal example using `localhost`:
+To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, specifying a URL for a Pulsar [broker](reference-terminology.md#broker) and a {@inject: javadoc:PulsarAdminBuilder:/admin/org/apache/pulsar/client/admin/PulsarAdminBuilder}. Here's a minimal example using `localhost`:
 
 ```java
-URL url = new URL("http://localhost:8080");
+String url = "http://localhost:8080";
 // Pass auth-plugin class fully-qualified name if Pulsar-security enabled
-String authPluginClassName = "com.org.MyAuthPluginClass"; 
+String authPluginClassName = "com.org.MyAuthPluginClass";
 // Pass auth-param if auth-plugin class requires it
 String authParams = "param1=value1";
 boolean useTls = false;
 boolean tlsAllowInsecureConnection = false;
 String tlsTrustCertsFilePath = null;
-
-ClientConfiguration config = new ClientConfiguration();
-config.setAuthentication(authPluginClassName, authParams);
-config.setUseTls(useTls);
-config.setTlsAllowInsecureConnection(tlsAllowInsecureConnection);
-config.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
-
-PulsarAdmin admin = new PulsarAdmin(url, config);
+PulsarAdmin admin = PulsarAdmin.builder()
+.authentication(authPluginClassName,authParams)
+.serviceHttpUrl(url)
+.tlsTrustCertsFilePath(tlsTrustCertsFilePath)
+.allowTlsInsecureConnection(tlsAllowInsecureConnection)
+.build();
 ```
 
 If you have multiple brokers to use, you can use multi-host like Pulsar service. For example,
 ```java
-URL url = new URL("http://localhost:8080,localhost:8081,localhost:8082");
-// Pass auth-plugin class fully-qualified name if Pulsar-security is enabled.
-String authPluginClassName = "com.org.MyAuthPluginClass"; 
+String url = "http://localhost:8080,localhost:8081,localhost:8082";
+// Pass auth-plugin class fully-qualified name if Pulsar-security enabled
+String authPluginClassName = "com.org.MyAuthPluginClass";
 // Pass auth-param if auth-plugin class requires it
 String authParams = "param1=value1";
 boolean useTls = false;
 boolean tlsAllowInsecureConnection = false;
 String tlsTrustCertsFilePath = null;
-
-ClientConfiguration config = new ClientConfiguration();
-config.setAuthentication(authPluginClassName, authParams);
-config.setUseTls(useTls);
-config.setTlsAllowInsecureConnection(tlsAllowInsecureConnection);
-config.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
-
-PulsarAdmin admin = new PulsarAdmin(url, config);
+PulsarAdmin admin = PulsarAdmin.builder()
+.authentication(authPluginClassName,authParams)
+.serviceHttpUrl(url)
+.tlsTrustCertsFilePath(tlsTrustCertsFilePath)
+.allowTlsInsecureConnection(tlsAllowInsecureConnection)
+.build();
 ```


### PR DESCRIPTION
Fixes #4914

### Motivation
   1.Go to 'http://pulsar.apache.org/docs/en/admin-api-overview'
   2.Scroll down to 'Java admin client' and click ClientConfiguration link
   3.404 not found error is displayed "The requested URL /api/admin/org/apache/pulsar/client/admin/ClientConfiguration was not found on this server."
   4.the examples can't work.

### Modifications
1.The link to ClientConfiguration  changed to PulsarAdminBuilder.
2.The example changed to 
String url = "http://localhost:8080";
// Pass auth-plugin class fully-qualified name if Pulsar-security enabled
String authPluginClassName = "com.org.MyAuthPluginClass";
// Pass auth-param if auth-plugin class requires it
String authParams = "param1=value1";
boolean useTls = false;
boolean tlsAllowInsecureConnection = false;
String tlsTrustCertsFilePath = null;
PulsarAdmin admin = PulsarAdmin.builder()
.authentication(authPluginClassName,authParams)
.serviceHttpUrl(url)
.tlsTrustCertsFilePath(tlsTrustCertsFilePath)
.allowTlsInsecureConnection(tlsAllowInsecureConnection)
.build();