### PR TITLE
Fixed the cleanup of non-durable cursors when a reader is closed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -910,8 +910,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                                 ledger.getName(), newPosition, name);
                     }
                 }
-                callback.resetComplete(newPosition);
 
+                callback.resetComplete(newPosition);
+                notifyEntriesAvailable();
             }
 
             @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -679,70 +679,42 @@ public class PersistentSubscription implements Subscription {
             return;
         }
 
-        final CompletableFuture<Void> disconnectFuture;
+        try {
+            cursor.asyncResetCursor(finalPosition, new AsyncCallbacks.ResetCursorCallback() {
+                @Override
+                public void resetComplete(Object ctx) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Successfully reset subscription to position {}", topicName, subName,
+                                finalPosition);
+                    }
+                    if (dispatcher != null) {
+                        dispatcher.cursorIsReset();
+                    }
+                    IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                    future.complete(null);
+                }
 
-        // Lock the Subscription object before locking the Dispatcher object to avoid deadlocks
-        synchronized (this) {
-            if (dispatcher != null && dispatcher.isConsumerConnected()) {
-                disconnectFuture = dispatcher.disconnectAllConsumers();
-            } else {
-                disconnectFuture = CompletableFuture.completedFuture(null);
-            }
+                @Override
+                public void resetFailed(ManagedLedgerException exception, Object ctx) {
+                    log.error("[{}][{}] Failed to reset subscription to position {}", topicName, subName,
+                            finalPosition, exception);
+                    IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                    // todo - retry on InvalidCursorPositionException
+                    // or should we just ask user to retry one more time?
+                    if (exception instanceof InvalidCursorPositionException) {
+                        future.completeExceptionally(new SubscriptionInvalidCursorPosition(exception.getMessage()));
+                    } else if (exception instanceof ConcurrentFindCursorPositionException) {
+                        future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
+                    } else {
+                        future.completeExceptionally(new BrokerServiceException(exception));
+                    }
+                }
+            });
+        } catch (Exception e) {
+            log.error("[{}][{}] Error while resetting cursor", topicName, subName, e);
+            IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+            future.completeExceptionally(new BrokerServiceException(e));
         }
-
-        disconnectFuture.whenComplete((aVoid, throwable) -> {
-            if (dispatcher != null) {
-                dispatcher.resetCloseFuture();
-            }
-
-            if (throwable != null) {
-                log.error("[{}][{}] Failed to disconnect consumer from subscription", topicName, subName, throwable);
-                IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                future.completeExceptionally(
-                        new SubscriptionBusyException("Failed to disconnect consumers from subscription"));
-                return;
-            }
-
-            log.info("[{}][{}] Successfully disconnected consumers from subscription, proceeding with cursor reset",
-                    topicName, subName);
-
-            try {
-                cursor.asyncResetCursor(finalPosition, new AsyncCallbacks.ResetCursorCallback() {
-                    @Override
-                    public void resetComplete(Object ctx) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}][{}] Successfully reset subscription to position {}", topicName, subName,
-                                    finalPosition);
-                        }
-                        if (dispatcher != null) {
-                            dispatcher.cursorIsReset();
-                        }
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        future.complete(null);
-                    }
-
-                    @Override
-                    public void resetFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("[{}][{}] Failed to reset subscription to position {}", topicName, subName,
-                                finalPosition, exception);
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        // todo - retry on InvalidCursorPositionException
-                        // or should we just ask user to retry one more time?
-                        if (exception instanceof InvalidCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionInvalidCursorPosition(exception.getMessage()));
-                        } else if (exception instanceof ConcurrentFindCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
-                        } else {
-                            future.completeExceptionally(new BrokerServiceException(exception));
-                        }
-                    }
-                });
-            } catch (Exception e) {
-                log.error("[{}][{}] Error while resetting cursor", topicName, subName, e);
-                IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                future.completeExceptionally(new BrokerServiceException(e));
-            }
-        });
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -283,7 +283,7 @@ public class PersistentSubscription implements Subscription {
                 });
 
                 try {
-                    cursor.getManagedLedger().deleteCursor(cursor.getName());
+                    topic.getManagedLedger().deleteCursor(cursor.getName());
                 } catch (InterruptedException | ManagedLedgerException e) {
                     log.warn("[{}] [{}] Failed to remove non durable cursor", topic.getName(), subName, e);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -282,6 +282,12 @@ public class PersistentSubscription implements Subscription {
                     return null;
                 });
 
+                try {
+                    cursor.getManagedLedger().deleteCursor(cursor.getName());
+                } catch (InterruptedException | ManagedLedgerException e) {
+                    log.warn("[{}] [{}] Failed to remove non durable cursor", topic.getName(), subName, e);
+                }
+
                 // when topic closes: it iterates through concurrent-subscription map to close each subscription. so,
                 // topic.remove again try to access same map which creates deadlock. so, execute it in different thread.
                 topic.getBrokerService().pulsar().getExecutor().submit(() ->{


### PR DESCRIPTION
### Motivation

The non-durable cursors associated with readers are not being cleaned up from the managed ledger. This causes these objects to keep hanging around in memory after the reader is gone.