### PR TITLE
[Transaction][Buffer] Provide an asynchronous method to create a transaction buffer

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -109,12 +109,14 @@ public class TopicName implements ServiceUnitId {
                 // The short topic name can be:
                 // - <topic>
                 // - <property>/<namespace>/<topic>
+                // When the topic is transaction topic, the topic name is:
+                // - <property>/<namespace>/<topic>/_txnlog
                 String[] parts = StringUtils.split(completeTopicName, '/');
                 if (parts.length == 3) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else if (parts.length == 1) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE + "/" + parts[0];
-                } else if (parts.length == 5) {
+                } else if (parts.length == 4) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else {
                     throw new IllegalArgumentException(

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -114,6 +114,8 @@ public class TopicName implements ServiceUnitId {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else if (parts.length == 1) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE + "/" + parts[0];
+                } else if (parts.length == 5) {
+                    completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else {
                     throw new IllegalArgumentException(
                         "Invalid short topic name '" + completeTopicName + "', it should be in the format of "

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -116,7 +116,7 @@ public class TopicName implements ServiceUnitId {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else if (parts.length == 1) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE + "/" + parts[0];
-                } else if (parts.length == 4) {
+                } else if (parts.length == 4 && completeTopicName.endsWith("/_txnlog")) {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else {
                     throw new IllegalArgumentException(

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/TransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/TransactionBufferProvider.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.Beta;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.broker.service.BrokerService;
 
 /**
  * A provider that provides {@link TransactionBuffer}.
@@ -44,6 +45,21 @@ public interface TransactionBufferProvider {
             checkArgument(obj instanceof TransactionBufferProvider,
                 "The factory has to be an instance of "
                     + TransactionBufferProvider.class.getName());
+
+            return (TransactionBufferProvider) obj;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    static TransactionBufferProvider newProvider(String providerClassName, Object... args) throws IOException {
+        Class<?> providerClass;
+        try {
+            providerClass = Class.forName(providerClassName);
+            Object obj = providerClass.getConstructor(BrokerService.class, String.class).newInstance(args);
+            checkArgument(obj instanceof TransactionBufferProvider,
+                          "The factory has to be an instance of "
+                          + TransactionBufferProvider.class.getName());
 
             return (TransactionBufferProvider) obj;
         } catch (Exception e) {

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/TransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/TransactionBufferProvider.java
@@ -52,21 +52,6 @@ public interface TransactionBufferProvider {
         }
     }
 
-    static TransactionBufferProvider newProvider(String providerClassName, Object... args) throws IOException {
-        Class<?> providerClass;
-        try {
-            providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.getConstructor(BrokerService.class, String.class).newInstance(args);
-            checkArgument(obj instanceof TransactionBufferProvider,
-                          "The factory has to be an instance of "
-                          + TransactionBufferProvider.class.getName());
-
-            return (TransactionBufferProvider) obj;
-        } catch (Exception e) {
-            throw new IOException(e);
-        }
-    }
-
     /**
      * Open the transaction buffer.
      *
@@ -75,4 +60,6 @@ public interface TransactionBufferProvider {
      *         if the operation succeeds.
      */
     CompletableFuture<TransactionBuffer> newTransactionBuffer();
+
+    CompletableFuture<TransactionBuffer> newTransactionBuffer(BrokerService brokerService, String topic);
 }

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/InMemTransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/InMemTransactionBufferProvider.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.transaction.buffer.impl;
 
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.transaction.buffer.TransactionBufferProvider;
 
@@ -29,5 +31,10 @@ public class InMemTransactionBufferProvider implements TransactionBufferProvider
     @Override
     public CompletableFuture<TransactionBuffer> newTransactionBuffer() {
         return CompletableFuture.completedFuture(new InMemTransactionBuffer());
+    }
+
+    @Override
+    public CompletableFuture<TransactionBuffer> newTransactionBuffer(BrokerService brokerService, String topic) {
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 }

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -88,6 +88,7 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
 
     @Override
     public CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID) {
+        log.info("Getting transaction {} meta", txnID);
         return txnCursor.getTxnMeta(txnID, false);
     }
 

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -88,7 +88,6 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
 
     @Override
     public CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID) {
-        log.info("Getting transaction {} meta", txnID);
         return txnCursor.getTxnMeta(txnID, false);
     }
 

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.pulsar.transaction.buffer.impl;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.transaction.buffer.TransactionBuffer;
+import org.apache.pulsar.transaction.buffer.TransactionBufferProvider;
+
+public class PersistentTransactionBufferProvider implements TransactionBufferProvider {
+    private final BrokerService brokerService;
+    private final String topic;
+    private final String txnTopic;
+
+    public PersistentTransactionBufferProvider(BrokerService service, String topic) {
+        this.brokerService = service;
+        // TODO: get the transaction topic name by the TopicName.getPersistentNamingEncoding(isTxn)
+        this.txnTopic = TopicName.get(topic).getPersistenceNamingEncoding() + "/_txnlog";
+        this.topic = topic;
+    }
+
+    @Override
+    public CompletableFuture<TransactionBuffer> newTransactionBuffer() {
+        CompletableFuture<TransactionBuffer> newBufferFuture = new CompletableFuture<>();
+        brokerService.getManagedLedgerConfig(TopicName.get(topic)).thenAccept(config -> {
+            config.setCreateIfMissing(true);
+            brokerService.getManagedLedgerFactory()
+                         .asyncOpen(txnTopic, config, new AsyncCallbacks.OpenLedgerCallback() {
+                             @Override
+                             public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
+                                 try {
+                                     PersistentTransactionBuffer buffer =
+                                         new PersistentTransactionBuffer(txnTopic, ledger, brokerService);
+                                     newBufferFuture.complete(buffer);
+                                 } catch (Exception e) {
+                                     newBufferFuture.completeExceptionally(e);
+                                 }
+                             }
+
+                             @Override
+                             public void openLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                                 newBufferFuture.completeExceptionally(exception);
+                             }
+                         }, null);
+        });
+        return newBufferFuture;
+    }
+}

--- a/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
+++ b/pulsar-transaction/buffer/src/main/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferProvider.java
@@ -15,9 +15,7 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-
 package org.apache.pulsar.transaction.buffer.impl;
 
 import java.util.concurrent.CompletableFuture;

--- a/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferTest.java
+++ b/pulsar-transaction/buffer/src/test/java/org/apache/pulsar/transaction/buffer/impl/PersistentTransactionBufferTest.java
@@ -128,7 +128,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
     private ConfigurationCacheService configCacheService;
 
     final String successTopicName = "persistent://prop/use/ns-abc/successTopic_txn";
-    final String txnTopicName = "success-test-txn";
+    final String txnTopicName = "tenant/namespace/success-test-txn";
     private static final Logger log = LoggerFactory.getLogger(PersistentTransactionBufferTest.class);
 
     private TransactionBufferProvider provider;
@@ -183,7 +183,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
         doReturn(true).when(nsSvc).isServiceUnitOwned(any(NamespaceBundle.class));
         doReturn(true).when(nsSvc).isServiceUnitActive(any(TopicName.class));
 
-        this.provider = TransactionBufferProvider.newProvider(providerName, brokerService, txnTopicName);
+        this.provider = TransactionBufferProvider.newProvider(providerName);
         setupMLAsyncCallbackMocks();
     }
 
@@ -311,7 +311,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
             return null;
         }).when(cursorMock).asyncMarkDelete(anyObject(), anyObject(), any(MarkDeleteCallback.class), anyObject());
 
-        this.buffer = (PersistentTransactionBuffer) provider.newTransactionBuffer().get();
+        this.buffer = (PersistentTransactionBuffer) provider.newTransactionBuffer(brokerService, txnTopicName).get();
     }
 
     @AfterMethod
@@ -389,7 +389,6 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
             reader.readNext(1).get();
 
         } catch (ExecutionException ee) {
-            System.out.println(ee.getMessage());
             assertTrue(ee.getCause() instanceof EndOfTransactionException);
         }
 


### PR DESCRIPTION

*Motivation*

In Pulsar, most functions are in asynchronous, so we need to provide an asynchronous method to create a transaction buffer.

*Modifications*

- Provide a transaction provider to create a transaction buffer in asynchronous
