### PR TITLE
[pulsar-functions][python-examples] Fixing python function example custom_object_function.py

### DIFF
--- a/pulsar-functions/python-examples/custom_object_function.py
+++ b/pulsar-functions/python-examples/custom_object_function.py
@@ -31,10 +31,10 @@ class CustomSerDe(SerDe):
     pass
 
   def serialize(self, object):
-    return "%d,%d" % (object.a, object.b)
+    return ("%d,%d" % (object.a, object.b)).encode('utf-8')
 
   def deserialize(self, input_bytes):
-    split = str(input_bytes).split(',')
+    split = str(input_bytes.decode()).split(',')
     retval = MyObject()
     retval.a = int(split[0])
     retval.b = int(split[1])


### PR DESCRIPTION
### Motivation

Fixing Python examples for pulsar-functions custom_object_function.py

### Modifications

Adding conversion of "str" to "bytes" using the methods "encode" and "decode" from string.

To perform the tests run:
```sh
$ bin/pulsar-admin functions create \
 --py $PULSAR_HOME/examples/python-examples/custom_object_function.py \
 --tenant public \
 --namespace default \
 --name custom_object \
 --inputs input-topic \
 --custom-serde-inputs '{"input-topic": "custom_object_function.CustomSerDe"}' \
 --output output-topic \
 --output-serde-classname custom_object_function.CustomSerDe \
 --classname custom_object_function.CustomObjectFunction 
 ```

And trigger the function using the CLI "functions trigger" :
```sh
$ pulsar-admin functions trigger \
  --name custom \
  --tenant public \ 
  --namespace default \
  --trigger-value "1,2"
```
And should return:
 
12, 26

 
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
 
Hi, @srkukarni, can you please take a look?