### PR TITLE
[Issue 4969] fix fd leakage in FunctionActioner.downloadFile

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -219,10 +219,14 @@ public class FunctionActioner {
         if(downloadFromHttp) {
             FunctionCommon.downloadFromHttpUrl(pkgLocationPath, tempPkgFile);
         } else {
+            FileOutputStream tempPkgFos = new FileOutputStream(tempPkgFile);
             WorkerUtils.downloadFromBookkeeper(
                     dlogNamespace,
-                    new FileOutputStream(tempPkgFile),
+                    tempPkgFos,
                     pkgLocationPath);
+            if (tempPkgFos != null) {
+                tempPkgFos.close();
+            }
         }
 
         try {


### PR DESCRIPTION
Fixes #4969

### Motivation

close `FileOutputStream` after `WorkerUtils.downloadFromBookkeeper`