### PR TITLE
Add different cache flags to  ConcurrentOpenLongPairRangeSet for size() and toString()

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -56,7 +56,8 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
     // caching place-holder for cpu-optimization to avoid calculating ranges again
     private volatile int cachedSize = 0;
     private volatile String cachedToString = "[]";
-    private volatile boolean updatedAfterCached = true;
+    private volatile boolean updatedAfterCachedForSize = true;
+    private volatile boolean updatedAfterCachedForToString = true;
 
     public ConcurrentOpenLongPairRangeSet(LongPairConsumer<T> consumer) {
         this(1024, true, consumer);
@@ -110,7 +111,8 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
             BitSet rangeBitSet = rangeBitSetMap.computeIfAbsent(key, (k) -> createNewBitSet());
             rangeBitSet.set((int) lowerValue, (int) upperValue + 1);
         }
-        updatedAfterCached = true;
+        updatedAfterCachedForSize = true;
+        updatedAfterCachedForToString = true;
     }
 
     private boolean isValid(long key, long value) {
@@ -168,7 +170,8 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
     @Override
     public void clear() {
         rangeBitSetMap.clear();
-        updatedAfterCached = true;
+        updatedAfterCachedForSize = true;
+        updatedAfterCachedForToString = true;
     }
 
     @Override
@@ -231,21 +234,21 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
 
     @Override
     public int size() {
-        if (updatedAfterCached) {
+        if (updatedAfterCachedForSize) {
             AtomicInteger size = new AtomicInteger(0);
             forEach((range) -> {
                 size.getAndIncrement();
                 return true;
             });
             cachedSize = size.get();
-            updatedAfterCached = false;
+            updatedAfterCachedForSize = false;
         }
         return cachedSize;
     }
 
     @Override
     public String toString() {
-        if (updatedAfterCached) {
+        if (updatedAfterCachedForToString) {
             StringBuilder toString = new StringBuilder();
             AtomicBoolean first = new AtomicBoolean(true);
             if (toString != null) {
@@ -261,7 +264,7 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
             });
             toString.append("]");
             cachedToString = toString.toString();
-            updatedAfterCached = false;
+            updatedAfterCachedForToString = false;
         }
         return cachedToString;
     }
@@ -352,7 +355,8 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
             }
         });
 
-        updatedAfterCached = true;
+        updatedAfterCachedForSize = true;
+        updatedAfterCachedForToString = true;
     }
 
     private int getSafeEntry(LongPair position) {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -349,6 +349,18 @@ public class ConcurrentOpenLongPairRangeSetTest {
         assertEquals(set.rangeContaining(position.getKey(), position.getValue()), gSet.rangeContaining(position));
     }
 
+    /**
+     * fix : #4895
+     */
+    @Test
+    public void testCacheFlagConflict() {
+        ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
+        set.add(Range.openClosed(new LongPair(0, 1), new LongPair(0, 2)));
+        set.add(Range.openClosed(new LongPair(0, 3), new LongPair(0, 4)));
+        assertEquals(set.toString(), "[(0:1..0:2],(0:3..0:4]]");
+        assertEquals(set.size(), 2);
+    }
+
     private List<Range<LongPair>> getConnectedRange(Set<Range<LongPair>> gRanges) {
         List<Range<LongPair>> gRangeConnected = Lists.newArrayList();
         Range<LongPair> lastRange = null;


### PR DESCRIPTION
Fix #4895

### Motivation

In `ConcurrentOpenLongPairRangeSet`, `size()` and `toString()` use the same cache flag.
So, after using one of `size()` and `toString()`, another can't get the correct result.

### Modifications

- add different cache flags to  `ConcurrentOpenLongPairRangeSet` for `size()` and `toString() `
- add test for it