### PR TITLE
Fix pull request 4700

### DIFF
--- a/deployment/kubernetes/generic/k8s-1-9-and-above/bookie.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/bookie.yaml
@@ -62,6 +62,11 @@ metadata:
         app: pulsar
         component: bookkeeper
 spec:
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: bookkeeper
     template:
         metadata:
             labels:

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/broker.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/broker.yaml
@@ -68,6 +68,11 @@ kind: Deployment
 metadata:
     name: broker
 spec:
+    # Must match template:metdata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: broker
     replicas: 3
     template:
         metadata:

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/monitoring.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/monitoring.yaml
@@ -85,6 +85,11 @@ kind: Deployment
 metadata:
     name: prometheus
 spec:
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: prometheus
     replicas: 1
     template:
         metadata:
@@ -134,6 +139,11 @@ kind: Deployment
 metadata:
     name: grafana
 spec:
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: grafana
     replicas: 1
     template:
         metadata:
@@ -175,6 +185,11 @@ kind: Deployment
 metadata:
     name: pulsar-dashboard
 spec:
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: dashboard
     replicas: 1
     template:
         metadata:

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yaml
@@ -61,6 +61,11 @@ kind: Deployment
 metadata:
     name: proxy
 spec:
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: proxy
     replicas: 2
     template:
         metadata:

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
@@ -76,7 +76,7 @@ spec:
             labels:
                 app: pulsar
                 component: zookeeper
-                cluster: us-central
+                cluster: local
             annotations:
                 pod.alpha.kubernetes.io/initialized: "true"
                 prometheus.io/scrape: "true"

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
@@ -70,6 +70,12 @@ metadata:
         component: zookeeper
 spec:
     serviceName: zookeeper
+    # Must match template:metadata:labels
+    selector:
+        matchLabels:
+            app: pulsar
+            component: zookeeper
+            cluster: local
     replicas: 3
     template:
         metadata:


### PR DESCRIPTION
### Purpose

Fixes pull request #4700 

### Motivation

The updated API (using v1/apps for Workload API objects like DaemonSet, StatefulSet, and Deployment) introduced in #4700 requires a LabelSelector object for each Deployment, DaemonSet, and SatetfulSet object. The #4700 does not include those LabelSelector objects. This causes  the rejection of the K8S generic deployment scripts by the K8S API validator. 

### Changes

_deployment/kubernetes/generic/k8s-1-9-and-above/bookie.yml :_

- Add a LabelSelector object matching pods labels (required by API)
 to the DaemonSet:spec object 

_deployment/kubernetes/generic/k8s-1-9-and-above/broker.yml :_

- Add a LabelSelector object matching pods labels (required by API)
 to the Deployment:spec object .

_deployment/kubernetes/generic/k8s-1-9-and-above/monitoring.yml :_

- Add a LabelSelector object matching pods labels (required by API)
 to the Deployment:spec object for Prometheus.

- Add a LabelSelector object matching pods labels (required by API)
 to the Deployment:spec object for Grafana.

- Add a LabelSelector object matching pods labels (required by API)
 to the Deployment:spec object for the Pulsar Dashboard.

_deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yml :_

- Add a LabelSelector object matching pods labels (required by API)
 to the Deployment:spec object.

_deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yml :_

- Add a LabelSelector object matching pods labels (required by API)
 to the StatefulSet:spec object.

- Changing StatefulSet:spec:template:metadata:labels:cluster from 'us-central' to 'local'. All other scripts assume cluster is 'local' and not 'us-central'.

### Testing coverage

- All scripts have been succefully applied to a fresh Minikube cluster without rejection
- Cluster experiment (through admin pod) with a production rate of 100 has been done
- Monitoring has NOT been tested (deployed but not functionally tested)
