### PR TITLE
[pulsar-client] Fix broken replication msg to specific cluster

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1420,6 +1420,9 @@ public class Commands {
         if (builder.hasReplicatedFrom()) {
             messageMetadata.setReplicatedFrom(builder.getReplicatedFrom());
         }
+        if (builder.getReplicateToCount() > 0) {
+            messageMetadata.addAllReplicateTo(builder.getReplicateToList());
+        }
         if (builder.hasSchemaVersion()) {
             messageMetadata.setSchemaVersion(builder.getSchemaVersion());
         }


### PR DESCRIPTION
### Motivation
Right now, pulsar-client-java doesn't set `replicator_to` into message when batching is enabled so, user wants to use feature to replicate message to specific colo is broken.

### Modification
Set the replicate_to field and added test to verify the fix.