### PR TITLE
[Dashboard] Fix incorrect statistics on tenants page

### DIFF
--- a/dashboard/django/stats/views.py
+++ b/dashboard/django/stats/views.py
@@ -112,28 +112,20 @@ class HomeView(generic.ListView):
 def home(request):
     ts = get_timestamp()
     properties = Property.objects.filter(
-        ).annotate(
-            numNamespaces = Subquery(
-                Namespace.objects.filter(
-                    deleted=False,
-                    timestamp=ts,
-                    property=OuterRef('pk')
-                ).values('property')
-                    .annotate(cnt=Count('pk'))
-                    .values('cnt'),
-                output_field=IntegerField()
-            ),
-            numTopics    = Count('namespace__topic__name', distinct=True),
-            numProducers = Sum('namespace__topic__producerCount'),
-            numSubscriptions = Sum('namespace__topic__subscriptionCount'),
-            numConsumers  = Sum('namespace__topic__consumerCount'),
-            backlog       = Sum('namespace__topic__backlog'),
-            storage       = Sum('namespace__topic__storageSize'),
-            rateIn        = Sum('namespace__topic__msgRateIn'),
-            rateOut       = Sum('namespace__topic__msgRateOut'),
-            throughputIn  = Sum('namespace__topic__msgThroughputIn'),
-            throughputOut = Sum('namespace__topic__msgThroughputOut'),
-        )
+        namespace__topic__timestamp = ts,
+    ).annotate(
+        numNamespaces = Count('namespace__name', distinct=True),
+        numTopics    = Count('namespace__topic__name', distinct=True),
+        numProducers = Sum('namespace__topic__producerCount', filter=Q(topic__timestamp__eq=ts)),
+        numSubscriptions = Sum('namespace__topic__subscriptionCount'),
+        numConsumers  = Sum('namespace__topic__consumerCount'),
+        backlog       = Sum('namespace__topic__backlog'),
+        storage       = Sum('namespace__topic__storageSize'),
+        rateIn        = Sum('namespace__topic__msgRateIn'),
+        rateOut       = Sum('namespace__topic__msgRateOut'),
+        throughputIn  = Sum('namespace__topic__msgThroughputIn'),
+        throughputOut = Sum('namespace__topic__msgThroughputOut'),
+    )
 
     logger.info(properties.query)
 


### PR DESCRIPTION
### Motivation

After adding timestamp to the namespace object this lead to the statistics on the tenants page over counting. The fix currently in place only handles the count of namespaces and topics.

### Modifications

Add a filter on timestamp. As a side effect this removes the need for the previous fix attempt (a subquery) and so that was also removed.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no )
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: ( no)
  - The admin cli options: ( no)
  - Anything that affects deployment: ( no )

### Documentation

  - Does this pull request introduce a new feature? ( no)
