### PR TITLE
Reduce char[] creation on jvm heap.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -155,7 +155,7 @@ public class NonPersistentSubscription implements Subscription {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("topic", topicName).add("name", subName).toString();
+        return "NonPersistentSubscription{topic=" + topicName + ", name=" + subName + "}";
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -470,7 +470,7 @@ public class PersistentSubscription implements Subscription {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("topic", topicName).add("name", subName).toString();
+        return "NonPersistentSubscription{topic=" + topicName + ", name=" + subName + "}";
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Use MoreObjects at toString() method will resulting in the creation of a large number of chars []:

So this PR reduce the char[] creation on jvm heap while call subscription.toString().

### Modifications

Change implementation of subscription.toString()
