### PR TITLE
[k8s] convert to valid pod name part with k8s function runtime

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -1021,8 +1021,12 @@ public class KubernetesRuntime implements Runtime {
                 functionDetails.getName());
     }
 
+    private static String toValidPodName(String ori) {
+        return ori.toLowerCase().replaceAll("[^a-z0-9]", "-");
+    }
+
     private static String createJobName(String tenant, String namespace, String functionName) {
-        return "pf-" + tenant + "-" + namespace + "-" + functionName;
+        return "pf-" + toValidPodName(tenant) + "-" + toValidPodName(namespace) + "-" + toValidPodName(functionName);
     }
 
     private static String getServiceUrl(String jobName, String jobNamespace, int instanceId) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -1033,6 +1033,7 @@ public class KubernetesRuntime implements Runtime {
         if (jobName.equals(convertedJobName)) {
             return jobName;
         }
+        // toValidPodName may cause naming collisions, add a short hash here to avoid it
         final String shortHash = DigestUtils.sha1Hex(jobNameContent).toLowerCase().substring(0, 8);
         return convertedJobName + "-" + shortHash;
     }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntime.java
@@ -52,6 +52,7 @@ import io.kubernetes.client.models.V1StatefulSetSpec;
 import io.kubernetes.client.models.V1Toleration;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.pulsar.functions.auth.KubernetesFunctionAuthProvider;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
@@ -1015,18 +1016,25 @@ public class KubernetesRuntime implements Runtime {
         return ports;
     }
 
-    private static String createJobName(Function.FunctionDetails functionDetails) {
+    public static String createJobName(Function.FunctionDetails functionDetails) {
         return createJobName(functionDetails.getTenant(),
                 functionDetails.getNamespace(),
                 functionDetails.getName());
     }
 
     private static String toValidPodName(String ori) {
-        return ori.toLowerCase().replaceAll("[^a-z0-9]", "-");
+        return ori.toLowerCase().replaceAll("[^a-z0-9-\\.]", "-");
     }
 
     private static String createJobName(String tenant, String namespace, String functionName) {
-        return "pf-" + toValidPodName(tenant) + "-" + toValidPodName(namespace) + "-" + toValidPodName(functionName);
+        final String jobNameContent = String.format("%s-%s-%s", tenant, namespace,functionName);
+        final String jobName = "pf-" + jobNameContent;
+        final String convertedJobName = toValidPodName(jobName);
+        if (jobName.equals(convertedJobName)) {
+            return jobName;
+        }
+        final String shortHash = DigestUtils.sha1Hex(jobNameContent).toLowerCase().substring(0, 8);
+        return convertedJobName + "-" + shortHash;
     }
 
     private static String getServiceUrl(String jobName, String jobNamespace, int instanceId) {


### PR DESCRIPTION
### Motivation

k8s runtime use tenant, namespace, functionName to create k8s pod name, but functionName might not meet the k8s pod name rule. `"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"`, which will cause pod create failed.

### Modifications

This PR create a new function called `toValidPodName` which convert a string to valid pod name part, including convert to lower case and replace all non-char part to "-".

