### PR TITLE
[security] Upgrade jackson-databind

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -314,14 +314,14 @@ The Apache Software License, Version 2.0
  * Jackson
      - org.codehaus.jackson-jackson-core-asl-1.9.13.jar
      - org.codehaus.jackson-jackson-mapper-asl-1.9.13.jar
-     - com.fasterxml.jackson.core-jackson-annotations-2.9.8.jar
-     - com.fasterxml.jackson.core-jackson-core-2.9.8.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.9.8.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.8.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.8.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.8.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.8.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.8.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.9.9.jar
+     - com.fasterxml.jackson.core-jackson-core-2.9.9.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.9.9.3.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.9.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.9.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.9.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.9.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.9.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
  * Gson -- com.google.code.gson-gson-2.8.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,8 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
+    <jackson.databind.version>2.9.9.3</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
@@ -644,7 +645,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson.databind.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -35,7 +35,7 @@
         <jackson.version>2.8.11</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.3</jackson.databind.version>
+        <jackson.databind.version>2.8.11.4</jackson.databind.version>
     </properties>
 
     <modules>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -209,7 +209,7 @@ The Apache Software License, Version 2.0
 
   * Jackson
     - jackson-annotations-2.8.11.jar
-    - jackson-databind-2.8.11.3.jar
+    - jackson-databind-2.8.11.4.jar
     - jackson-dataformat-smile-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -45,7 +45,7 @@
         <jackson.version>2.8.11</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.3</jackson.databind.version>
+        <jackson.databind.version>2.8.11.4</jackson.databind.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Motivation

Currently, `jackson-databind` in the Pulsar distribution has a security vulnerability and should be upgraded to the latest version.
https://nvd.nist.gov/vuln/detail/CVE-2019-14379

### Modifications

Upgraded the version of `jackson-databind` to 2.9.9.3. However, only `jackson-databind` used in pulsar-sql is 2.8.11.4 (cf. #2978).