### PR TITLE
[Pulsar IO]Completing connector configuration

### DIFF
--- a/distribution/io/src/assemble/io.xml
+++ b/distribution/io/src/assemble/io.xml
@@ -67,5 +67,8 @@
     <file><source>${basedir}/../../pulsar-io/debezium/mysql/target/pulsar-io-debezium-mysql-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/debezium/postgres/target/pulsar-io-debezium-postgres-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/influxdb/target/pulsar-io-influxdb-${project.version}.nar</source></file>
+    <file><source>${basedir}/../../pulsar-io/redis/target/pulsar-io-redis-${project.version}.nar</source></file>
+    <file><source>${basedir}/../../pulsar-io/flume/target/pulsar-io-flume-${project.version}.nar</source></file>
+    <file><source>${basedir}/../../pulsar-io/solr/target/pulsar-io-solr-${project.version}.nar</source></file>
   </files>
 </assembly>


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/4997

Master Issue: https://github.com/apache/pulsar/issues/4997

### Motivation
In the official download address of the connector, the connector of Flume, Solr and Redis was not generated correctly.

### Modifications
* Add configuration to io.xml for generate connectors

### Verifying this change
The local build generated a complete list of connectors in folder pulsar/distribution/io/target/apache-pulsar-io-connectors-2.5.0-SNAPSHOT-bin/