### PR TITLE
modify BatcherBuilder interface and it's subs to implement java.io.Serializable, otherwise java.io.NotSerializableException occurs when we use plusar-flink-connector.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatcherBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatcherBuilder.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.client.api;
 
 import org.apache.pulsar.client.internal.DefaultImplementation;
 
+import java.io.Serializable;
+
 /**
  * Batcher builder
  */
-public interface BatcherBuilder {
+public interface BatcherBuilder extends Serializable {
 
     /**
      * Default batch message container

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultBatcherBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultBatcherBuilder.java
@@ -23,6 +23,8 @@ import org.apache.pulsar.client.api.BatcherBuilder;
 
 public class DefaultBatcherBuilder implements BatcherBuilder {
 
+    private static final long serialVersionUID = 1L;
+
     @Override
     public BatchMessageContainer build() {
         return new BatchMessageContainerImpl();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/KeyBasedBatcherBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/KeyBasedBatcherBuilder.java
@@ -23,6 +23,8 @@ import org.apache.pulsar.client.api.BatcherBuilder;
 
 public class KeyBasedBatcherBuilder implements BatcherBuilder {
 
+    private static final long serialVersionUID = 1L;
+
     @Override
     public BatchMessageContainer build() {
         return new BatchMessageKeyBasedContainer();


### PR DESCRIPTION
modify BatcherBuilder interface and it's subs to implement java.io.Serializable, otherwise java.io.NotSerializableException occurs when we use plusar-flink-connector.