### PR TITLE
[site2] Fix swagger of SourceBase and SinkBase display problem

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
@@ -61,7 +61,7 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     @POST
     @ApiOperation(value = "Creates a new Pulsar Sink in cluster mode")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Invalid request (sink already exists, etc.)"),
+            @ApiResponse(code = 400, message = "Invalid request (The Pulsar Sink already exists, etc.)"),
             @ApiResponse(code = 200, message = "Pulsar Sink successfully created"),
             @ApiResponse(code = 500, message = "Internal server error (failed to authorize, failed to get tenant data, failed to process package, etc.)"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
@@ -69,60 +69,60 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     })
     @Path("/{tenant}/{namespace}/{sinkName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public void registerSink(@ApiParam(value = "The sink's tenant")
+    public void registerSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                              final @PathParam("tenant") String tenant,
-                             @ApiParam(value = "The sink's namespace")
+                             @ApiParam(value = "The namespace of a Pulsar Sink")
                              final @PathParam("namespace") String namespace,
-                             @ApiParam(value = "The sink's name")
+                             @ApiParam(value = "The name of a Pulsar Sink")
                              final @PathParam("sinkName") String sinkName,
                              final @FormDataParam("data") InputStream uploadedInputStream,
                              final @FormDataParam("data") FormDataContentDisposition fileDetail,
                              final @FormDataParam("url") String sinkPkgUrl,
                              @ApiParam(
                                  value =
-                                     "A JSON value presenting a sink config playload. All available configuration options are:  \n" +
-                                     "classname  \n" +
-                                     "   The sink's class name if archive is file-url-path (file://)  \n" +
-                                     "sourceSubscriptionName  \n" +
+                                     "A JSON value presenting config payload of a Pulsar Sink. All available configuration options are:  \n" +
+                                     "- **classname**  \n" +
+                                     "   The class name of a Pulsar Sink if archive is file-url-path (file://)  \n" +
+                                     "- **sourceSubscriptionName**  \n" +
                                      "   Pulsar source subscription name if user wants a specific  \n" +
                                      "   subscription-name for input-topic consumer  \n" +
-                                     "inputs  \n" +
-                                     "   The sink's input topic or topics (specified as a JSON array)  \n" +
-                                     "topicsPattern  \n" +
+                                     "- **inputs**  \n" +
+                                     "   The input topic or topics of a Pulsar Sink (specified as a JSON array)  \n" +
+                                     "- **topicsPattern**  \n" +
                                      "   TopicsPattern to consume from list of topics under a namespace that " +
                                      "   match the pattern. [input] and [topicsPattern] are mutually " +
                                      "   exclusive. Add SerDe class name for a pattern in customSerdeInputs " +
                                      "   (supported for java fun only)" +
-                                     "topicToSerdeClassName  \n" +
+                                     "- **topicToSerdeClassName**  \n" +
                                      "   The map of input topics to SerDe class names (specified as a JSON object)  \n" +
-                                     "topicToSchemaType  \n" +
+                                     "- **topicToSchemaType**  \n" +
                                      "   The map of input topics to Schema types or class names (specified as a JSON object)  \n" +
-                                     "inputSpecs  \n" +
+                                     "- **inputSpecs**  \n" +
                                      "   The map of input topics to its consumer configuration, each configuration has schema of " +
                                      "   {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \n" +
-                                     "configs  \n" +
+                                     "- **configs**  \n" +
                                      "   The map of configs (specified as a JSON object)  \n" +
-                                     "secrets  \n" +
+                                     "- **secrets**  \n" +
                                      "   a map of secretName(aka how the secret is going to be \n" +
                                      "   accessed in the function via context) to an object that \n" +
                                      "   encapsulates how the secret is fetched by the underlying \n" +
                                      "   secrets provider. The type of an value here can be found by the \n" +
                                      "   SecretProviderConfigurator.getSecretObjectType() method. (specified as a JSON object)  \n" +
-                                     "parallelism  \n" +
-                                     "   The sink's parallelism factor (i.e. the number of sink instances to run \n" +
-                                     "processingGuarantees  \n" +
-                                     "   The processing guarantees (aka delivery semantics) applied to the sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \n" +
-                                     "retainOrdering  \n" +
-                                     "   Boolean denotes whether sink consumes and sinks messages in order  \n" +
-                                     "resources  \n" +
-                                     "   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per sink instance (applicable only to Docker runtime)  \n" +
-                                     "autoAck  \n" +
+                                     "- **parallelism**  \n" +
+                                     "   The parallelism factor of a Pulsar Sink (i.e. the number of a Pulsar Sink instances to run \n" +
+                                     "- **processingGuarantees**  \n" +
+                                     "   The processing guarantees (aka delivery semantics) applied to the Pulsar Sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \n" +
+                                     "- **retainOrdering**  \n" +
+                                     "   Boolean denotes whether the Pulsar Sink consumes and processes messages in order  \n" +
+                                     "- **resources**  \n" +
+                                     "   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per Pulsar Sink instance (applicable only to Docker runtime)  \n" +
+                                     "- **autoAck**  \n" +
                                      "   Boolean denotes whether or not the framework will automatically acknowledge messages  \n" +
-                                     "timeoutMs  \n" +
+                                     "- **timeoutMs**  \n" +
                                      "   Long denotes the message timeout in milliseconds  \n" +
-                                     "cleanupSubscription  \n" +
+                                     "- **cleanupSubscription**  \n" +
                                      "   Boolean denotes whether the subscriptions the functions created/used should be deleted when the functions is deleted  \n" +
-                                     "runtimeFlags  \n" +
+                                     "- **runtimeFlags**  \n" +
                                      "   Any flags that you want to pass to the runtime as a single string  \n",
                                  examples = @Example(
                                      value = @ExampleProperty(
@@ -144,70 +144,69 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     @PUT
     @ApiOperation(value = "Updates a Pulsar Sink currently running in cluster mode")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Invalid request (sink doesn't exist, update contains no change, etc.)"),
+            @ApiResponse(code = 400, message = "Invalid request (The Pulsar Sink doesn't exist, update contains no change, etc.)"),
             @ApiResponse(code = 200, message = "Pulsar Sink successfully updated"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink doesn't exist"),
             @ApiResponse(code = 500, message = "Internal server error (failed to authorize, failed to process package, etc.)"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public void updateSink(@ApiParam(value = "The sink's tenant")
+    public void updateSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                            final @PathParam("tenant") String tenant,
-                           @ApiParam(value = "The sink's namespace")
+                           @ApiParam(value = "The namespace of a Pulsar Sink")
                            final @PathParam("namespace") String namespace,
-                           @ApiParam(value = "The sink's name")
+                           @ApiParam(value = "The name of a Pulsar Sink")
                            final @PathParam("sinkName") String sinkName,
                            final @FormDataParam("data") InputStream uploadedInputStream,
                            final @FormDataParam("data") FormDataContentDisposition fileDetail,
-                           @ApiParam(value = "URL of sink's archive")
                            final @FormDataParam("url") String sinkPkgUrl,
                            @ApiParam(
                                value =
-                                   "A JSON value presenting a sink config playload. All available configuration options are:  \n" +
-                                       "classname  \n" +
-                                       "   The sink's class name if archive is file-url-path (file://)  \n" +
-                                       "sourceSubscriptionName  \n" +
+                                   "A JSON value presenting config payload of a Pulsar Sink. All available configuration options are:  \n" +
+                                       "- **classname**  \n" +
+                                       "   The class name of a Pulsar Sink if archive is file-url-path (file://)  \n" +
+                                       "- **sourceSubscriptionName**  \n" +
                                        "   Pulsar source subscription name if user wants a specific  \n" +
                                        "   subscription-name for input-topic consumer  \n" +
-                                       "inputs  \n" +
-                                       "   The sink's input topic or topics (specified as a JSON array)  \n" +
-                                       "topicsPattern  \n" +
+                                       "- **inputs**  \n" +
+                                       "   The input topic or topics of a Pulsar Sink (specified as a JSON array)  \n" +
+                                       "- **topicsPattern**  \n" +
                                        "   TopicsPattern to consume from list of topics under a namespace that " +
                                        "   match the pattern. [input] and [topicsPattern] are mutually " +
                                        "   exclusive. Add SerDe class name for a pattern in customSerdeInputs " +
                                        "   (supported for java fun only)" +
-                                       "topicToSerdeClassName  \n" +
+                                       "- **topicToSerdeClassName**  \n" +
                                        "   The map of input topics to SerDe class names (specified as a JSON object)  \n" +
-                                       "topicToSchemaType  \n" +
+                                       "- **topicToSchemaType**  \n" +
                                        "   The map of input topics to Schema types or class names (specified as a JSON object)  \n" +
-                                       "inputSpecs  \n" +
+                                       "- **inputSpecs**  \n" +
                                        "   The map of input topics to its consumer configuration, each configuration has schema of " +
                                        "   {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \n" +
-                                       "configs  \n" +
+                                       "- **configs**  \n" +
                                        "   The map of configs (specified as a JSON object)  \n" +
-                                       "secrets  \n" +
+                                       "- **secrets**  \n" +
                                        "   a map of secretName(aka how the secret is going to be \n" +
                                        "   accessed in the function via context) to an object that \n" +
                                        "   encapsulates how the secret is fetched by the underlying \n" +
                                        "   secrets provider. The type of an value here can be found by the \n" +
                                        "   SecretProviderConfigurator.getSecretObjectType() method. (specified as a JSON object)  \n" +
-                                       "parallelism  \n" +
-                                       "   The sink's parallelism factor (i.e. the number of sink instances to run \n" +
-                                       "processingGuarantees  \n" +
-                                       "   The processing guarantees (aka delivery semantics) applied to the sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \n" +
-                                       "retainOrdering  \n" +
-                                       "   Boolean denotes whether sink consumes and sinks messages in order  \n" +
-                                       "resources  \n" +
-                                       "   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per sink instance (applicable only to Docker runtime)  \n" +
-                                       "autoAck  \n" +
+                                       "- **parallelism**  \n" +
+                                       "   The parallelism factor of a Pulsar Sink (i.e. the number of a Pulsar Sink instances to run \n" +
+                                       "- **processingGuarantees**  \n" +
+                                       "   The processing guarantees (aka delivery semantics) applied to the Pulsar Sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \n" +
+                                       "- **retainOrdering**  \n" +
+                                       "   Boolean denotes whether the Pulsar Sink consumes and processes messages in order  \n" +
+                                       "- **resources**  \n" +
+                                       "   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per Pulsar Sink instance (applicable only to Docker runtime)  \n" +
+                                       "- **autoAck**  \n" +
                                        "   Boolean denotes whether or not the framework will automatically acknowledge messages  \n" +
-                                       "timeoutMs  \n" +
+                                       "- **timeoutMs**  \n" +
                                        "   Long denotes the message timeout in milliseconds  \n" +
-                                       "cleanupSubscription  \n" +
+                                       "- **cleanupSubscription**  \n" +
                                        "   Boolean denotes whether the subscriptions the functions created/used should be deleted when the functions is deleted  \n" +
-                                       "runtimeFlags  \n" +
+                                       "- **runtimeFlags**  \n" +
                                        "   Any flags that you want to pass to the runtime as a single string  \n",
                                examples = @Example(
                                    value = @ExampleProperty(
@@ -222,7 +221,7 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
                                )
                            )
                            final @FormDataParam("sinkConfig") SinkConfig sinkConfig,
-                           @ApiParam(value = "Update options for sink")
+                           @ApiParam(value = "Update options for the Pulsar Sink")
                            final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
          sink.updateSink(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
                 sinkPkgUrl, sinkConfig, clientAppId(), clientAuthData(), updateOptions);
@@ -234,19 +233,19 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     @ApiOperation(value = "Deletes a Pulsar Sink currently running in cluster mode")
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid deregister request"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 200, message = "The sink was successfully deleted"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 200, message = "The Pulsar Sink was successfully deleted"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 500, message = "Internal server error (failed to authorize, failed to deregister, etc.)"),
-            @ApiResponse(code = 408, message = "Got InterruptedException while deregistering the sink"),
+            @ApiResponse(code = 408, message = "Got InterruptedException while deregistering the Pulsar Sink"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}")
-    public void deregisterSink(@ApiParam(value = "The sink's tenant")
+    public void deregisterSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                                final @PathParam("tenant") String tenant,
-                               @ApiParam(value = "The sink's namespace")
+                               @ApiParam(value = "The namespace of a Pulsar Sink")
                                final @PathParam("namespace") String namespace,
-                               @ApiParam(value = "The sink's name")
+                               @ApiParam(value = "The name of a Pulsar Sink")
                                final @PathParam("sinkName") String sinkName) {
         sink.deregisterFunction(tenant, namespace, sinkName, clientAppId(), clientAuthData());
     }
@@ -258,15 +257,15 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     )
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
+            @ApiResponse(code = 404, message = "The Pulsar Sinj does not exist"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}")
-    public SinkConfig getSinkInfo(@ApiParam(value = "The sink's tenant")
+    public SinkConfig getSinkInfo(@ApiParam(value = "The tenant of a Pulsar Sink")
                                   final @PathParam("tenant") String tenant,
-                                  @ApiParam(value = "The sink's namespace")
+                                  @ApiParam(value = "The namespace of a Pulsar Sink")
                                   final @PathParam("namespace") String namespace,
-                                  @ApiParam(value = "The sink's name")
+                                  @ApiParam(value = "The name of a Pulsar Sink")
                                   final @PathParam("sinkName") String sinkName) throws IOException {
         return sink.getSinkInfo(tenant, namespace, sinkName);
     }
@@ -277,21 +276,21 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
             response = SinkStatus.SinkInstanceStatus.SinkInstanceStatusData.class
     )
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "The sink instance does not exist"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
+            @ApiResponse(code = 400, message = "The Pulsar Sink instance does not exist"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 500, message = "Internal Server Error (got exception while getting status, etc.)"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{tenant}/{namespace}/{sinkName}/{instanceId}/status")
     public SinkStatus.SinkInstanceStatus.SinkInstanceStatusData getSinkInstanceStatus(
-            @ApiParam(value = "The sink's tenant")
+            @ApiParam(value = "The tenant of a Pulsar Sink")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The sink's namespace")
+            @ApiParam(value = "The namespace of a Pulsar Sink")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The sink's name")
+            @ApiParam(value = "The name of a Pulsar Sink")
             final @PathParam("sinkName") String sinkName,
-            @ApiParam(value = "The sink instanceId")
+            @ApiParam(value = "The instanceId of a Pulsar Sink")
             final @PathParam("instanceId") String instanceId) throws IOException {
         return sink.getSinkInstanceStatus(
             tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
@@ -305,16 +304,16 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid get status request"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later."),
     })
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{tenant}/{namespace}/{sinkName}/status")
-    public SinkStatus getSinkStatus(@ApiParam(value = "The sink's tenant")
+    public SinkStatus getSinkStatus(@ApiParam(value = "The tenant of a Pulsar Sink")
                                     final @PathParam("tenant") String tenant,
-                                    @ApiParam(value = "The sink's namespace")
+                                    @ApiParam(value = "The namespace of a Pulsar Sink")
                                     final @PathParam("namespace") String namespace,
-                                    @ApiParam(value = "The sink's name")
+                                    @ApiParam(value = "The name of a Pulsar Sink")
                                     final @PathParam("sinkName") String sinkName) throws IOException {
         return sink.getSinkStatus(tenant, namespace, sinkName, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
@@ -332,135 +331,135 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}")
-    public List<String> listSinks(@ApiParam(value = "The sink's tenant")
+    public List<String> listSinks(@ApiParam(value = "The tenant of a Pulsar Sink")
                                   final @PathParam("tenant") String tenant,
-                                  @ApiParam(value = "The sink's namespace")
+                                  @ApiParam(value = "The namespace of a Pulsar Sink")
                                   final @PathParam("namespace") String namespace) {
         return sink.listFunctions(tenant, namespace, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Restart sink instance", response = Void.class)
+    @ApiOperation(value = "Restart an instance of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid restart request"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to restart the sink instance, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to restart the instance of a Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/{instanceId}/restart")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void restartSink(@ApiParam(value = "The sink's tenant")
+    public void restartSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                             final @PathParam("tenant") String tenant,
-                            @ApiParam(value = "The sink's namespace")
+                            @ApiParam(value = "The namespace of a Pulsar Sink")
                             final @PathParam("namespace") String namespace,
-                            @ApiParam(value = "The sink's name")
+                            @ApiParam(value = "The name of a Pulsar Sink")
                             final @PathParam("sinkName") String sinkName,
-                            @ApiParam(value = "The sink instanceId")
+                            @ApiParam(value = "The instanceId of a Pulsar Sink")
                             final @PathParam("instanceId") String instanceId) {
         sink.restartFunctionInstance(tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Restart all sink instances", response = Void.class)
+    @ApiOperation(value = "Restart all instances of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid restart request"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to restart the sink, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to restart the Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/restart")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void restartSink(@ApiParam(value = "The sink's tenant")
+    public void restartSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                             final @PathParam("tenant") String tenant,
-                            @ApiParam(value = "The sink's namespace")
+                            @ApiParam(value = "The namespace of a Pulsar Sink")
                             final @PathParam("namespace") String namespace,
-                            @ApiParam(value = "The sink's name")
+                            @ApiParam(value = "The name of a Pulsar Sink")
                             final @PathParam("sinkName") String sinkName) {
         sink.restartFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Stop sink instance", response = Void.class)
+    @ApiOperation(value = "Stop an instance of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid stop request"),
-            @ApiResponse(code = 404, message = "The sink instance does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to stop the sink, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink instance does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to stop the Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/{instanceId}/stop")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void stopSink(@ApiParam(value = "The sink's tenant")
+    public void stopSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                          final @PathParam("tenant") String tenant,
-                         @ApiParam(value = "The sink's namespace")
+                         @ApiParam(value = "The namespace of a Pulsar Sink")
                          final @PathParam("namespace") String namespace,
-                         @ApiParam(value = "The sink's name")
+                         @ApiParam(value = "The name of a Pulsar Sink")
                          final @PathParam("sinkName") String sinkName,
-                         @ApiParam(value = "The sink instanceId")
+                         @ApiParam(value = "The instanceId of a Pulsar Sink")
                          final @PathParam("instanceId") String instanceId) {
         sink.stopFunctionInstance(tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Stop all sink instances", response = Void.class)
+    @ApiOperation(value = "Stop all instances of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid stop request"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to stop the sink, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to stop the Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/stop")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void stopSink(@ApiParam(value = "The sink's tenant")
+    public void stopSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                          final @PathParam("tenant") String tenant,
-                         @ApiParam(value = "The sink's namespace")
+                         @ApiParam(value = "The namespace of a Pulsar Sink")
                          final @PathParam("namespace") String namespace,
-                         @ApiParam(value = "The sink's name")
+                         @ApiParam(value = "The name of a Pulsar Sink")
                          final @PathParam("sinkName") String sinkName) {
         sink.stopFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Start sink instance", response = Void.class)
+    @ApiOperation(value = "Start an instance of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid start request"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to start the sink, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to start the Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/{instanceId}/start")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void startSink(@ApiParam(value = "The sink's tenant")
+    public void startSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                           final @PathParam("tenant") String tenant,
-                          @ApiParam(value = "The sink's namespace")
+                          @ApiParam(value = "The namespace of a Pulsar Sink")
                           final @PathParam("namespace") String namespace,
-                          @ApiParam(value = "The sink's name")
+                          @ApiParam(value = "The name of a Pulsar Sink")
                           final @PathParam("sinkName") String sinkName,
-                          @ApiParam(value = "The sink instanceId")
+                          @ApiParam(value = "The instanceId of a Pulsar Sink")
                           final @PathParam("instanceId") String instanceId) {
         sink.startFunctionInstance(tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Start all sink instances", response = Void.class)
+    @ApiOperation(value = "Start all instances of a Pulsar Sink", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid start request"),
-            @ApiResponse(code = 404, message = "The sink does not exist"),
-            @ApiResponse(code = 500, message = "Internal server error (failed to start the sink, failed to authorize, etc.)"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
+            @ApiResponse(code = 500, message = "Internal server error (failed to start the Pulsar Sink, failed to authorize, etc.)"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}/start")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void startSink(@ApiParam(value = "The sink's tenant")
+    public void startSink(@ApiParam(value = "The tenant of a Pulsar Sink")
                           final @PathParam("tenant") String tenant,
-                          @ApiParam(value = "The sink's namespace")
+                          @ApiParam(value = "The namespace of a Pulsar Sink")
                           final @PathParam("namespace") String namespace,
-                          @ApiParam(value = "The sink's name")
+                          @ApiParam(value = "The name of a Pulsar Sink")
                           final @PathParam("sinkName") String sinkName) {
         sink.startFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
@@ -257,7 +257,7 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
     )
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
-            @ApiResponse(code = 404, message = "The Pulsar Sinj does not exist"),
+            @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sinkName}")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
@@ -71,44 +71,44 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     @Path("/{tenant}/{namespace}/{sourceName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public void registerSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of source")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
             final @FormDataParam("data") InputStream uploadedInputStream,
             final @FormDataParam("data") FormDataContentDisposition fileDetail,
             final @FormDataParam("url") String sourcePkgUrl,
             @ApiParam(
-                    value = "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \n" +
-                            "classname  \n" +
-                            "  The source's class name if archive is file-url-path (file://).  \n" +
-                            "topicName  \n" +
+                    value = "A JSON value presenting configuration payload of a Pulsar Source. An example of the expected functions can be found here.  \n" +
+                            "- **classname**  \n" +
+                            "  The class name of a Pulsar Source if archive is file-url-path (file://).  \n" +
+                            "- **topicName**  \n" +
                             "  The Pulsar topic to which data is sent.  \n" +
-                            "serdeClassName  \n" +
-                            "  The SerDe classname for the source.  \n" +
-                            "schemaType  \n" +
+                            "- **serdeClassName**  \n" +
+                            "  The SerDe classname for the Pulsar Source.  \n" +
+                            "- **schemaType**  \n" +
                             "  The schema type (either a builtin schema like 'avro', 'json', etc.. or  " +
-                            "  custom Schema class name to be used to encode messages emitted from the source  \n" +
-                            "configs  \n" +
+                            "  custom Schema class name to be used to encode messages emitted from the Pulsar Source  \n" +
+                            "- **configs**  \n" +
                             "  Source config key/values  \n" +
-                            "secrets  \n" +
+                            "- **secrets**  \n" +
                             "  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that" +
                             "  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the" +
                             "  SecretProviderConfigurator.getSecretObjectType() method. \n" +
-                            "parallelism  \n" +
-                            "  The source's parallelism factor (i.e. the number of source instances to run).  \n" +
-                            "processingGuarantees  \n" +
-                            "  The processing guarantees (aka delivery semantics) applied to the source  " +
+                            "- **parallelism**  \n" +
+                            "  The parallelism factor of a Pulsar Source (i.e. the number of a Pulsar Source instances to run).  \n" +
+                            "- **processingGuarantees**  \n" +
+                            "  The processing guarantees (aka delivery semantics) applied to the Pulsar Source.  " +
                             "  Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \n" +
-                            "resources  \n" +
-                            "  The size of the system resources allowed by the source runtime. The resources include: cpu, ram, disk.  \n" +
-                            "archive  \n" +
-                            "  The path to the NAR archive for the Source. It also supports url-path " +
+                            "- **resources**  \n" +
+                            "  The size of the system resources allowed by the Pulsar Source runtime. The resources include: cpu, ram, disk.  \n" +
+                            "- **archive**  \n" +
+                            "  The path to the NAR archive for the Pulsar Source. It also supports url-path " +
                             "  [http/https/file (file protocol assumes that file already exists on worker host)] " +
                             "  from which worker can download the package.  \n" +
-                            "runtimeFlags  \n" +
+                            "- **runtimeFlags**  \n" +
                             "  Any flags that you want to pass to the runtime.  \n",
                     examples = @Example(
                             value = @ExampleProperty(
@@ -138,52 +138,51 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
             @ApiResponse(code = 400, message = "Invalid request (Function already exists or Tenant, Namespace or Name is not provided, etc.)"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
             @ApiResponse(code = 200, message = "Pulsar Function successfully updated"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal Server Error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public void updateSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of source")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
             final @FormDataParam("data") InputStream uploadedInputStream,
             final @FormDataParam("data") FormDataContentDisposition fileDetail,
-            @ApiParam(value = "URL of sources' archive")
             final @FormDataParam("url") String sourcePkgUrl,
             @ApiParam(
-                    value = "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \n" +
-                            "classname  \n" +
-                            "  The source's class name if archive is file-url-path (file://).  \n" +
-                            "topicName  \n" +
+                    value = "A JSON value presenting configuration payload of a Pulsar Source. An example of the expected functions can be found here.  \n" +
+                            "- **classname**  \n" +
+                            "  The class name of a Pulsar Source if archive is file-url-path (file://).  \n" +
+                            "- **topicName**  \n" +
                             "  The Pulsar topic to which data is sent.  \n" +
-                            "serdeClassName  \n" +
-                            "  The SerDe classname for the source.  \n" +
-                            "schemaType  \n" +
+                            "- **serdeClassName**  \n" +
+                            "  The SerDe classname for the Pulsar Source.  \n" +
+                            "- **schemaType**  \n" +
                             "  The schema type (either a builtin schema like 'avro', 'json', etc.. or  " +
-                            "  custom Schema class name to be used to encode messages emitted from the source  \n" +
-                            "configs  \n" +
-                            "  Source config key/values  \n" +
-                            "secrets  \n" +
+                            "  custom Schema class name to be used to encode messages emitted from the Pulsar Source  \n" +
+                            "- **configs**  \n" +
+                            "  Pulsar Source config key/values  \n" +
+                            "- **secrets**  \n" +
                             "  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that" +
                             "  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the" +
                             "  SecretProviderConfigurator.getSecretObjectType() method. \n" +
-                            "parallelism  \n" +
-                            "  The source's parallelism factor (i.e. the number of source instances to run).  \n" +
-                            "processingGuarantees  \n" +
-                            "  The processing guarantees (aka delivery semantics) applied to the source  " +
+                            "- **parallelism**  \n" +
+                            "  The parallelism factor of a Pulsar Source (i.e. the number of a Pulsar Source instances to run).  \n" +
+                            "- **processingGuarantees**  \n" +
+                            "  The processing guarantees (aka delivery semantics) applied to the Pulsar Source.  " +
                             "  Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \n" +
-                            "resources  \n" +
-                            "  The size of the system resources allowed by the source runtime. The resources include: cpu, ram, disk.  \n" +
-                            "archive  \n" +
-                            "  The path to the NAR archive for the Source. It also supports url-path " +
+                            "- **resources**  \n" +
+                            "  The size of the system resources allowed by the Pulsar Source runtime. The resources include: cpu, ram, disk.  \n" +
+                            "- **archive**  \n" +
+                            "  The path to the NAR archive for the Pulsar Source. It also supports url-path " +
                             "  [http/https/file (file protocol assumes that file already exists on worker host)] " +
                             "  from which worker can download the package.  \n" +
-                            "runtimeFlags  \n" +
+                            "- **runtimeFlags**  \n" +
                             "  Any flags that you want to pass to the runtime.  \n",
                     examples = @Example(
                             value = @ExampleProperty(
@@ -202,7 +201,7 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
                     )
             )
             final @FormDataParam("sourceConfig") SourceConfig sourceConfig,
-            @ApiParam(value = "Update options for source")
+            @ApiParam(value = "Update options for Pulsar Source")
             final @FormDataParam("updateOptions") UpdateOptions updateOptions) {
         source.updateSource(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
             sourcePkgUrl, sourceConfig, clientAppId(), clientAuthData(), updateOptions);
@@ -214,7 +213,7 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 408, message = "Request timeout"),
             @ApiResponse(code = 200, message = "The function was successfully deleted"),
             @ApiResponse(code = 500, message = "Internal Server Error"),
@@ -222,11 +221,11 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     })
     @Path("/{tenant}/{namespace}/{sourceName}")
     public void deregisterSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
         source.deregisterFunction(tenant, namespace, sourceName, clientAppId(), clientAuthData());
     }
@@ -238,16 +237,16 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     )
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}")
     public SourceConfig getSourceInfo(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) throws IOException {
         return source.getSourceInfo(tenant, namespace, sourceName);
     }
@@ -264,13 +263,13 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{tenant}/{namespace}/{sourceName}/{instanceId}/status")
     public SourceStatus.SourceInstanceStatus.SourceInstanceStatusData getSourceInstanceStatus(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
-            @ApiParam(value = "The source instanceId (if instance-id is not provided, the stats of all instances is returned).")
+            @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided, the stats of all instances is returned).")
             final @PathParam("instanceId") String instanceId) throws IOException {
         return source.getSourceInstanceStatus(
             tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
@@ -288,11 +287,11 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{tenant}/{namespace}/{sourceName}/status")
     public SourceStatus getSourceStatus(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) throws IOException {
         return source.getSourceStatus(tenant, namespace, sourceName, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
@@ -312,141 +311,141 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{tenant}/{namespace}")
     public List<String> listSources(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace) {
         return source.listFunctions(tenant, namespace, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Restart source instance", response = Void.class)
+    @ApiOperation(value = "Restart an instance of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/{instanceId}/restart")
     @Consumes(MediaType.APPLICATION_JSON)
     public void restartSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
-            @ApiParam(value = "The source instanceId (if instance-id is not provided, the stats of all instances is returned).")
+            @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided, the stats of all instances is returned).")
             final @PathParam("instanceId") String instanceId) {
         source.restartFunctionInstance(tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Restart all source instances", response = Void.class)
+    @ApiOperation(value = "Restart all instances of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/restart")
     @Consumes(MediaType.APPLICATION_JSON)
     public void restartSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
         source.restartFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Stop source instance", response = Void.class)
+    @ApiOperation(value = "Stop instance of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/{instanceId}/stop")
     @Consumes(MediaType.APPLICATION_JSON)
     public void stopSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
-            @ApiParam(value = "The source instanceId (if instance-id is not provided, the stats of all instances is returned).")
+            @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided, the stats of all instances is returned).")
             final @PathParam("instanceId") String instanceId) {
         source.stopFunctionInstance(tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Stop all source instances", response = Void.class)
+    @ApiOperation(value = "Stop all instances of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/stop")
     @Consumes(MediaType.APPLICATION_JSON)
     public void stopSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
         source.stopFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Start source instance", response = Void.class)
+    @ApiOperation(value = "Start an instance of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/{instanceId}/start")
     @Consumes(MediaType.APPLICATION_JSON)
     public void startSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName,
-            @ApiParam(value = "The source instanceId (if instance-id is not provided, the stats of all instances is returned).")
+            @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided, the stats of all instances is returned).")
             final @PathParam("instanceId") String instanceId) {
         source.startFunctionInstance(tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
     }
 
     @POST
-    @ApiOperation(value = "Start all source instances", response = Void.class)
+    @ApiOperation(value = "Start all instances of a Pulsar Source", response = Void.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorize to perform operation"),
-            @ApiResponse(code = 404, message = "Not Found(The source doesn't exist)"),
+            @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later.")
     })
     @Path("/{tenant}/{namespace}/{sourceName}/start")
     @Consumes(MediaType.APPLICATION_JSON)
     public void startSource(
-            @ApiParam(value = "The name of tenant")
+            @ApiParam(value = "The tenant of a Pulsar Source")
             final @PathParam("tenant") String tenant,
-            @ApiParam(value = "The name of namespace")
+            @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace,
-            @ApiParam(value = "The name of name")
+            @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
         source.startFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
     }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

There are some display problems and there is some ambiguity in the description information output, as follows:

#### Source

-  [Creates a new Pulsar Source in cluster mode](https://pulsar.apache.org/source-rest-api/#operation/registerSource) 
- [Updates a Pulsar Source currently running in cluster mode](https://pulsar.apache.org/source-rest-api/#operation/updateSource)

#### Sink

- [Creates a new Pulsar Sink in cluster mode](https://pulsar.apache.org/sink-rest-api/#operation/registerSink)
- [Updates a Pulsar Sink currently running in cluster mode](https://pulsar.apache.org/sink-rest-api/#operation/updateSink)

In the pull request, will fix them, the display after fix is as follows:

![image](https://user-images.githubusercontent.com/20965307/62850348-3274f780-bd15-11e9-98b0-179cefdadd46.png)
