### PR TITLE
[pulsar-client] support set read-position based on timestamp

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -611,6 +611,9 @@ public class ServerCnx extends PulsarHandler {
         final boolean readCompacted = subscribe.getReadCompacted();
         final Map<String, String> metadata = CommandUtils.metadataFromCommand(subscribe);
         final InitialPosition initialPosition = subscribe.getInitialPosition();
+        final long startMessageRollbackDurationSec = subscribe.hasStartMessageRollbackDurationSec()
+                ? subscribe.getStartMessageRollbackDurationSec()
+                : -1;
         final SchemaData schema = subscribe.hasSchema() ? getSchema(subscribe.getSchema()) : null;
         final boolean isReplicated = subscribe.hasReplicateSubscriptionState() && subscribe.getReplicateSubscriptionState();
         final boolean forceTopicCreation = subscribe.getForceTopicCreation();
@@ -698,7 +701,7 @@ public class ServerCnx extends PulsarHandler {
                                                         return topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                                                 subType, priorityLevel, consumerName, isDurable,
                                                                 startMessageId, metadata,
-                                                                readCompacted, initialPosition, isReplicated);
+                                                                readCompacted, initialPosition, startMessageRollbackDurationSec, isReplicated);
                                                     } else {
                                                         return FutureUtil.failedFuture(
                                                                 new IncompatibleSchemaException(
@@ -710,7 +713,7 @@ public class ServerCnx extends PulsarHandler {
                                         return topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                             subType, priorityLevel, consumerName, isDurable,
                                             startMessageId, metadata, readCompacted, initialPosition,
-                                            isReplicated);
+                                            startMessageRollbackDurationSec, isReplicated);
                                     }
                                 })
                                 .thenAccept(consumer -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -92,7 +92,7 @@ public interface Topic {
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            boolean replicateSubscriptionState);
+            long startMessageRollbackDurationSec, boolean replicateSubscriptionState);
 
     CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition,
             boolean replicateSubscriptionState);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -245,7 +245,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            boolean replicateSubscriptionState) {
+            long resetStartMessageBackInSec, boolean replicateSubscriptionState) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -495,7 +495,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            boolean replicatedSubscriptionState) {
+            long startMessageRollbackDurationSec, boolean replicatedSubscriptionState) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -570,10 +570,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         CompletableFuture<? extends Subscription> subscriptionFuture = isDurable ? //
-                getDurableSubscription(subscriptionName, initialPosition, replicatedSubscriptionState) //
-                : getNonDurableSubscription(subscriptionName, startMessageId);
+                getDurableSubscription(subscriptionName, initialPosition, startMessageRollbackDurationSec, replicatedSubscriptionState) //
+                : getNonDurableSubscription(subscriptionName, startMessageId, startMessageRollbackDurationSec);
 
-        int maxUnackedMessages  = isDurable ? brokerService.pulsar().getConfiguration().getMaxUnackedMessagesPerConsumer() :0;
+        int maxUnackedMessages = isDurable
+                ? brokerService.pulsar().getConfiguration().getMaxUnackedMessagesPerConsumer()
+                : 0;
 
         subscriptionFuture.thenAccept(subscription -> {
             try {
@@ -618,7 +620,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private CompletableFuture<Subscription> getDurableSubscription(String subscriptionName,
-            InitialPosition initialPosition, boolean replicated) {
+            InitialPosition initialPosition, long startMessageRollbackDurationSec, boolean replicated) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
 
         Map<String, Long> properties = PersistentSubscription.getBaseCursorProperties(replicated);
@@ -654,7 +656,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return subscriptionFuture;
     }
 
-    private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName, MessageId startMessageId) {
+    private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName,
+            MessageId startMessageId, long startMessageRollbackDurationSec) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
         log.info("[{}][{}] Creating non-durable subscription at msg id {}", topic, subscriptionName, startMessageId);
 
@@ -684,7 +687,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
 
         if (!subscriptionFuture.isDone()) {
-            subscriptionFuture.complete(subscription);
+            if (startMessageRollbackDurationSec > 0) {
+                long timestamp = System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(startMessageRollbackDurationSec);
+                subscription.resetCursor(timestamp).handle((s, ex) -> {
+                    if (ex != null) {
+                        log.warn("[{}] Failed to reset cursor {} position at timestamp {}", topic, subscriptionName,
+                                startMessageRollbackDurationSec);
+                    }
+                    subscriptionFuture.complete(subscription);
+                    return null;
+                });
+            } else {
+                subscriptionFuture.complete(subscription);
+            }
         } else {
             // failed to initialize managed-cursor: clean up created subscription
             subscriptions.remove(subscriptionName);
@@ -695,7 +710,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition, boolean replicateSubscriptionState) {
-        return getDurableSubscription(subscriptionName, initialPosition, replicateSubscriptionState);
+        return getDurableSubscription(subscriptionName, initialPosition, 0 /*avoid reseting cursor*/, replicateSubscriptionState);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -112,6 +112,7 @@ public class RawReaderImpl implements RawReader {
                 consumerFuture,
                 SubscriptionMode.Durable,
                 MessageId.earliest,
+                0 /* startMessageRollbackDurationInSec */,
                 Schema.BYTES, null,
                 true
             );

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -121,7 +121,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -180,7 +180,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -243,7 +243,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -302,7 +302,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -432,7 +432,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false);
+                0 /*avoid reseting cursor*/, false);
         try {
             f1.get();
             fail("should fail with exception");
@@ -452,13 +452,13 @@ public class PersistentTopicTest {
         // 1. simple subscribe
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false);
+                0 /*avoid reseting cursor*/,false);
         f1.get();
 
         // 2. duplicate subscribe
         Future<Consumer> f2 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false);
