### PR TITLE
[Issue 4971] fix docker image not have cpp client installed

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -62,9 +62,14 @@ RUN pip install kazoo pyyaml
 RUN python3.5 get-pip.py
 
 ADD target/python-client/ /pulsar/pulsar-client
+ADD target/cpp-client/ /pulsar/cpp-client
 RUN /pulsar/bin/install-pulsar-client-27.sh
 RUN /pulsar/bin/install-pulsar-client-35.sh
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/jre/lib/security/java.security
+RUN apt-get update \
+     && apt install -y /pulsar/cpp-client/*.deb \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /pulsar
 

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -85,6 +85,18 @@
                   </arguments>
                 </configuration>
               </execution>
+              <execution>
+                <id>build-pulsar-cpp-client-deb</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipBuildCppClient}</skip>
+                  <workingDirectory>${project.basedir}/target</workingDirectory>
+                  <executable>${project.basedir}/../../pulsar-client-cpp/pkg/deb/docker-build-deb.sh</executable>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -92,6 +104,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
+                <id>copy-pulsar-clients-python</id>
                 <phase>compile</phase>
                 <goals>
                   <goal>run</goal>
@@ -102,6 +115,21 @@
                     <echo>copy python wheel file</echo>
                     <mkdir dir="${basedir}/target/python-client"/>
                     <copydir src="${basedir}/../../pulsar-client-cpp/python/wheelhouse" dest="${basedir}/target/python-client"/>
+                  </tasks>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-pulsar-cpp-client</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipCopyCppClient}</skip>
+                  <tasks>
+                    <echo>copy cpp client deb file</echo>
+                    <mkdir dir="${basedir}/target/cpp-client"/>
+                    <copydir src="${basedir}/../../pulsar-client-cpp/pkg/deb/BUILD/DEB" dest="${basedir}/target/cpp-client"/>
                   </tasks>
                 </configuration>
               </execution>

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -24,5 +24,5 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 docker pull apachepulsar/pulsar-build:debian-9
 
-docker run -it -v $ROOT_DIR:/pulsar apachepulsar/pulsar-build:debian-9 \
+docker run -i -v $ROOT_DIR:/pulsar apachepulsar/pulsar-build:debian-9 \
         /pulsar/pulsar-client-cpp/pkg/deb/build-deb.sh


### PR DESCRIPTION
Fixes #4971

### Motivation
- currently go function require cpp client lib to execute, but cpp client is not installed properly

### Modification
- add pulsar cpp client DEB package to docker image
- install cpp client from DEB packages (dev included) (not sure if is required)
- run build pulsar cpp client DEB package when build docker images
- change `docker-build-deb.sh` not run docker container with pseudo-TTY
