### PR TITLE
Fix: NPE while cleaning up namespace node

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitZkUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitZkUtils.java
@@ -153,7 +153,7 @@ public final class ServiceUnitZkUtils {
         String brokerUrl = null;
         try {
             byte[] data = zkc.getData(path, false, null);
-            if (data.length == 0) {
+            if (data == null || data.length == 0) {
                 // skip, ephemeral node will not have zero byte
                 return;
             }


### PR DESCRIPTION
### Motivation
It fixes below NPE
```
16:17:50.180 [main INFO  org.apache.pulsar.broker.PulsarService - Starting name space service, bootstrap namespaces=
16:17:50.204 [main ERROR org.apache.pulsar.broker.namespace.NamespaceService - null
java.lang.NullPointerException: null
    at org.apache.pulsar.broker.namespace.ServiceUnitZkUtils.cleanupSingleNamespaceNode(ServiceUnitZkUtils.java:156) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
    at org.apache.pulsar.broker.namespace.ServiceUnitZkUtils.cleanupNamespaceNodes(ServiceUnitZkUtils.java:134) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
    at org.apache.pulsar.broker.namespace.ServiceUnitZkUtils.cleanupNamespaceNodes(ServiceUnitZkUtils.java:137) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
    at org.apache.pulsar.broker.namespace.ServiceUnitZkUtils.initZK(ServiceUnitZkUtils.java:113) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
    at org.apache.pulsar.broker.namespace.NamespaceService.<init>(NamespaceService.java:151) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
    at org.apache.pulsar.broker.PulsarService.lambda$getNamespaceServiceProvider$1(PulsarService.java:584) ~[org.apache.pulsar-pulsar-broker-2.4.0.jar:2.4.0
```