### PR TITLE
[Issue 4956]Add default loader for latest pyyaml

### DIFF
--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -46,7 +46,7 @@ if len(sys.argv) < 2:
 conf_files = sys.argv[1:]
 
 for conf_filename in conf_files:
-    conf = yaml.load(open(conf_filename))
+    conf = yaml.load(open(conf_filename), Loader=yaml.FullLoader)
 
     # update the config
     modified = False


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/4956


Master Issue: https://github.com/apache/pulsar/issues/4956

### Motivation

In the latest version of pyyaml, using load will issue a warning and explain some reasons here https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.

### Modifications

* Use yaml.FullLoader as default loader

