### PR TITLE
[docs] Clarify non-persistent topics guaranties part

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -334,7 +334,7 @@ By default, non-persistent topics are enabled on Pulsar brokers. You can disable
 
 ### Performance
 
-Non-persistent messaging is usually faster than persistent messaging because brokers don't persist messages and immediately send acks back to the producer as soon as that message is deliver to all connected subscribers. Producers thus see comparatively low publish latency with non-persistent topic.
+Non-persistent messaging is usually faster than persistent messaging because brokers don't persist messages and immediately send acks back to the producer as soon as that message is delivered to connected brokers. Producers thus see comparatively low publish latency with non-persistent topic.
 
 ### Client API
 


### PR DESCRIPTION
It was unclear. 
"Consumers" looks like chain of persistent-topic-A -> function -> non-persistent-topic-B -> function -> persistent-topic-C will be zero loss on restart of brokers, but unfortunately it's seems not to be true:)
