### PR TITLE
Fix the getSchema logic in pulsar proxy

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1014,10 +1014,23 @@ public class Commands {
             schema.setSchemaVersion(ByteString.copyFrom(version.get().bytes()));
         }
 
+        CommandGetSchema getSchema = schema.build();
+
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder()
             .setType(Type.GET_SCHEMA)
-            .setGetSchema(schema.build()));
+            .setGetSchema(getSchema));
         schema.recycle();
+        return res;
+    }
+
+    public static ByteBuf newGetSchemaResponse(long requestId, CommandGetSchemaResponse response) {
+        CommandGetSchemaResponse.Builder schemaResponseBuilder = CommandGetSchemaResponse.newBuilder(response)
+            .setRequestId(requestId);
+
+        ByteBuf res = serializeWithSize(BaseCommand.newBuilder()
+            .setType(Type.GET_SCHEMA_RESPONSE)
+            .setGetSchemaResponse(schemaResponseBuilder.build()));
+        schemaResponseBuilder.recycle();
         return res;
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -226,7 +226,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    private void testGetSchema() throws Exception {
+    public void testGetSchema() throws Exception {
         PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:" + proxyConfig.getServicePort().get())
                 .build();
         Producer<Foo> producer;
@@ -249,7 +249,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    private void testProtocolVersionAdvertisement() throws Exception {
+    public void testProtocolVersionAdvertisement() throws Exception {
         final String url = "pulsar://localhost:" + proxyConfig.getServicePort().get();
         final String topic = "persistent://sample/test/local/protocol-version-advertisement";
         final String sub = "my-sub";


### PR DESCRIPTION
*Motivation*

The getSchema logic in Pulsar proxy handler doesn't handle the case that
the request doesn't have schema version.

*Modification*

- Fix the logic to handle the case that a GetSchema request doesn't have schema version.
- Forward the GetSchemaResponse back to the client

*Tests*

The GetSchema tests in ProxyTest was disabled by mistake. Turn it on.

