### PR TITLE
[docker]Fix the problem of missing dependencies less

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=pulsar /pulsar /pulsar
 
 # Install some utilities
 RUN apt-get update \
-     && apt-get install -y netcat dnsutils \
+     && apt-get install -y netcat dnsutils less \
                  python2.7 python-setuptools \
                  python3-setuptools \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/4957

Master Issue: https://github.com/apache/pulsar/issues/4957

### Motivation

Currently, when packaging the docker image, the dependency less is lost, resulting in the following exception being thrown when presto SQL is running
```
Cannot run program "less": error=2, No such file or directory
```

### Modifications

* Add dependency less

