### PR TITLE
[Pulsar-sql]Using pulsar SQL query messages will appear `NoSuchLedger` when zk root directory changed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -103,8 +103,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
     private static final int StatsPeriodSeconds = 60;
 
-    public ManagedLedgerFactoryImpl(ClientConfiguration bkClientConfiguration) throws Exception {
-        this(bkClientConfiguration, new ManagedLedgerFactoryConfig());
+    public ManagedLedgerFactoryImpl(ClientConfiguration bkClientConfiguration, String zkConnection) throws Exception {
+        this(bkClientConfiguration, new ManagedLedgerFactoryConfig(), zkConnection);
     }
 
     @SuppressWarnings("deprecation")
@@ -114,6 +114,14 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 .connectString(bkClientConfiguration.getZkServers())
                 .sessionTimeoutMs(bkClientConfiguration.getZkTimeout())
                 .build(), bkClientConfiguration, config);
+    }
+
+    public ManagedLedgerFactoryImpl(ClientConfiguration bkClientConfiguration, ManagedLedgerFactoryConfig config,
+                                    String zkConnection) throws Exception {
+        this(ZooKeeperClient.newBuilder()
+                            .connectString(zkConnection)
+                            .sessionTimeoutMs(bkClientConfiguration.getZkTimeout())
+                            .build(), bkClientConfiguration, config);
     }
 
     private ManagedLedgerFactoryImpl(ZooKeeper zkc, ClientConfiguration bkClientConfiguration,
@@ -171,7 +179,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
         public DefaultBkFactory(ClientConfiguration bkClientConfiguration, ZooKeeper zkc)
                 throws BKException, IOException, InterruptedException {
-            bkClient = new BookKeeper(bkClientConfiguration, zkc);
+            bkClient = new BookKeeper(bkClientConfiguration);
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
 import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -49,6 +50,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.pulsar.common.policies.data.PersistentOfflineTopicStats;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
@@ -539,5 +541,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
 
         factory.shutdown();
     }
+
+
 
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryChangeLedgerPathTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryChangeLedgerPathTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.List;
+import org.apache.bookkeeper.common.allocator.PoolingPolicy;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ManagedLedgerFactoryChangeLedgerPathTest extends BookKeeperClusterTestCase {
+
+    public ManagedLedgerFactoryChangeLedgerPathTest() {
+        super(2);
+    }
+
+    @Override
+    protected String changeLedgerPath() {
+        return "/test";
+    }
+
+    @Test()
+    public void testChangeZKPath() throws Exception {
+        ClientConfiguration configuration = new ClientConfiguration();
+        String zkConnectString = zkUtil.getZooKeeperConnectString() + "/test";
+        configuration.setMetadataServiceUri("zk://" + zkConnectString + "/ledgers");
+        configuration.setUseV2WireProtocol(true);
+        configuration.setEnableDigestTypeAutodetection(true);
+        configuration.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
+        configuration.setZkTimeout(10);
+
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(configuration, zkConnectString);
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setEnsembleSize(1)
+            .setWriteQuorumSize(1)
+            .setAckQuorumSize(1)
+            .setMetadataAckQuorumSize(1)
+            .setMetadataAckQuorumSize(1);
+        ManagedLedger ledger = factory.open("test-ledger", config);
+        ManagedCursor cursor = ledger.openCursor("test-c1");
+
+        for (int i = 0; i < 10; i++) {
+            String entry = "entry" + i;
+            ledger.addEntry(entry.getBytes("UTF8"));
+        }
+
+        List<Entry> entryList = cursor.readEntries(10);
+        Assert.assertEquals(10, entryList.size());
+
+        for (int i = 0; i < 10; i++) {
+            Entry entry = entryList.get(i);
+            Assert.assertEquals(("entry" + i).getBytes("UTF8"), entry.getData());
+        }
+        factory.shutdown();
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
@@ -20,13 +20,21 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static org.testng.Assert.assertEquals;
 
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo.CursorInfo;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo.MessageRangeInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.bookkeeper.test.ZooKeeperUtil;
+import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 public class ManagedLedgerFactoryTest extends MockedBookKeeperTestCase {
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -24,7 +24,6 @@
 package org.apache.bookkeeper.test;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.UnpooledByteBufAllocator;
 
 import java.io.File;
 import java.io.IOException;
@@ -100,16 +99,21 @@ public abstract class BookKeeperClusterTestCase {
         setMetastoreImplClass(baseClientConf);
 
         try {
+            String zkPath = changeLedgerPath();
             // start zookeeper service
-            startZKCluster();
+            startZKCluster(zkPath);
             // start bookkeeper service
-            startBKCluster();
+            startBKCluster(zkPath);
 
-            zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            zkc.create(zkPath + "/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         } catch (Exception e) {
             LOG.error("Error setting up", e);
             throw e;
         }
+    }
+
+    protected String changeLedgerPath() {
+        return "";
     }
 
     @AfterMethod
@@ -127,7 +131,11 @@ public abstract class BookKeeperClusterTestCase {
      * @throws Exception
      */
     protected void startZKCluster() throws Exception {
-        zkUtil.startServer();
+        startZKCluster("");
+    }
+
+    protected void startZKCluster(String path) throws Exception {
+        zkUtil.startServer(path);
         zkc = zkUtil.getZooKeeperClient();
     }
 
@@ -145,8 +153,8 @@ public abstract class BookKeeperClusterTestCase {
      *
      * @throws Exception
      */
-    protected void startBKCluster() throws Exception {
-        baseClientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+    protected void startBKCluster(String ledgerPath) throws Exception {
+        baseClientConf.setMetadataServiceUri("zk://" + zkUtil.getZooKeeperConnectString() + ledgerPath + "/ledgers");
         baseClientConf.setUseV2WireProtocol(true);
         baseClientConf.setEnableDigestTypeAutodetection(true);
         baseClientConf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
@@ -156,7 +164,12 @@ public abstract class BookKeeperClusterTestCase {
 
         // Create Bookie Servers (B1, B2, B3)
         for (int i = 0; i < numBookies; i++) {
-            startNewBookie();
+            if (ledgerPath != "") {
+                ServerConfiguration configuration = newServerConfiguration(ledgerPath + "/ledgers");
+                startBookie(configuration, ledgerPath + "/ledgers");
+            }else {
+                startNewBookie();
+            }
         }
     }
 
@@ -186,13 +199,17 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     protected ServerConfiguration newServerConfiguration() throws Exception {
+        return newServerConfiguration("");
+    }
+
+    protected ServerConfiguration newServerConfiguration(String ledgerRootPath) throws Exception {
         File f = File.createTempFile("bookie", "test");
         tmpDirs.add(f);
         f.delete();
         f.mkdir();
 
         int port = PortManager.nextFreePort();
-        return newServerConfiguration(port, zkUtil.getZooKeeperConnectString(), f, new File[] { f });
+        return newServerConfiguration(port, zkUtil.getZooKeeperConnectString(), f, new File[] { f }, ledgerRootPath);
     }
 
     protected ClientConfiguration newClientConfiguration() {
@@ -200,10 +217,14 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     protected ServerConfiguration newServerConfiguration(int port, String zkServers, File journalDir,
-            File[] ledgerDirs) {
+            File[] ledgerDirs, String ledgerRootPath) {
         ServerConfiguration conf = new ServerConfiguration(baseConf);
         conf.setBookiePort(port);
-        conf.setZkServers(zkServers);
+        if (ledgerRootPath != "") {
+            conf.setMetadataServiceUri("zk://" + zkUtil.getZooKeeperConnectString() + ledgerRootPath);
+        }else {
+            conf.setZkServers(zkServers);
+        }
         conf.setJournalDirName(journalDir.getPath());
         conf.setAllowLoopback(true);
         conf.setFlushInterval(60 * 1000);
@@ -413,7 +434,7 @@ public abstract class BookKeeperClusterTestCase {
      *            Server Configuration Object
      *
      */
-    protected BookieServer startBookie(ServerConfiguration conf) throws Exception {
+    protected BookieServer startBookie(ServerConfiguration conf, String ledgerRootPath) throws Exception {
         BookieServer server = new BookieServer(conf);
         bsConfs.add(conf);
         bs.add(server);
@@ -425,8 +446,9 @@ public abstract class BookKeeperClusterTestCase {
         }
 
         int port = conf.getBookiePort();
-        while (bkc.getZkHandle().exists(
-                "/ledgers/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port, false) == null) {
+        while (bkc.getZkHandle()
+            .exists(ledgerRootPath + "/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port,
+                false) == null) {
             Thread.sleep(500);
         }
 
@@ -434,6 +456,10 @@ public abstract class BookKeeperClusterTestCase {
         LOG.info("New bookie on port " + port + " has been created.");
 
         return server;
+    }
+
+    protected BookieServer startBookie(ServerConfiguration conf) throws Exception {
+        return startBookie(conf, "/ledgers");
     }
 
     /**

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorCache.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorCache.java
@@ -88,12 +88,12 @@ public class PulsarConnectorCache {
     private static ManagedLedgerFactory initManagedLedgerFactory(PulsarConnectorConfig pulsarConnectorConfig)
         throws Exception {
         ClientConfiguration bkClientConfiguration = new ClientConfiguration()
-                .setZkServers(pulsarConnectorConfig.getZookeeperUri())
+                .setMetadataServiceUri("zk://" + pulsarConnectorConfig.getZookeeperUri() + "/ledgers")
                 .setClientTcpNoDelay(false)
                 .setUseV2WireProtocol(true)
                 .setStickyReadsEnabled(false)
                 .setReadEntryTimeout(60);
-        return new ManagedLedgerFactoryImpl(bkClientConfiguration);
+        return new ManagedLedgerFactoryImpl(bkClientConfiguration, pulsarConnectorConfig.getZookeeperUri());
     }
 
     public ManagedLedgerConfig getManagedLedgerConfig() {


### PR DESCRIPTION

Fixes #4715 

*Motivation*

When zookeeper ledgers root path is changed, using pulsar-sql to query messages will cause `BKNoSuchLedgerExistsException`.

*Modifications*

Make bookie using `setMetadataServiceUri` to set zookeeper uri.
