### PR TITLE
[pulsar-client] auto produce support message with schema version

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -107,6 +107,10 @@ public interface Producer<T> extends Closeable {
      */
     TypedMessageBuilder<T> newMessage();
 
+    default TypedMessageBuilder<T> newMessage(long schemaVersion) {
+        return newMessage();
+    }
+
     /**
      * Get the last sequence id that was published by this producer.
      * <p>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -54,6 +54,14 @@ public interface Schema<T> {
         decode(message);
     }
 
+    default void validate(byte[] message, byte[] schemaVersion) {
+        if (schemaVersion == null) {
+            decode(message);
+        } else {
+            decode(message, schemaVersion);
+        }
+    }
+
     /**
      * Encode an object representing the message content into a byte array.
      *
@@ -64,6 +72,10 @@ public interface Schema<T> {
      *             if the serialization fails
      */
     byte[] encode(T message);
+
+    default byte[] encode(T message, byte[] schemaVersion) {
+        return encode(message);
+    }
 
     /**
      * Returns whether this schema supports versioning.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -252,6 +252,8 @@ public interface TypedMessageBuilder<T> extends Serializable {
      */
     TypedMessageBuilder<T> loadConf(Map<String, Object> config);
 
+    TypedMessageBuilder<T> schemaVersion(long schemaVersion);
+
     static final String CONF_KEY = "key";
     static final String CONF_PROPERTIES = "properties";
     static final String CONF_EVENT_TIME = "eventTime";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -73,6 +73,11 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
         return new TypedMessageBuilderImpl<>(this, schema);
     }
 
+    @Override
+    public TypedMessageBuilder<T> newMessage(long schemaVersion) {
+        return new TypedMessageBuilderImpl<>(this, schema, schemaVersion);
+    }
+
     // TODO: add this method to the Producer interface
     // @Override
     public TypedMessageBuilder<T> newMessage(Transaction txn) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -36,6 +36,8 @@ import io.netty.util.TimerTask;
 import io.netty.util.concurrent.ScheduledFuture;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -338,7 +340,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             return;
         }
 
-        if (schemaVersion.isPresent()) {
+        if (!msgMetadataBuilder.hasSchemaVersion() && schemaVersion.isPresent()) {
             msgMetadataBuilder.setSchemaVersion(ByteString.copyFrom(schemaVersion.get()));
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -21,8 +21,11 @@ package org.apache.pulsar.client.impl.schema;
 import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Arrays;
 
 /**
  * Auto detect schema.
@@ -57,6 +60,18 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
         if (requireSchemaValidation) {
             // verify if the message can be decoded by the underlying schema
             schema.validate(message);
+        }
+
+        return message;
+    }
+
+    @Override
+    public byte[] encode(byte[] message, byte[] schemaVersion) {
+        ensureSchemaInitialized();
+
+        if (requireSchemaValidation) {
+            // verify if the message can be decoded by the underlying schema
+            schema.validate(message, schemaVersion);
         }
 
         return message;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -530,6 +530,12 @@ class ContextImpl implements Context, SinkContext, SourceContext {
             return this;
         }
 
+        @Override
+        public TypedMessageBuilder<O> schemaVersion(long schemaVersion) {
+            underlyingBuilder.schemaVersion(schemaVersion);
+            return this;
+        }
+
         public void setUnderlyingBuilder(TypedMessageBuilder<O> underlyingBuilder) {
             this.underlyingBuilder = underlyingBuilder;
         }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Master Issue: #4806 

### Motivation

auto produce will always encode and tag message with the latest version of schema,
which may be conflict with bytes encoded by lower version schema

### Modifications

support to specify schema version for one single message, which would be used when validate and filled into message metadata.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is already covered by existing tests, such as *SimpleSchemaTest.newProducerWithoutSchemaOnTopicWithMultiVersionSchema*.

### Does this pull request potentially affect one of the following parts:

  - The public API: (yes)
  - The schema: (yes)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
