### PR TITLE
[bookkeeper] Don't return DEFAULT_RACK if ZkBookieRackAffinityMapping can't resolve network location

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.zookeeper;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.net.UnknownHostException;
@@ -39,7 +38,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -155,7 +153,9 @@ public class ZkBookieRackAffinityMapping extends AbstractDNSToSwitchMapping
             // Trigger load of z-node in case it didn't exist
             Optional<BookiesRackConfiguration> racks = bookieMappingCache.get(BOOKIE_INFO_ROOT_PATH);
             if (!racks.isPresent()) {
-                return NetworkTopology.DEFAULT_RACK;
+                // since different placement policy will have different default rack,
+                // don't be smart here and just return null
+                return null;
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -170,7 +170,9 @@ public class ZkBookieRackAffinityMapping extends AbstractDNSToSwitchMapping
             }
             return rack;
         } else {
-            return NetworkTopology.DEFAULT_RACK;
+            // since different placement policy will have different default rack,
+            // don't be smart here and just return null
+            return null;
         }
     }
 

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
@@ -86,7 +85,7 @@ public class ZkBookieRackAffinityMappingTest {
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
         assertEquals(racks1.get(0), "/rack0");
         assertEquals(racks1.get(1), "/rack1");
-        assertEquals(racks1.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks1.get(2), null);
 
         // Case 2: ZkServers and ZkTimeout are given (ZKCache will be constructed in
         // ZkBookieRackAffinityMapping#setConf)
@@ -99,7 +98,7 @@ public class ZkBookieRackAffinityMappingTest {
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
         assertEquals(racks2.get(0), "/rack0");
         assertEquals(racks2.get(1), "/rack1");
-        assertEquals(racks2.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks2.get(2), null);
 
         localZkc.delete(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, -1);
     }
@@ -112,9 +111,9 @@ public class ZkBookieRackAffinityMappingTest {
         });
         mapping.setConf(bkClientConf);
         List<String> racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
-        assertEquals(racks.get(0), NetworkTopology.DEFAULT_RACK);
-        assertEquals(racks.get(1), NetworkTopology.DEFAULT_RACK);
-        assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks.get(0), null);
+        assertEquals(racks.get(1), null);
+        assertEquals(racks.get(2), null);
 
         Map<String, Map<BookieSocketAddress, BookieInfo>> bookieMapping = new HashMap<>();
         Map<BookieSocketAddress, BookieInfo> mainBookieGroup = new HashMap<>();
@@ -132,7 +131,7 @@ public class ZkBookieRackAffinityMappingTest {
         racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
         assertEquals(racks.get(0), "/rack0");
         assertEquals(racks.get(1), "/rack1");
-        assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks.get(2), null);
 
         localZkc.delete(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, -1);
     }
@@ -159,7 +158,7 @@ public class ZkBookieRackAffinityMappingTest {
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
         assertEquals(racks.get(0), "/rack0");
         assertEquals(racks.get(1), "/rack1");
-        assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks.get(2), null);
 
         // add info for BOOKIE3 and check if the mapping picks up the change
         Map<BookieSocketAddress, BookieInfo> secondaryBookieGroup = new HashMap<>();
@@ -182,8 +181,8 @@ public class ZkBookieRackAffinityMappingTest {
         Thread.sleep(100);
 
         racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
-        assertEquals(racks.get(0), NetworkTopology.DEFAULT_RACK);
-        assertEquals(racks.get(1), NetworkTopology.DEFAULT_RACK);
-        assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
+        assertEquals(racks.get(0), null);
+        assertEquals(racks.get(1), null);
+        assertEquals(racks.get(2), null);
     }
 }


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


*Motivation*

Different placement policy has different default rack information. For example, the default rack for `RackAware`
is `/default-rack` and the default rack for `RegionAware` is `/default-region/default-rack`. If we return the
wrong default rack, it can potentially cause inconsistent network locations inserted to the network topology and
causing the following errors.

```
15:36:30.083 [BookKeeperClientScheduler-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.net.NetworkTopologyImpl - Error: can't add leaf node <Bookie:1.1.1.2:3181> at depth 2 to topology:
Number of racks: 1
Expected number of leaves:1
/sh/rack1/1.1.1.1:3181

15:36:30.083 [BookKeeperClientScheduler-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl - Unexpected exception while handling joining bookie 1.1.1.2:3181
org.apache.bookkeeper.net.NetworkTopologyImpl$InvalidTopologyException: Invalid network topology. You cannot have a rack and a non-rack node at the same level of the network topology.
```