### PR TITLE
Admin pod should use broker service to discover broker pods

### DIFF
--- a/deployment/kubernetes/generic/k8s-1-9-and-above/admin.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/admin.yaml
@@ -37,8 +37,8 @@ spec:
                 name: broker-config
         env:
           - name: webServiceUrl
-            value: "http://proxy:8080/"
+            value: "http://broker:8080/"
           - name: brokerServiceUrl
-            value: "pulsar://proxy:6650/"
+            value: "pulsar://broker:6650/"
           - name: PULSAR_MEM
             value: "\"-Xms64m -Xmx128m\""

--- a/deployment/kubernetes/generic/original/admin.yaml
+++ b/deployment/kubernetes/generic/original/admin.yaml
@@ -37,8 +37,8 @@ spec:
                 name: broker-config
         env:
           - name: webServiceUrl
-            value: "http://proxy:8080/"
+            value: "http://broker:8080/"
           - name: brokerServiceUrl
-            value: "pulsar://proxy:6650/"
+            value: "pulsar://broker:6650/"
           - name: PULSAR_MEM
             value: "\"-Xms64m -Xmx128m\""


### PR DESCRIPTION
### Motivation

Add enhancement proposed in #4978 

### Changes

deployment/kubernetes/generic/original/admin.yaml :

- Use broker service to discover broker pods instead of using proxy service to do so.

deployment/kubernetes/generic/k8s-1-9-and-above/admin.yaml :

- Use broker service to discover broker pods instead of using proxy service to do so 

### Testing coverage

Changes have been tested on a fresh Digital Ocean managed Kubernetes cluster. A producer and a consumer were created as described in the "Experimenting with your cluster" section of the documentation (cf. https://pulsar.apache.org/docs/en/deploy-kubernetes).