### PR TITLE
Add Github workflow for gated checkin

### DIFF
--- a/.github/workflows/cpp-ci.yaml
+++ b/.github/workflows/cpp-ci.yaml
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/.github/workflows/cpp-ci.yaml
+++ b/.github/workflows/cpp-ci.yaml
@@ -8,13 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Checkout code
         uses: actions/checkout@master
 
       - name: run c++ tests
         run: |
-          java -version
-          javac -version
           mvn -B clean package -DskipTests
           echo "Build C++ client library"
           export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF"

--- a/.github/workflows/cpp-ci.yaml
+++ b/.github/workflows/cpp-ci.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 name: CI
 on: [pull_request]
 

--- a/.github/workflows/cpp-ci.yaml
+++ b/.github/workflows/cpp-ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+on: [pull_request]
+
+jobs:
+  
+  cpp-integration:
+    name: C++ / Python tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: run c++ tests
+        run: |
+          java -version
+          javac -version
+          mvn -B clean package -DskipTests
+          echo "Build C++ client library"
+          export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF"
+          pulsar-client-cpp/docker-build.sh
+          pulsar-client-cpp/docker-tests.sh 

--- a/.github/workflows/integration-ci.yaml
+++ b/.github/workflows/integration-ci.yaml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -13,7 +14,8 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
+#
 
 name: CI
 on: [pull_request]

--- a/.github/workflows/integration-ci.yaml
+++ b/.github/workflows/integration-ci.yaml
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,4 +38,4 @@ jobs:
       - name: run integration tests
         run: |
           mvn -B clean install -Pdocker -DskipTests
-          mvn -f tests/pom.xml -DintegrationTests -DredirectTestOutputToFile=false
+          mvn -f tests/pom.xml test -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/integration-ci.yaml
+++ b/.github/workflows/integration-ci.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License. 
+
 name: CI
 on: [pull_request]
 

--- a/.github/workflows/integration-ci.yaml
+++ b/.github/workflows/integration-ci.yaml
@@ -8,12 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Checkout code
         uses: actions/checkout@master
 
       - name: run integration tests
         run: |
-          java -version
-          javac -version
-          mvn install -Pdocker -DskipTests
-          mvn -f tests/pom.xml test -DintegrationTests
+          mvn -B clean install -Pdocker -DskipTests
+          mvn -f tests/pom.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/integration-ci.yaml
+++ b/.github/workflows/integration-ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+on: [pull_request]
+
+jobs:
+    
+  build-integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: run integration tests
+        run: |
+          java -version
+          javac -version
+          mvn install -Pdocker -DskipTests
+          mvn -f tests/pom.xml test -DintegrationTests

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -13,7 +14,8 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
+#
 
 name: CI
 on: [pull_request]

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -8,13 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Checkout code
         uses: actions/checkout@master
 
       - name: run unit tests
         run: |
-          java -version
-          javac -version
           export TEST_TIMEOUT_ENV_MILLIS=30000
           export TEST_RETRY_COUNT=3
-          mvn install
+          mvn -B clean license:check install
+          src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -25,8 +25,6 @@ jobs:
   build-unit:
     name: Unit tests
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Set up JDK 1.8
@@ -45,6 +43,7 @@ jobs:
           src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz
 
       - name: package surefire artifacts
+        if: failure()
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -53,6 +52,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
+        if: failure()
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -25,6 +25,8 @@ jobs:
   build-unit:
     name: Unit tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
       - name: Set up JDK 1.8
@@ -41,3 +43,16 @@ jobs:
           export TEST_RETRY_COUNT=3
           mvn -B clean license:check install
           src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz
+
+      - name: package surefire artifacts
+        run: |
+          rm -rf artifacts
+          mkdir artifacts
+          find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+          zip -r artifacts.zip artifacts
+
+      - uses: actions/upload-artifact@master
+        name: upload surefire-artifacts
+        with:
+          name: surefire-artifacts
+          path: artifacts.zip

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+on: [pull_request]
+
+jobs:
+
+  build-unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: run unit tests
+        run: |
+          java -version
+          javac -version
+          export TEST_TIMEOUT_ENV_MILLIS=30000
+          export TEST_RETRY_COUNT=3
+          mvn install

--- a/.github/workflows/unit-ci.yaml
+++ b/.github/workflows/unit-ci.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License. 
+
 name: CI
 on: [pull_request]
 

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,6 +41,11 @@
       <version>6.14.3</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>2.10.0</version>

--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
 
@@ -29,6 +30,14 @@ import org.testng.annotations.ITestAnnotation;
 public class AnnotationListener implements IAnnotationTransformer {
 
     private static final long DEFAULT_TEST_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    private static final long TEST_TIMEOUT_MILLIS_PROPERTY =
+            Integer.parseInt(System.getProperty("testTimeOut", Long.toString(DEFAULT_TEST_TIMEOUT_MILLIS)));
+
+     private static final long TEST_TIMEOUT_MILLIS_ENV =
+            NumberUtils.toLong(System.getenv("TEST_TIMEOUT_ENV_MILLIS"), DEFAULT_TEST_TIMEOUT_MILLIS);
+
+     private static final long TEST_TIMEOUT_MILLIS = Math.max(TEST_TIMEOUT_MILLIS_PROPERTY, TEST_TIMEOUT_MILLIS_ENV);
 
     public AnnotationListener() {
         System.out.println("Created annotation listener");
@@ -40,7 +49,7 @@ public class AnnotationListener implements IAnnotationTransformer {
 
         // Enforce default test timeout
         if (annotation.getTimeOut() == 0) {
-            annotation.setTimeOut(DEFAULT_TEST_TIMEOUT_MILLIS);
+            annotation.setTimeOut(TEST_TIMEOUT_MILLIS);
         }
     }
 }

--- a/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,19 +18,30 @@
  */
 package org.apache.pulsar.tests;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 
 public class RetryAnalyzer implements IRetryAnalyzer {
 
-    private int count = 0;
+    private int currentRetryCount = 1;
 
-    // Only try again once
-    private static final int MAX_RETRIES = Integer.valueOf(System.getProperty("testRetryCount", "1"));
+    private static final int MAX_RETRIES_SYSTEM = Integer.parseInt(System.getProperty("testRetryCount", "1"));
+    private static final int MAX_RETRIES_ENV = NumberUtils.toInt(System.getenv("TEST_RETRY_COUNT"), 1);
+    private static final int MAX_RETRIES_COUNT = Math.max(MAX_RETRIES_SYSTEM, MAX_RETRIES_ENV);
 
     @Override
     public boolean retry(ITestResult result) {
-        return count++ < MAX_RETRIES;
+
+        if (currentRetryCount <= MAX_RETRIES_COUNT) {
+            final String message = "running retry for '" + result.getName() + "' on class " + this.getClass().getName()
+                    + " Retry count : " + currentRetryCount;
+
+            System.out.println(message);
+            currentRetryCount++;
+            return true;
+        }
+        return false;
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
@@ -76,6 +76,8 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
         config.setBrokerClientAuthenticationParameters("tlsCertFile:" + TLS_CLIENT_CERT_FILE_PATH + ",tlsKeyFile:" + TLS_CLIENT_KEY_FILE_PATH);
         config.setBrokerClientAuthenticationPlugin(AuthenticationTls.class.getName());
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT_TLS).toString();
+        // Add the required number of thread for testing in low core count machines
+        config.setNumHttpServerThreads(6);
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);


### PR DESCRIPTION
We are adding support for complementary ci cd jobs based on Github actions. these jobs will run in parallel and thereafter we can deprecate the jenkins check in jobs.