### PR TITLE
[Pulsar IO]Support reload Source and Sink for Pulsar IO

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
@@ -483,4 +483,18 @@ public class SinksBase extends AdminResource implements Supplier<WorkerService> 
         }
         return retval;
     }
+
+    @POST
+    @ApiOperation(
+            value = "Reload the available built-in connectors, include Source and Sink",
+            response = Void.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+            @ApiResponse(code = 500, message = "Internal server error")
+    })
+    @Path("/reloadBuiltInSinks")
+    public void reloadSinks() {
+        sink.reloadConnectors();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
@@ -473,4 +473,18 @@ public class SourcesBase extends AdminResource implements Supplier<WorkerService
         }
         return retval;
     }
+
+    @POST
+    @ApiOperation(
+            value = "Reload the available built-in connectors, include Source and Sink",
+            response = Void.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+            @ApiResponse(code = 500, message = "Internal server error")
+    })
+    @Path("/reloadBuiltInSources")
+    public void reloadSources() {
+        source.reloadConnectors();
+    }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sinks.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sinks.java
@@ -347,4 +347,12 @@ public interface Sinks {
      *
      */
     List<ConnectorDefinition> getBuiltInSinks() throws PulsarAdminException;
+
+    /**
+     * Reload the available built-in connectors, include Source and Sink
+     *
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void reloadBuiltInSinks() throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sources.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Sources.java
@@ -347,4 +347,13 @@ public interface Sources {
      *
      */
     List<ConnectorDefinition> getBuiltInSources() throws PulsarAdminException;
+
+
+    /**
+     * Reload the available built-in connectors, include Source and Sink
+     *
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void reloadBuiltInSources() throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
@@ -301,4 +301,14 @@ public class SinksImpl extends ComponentResource implements Sinks, Sink {
             throw getApiException(e);
         }
     }
+
+    @Override
+    public void reloadBuiltInSinks() throws PulsarAdminException {
+        try {
+            request(sink.path("reloadBuiltInSinks"))
+                    .post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
@@ -299,4 +299,14 @@ public class SourcesImpl extends ComponentResource implements Sources, Source {
             throw getApiException(e);
         }
     }
+
+    @Override
+    public void reloadBuiltInSources() throws PulsarAdminException {
+        try {
+            request(source.path("reloadBuiltInSources"))
+                    .post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -94,6 +94,7 @@ public class CmdSinks extends CmdBase {
         jcommander.addCommand("restart", restartSink);
         jcommander.addCommand("localrun", localSinkRunner);
         jcommander.addCommand("available-sinks", new ListBuiltInSinks());
+        jcommander.addCommand("reload", new ReloadBuiltInSinks());
     }
 
     /**
@@ -649,6 +650,15 @@ public class CmdSinks extends CmdBase {
                         System.out.println(WordUtils.wrap(connector.getDescription(), 80));
                         System.out.println("----------------------------------------");
                     });
+        }
+    }
+
+    @Parameters(commandDescription = "Reload the available built-in connectors")
+    public class ReloadBuiltInSinks extends BaseCommand {
+
+        @Override
+        void runCmd() throws Exception {
+            admin.sinks().reloadBuiltInSinks();
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -97,6 +97,7 @@ public class CmdSources extends CmdBase {
         jcommander.addCommand("restart", restartSource);
         jcommander.addCommand("localrun", localSourceRunner);
         jcommander.addCommand("available-sources", new ListBuiltInSources());
+        jcommander.addCommand("reload", new ReloadBuiltInSources());
     }
 
     /**
@@ -603,6 +604,15 @@ public class CmdSources extends CmdBase {
                         System.out.println(WordUtils.wrap(connector.getDescription(), 80));
                         System.out.println("----------------------------------------");
                     });
+        }
+    }
+
+    @Parameters(commandDescription = "Reload the available built-in connectors")
+    public class ReloadBuiltInSources extends BaseCommand {
+
+        @Override
+        void runCmd() throws Exception {
+            admin.sources().reloadBuiltInSources();
         }
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/ConnectorsManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/ConnectorsManager.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.functions.utils.io.Connectors;
 
 public class ConnectorsManager {
 
-    private final Connectors connectors;
+    private Connectors connectors;
 
     public ConnectorsManager(WorkerConfig workerConfig) throws IOException {
         this.connectors = ConnectorUtils.searchForConnectors(workerConfig.getConnectorsDirectory());
@@ -44,5 +44,9 @@ public class ConnectorsManager {
 
     public Path getSinkArchive(String sinkType) {
         return connectors.getSinks().get(sinkType);
+    }
+
+    public void reloadConnectors(WorkerConfig workerConfig) throws IOException {
+        this.connectors = ConnectorUtils.searchForConnectors(workerConfig.getConnectorsDirectory());
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -897,6 +897,17 @@ public abstract class ComponentImpl {
         return this.worker().getConnectorsManager().getConnectors();
     }
 
+    public void reloadConnectors() {
+        if (!isWorkerServiceAvailable()) {
+            throwUnavailableException();
+        }
+        try {
+            this.worker().getConnectorsManager().reloadConnectors(worker().getWorkerConfig());
+        } catch (IOException e) {
+            throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
     public String triggerFunction(final String tenant,
                                   final String namespace,
                                   final String functionName,

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1488,6 +1488,7 @@ Subcommands
 * `restart`
 * `localrun`
 * `available-sinks`
+* `reload`
 
 
 ### `create`
@@ -1717,6 +1718,9 @@ Options
 ### `available-sinks`
 Get the list of Pulsar IO connector sinks supported by Pulsar cluster
 
+### `reload`
+Reload the available built-in connectors
+
 Usage
 ```bash
 $ pulsar-admin sinks available-sinks
@@ -1743,6 +1747,7 @@ Subcommands
 * `restart`
 * `localrun`
 * `available-sources`
+* `reload`
 
 
 ### `create`
@@ -1956,6 +1961,9 @@ Options
 
 ### `available-sources`
 Get the list of Pulsar IO connector sources supported by Pulsar cluster
+
+### `reload`
+Reload the available built-in connectors
 
 Usage
 ```bash


### PR DESCRIPTION

Fixes: https://github.com/apache/pulsar/issues/4904

Master Issue: https://github.com/apache/pulsar/issues/4904

### Motivation

At present, pulsar can only load the built-in connector when starting the service, but some users want to automatically load the feature of the connector, which is very useful when adding, updating and deleting the built-in connector.

### Modifications

* Add reload rest API for source and sink

### Verifying this change

I haven't found an automated integration testing method for this API. If there is a better method, please let me know.

I just verified it in the following way:
```
./bin/pulsar-admin sources available-sources
mv pulsar-io-debezium-mysql-2.4.0.nar ./connectors
./bin/pulsar-admin sources reload
./bin/pulsar-admin sources available-sources

./bin/pulsar-admin sinks available-sinks
mv pulsar-io-jdbc-2.4.0.nar ./connectors
./bin/pulsar-admin sinks reload
./bin/pulsar-admin sinks available-sinks
```

### Documentation

  - Does this pull request introduce a new feature? (`yes` / no)
  - If yes, how is the feature documented? (not applicable /` docs` / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