+                0 /*avoid reseting cursor*/,false);
 
         try {
             f2.get();
@@ -778,7 +778,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
         f1.get();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -794,7 +794,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -849,7 +849,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -937,7 +937,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
 
         try {
             f.get();
@@ -1067,7 +1067,7 @@ public class PersistentTopicTest {
         Future<Consumer> f1 = topic1.subscribe(serverCnx, cmd1.getSubscription(), cmd1.getConsumerId(),
                 cmd1.getSubType(), 0, cmd1.getConsumerName(), cmd1.getDurable(), null, Collections.emptyMap(),
                 cmd1.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
         f1.get();
 
         // 2. Subscribe with partition topic
@@ -1080,7 +1080,7 @@ public class PersistentTopicTest {
         Future<Consumer> f2 = topic2.subscribe(serverCnx, cmd2.getSubscription(), cmd2.getConsumerId(),
                 cmd2.getSubType(), 0, cmd2.getConsumerName(), cmd2.getDurable(), null, Collections.emptyMap(),
                 cmd2.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f2.get();
 
         // 3. Subscribe and create second consumer
@@ -1091,7 +1091,7 @@ public class PersistentTopicTest {
         Future<Consumer> f3 = topic2.subscribe(serverCnx, cmd3.getSubscription(), cmd3.getConsumerId(),
                 cmd3.getSubType(), 0, cmd3.getConsumerName(), cmd3.getDurable(), null, Collections.emptyMap(),
                 cmd3.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f3.get();
 
         assertEquals(
@@ -1113,7 +1113,7 @@ public class PersistentTopicTest {
         Future<Consumer> f4 = topic2.subscribe(serverCnx, cmd4.getSubscription(), cmd4.getConsumerId(),
                 cmd4.getSubType(), 0, cmd4.getConsumerName(), cmd4.getDurable(), null, Collections.emptyMap(),
                 cmd4.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f4.get();
 
         assertEquals(
@@ -1140,7 +1140,7 @@ public class PersistentTopicTest {
         Future<Consumer> f5 = topic2.subscribe(serverCnx, cmd5.getSubscription(), cmd5.getConsumerId(),
                 cmd5.getSubType(), 0, cmd5.getConsumerName(), cmd5.getDurable(), null, Collections.emptyMap(),
                 cmd5.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */);
 
         try {
             f5.get();
@@ -1158,7 +1158,7 @@ public class PersistentTopicTest {
         Future<Consumer> f6 = topic2.subscribe(serverCnx, cmd6.getSubscription(), cmd6.getConsumerId(),
                 cmd6.getSubType(), 0, cmd6.getConsumerName(), cmd6.getDurable(), null, Collections.emptyMap(),
                 cmd6.getReadCompacted(), InitialPosition.Latest,
-                false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */);
         f6.get();
 
         // 7. unsubscribe exclusive sub

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -520,7 +520,7 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf newSubscribeCmd = Commands.newSubscribe(nonExistentTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */, 0);
         channel.writeInbound(newSubscribeCmd);
         assertTrue(getResponse() instanceof CommandError);
     }
@@ -582,7 +582,8 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf newSubscribeCmd = Commands.newSubscribe(nonExistentTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(newSubscribeCmd);
         topicRef = (PersistentTopic) brokerService.getTopicReference(nonExistentTopicName).get();
         assertNotNull(topicRef);
@@ -697,7 +698,8 @@ public class ServerCnxTest {
         // Sending multiple subscribe commands for the same consumer should succeed
 
         ByteBuf subscribe1 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe1);
 
         // 1st subscribe succeeds
@@ -706,7 +708,8 @@ public class ServerCnxTest {
         assertEquals(((CommandSuccess) response).getRequestId(), 1);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 2 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 2 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe2);
 
         // 2nd subscribe succeeds
@@ -726,12 +729,14 @@ public class ServerCnxTest {
         doReturn(delayFuture).when(brokerService).getOrCreateTopic(any(String.class));
         // Create subscriber first time
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(clientCommand);
 
         // Create producer second time
         clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(clientCommand);
 
         Object response = getResponse();
@@ -972,19 +977,23 @@ public class ServerCnxTest {
         // (There can be more subscribe/close pairs in the sequence, depending on the client timeout
 
         ByteBuf subscribe1 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe1);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe2);
 
         ByteBuf subscribe3 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe3);
 
         ByteBuf subscribe4 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 5 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 5 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe4);
 
         openTopicTask.get().run();
@@ -1051,14 +1060,16 @@ public class ServerCnxTest {
         // These operations need to be serialized, to allow the last subscribe operation to finally succeed
         // (There can be more subscribe/close pairs in the sequence, depending on the client timeout
         ByteBuf subscribe1 = Commands.newSubscribe(failTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe1);
 
         ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */ );
         channel.writeInbound(closeConsumer);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe2);
 
         openTopicFail.get().run();
@@ -1080,7 +1091,8 @@ public class ServerCnxTest {
         }
 
         ByteBuf subscribe3 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe3);
 
         openTopicSuccess.get().run();
@@ -1109,7 +1121,8 @@ public class ServerCnxTest {
         doReturn(false).when(brokerService).isAuthorizationEnabled();
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1121,17 +1134,13 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic creation success and cursor failure
         clientCommand = Commands.newSubscribe(successTopicName, failSubName, 2, 2, SubType.Exclusive,
-                0, "test" /*
-                        * consumer name
-                        */);
+                0, "test", 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandError);
 
         // test SUBSCRIBE on topic creation failure
         clientCommand = Commands.newSubscribe(failTopicName, successSubName, 3, 3, SubType.Exclusive,
-                0, "test" /*
-                        * consumer name
-                        */);
+                0, "test", 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         assertEquals(getResponse().getClass(), CommandError.class);
 
@@ -1153,7 +1162,7 @@ public class ServerCnxTest {
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
                 successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0 /* priority */,
-                "test" /* consumer name */);
+                "test" /* consumer name */, 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1162,7 +1171,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic and cursor creation success
         clientCommand = Commands.newSubscribe(successTopicName, failSubName, 2, 2, SubType.Exclusive, 0 /* priority */,
-                "test" /* consumer name */);
+                "test" /* consumer name */, 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         Object response = getResponse();
         assertTrue(response instanceof CommandError);
@@ -1187,7 +1196,8 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(clientCommand);
 
         assertTrue(getResponse() instanceof CommandSuccess);
@@ -1209,7 +1219,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */, 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandError);
 
@@ -1224,7 +1234,7 @@ public class ServerCnxTest {
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, successSubName, 1 /* consumer id */,
                 1 /*
                    * request id
-                   */, SubType.Exclusive, 0, "test" /* consumer name */);
+                   */, SubType.Exclusive, 0, "test" /* consumer name */, 0 /*avoid reseting cursor*/);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1245,7 +1255,8 @@ public class ServerCnxTest {
         setChannelConnected();
 
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, successSubName, //
-                1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
+                1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */,
+                0 /* avoid reseting cursor */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1584,7 +1595,7 @@ public class ServerCnxTest {
         setChannelConnected();
 
         channel.writeInbound(Commands.newSubscribe(invalidTopicName, "test-subscription", 1, 1, SubType.Exclusive, 0,
-                "consumerName"));
+                "consumerName", 0 /*avoid reseting cursor*/));
         Object obj = getResponse();
         assertEquals(obj.getClass(), CommandError.class);
         CommandError res = (CommandError) obj;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3197,4 +3197,5 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         log.info("-- Exiting {} test --", methodName);
     }
+    
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -26,16 +31,25 @@ import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.Builder;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 public class ReaderTest extends MockedPulsarServiceBaseTest {
 
@@ -132,5 +146,78 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
             Assert.assertTrue(keys.remove(message.getKey()));
         }
         Assert.assertTrue(keys.isEmpty());
+    }
+
+    /**
+     * It verifies that reader can set initial position based on provided rollback time.
+     * <pre>
+     * 1. publish messages which are 5 hour old
+     * 2. publish messages which are 1 hour old
+     * 3. Create reader with rollback time 2 hours 
+     * 4. Reader should be able to read only messages which are only 2 hours old
+     * </pre> 
+     * @throws Exception
+     */
+    @Test
+    public void testReaderWithTimeLong() throws Exception {
+        String ns = "my-property/my-ns";
+        String topic = "persistent://" + ns + "/testReadFromPartition";
+        RetentionPolicies retention = new RetentionPolicies(-1, -1);
+        admin.namespaces().setRetention(ns, retention);
+
+        ProducerBuilder<byte[]> produceBuilder = pulsarClient.newProducer();
+        produceBuilder.topic(topic);
+        produceBuilder.enableBatching(false);
+        Producer<byte[]> producer = produceBuilder.create();
+        MessageId lastMsgId = null;
+        int totalMsg = 10;
+        // (1) Publish 10 messages with publish-time 5 HOUR back
+        long oldMsgPublishTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(5); // 5 hours old
+        for (int i = 0; i < totalMsg; i++) {
+            TypedMessageBuilderImpl<byte[]> msg = (TypedMessageBuilderImpl<byte[]>) producer.newMessage()
+                    .value(("old" + i).getBytes());
+            Builder metadataBuilder = msg.getMetadataBuilder();
+            metadataBuilder.setPublishTime(oldMsgPublishTime).setSequenceId(i);
+            metadataBuilder.setProducerName(producer.getProducerName()).setReplicatedFrom("us-west1");
+            lastMsgId = msg.send();
+        }
+
+        // (2) Publish 10 messages with publish-time 1 HOUR back
+        long newMsgPublishTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1); // 1 hour old
+        MessageId firstMsgId = null;
+        for (int i = 0; i < totalMsg; i++) {
+            TypedMessageBuilderImpl<byte[]> msg = (TypedMessageBuilderImpl<byte[]>) producer.newMessage()
+                    .value(("new" + i).getBytes());
+            Builder metadataBuilder = msg.getMetadataBuilder();
+            metadataBuilder.setPublishTime(newMsgPublishTime);
+            metadataBuilder.setProducerName(producer.getProducerName()).setReplicatedFrom("us-west1");
+            MessageId msgId = msg.send();
+            if (firstMsgId == null) {
+                firstMsgId = msgId;
+            }
+        }
+        
+        // (3) Create reader and set position 1 hour back so, it should only read messages which are 2 hours old which
+        // published on step 2 
+        Reader<byte[]> reader = pulsarClient.newReader().topic(topic).startMessageId(MessageId.earliest)
+                .startMessageFromRollbackDuration(2, TimeUnit.HOURS).create();
+
+        List<MessageId> receivedMessageIds = Lists.newArrayList();
+
+        while (reader.hasMessageAvailable()) {
+            Message<byte[]> msg = reader.readNext(1, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+            System.out.println("msg.getMessageId()=" + msg.getMessageId() + ", data=" + (new String(msg.getData())));
+            receivedMessageIds.add(msg.getMessageId());
+        }
+
+        assertEquals(receivedMessageIds.size(), totalMsg + 1);
+        assertEquals(receivedMessageIds.get(0), lastMsgId);
+
+        restartBroker();
+
+        assertFalse(reader.hasMessageAvailable());
     }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.api;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link ReaderBuilder} is used to configure and create instances of {@link Reader}.
@@ -121,6 +122,18 @@ public interface ReaderBuilder<T> extends Cloneable {
      * @return the reader builder instance
      */
     ReaderBuilder<T> startMessageId(MessageId startMessageId);
+
+    /**
+     * The initial reader positioning can be set at specific timestamp by providing total rollback duration. so, broker
+     * can find a latest message that was published before given duration. <br/>
+     * eg: rollbackDuration in minute = 5 suggests broker to find message which was published 5 mins back and set the
+     * inital position on that messageId.
+     *
+     * @param rollbackDuration
+     *            duration which position should be rolled back.
+     * @return
+     */
+    ReaderBuilder<T> startMessageFromRollbackDuration(long rollbackDuration, TimeUnit timeunit);
 
     /**
      * Set the reader to include the given position of {@link ReaderBuilder#startMessageId(MessageId)}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -106,6 +107,12 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
         return this;
     }
 
+    @Override
+    public ReaderBuilder<T> startMessageFromRollbackDuration(long rollbackDuration, TimeUnit timeunit) {
+        conf.setStartMessageFromRollbackDurationInSec(timeunit.toSeconds(rollbackDuration));
+        return this;
+    }
+    
     @Override
     public ReaderBuilder<T> startMessageIdInclusive() {
         conf.setResetIncludeHead(true);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -82,9 +82,10 @@ public class ReaderImpl<T> implements Reader<T> {
         }
 
         final int partitionIdx = TopicName.getPartitionIndex(readerConfiguration.getTopicName());
-        consumer = new ConsumerImpl<>(client, readerConfiguration.getTopicName(), consumerConfiguration, listenerExecutor,
-                partitionIdx, false, consumerFuture, SubscriptionMode.NonDurable, readerConfiguration.getStartMessageId(), schema, null,
-                true /* createTopicIfDoesNotExist */);
+        consumer = new ConsumerImpl<>(client, readerConfiguration.getTopicName(), consumerConfiguration,
+                listenerExecutor, partitionIdx, false, consumerFuture, SubscriptionMode.NonDurable,
+                readerConfiguration.getStartMessageId(), readerConfiguration.getStartMessageFromRollbackDurationInSec(),
+                schema, null, true /* createTopicIfDoesNotExist */);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -51,8 +51,9 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
             SubscriptionMode subscriptionMode, MessageId startMessageId, Schema<T> schema,
             ConsumerInterceptors<T> interceptors,
             boolean createTopicIfDoesNotExist) {
-        super(client, topic, conf, listenerExecutor, partitionIndex, hasParentConsumer, subscribeFuture, subscriptionMode, startMessageId,
-              schema, interceptors, createTopicIfDoesNotExist);
+        super(client, topic, conf, listenerExecutor, partitionIndex, hasParentConsumer, subscribeFuture,
+                subscriptionMode, startMessageId, 0 /* startMessageRollbackDurationInSec */, schema, interceptors,
+                createTopicIfDoesNotExist);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.ReaderListener;
 
 import lombok.Data;
@@ -35,6 +37,9 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
 
     @JsonIgnore
     private MessageId startMessageId;
+
+    @JsonIgnore
+    private long startMessageFromRollbackDurationInSec;
 
     private int receiverQueueSize = 1000;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -8808,6 +8808,10 @@ public final class PulsarApi {
     // optional bool force_topic_creation = 15 [default = true];
     boolean hasForceTopicCreation();
     boolean getForceTopicCreation();
+    
+    // optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
+    boolean hasStartMessageRollbackDurationSec();
+    long getStartMessageRollbackDurationSec();
   }
   public static final class CommandSubscribe extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -9159,6 +9163,16 @@ public final class PulsarApi {
       return forceTopicCreation_;
     }
     
+    // optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
+    public static final int START_MESSAGE_ROLLBACK_DURATION_SEC_FIELD_NUMBER = 16;
+    private long startMessageRollbackDurationSec_;
+    public boolean hasStartMessageRollbackDurationSec() {
+      return ((bitField0_ & 0x00004000) == 0x00004000);
+    }
+    public long getStartMessageRollbackDurationSec() {
+      return startMessageRollbackDurationSec_;
+    }
+    
     private void initFields() {
       topic_ = "";
       subscription_ = "";
@@ -9175,6 +9189,7 @@ public final class PulsarApi {
       initialPosition_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.Latest;
       replicateSubscriptionState_ = false;
       forceTopicCreation_ = true;
+      startMessageRollbackDurationSec_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -9276,6 +9291,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00002000) == 0x00002000)) {
         output.writeBool(15, forceTopicCreation_);
       }
+      if (((bitField0_ & 0x00004000) == 0x00004000)) {
+        output.writeUInt64(16, startMessageRollbackDurationSec_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -9343,6 +9361,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00002000) == 0x00002000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeBoolSize(15, forceTopicCreation_);
+      }
+      if (((bitField0_ & 0x00004000) == 0x00004000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(16, startMessageRollbackDurationSec_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -9487,6 +9509,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00002000);
         forceTopicCreation_ = true;
         bitField0_ = (bitField0_ & ~0x00004000);
+        startMessageRollbackDurationSec_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
       
@@ -9581,6 +9605,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00002000;
         }
         result.forceTopicCreation_ = forceTopicCreation_;
+        if (((from_bitField0_ & 0x00008000) == 0x00008000)) {
+          to_bitField0_ |= 0x00004000;
+        }
+        result.startMessageRollbackDurationSec_ = startMessageRollbackDurationSec_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -9638,6 +9666,9 @@ public final class PulsarApi {
         }
         if (other.hasForceTopicCreation()) {
           setForceTopicCreation(other.getForceTopicCreation());
+        }
+        if (other.hasStartMessageRollbackDurationSec()) {
+          setStartMessageRollbackDurationSec(other.getStartMessageRollbackDurationSec());
         }
         return this;
       }
@@ -9798,6 +9829,11 @@ public final class PulsarApi {
             case 120: {
               bitField0_ |= 0x00004000;
               forceTopicCreation_ = input.readBool();
+              break;
+            }
+            case 128: {
+              bitField0_ |= 0x00008000;
+              startMessageRollbackDurationSec_ = input.readUInt64();
               break;
             }
           }
@@ -10280,6 +10316,27 @@ public final class PulsarApi {
       public Builder clearForceTopicCreation() {
         bitField0_ = (bitField0_ & ~0x00004000);
         forceTopicCreation_ = true;
+        
+        return this;
+      }
+      
+      // optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
+      private long startMessageRollbackDurationSec_ ;
+      public boolean hasStartMessageRollbackDurationSec() {
+        return ((bitField0_ & 0x00008000) == 0x00008000);
+      }
+      public long getStartMessageRollbackDurationSec() {
+        return startMessageRollbackDurationSec_;
+      }
+      public Builder setStartMessageRollbackDurationSec(long value) {
+        bitField0_ |= 0x00008000;
+        startMessageRollbackDurationSec_ = value;
+        
+        return this;
+      }
+      public Builder clearStartMessageRollbackDurationSec() {
+        bitField0_ = (bitField0_ & ~0x00008000);
+        startMessageRollbackDurationSec_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -464,17 +464,17 @@ public class Commands {
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
-            SubType subType, int priorityLevel, String consumerName) {
+            SubType subType, int priorityLevel, String consumerName, long resetStartMessageBackInSeconds) {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 true /* isDurable */, null /* startMessageId */, Collections.emptyMap(), false,
-                false /* isReplicated */, InitialPosition.Earliest, null,
+                false /* isReplicated */, InitialPosition.Earliest, resetStartMessageBackInSeconds, null,
                 true /* createTopicIfDoesNotExist */);
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
             Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
-            InitialPosition subscriptionInitialPosition, SchemaInfo schemaInfo,
+            InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
             boolean createTopicIfDoesNotExist) {
         CommandSubscribe.Builder subscribeBuilder = CommandSubscribe.newBuilder();
         subscribeBuilder.setTopic(topic);
@@ -492,6 +492,9 @@ public class Commands {
 
         if (startMessageId != null) {
             subscribeBuilder.setStartMessageId(startMessageId);
+        }
+        if (startMessageRollbackDurationInSec > 0) {
+            subscribeBuilder.setStartMessageRollbackDurationSec(startMessageRollbackDurationInSec);
         }
         subscribeBuilder.addAllMetadata(CommandUtils.toKeyValueList(metadata));
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -284,7 +284,7 @@ message CommandSubscribe {
         Latest   = 0;
         Earliest = 1;
     }
-    // Signal wthether the subscription will initialize on latest
+    // Signal whether the subscription will initialize on latest
     // or not -- earliest
     optional InitialPosition initialPosition = 13 [default = Latest];
 
@@ -299,6 +299,10 @@ message CommandSubscribe {
     // If false, the subscribe operation will fail if the topic 
     // does not exist.
     optional bool force_topic_creation = 15 [default = true];
+
+    // If specified, the subscription will reset cursor's position back 
+    // to specified seconds and  will send messages from that point
+    optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION
### Motivation
Right now, Pulsar-Reader can set the initial position by providing messageId. However, some of the users have usecase to only consume messages which are older than X hours and they want to set reader position at specific time and start consuming messages.

### Modification
Allow reader to set initial position based on time where user can provide rollback time from where user wants to start reading messages. 

### Result
- This will not change existing behavior
- User can define rollback time from where it can start reading messages on pulsar-reader