### PR TITLE
[website]The website cannot get the swagger version file

### DIFF
--- a/site2/.gitignore
+++ b/site2/.gitignore
@@ -10,4 +10,4 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
-website/static/swagger/*
+website/static/swagger/master/*

--- a/site2/website/pages/en/admin-rest-api.js
+++ b/site2/website/pages/en/admin-rest-api.js
@@ -11,7 +11,7 @@ class AdminRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="../js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/admin-rest-api.js
+++ b/site2/website/pages/en/admin-rest-api.js
@@ -11,7 +11,7 @@ class AdminRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/functions-rest-api.js
+++ b/site2/website/pages/en/functions-rest-api.js
@@ -11,7 +11,7 @@ class FunctionsRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/functions-rest-api.js
+++ b/site2/website/pages/en/functions-rest-api.js
@@ -11,7 +11,7 @@ class FunctionsRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="../js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/sink-rest-api.js
+++ b/site2/website/pages/en/sink-rest-api.js
@@ -11,7 +11,7 @@ class SinkRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="../js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/sink-rest-api.js
+++ b/site2/website/pages/en/sink-rest-api.js
@@ -11,7 +11,7 @@ class SinkRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/source-rest-api.js
+++ b/site2/website/pages/en/source-rest-api.js
@@ -11,7 +11,7 @@ class SourceRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="../js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/pages/en/source-rest-api.js
+++ b/site2/website/pages/en/source-rest-api.js
@@ -11,7 +11,7 @@ class SourceRestApi extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer" >
-          <script base-url={`${swaggerUrl}`} src="js/getSwaggerByVersion.js"></script>
+          <script base-url={`${swaggerUrl}`} src="/js/getSwaggerByVersion.js"></script>
         </Container>
       </div>
     );

--- a/site2/website/static/swagger/2.3.0/swagger.json
+++ b/site2/website/static/swagger/2.3.0/swagger.json
@@ -1,0 +1,8191 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for admin operations",
+    "version" : "v2",
+    "title" : "Pulsar Admin REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v2",
+  "tags" : [ {
+    "name" : "bookies"
+  }, {
+    "name" : "broker-stats"
+  }, {
+    "name" : "brokers"
+  }, {
+    "name" : "clusters"
+  }, {
+    "name" : "namespaces"
+  }, {
+    "name" : "non-persistent topic"
+  }, {
+    "name" : "persistent topic"
+  }, {
+    "name" : "resource-quotas"
+  }, {
+    "name" : "schemas"
+  }, {
+    "name" : "tenants"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/bookies/racks-info" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for all the bookies in the cluster",
+        "description" : "",
+        "operationId" : "getBookiesRackInfo",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "$ref" : "#/definitions/BookieInfo"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/bookies/racks-info/{bookie}" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "getBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BookieInfo"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Updates the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "updateBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Removed the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "deleteBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/allocator-stats/{allocator}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get the stats for the Netty allocator. Available allocators are 'default' and 'ml-cache'",
+        "description" : "",
+        "operationId" : "getAllocatorStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "allocator",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AllocatorStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/bookieops" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get pending bookie client op stats by namesapce",
+        "description" : "",
+        "operationId" : "getPendingBookieOpsStats",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/PendingBookieOpsStats"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/broker-resource-availability/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Broker availability report",
+        "description" : "This API gives the current broker availability in percent, each resource percentage usage is calculated and thensum of all of the resource usage percent is called broker-resource-availability<br/><br/>THIS API IS ONLY FOR USE BY TESTING FOR CONFIRMING NAMESPACE ALLOCATION ALGORITHM",
+        "operationId" : "getBrokerResourceAvailability",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/ResourceUnit"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Load-manager doesn't support operation"
+          }
+        }
+      }
+    },
+    "/broker-stats/load-report" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get Load for this broker",
+        "description" : "consists of topics stats & systemResourceUsage",
+        "operationId" : "getLoadReport",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LoadReport"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/mbeans" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the mbean details of this broker JVM",
+        "description" : "",
+        "operationId" : "getMBeans",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/metrics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Gets the metrics for Monitoring",
+        "description" : "Requested should be executed by Monitoring agent on each broker to fetch the metrics",
+        "operationId" : "getMetrics",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/topics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the topic stats by namespace",
+        "description" : "",
+        "operationId" : "getTopics2",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OutputStream"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/brokers/configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all updatable dynamic configurations's name",
+        "description" : "",
+        "operationId" : "getDynamicConfigurationName",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brokers/configuration/values" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get value of all dynamic configurations' value overridden on local config",
+        "description" : "",
+        "operationId" : "getAllDynamicConfigurations",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          }
+        }
+      }
+    },
+    "/brokers/configuration/{configName}/{configValue}" : {
+      "post" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Update dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "updateDynamicConfiguration",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "configName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "configValue",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Service configuration updated successfully"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to update service-configuration"
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          },
+          "412" : {
+            "description" : "Configuration can't be updated dynamically"
+          }
+        }
+      }
+    },
+    "/brokers/health" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Run a healthcheck against the broker",
+        "description" : "",
+        "operationId" : "healthcheck",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Everything is OK"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/internal-configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the internal configuration data",
+        "description" : "",
+        "operationId" : "getInternalConfigurationData",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/InternalConfigurationData"
+            }
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of active brokers (web service addresses) in the cluster.",
+        "description" : "",
+        "operationId" : "getActiveBrokers",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}/{broker}/ownedNamespaces" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of namespaces served by the specific broker",
+        "description" : "",
+        "operationId" : "getOwnedNamespaes",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceOwnershipStatus"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the list of all the Pulsar clusters.",
+        "description" : "",
+        "operationId" : "getClusters",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the configuration data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ClusterData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update the configuration for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Provisions a new cluster. This operation requires Pulsar super-user privileges.",
+        "description" : "The name cannot contain '/' characters.",
+        "operationId" : "createCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been created"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to create the cluster"
+          },
+          "409" : {
+            "description" : "Cluster already exists"
+          },
+          "412" : {
+            "description" : "Cluster name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete an existing cluster",
+        "description" : "",
+        "operationId" : "deleteCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster is not empty"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the cluster failure domains",
+        "description" : "",
+        "operationId" : "getFailureDomains",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/FailureDomain"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains/{domainName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a domain in a cluster",
+        "description" : "",
+        "operationId" : "getDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FailureDomain"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Domain doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set cluster's failure Domain",
+        "description" : "",
+        "operationId" : "setFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Broker already exists in another domain"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete cluster's failure omain",
+        "description" : "",
+        "operationId" : "deleteFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the namespace isolation policies assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicies",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceIsolationData"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get list of brokers with namespace-isolation policies attached to them",
+        "description" : "",
+        "operationId" : "getBrokersWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers/{broker}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a broker with namespace-isolation policies attached to it",
+        "description" : "",
+        "operationId" : "getBrokerWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies/ Broker not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/{policyName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a single namespace isolation policy assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Policy doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set namespace isolation policy",
+        "description" : "",
+        "operationId" : "setNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete namespace isolation policy",
+        "description" : "",
+        "operationId" : "deleteNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/peers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the peer-cluster data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getPeerCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update peer-cluster-list for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "setPeerClusterNames",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Peer cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{cluster}/antiAffinity/{group}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get all namespaces that are grouped by given anti-affinity group in a given cluster. api can be only accessed by admin of any of the existing tenant",
+        "description" : "",
+        "operationId" : "getAntiAffinityNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tenant",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "412" : {
+            "description" : "Cluster not exist/Anti-affinity group can't be empty."
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the namespaces for a certain tenant.",
+        "description" : "",
+        "operationId" : "getTenantNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the dump all the policies specified for a namespace.",
+        "description" : "",
+        "operationId" : "getPolicies",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Policies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Creates a new namespace with the specified policies",
+        "description" : "",
+        "operationId" : "createNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace already exists"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/antiAffinity" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set anti-affinity group for a namespace",
+        "description" : "",
+        "operationId" : "setNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid antiAffinityGroup"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuota" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a backlog quota for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Specified backlog quota exceeds retention quota. Increase retention quota and retry request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove a backlog quota policy from a namespace.",
+        "description" : "",
+        "operationId" : "removeBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuotaMap" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get backlog quota map on a namespace.",
+        "description" : "",
+        "operationId" : "getBacklogQuotaMap",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/bundles" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the bundles split data.",
+        "description" : "",
+        "operationId" : "getBundlesData",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BundlesData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not setup to split in bundles"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/deduplication" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Enable or disable broker side deduplication for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyDeduplication",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/dispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/encryptionRequired" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Message encryption is required or not for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyEncryptionRequired",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerSubscription" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerSubscription config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerSubscription configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerSubscription value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxProducersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxProducersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxProducersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxProducersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/messageTTL" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the message TTL for the namespace",
+        "description" : "",
+        "operationId" : "getNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set message TTL in seconds for namespace",
+        "description" : "",
+        "operationId" : "setNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid TTL"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Retrieve the permissions for a namespace.",
+        "description" : "",
+        "operationId" : "getPermissions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Grant a new permission to a role on a namespace.",
+        "description" : "",
+        "operationId" : "grantPermissionOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "501" : {
+            "description" : "Authorization is not enabled"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Revoke all permissions to a role on a namespace.",
+        "description" : "",
+        "operationId" : "revokePermissionsOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/persistence" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the persistence configuration for a namespace.",
+        "description" : "",
+        "operationId" : "getPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistencePolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the persistence configuration for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid persistence policies"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/replication" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not global"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Peer-cluster can't be part of replication-cluster"
+          },
+          "412" : {
+            "description" : "Namespace is not global or invalid cluster ids"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/retention" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get retention config on a namespace.",
+        "description" : "",
+        "operationId" : "getRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RetentionPolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set retention configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Retention Quota must exceed backlog quota"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get subscribe-rate configured for the namespace",
+        "description" : "",
+        "operationId" : "getSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SubscribeRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a subscription auth mode for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setSubscriptionAuthMode",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionDispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get Subscription dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set Subscription dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/topics" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the topics under a certain namespace.",
+        "description" : "",
+        "operationId" : "getTopics",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "PERSISTENT",
+          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload namespace",
+        "description" : "Unload an active namespace from the current broker serving it. Performing this operation will let the brokerremoves all producers, consumers, and connections using this namespace, and close all topics (includingtheir persistent store). During that operation, the namespace is marked as tentatively unavailable until thebroker completes the unloading action. This operation requires strictly super user privileges, since it wouldresult in non-persistent message loss and unexpected connection closure to the clients.",
+        "operationId" : "unloadNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is already unloaded or Namespace has bundles activated"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}" : {
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace bundle and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace bundle is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/split" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Split a namespace bundle",
+        "description" : "",
+        "operationId" : "splitNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "unload",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload a namespace bundle",
+        "description" : "",
+        "operationId" : "unloadNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace bundle.",
+        "description" : "",
+        "operationId" : "getListFromBundle",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exists"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NonPersistentTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/resource-quotas" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get the default quota",
+        "description" : "",
+        "operationId" : "getDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set the default quota",
+        "description" : "",
+        "operationId" : "setDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/resource-quotas/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get resource quota of a namespace bundle.",
+        "description" : "",
+        "operationId" : "getNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ResourceQuota"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set resource quota on a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Remove resource quota for a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Update the schema of a topic",
+        "description" : "",
+        "operationId" : "postSchema",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a schema playload. An example of the expected schema can be found down here.",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/PostSchemaPayload"
+          },
+          "x-examples" : {
+            "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
+          }
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PostSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Delete the schema of a topic",
+        "description" : "",
+        "operationId" : "deleteSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DeleteSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema/{version}" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic at a given version",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/tenants" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the list of tenants.",
+        "description" : "",
+        "operationId" : "getTenants",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/tenants/{tenant}" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the admin configuration for a given tenant.",
+        "description" : "",
+        "operationId" : "getTenantAdmin",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TenantInfo"
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Update the admins for a tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Create a new tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "createTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          },
+          "412" : {
+            "description" : "Tenant name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Delete a tenant and all namespaces and topics under it.",
+        "description" : "",
+        "operationId" : "deleteTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "The tenant still has active namespaces"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "AllocatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "numDirectArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numHeapArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numThreadLocalCaches" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "normalCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "smallCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinyCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "directArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        },
+        "heapArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        }
+      }
+    },
+    "AuthPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "namespace_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume" ]
+            }
+          }
+        },
+        "destination_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string",
+                "enum" : [ "produce", "consume" ]
+              }
+            }
+          }
+        },
+        "subscription_auth_roles" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "AutoFailoverPolicyData" : {
+      "type" : "object",
+      "properties" : {
+        "policy_type" : {
+          "type" : "string",
+          "enum" : [ "min_available" ]
+        },
+        "parameters" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BacklogQuota" : {
+      "type" : "object",
+      "properties" : {
+        "limit" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "policy" : {
+          "type" : "string",
+          "enum" : [ "producer_request_hold", "producer_exception", "consumer_backlog_eviction" ]
+        }
+      }
+    },
+    "BookieInfo" : {
+      "type" : "object",
+      "properties" : {
+        "rack" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        }
+      }
+    },
+    "BrokerNamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "brokerName" : {
+          "type" : "string"
+        },
+        "namespaceRegex" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BundlesData" : {
+      "type" : "object",
+      "properties" : {
+        "boundaries" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "ClusterData" : {
+      "type" : "object",
+      "properties" : {
+        "serviceUrl" : {
+          "type" : "string"
+        },
+        "serviceUrlTls" : {
+          "type" : "string"
+        },
+        "brokerServiceUrl" : {
+          "type" : "string"
+        },
+        "brokerServiceUrlTls" : {
+          "type" : "string"
+        },
+        "peerClusterNames" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "ConsumerStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerName" : {
+          "type" : "string"
+        },
+        "availablePermits" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "blockedConsumerOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "CursorDetails" : {
+      "type" : "object",
+      "properties" : {
+        "cursorBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "CursorStats" : {
+      "type" : "object",
+      "properties" : {
+        "markDeletePosition" : {
+          "type" : "string"
+        },
+        "readPosition" : {
+          "type" : "string"
+        },
+        "waitingReadOp" : {
+          "type" : "boolean"
+        },
+        "pendingReadOps" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "messagesConsumedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedger" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerLastEntry" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "individuallyDeletedMessages" : {
+          "type" : "string"
+        },
+        "lastLedgerSwitchTimestamp" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "numberOfEntriesSinceFirstNotAckedMessage" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalNonContiguousDeletedMessagesRange" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      }
+    },
+    "DeleteSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "DispatchRate" : {
+      "type" : "object",
+      "properties" : {
+        "dispatchThrottlingRateInMsg" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dispatchThrottlingRateInByte" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "FailureDomain" : {
+      "type" : "object",
+      "properties" : {
+        "brokers" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "GetSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "DATE", "TIME", "TIMESTAMP", "KEY_VALUE", "BYTES", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH" ]
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "data" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "InternalConfigurationData" : {
+      "type" : "object",
+      "properties" : {
+        "zookeeperServers" : {
+          "type" : "string"
+        },
+        "configurationStoreServers" : {
+          "type" : "string"
+        },
+        "ledgersRootPath" : {
+          "type" : "string"
+        },
+        "stateStorageServiceUrl" : {
+          "type" : "string"
+        }
+      }
+    },
+    "LedgerDetails" : {
+      "type" : "object",
+      "properties" : {
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "LedgerInfo" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offloaded" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "LoadReport" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "brokerVersionString" : {
+          "type" : "string"
+        },
+        "webServiceUrl" : {
+          "type" : "string"
+        },
+        "webServiceUrlTls" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrl" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrlTls" : {
+          "type" : "string"
+        },
+        "persistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "nonPersistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "numTopics" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numConsumers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numProducers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "systemResourceUsage" : {
+          "$ref" : "#/definitions/SystemResourceUsage"
+        },
+        "bundleStats" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NamespaceBundleStats"
+          }
+        },
+        "bundleGains" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundleLosses" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "underLoaded" : {
+          "type" : "boolean"
+        },
+        "overLoaded" : {
+          "type" : "boolean"
+        },
+        "loadReportType" : {
+          "type" : "string"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "lastUpdate" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "LongRunningProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageIdImpl" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entryId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "partitionIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "Metrics" : {
+      "type" : "object",
+      "properties" : {
+        "metrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "dimensions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "NamespaceBundleStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "producerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topics" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cacheSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "NamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "namespaces" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "primary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "secondary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "auto_failover_policy" : {
+          "$ref" : "#/definitions/AutoFailoverPolicyData"
+        }
+      }
+    },
+    "NamespaceOwnershipStatus" : {
+      "type" : "object",
+      "properties" : {
+        "broker_assignment" : {
+          "type" : "string",
+          "enum" : [ "primary", "secondary", "shared" ]
+        },
+        "is_controlled" : {
+          "type" : "boolean"
+        },
+        "is_active" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "NonPersistentPublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NonPersistentReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentSubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NonPersistentPublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentSubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "OffloadProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        },
+        "firstUnoffloadedMessage" : {
+          "$ref" : "#/definitions/MessageIdImpl"
+        }
+      }
+    },
+    "OutputStream" : {
+      "type" : "object"
+    },
+    "PartitionedTopicMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "partitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PartitionedTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "metadata" : {
+          "$ref" : "#/definitions/PartitionedTopicMetadata"
+        },
+        "partitions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/TopicStats"
+          }
+        }
+      }
+    },
+    "PendingBookieOpsStats" : {
+      "type" : "object",
+      "properties" : {
+        "dataLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PersistencePolicies" : {
+      "type" : "object",
+      "properties" : {
+        "bookkeeperEnsemble" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperWriteQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperAckQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "managedLedgerMaxMarkDeleteRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "PersistentOfflineTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "messageBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "brokerName" : {
+          "type" : "string"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "dataLedgerDetails" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerDetails"
+          }
+        },
+        "cursorDetails" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorDetails"
+          }
+        },
+        "statGeneratedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      }
+    },
+    "PersistentTopicInternalStats" : {
+      "type" : "object",
+      "properties" : {
+        "entriesAddedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numberOfEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastLedgerCreatedTimestamp" : {
+          "type" : "string"
+        },
+        "lastLedgerCreationFailureTimestamp" : {
+          "type" : "string"
+        },
+        "waitingCursorsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pendingAddEntriesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastConfirmedEntry" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "ledgers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerInfo"
+          }
+        },
+        "cursors" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorStats"
+          }
+        }
+      }
+    },
+    "Policies" : {
+      "type" : "object",
+      "properties" : {
+        "auth_policies" : {
+          "$ref" : "#/definitions/AuthPolicies"
+        },
+        "replication_clusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundles" : {
+          "$ref" : "#/definitions/BundlesData"
+        },
+        "backlog_quota_map" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/BacklogQuota"
+          }
+        },
+        "clusterDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "subscriptionDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "clusterSubscribeRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscribeRate"
+          }
+        },
+        "persistence" : {
+          "$ref" : "#/definitions/PersistencePolicies"
+        },
+        "deduplicationEnabled" : {
+          "type" : "boolean"
+        },
+        "latency_stats_sample_rate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "message_ttl_in_seconds" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retention_policies" : {
+          "$ref" : "#/definitions/RetentionPolicies"
+        },
+        "deleted" : {
+          "type" : "boolean"
+        },
+        "antiAffinityGroup" : {
+          "type" : "string"
+        },
+        "encryption_required" : {
+          "type" : "boolean"
+        },
+        "subscription_auth_mode" : {
+          "type" : "string",
+          "enum" : [ "None", "Prefix" ]
+        },
+        "max_producers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_subscription" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "compaction_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_deletion_lag_ms" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "schema_auto_update_compatibility_strategy" : {
+          "type" : "string",
+          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+        }
+      }
+    },
+    "PoolArenaStats" : {
+      "type" : "object",
+      "properties" : {
+        "numTinySubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numSmallSubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numChunkLists" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinySubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "smallSubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "chunkLists" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkListStats"
+          }
+        },
+        "numAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PoolChunkListStats" : {
+      "type" : "object",
+      "properties" : {
+        "minUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunks" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkStats"
+          }
+        }
+      }
+    },
+    "PoolChunkStats" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunkSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "freeBytes" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PoolSubpageStats" : {
+      "type" : "object",
+      "properties" : {
+        "maxNumElements" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numAvailable" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "elementSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PostSchemaPayload" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "schema" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "PostSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "$ref" : "#/definitions/SchemaVersion"
+        }
+      }
+    },
+    "PublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ResourceDescription" : {
+      "type" : "object",
+      "properties" : {
+        "usagePct" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "resourceUsage" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ResourceUsage"
+          }
+        }
+      }
+    },
+    "ResourceQuota" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "memory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "dynamic" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ResourceUnit" : {
+      "type" : "object",
+      "properties" : {
+        "resourceId" : {
+          "type" : "string"
+        },
+        "availableResource" : {
+          "$ref" : "#/definitions/ResourceDescription"
+        }
+      }
+    },
+    "ResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "limit" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "RetentionPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "retentionTimeInMinutes" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retentionSizeInMB" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SchemaVersion" : {
+      "type" : "object"
+    },
+    "SubscribeRate" : {
+      "type" : "object",
+      "properties" : {
+        "subscribeThrottlingRatePerConsumer" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "SubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        }
+      }
+    },
+    "SystemResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        }
+      }
+    },
+    "TenantInfo" : {
+      "type" : "object",
+      "properties" : {
+        "adminRoles" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allowedClusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "TopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.0/swaggerfunctions.json
+++ b/site2/website/static/swagger/2.3.0/swaggerfunctions.json
@@ -1,0 +1,3431 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Functions operations",
+    "version" : "v3",
+    "title" : "Pulsar Functions REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "functions"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/functions/connectors" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getConnectorsList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Lists all Pulsar Functions currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listFunctions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches information about a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getFunctionInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Creates a new Pulsar Function in cluster mode",
+        "description" : "",
+        "operationId" : "registerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "functions" ],
+        "summary" : "Updates a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "functions" ],
+        "summary" : "Deletes a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart all function instances",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start all function instances",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/state/{key}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetch the current state associated with a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionState",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "key",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The key does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStats"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop all function instances",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/trigger" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Triggers a Pulsar Function with a user-specified value or file data",
+        "description" : "",
+        "operationId" : "triggerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Message"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart function instance",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start function instance",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatsData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop function instance",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EncryptionContext" : {
+      "type" : "object",
+      "properties" : {
+        "keys" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/EncryptionKey"
+          }
+        },
+        "param" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "algorithm" : {
+          "type" : "string"
+        },
+        "compressionType" : {
+          "type" : "string",
+          "enum" : [ "NONE", "LZ4", "ZLIB", "ZSTD" ]
+        },
+        "uncompressedMessageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "batchSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "EncryptionKey" : {
+      "type" : "object",
+      "properties" : {
+        "keyValue" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionInstanceStats" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "metrics" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsData"
+        }
+      }
+    },
+    "FunctionInstanceStatsData" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userMetrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      }
+    },
+    "FunctionInstanceStatsDataBase" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "FunctionInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/FunctionInstanceStatusData"
+        }
+      }
+    },
+    "FunctionInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceived" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSuccessfullyProcessed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numUserExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestUserExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "averageLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "lastInvocationTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionStats" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStats"
+          }
+        }
+      }
+    },
+    "FunctionStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStatus"
+          }
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "object"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "messageId" : {
+          "$ref" : "#/definitions/MessageId"
+        },
+        "sequenceId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "keyBytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "encryptionCtx" : {
+          "$ref" : "#/definitions/EncryptionContext"
+        },
+        "redeliveryCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "schemaVersion" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "publishTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "eventTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.0/swaggersink.json
+++ b/site2/website/static/swagger/2.3.0/swaggersink.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Sink operations",
+    "version" : "v3",
+    "title" : "Pulsar Sink REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "sink"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/sink/builtinsinks" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches a list of supported Pulsar IO sink connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Lists all Pulsar Sinks currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSinks",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches information about a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Creates a new Pulsar Sink in cluster mode",
+        "description" : "",
+        "operationId" : "registerSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "sink" ],
+        "summary" : "Updates a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "sink" ],
+        "summary" : "Deletes a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart all sink instances",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start all sink instances",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop all sink instances",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart sink instance",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start sink instance",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink instance",
+        "description" : "",
+        "operationId" : "getSinkInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop sink instance",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SinkInstanceStatusData"
+        }
+      }
+    },
+    "SinkInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReadFromPulsar" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSinkExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSinkExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWrittenToSink" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SinkStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SinkInstanceStatus"
+          }
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.0/swaggersource.json
+++ b/site2/website/static/swagger/2.3.0/swaggersource.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Source operations",
+    "version" : "v3",
+    "title" : "Pulsar Source REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "source"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/source/builtinsources" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches a list of supported Pulsar IO source connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Lists all Pulsar Sources currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSources",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches information about a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Creates a new Pulsar Source in cluster mode",
+        "description" : "",
+        "operationId" : "registerSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "source" ],
+        "summary" : "Updates a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "source" ],
+        "summary" : "Deletes a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart all source instances",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start all source instances",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop all source instances",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart source instance",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start source instance",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source instance",
+        "description" : "",
+        "operationId" : "getSourceInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop source instance",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SourceInstanceStatusData"
+        }
+      }
+    },
+    "SourceInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceivedFromSource" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSourceExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSourceExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWritten" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SourceInstanceStatus"
+          }
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.1/swagger.json
+++ b/site2/website/static/swagger/2.3.1/swagger.json
@@ -1,0 +1,8191 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for admin operations",
+    "version" : "v2",
+    "title" : "Pulsar Admin REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v2",
+  "tags" : [ {
+    "name" : "bookies"
+  }, {
+    "name" : "broker-stats"
+  }, {
+    "name" : "brokers"
+  }, {
+    "name" : "clusters"
+  }, {
+    "name" : "namespaces"
+  }, {
+    "name" : "non-persistent topic"
+  }, {
+    "name" : "persistent topic"
+  }, {
+    "name" : "resource-quotas"
+  }, {
+    "name" : "schemas"
+  }, {
+    "name" : "tenants"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/bookies/racks-info" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for all the bookies in the cluster",
+        "description" : "",
+        "operationId" : "getBookiesRackInfo",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "$ref" : "#/definitions/BookieInfo"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/bookies/racks-info/{bookie}" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "getBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BookieInfo"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Updates the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "updateBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Removed the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "deleteBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/allocator-stats/{allocator}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get the stats for the Netty allocator. Available allocators are 'default' and 'ml-cache'",
+        "description" : "",
+        "operationId" : "getAllocatorStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "allocator",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AllocatorStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/bookieops" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get pending bookie client op stats by namesapce",
+        "description" : "",
+        "operationId" : "getPendingBookieOpsStats",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/PendingBookieOpsStats"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/broker-resource-availability/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Broker availability report",
+        "description" : "This API gives the current broker availability in percent, each resource percentage usage is calculated and thensum of all of the resource usage percent is called broker-resource-availability<br/><br/>THIS API IS ONLY FOR USE BY TESTING FOR CONFIRMING NAMESPACE ALLOCATION ALGORITHM",
+        "operationId" : "getBrokerResourceAvailability",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/ResourceUnit"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Load-manager doesn't support operation"
+          }
+        }
+      }
+    },
+    "/broker-stats/load-report" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get Load for this broker",
+        "description" : "consists of topics stats & systemResourceUsage",
+        "operationId" : "getLoadReport",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LoadReport"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/mbeans" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the mbean details of this broker JVM",
+        "description" : "",
+        "operationId" : "getMBeans",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/metrics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Gets the metrics for Monitoring",
+        "description" : "Requested should be executed by Monitoring agent on each broker to fetch the metrics",
+        "operationId" : "getMetrics",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/topics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the topic stats by namespace",
+        "description" : "",
+        "operationId" : "getTopics2",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OutputStream"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/brokers/configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all updatable dynamic configurations's name",
+        "description" : "",
+        "operationId" : "getDynamicConfigurationName",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brokers/configuration/values" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get value of all dynamic configurations' value overridden on local config",
+        "description" : "",
+        "operationId" : "getAllDynamicConfigurations",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          }
+        }
+      }
+    },
+    "/brokers/configuration/{configName}/{configValue}" : {
+      "post" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Update dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "updateDynamicConfiguration",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "configName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "configValue",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Service configuration updated successfully"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to update service-configuration"
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          },
+          "412" : {
+            "description" : "Configuration can't be updated dynamically"
+          }
+        }
+      }
+    },
+    "/brokers/health" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Run a healthcheck against the broker",
+        "description" : "",
+        "operationId" : "healthcheck",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Everything is OK"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/internal-configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the internal configuration data",
+        "description" : "",
+        "operationId" : "getInternalConfigurationData",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/InternalConfigurationData"
+            }
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of active brokers (web service addresses) in the cluster.",
+        "description" : "",
+        "operationId" : "getActiveBrokers",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}/{broker}/ownedNamespaces" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of namespaces served by the specific broker",
+        "description" : "",
+        "operationId" : "getOwnedNamespaes",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceOwnershipStatus"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the list of all the Pulsar clusters.",
+        "description" : "",
+        "operationId" : "getClusters",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the configuration data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ClusterData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update the configuration for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Provisions a new cluster. This operation requires Pulsar super-user privileges.",
+        "description" : "The name cannot contain '/' characters.",
+        "operationId" : "createCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been created"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to create the cluster"
+          },
+          "409" : {
+            "description" : "Cluster already exists"
+          },
+          "412" : {
+            "description" : "Cluster name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete an existing cluster",
+        "description" : "",
+        "operationId" : "deleteCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster is not empty"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the cluster failure domains",
+        "description" : "",
+        "operationId" : "getFailureDomains",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/FailureDomain"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains/{domainName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a domain in a cluster",
+        "description" : "",
+        "operationId" : "getDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FailureDomain"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Domain doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set cluster's failure Domain",
+        "description" : "",
+        "operationId" : "setFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Broker already exists in another domain"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete cluster's failure omain",
+        "description" : "",
+        "operationId" : "deleteFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the namespace isolation policies assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicies",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceIsolationData"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get list of brokers with namespace-isolation policies attached to them",
+        "description" : "",
+        "operationId" : "getBrokersWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers/{broker}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a broker with namespace-isolation policies attached to it",
+        "description" : "",
+        "operationId" : "getBrokerWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies/ Broker not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/{policyName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a single namespace isolation policy assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Policy doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set namespace isolation policy",
+        "description" : "",
+        "operationId" : "setNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete namespace isolation policy",
+        "description" : "",
+        "operationId" : "deleteNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/peers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the peer-cluster data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getPeerCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update peer-cluster-list for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "setPeerClusterNames",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Peer cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{cluster}/antiAffinity/{group}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get all namespaces that are grouped by given anti-affinity group in a given cluster. api can be only accessed by admin of any of the existing tenant",
+        "description" : "",
+        "operationId" : "getAntiAffinityNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tenant",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "412" : {
+            "description" : "Cluster not exist/Anti-affinity group can't be empty."
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the namespaces for a certain tenant.",
+        "description" : "",
+        "operationId" : "getTenantNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the dump all the policies specified for a namespace.",
+        "description" : "",
+        "operationId" : "getPolicies",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Policies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Creates a new namespace with the specified policies",
+        "description" : "",
+        "operationId" : "createNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace already exists"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/antiAffinity" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set anti-affinity group for a namespace",
+        "description" : "",
+        "operationId" : "setNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid antiAffinityGroup"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuota" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a backlog quota for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Specified backlog quota exceeds retention quota. Increase retention quota and retry request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove a backlog quota policy from a namespace.",
+        "description" : "",
+        "operationId" : "removeBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuotaMap" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get backlog quota map on a namespace.",
+        "description" : "",
+        "operationId" : "getBacklogQuotaMap",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/bundles" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the bundles split data.",
+        "description" : "",
+        "operationId" : "getBundlesData",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BundlesData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not setup to split in bundles"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/deduplication" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Enable or disable broker side deduplication for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyDeduplication",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/dispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/encryptionRequired" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Message encryption is required or not for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyEncryptionRequired",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerSubscription" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerSubscription config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerSubscription configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerSubscription value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxProducersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxProducersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxProducersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxProducersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/messageTTL" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the message TTL for the namespace",
+        "description" : "",
+        "operationId" : "getNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set message TTL in seconds for namespace",
+        "description" : "",
+        "operationId" : "setNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid TTL"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Retrieve the permissions for a namespace.",
+        "description" : "",
+        "operationId" : "getPermissions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Grant a new permission to a role on a namespace.",
+        "description" : "",
+        "operationId" : "grantPermissionOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "501" : {
+            "description" : "Authorization is not enabled"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Revoke all permissions to a role on a namespace.",
+        "description" : "",
+        "operationId" : "revokePermissionsOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/persistence" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the persistence configuration for a namespace.",
+        "description" : "",
+        "operationId" : "getPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistencePolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the persistence configuration for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid persistence policies"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/replication" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not global"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Peer-cluster can't be part of replication-cluster"
+          },
+          "412" : {
+            "description" : "Namespace is not global or invalid cluster ids"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/retention" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get retention config on a namespace.",
+        "description" : "",
+        "operationId" : "getRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RetentionPolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set retention configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Retention Quota must exceed backlog quota"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get subscribe-rate configured for the namespace",
+        "description" : "",
+        "operationId" : "getSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SubscribeRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a subscription auth mode for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setSubscriptionAuthMode",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionDispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get Subscription dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set Subscription dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/topics" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the topics under a certain namespace.",
+        "description" : "",
+        "operationId" : "getTopics",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "PERSISTENT",
+          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload namespace",
+        "description" : "Unload an active namespace from the current broker serving it. Performing this operation will let the brokerremoves all producers, consumers, and connections using this namespace, and close all topics (includingtheir persistent store). During that operation, the namespace is marked as tentatively unavailable until thebroker completes the unloading action. This operation requires strictly super user privileges, since it wouldresult in non-persistent message loss and unexpected connection closure to the clients.",
+        "operationId" : "unloadNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is already unloaded or Namespace has bundles activated"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}" : {
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace bundle and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace bundle is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/split" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Split a namespace bundle",
+        "description" : "",
+        "operationId" : "splitNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "unload",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload a namespace bundle",
+        "description" : "",
+        "operationId" : "unloadNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace bundle.",
+        "description" : "",
+        "operationId" : "getListFromBundle",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exists"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NonPersistentTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/resource-quotas" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get the default quota",
+        "description" : "",
+        "operationId" : "getDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set the default quota",
+        "description" : "",
+        "operationId" : "setDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/resource-quotas/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get resource quota of a namespace bundle.",
+        "description" : "",
+        "operationId" : "getNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ResourceQuota"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set resource quota on a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Remove resource quota for a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Update the schema of a topic",
+        "description" : "",
+        "operationId" : "postSchema",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a schema playload. An example of the expected schema can be found down here.",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/PostSchemaPayload"
+          },
+          "x-examples" : {
+            "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
+          }
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PostSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Delete the schema of a topic",
+        "description" : "",
+        "operationId" : "deleteSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DeleteSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema/{version}" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic at a given version",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/tenants" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the list of tenants.",
+        "description" : "",
+        "operationId" : "getTenants",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/tenants/{tenant}" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the admin configuration for a given tenant.",
+        "description" : "",
+        "operationId" : "getTenantAdmin",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TenantInfo"
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Update the admins for a tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Create a new tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "createTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          },
+          "412" : {
+            "description" : "Tenant name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Delete a tenant and all namespaces and topics under it.",
+        "description" : "",
+        "operationId" : "deleteTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "The tenant still has active namespaces"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "AllocatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "numDirectArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numHeapArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numThreadLocalCaches" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "normalCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "smallCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinyCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "directArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        },
+        "heapArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        }
+      }
+    },
+    "AuthPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "namespace_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume" ]
+            }
+          }
+        },
+        "destination_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string",
+                "enum" : [ "produce", "consume" ]
+              }
+            }
+          }
+        },
+        "subscription_auth_roles" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "AutoFailoverPolicyData" : {
+      "type" : "object",
+      "properties" : {
+        "policy_type" : {
+          "type" : "string",
+          "enum" : [ "min_available" ]
+        },
+        "parameters" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BacklogQuota" : {
+      "type" : "object",
+      "properties" : {
+        "limit" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "policy" : {
+          "type" : "string",
+          "enum" : [ "producer_request_hold", "producer_exception", "consumer_backlog_eviction" ]
+        }
+      }
+    },
+    "BookieInfo" : {
+      "type" : "object",
+      "properties" : {
+        "rack" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        }
+      }
+    },
+    "BrokerNamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "brokerName" : {
+          "type" : "string"
+        },
+        "namespaceRegex" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BundlesData" : {
+      "type" : "object",
+      "properties" : {
+        "boundaries" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "ClusterData" : {
+      "type" : "object",
+      "properties" : {
+        "serviceUrl" : {
+          "type" : "string"
+        },
+        "serviceUrlTls" : {
+          "type" : "string"
+        },
+        "brokerServiceUrl" : {
+          "type" : "string"
+        },
+        "brokerServiceUrlTls" : {
+          "type" : "string"
+        },
+        "peerClusterNames" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "ConsumerStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerName" : {
+          "type" : "string"
+        },
+        "availablePermits" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "blockedConsumerOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "CursorDetails" : {
+      "type" : "object",
+      "properties" : {
+        "cursorBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "CursorStats" : {
+      "type" : "object",
+      "properties" : {
+        "markDeletePosition" : {
+          "type" : "string"
+        },
+        "readPosition" : {
+          "type" : "string"
+        },
+        "waitingReadOp" : {
+          "type" : "boolean"
+        },
+        "pendingReadOps" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "messagesConsumedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedger" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerLastEntry" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "individuallyDeletedMessages" : {
+          "type" : "string"
+        },
+        "lastLedgerSwitchTimestamp" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "numberOfEntriesSinceFirstNotAckedMessage" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalNonContiguousDeletedMessagesRange" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      }
+    },
+    "DeleteSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "DispatchRate" : {
+      "type" : "object",
+      "properties" : {
+        "dispatchThrottlingRateInMsg" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dispatchThrottlingRateInByte" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "FailureDomain" : {
+      "type" : "object",
+      "properties" : {
+        "brokers" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "GetSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "DATE", "TIME", "TIMESTAMP", "KEY_VALUE", "BYTES", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH" ]
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "data" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "InternalConfigurationData" : {
+      "type" : "object",
+      "properties" : {
+        "zookeeperServers" : {
+          "type" : "string"
+        },
+        "configurationStoreServers" : {
+          "type" : "string"
+        },
+        "ledgersRootPath" : {
+          "type" : "string"
+        },
+        "stateStorageServiceUrl" : {
+          "type" : "string"
+        }
+      }
+    },
+    "LedgerDetails" : {
+      "type" : "object",
+      "properties" : {
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "LedgerInfo" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offloaded" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "LoadReport" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "brokerVersionString" : {
+          "type" : "string"
+        },
+        "webServiceUrl" : {
+          "type" : "string"
+        },
+        "webServiceUrlTls" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrl" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrlTls" : {
+          "type" : "string"
+        },
+        "persistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "nonPersistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "numTopics" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numConsumers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numProducers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "systemResourceUsage" : {
+          "$ref" : "#/definitions/SystemResourceUsage"
+        },
+        "bundleStats" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NamespaceBundleStats"
+          }
+        },
+        "bundleGains" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundleLosses" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "underLoaded" : {
+          "type" : "boolean"
+        },
+        "overLoaded" : {
+          "type" : "boolean"
+        },
+        "loadReportType" : {
+          "type" : "string"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "lastUpdate" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "LongRunningProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageIdImpl" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entryId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "partitionIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "Metrics" : {
+      "type" : "object",
+      "properties" : {
+        "metrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "dimensions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "NamespaceBundleStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "producerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topics" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cacheSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "NamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "namespaces" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "primary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "secondary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "auto_failover_policy" : {
+          "$ref" : "#/definitions/AutoFailoverPolicyData"
+        }
+      }
+    },
+    "NamespaceOwnershipStatus" : {
+      "type" : "object",
+      "properties" : {
+        "broker_assignment" : {
+          "type" : "string",
+          "enum" : [ "primary", "secondary", "shared" ]
+        },
+        "is_controlled" : {
+          "type" : "boolean"
+        },
+        "is_active" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "NonPersistentPublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NonPersistentReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentSubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NonPersistentPublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentSubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "OffloadProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        },
+        "firstUnoffloadedMessage" : {
+          "$ref" : "#/definitions/MessageIdImpl"
+        }
+      }
+    },
+    "OutputStream" : {
+      "type" : "object"
+    },
+    "PartitionedTopicMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "partitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PartitionedTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "metadata" : {
+          "$ref" : "#/definitions/PartitionedTopicMetadata"
+        },
+        "partitions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/TopicStats"
+          }
+        }
+      }
+    },
+    "PendingBookieOpsStats" : {
+      "type" : "object",
+      "properties" : {
+        "dataLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PersistencePolicies" : {
+      "type" : "object",
+      "properties" : {
+        "bookkeeperEnsemble" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperWriteQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperAckQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "managedLedgerMaxMarkDeleteRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "PersistentOfflineTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "messageBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "brokerName" : {
+          "type" : "string"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "dataLedgerDetails" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerDetails"
+          }
+        },
+        "cursorDetails" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorDetails"
+          }
+        },
+        "statGeneratedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      }
+    },
+    "PersistentTopicInternalStats" : {
+      "type" : "object",
+      "properties" : {
+        "entriesAddedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numberOfEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastLedgerCreatedTimestamp" : {
+          "type" : "string"
+        },
+        "lastLedgerCreationFailureTimestamp" : {
+          "type" : "string"
+        },
+        "waitingCursorsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pendingAddEntriesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastConfirmedEntry" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "ledgers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerInfo"
+          }
+        },
+        "cursors" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorStats"
+          }
+        }
+      }
+    },
+    "Policies" : {
+      "type" : "object",
+      "properties" : {
+        "auth_policies" : {
+          "$ref" : "#/definitions/AuthPolicies"
+        },
+        "replication_clusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundles" : {
+          "$ref" : "#/definitions/BundlesData"
+        },
+        "backlog_quota_map" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/BacklogQuota"
+          }
+        },
+        "clusterDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "subscriptionDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "clusterSubscribeRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscribeRate"
+          }
+        },
+        "persistence" : {
+          "$ref" : "#/definitions/PersistencePolicies"
+        },
+        "deduplicationEnabled" : {
+          "type" : "boolean"
+        },
+        "latency_stats_sample_rate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "message_ttl_in_seconds" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retention_policies" : {
+          "$ref" : "#/definitions/RetentionPolicies"
+        },
+        "deleted" : {
+          "type" : "boolean"
+        },
+        "antiAffinityGroup" : {
+          "type" : "string"
+        },
+        "encryption_required" : {
+          "type" : "boolean"
+        },
+        "subscription_auth_mode" : {
+          "type" : "string",
+          "enum" : [ "None", "Prefix" ]
+        },
+        "max_producers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_subscription" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "compaction_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_deletion_lag_ms" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "schema_auto_update_compatibility_strategy" : {
+          "type" : "string",
+          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+        }
+      }
+    },
+    "PoolArenaStats" : {
+      "type" : "object",
+      "properties" : {
+        "numTinySubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numSmallSubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numChunkLists" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinySubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "smallSubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "chunkLists" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkListStats"
+          }
+        },
+        "numAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PoolChunkListStats" : {
+      "type" : "object",
+      "properties" : {
+        "minUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunks" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkStats"
+          }
+        }
+      }
+    },
+    "PoolChunkStats" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunkSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "freeBytes" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PoolSubpageStats" : {
+      "type" : "object",
+      "properties" : {
+        "maxNumElements" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numAvailable" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "elementSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PostSchemaPayload" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "schema" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "PostSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "$ref" : "#/definitions/SchemaVersion"
+        }
+      }
+    },
+    "PublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ResourceDescription" : {
+      "type" : "object",
+      "properties" : {
+        "usagePct" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "resourceUsage" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ResourceUsage"
+          }
+        }
+      }
+    },
+    "ResourceQuota" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "memory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "dynamic" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ResourceUnit" : {
+      "type" : "object",
+      "properties" : {
+        "resourceId" : {
+          "type" : "string"
+        },
+        "availableResource" : {
+          "$ref" : "#/definitions/ResourceDescription"
+        }
+      }
+    },
+    "ResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "limit" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "RetentionPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "retentionTimeInMinutes" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retentionSizeInMB" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SchemaVersion" : {
+      "type" : "object"
+    },
+    "SubscribeRate" : {
+      "type" : "object",
+      "properties" : {
+        "subscribeThrottlingRatePerConsumer" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "SubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        }
+      }
+    },
+    "SystemResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        }
+      }
+    },
+    "TenantInfo" : {
+      "type" : "object",
+      "properties" : {
+        "adminRoles" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allowedClusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "TopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.1/swaggerfunctions.json
+++ b/site2/website/static/swagger/2.3.1/swaggerfunctions.json
@@ -1,0 +1,3431 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Functions operations",
+    "version" : "v3",
+    "title" : "Pulsar Functions REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "functions"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/functions/connectors" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getConnectorsList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Lists all Pulsar Functions currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listFunctions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches information about a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getFunctionInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Creates a new Pulsar Function in cluster mode",
+        "description" : "",
+        "operationId" : "registerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "functions" ],
+        "summary" : "Updates a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "functions" ],
+        "summary" : "Deletes a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart all function instances",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start all function instances",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/state/{key}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetch the current state associated with a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionState",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "key",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The key does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStats"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop all function instances",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/trigger" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Triggers a Pulsar Function with a user-specified value or file data",
+        "description" : "",
+        "operationId" : "triggerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Message"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart function instance",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start function instance",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatsData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop function instance",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EncryptionContext" : {
+      "type" : "object",
+      "properties" : {
+        "keys" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/EncryptionKey"
+          }
+        },
+        "param" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "algorithm" : {
+          "type" : "string"
+        },
+        "compressionType" : {
+          "type" : "string",
+          "enum" : [ "NONE", "LZ4", "ZLIB", "ZSTD" ]
+        },
+        "uncompressedMessageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "batchSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "EncryptionKey" : {
+      "type" : "object",
+      "properties" : {
+        "keyValue" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionInstanceStats" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "metrics" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsData"
+        }
+      }
+    },
+    "FunctionInstanceStatsData" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userMetrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      }
+    },
+    "FunctionInstanceStatsDataBase" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "FunctionInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/FunctionInstanceStatusData"
+        }
+      }
+    },
+    "FunctionInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceived" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSuccessfullyProcessed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numUserExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestUserExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "averageLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "lastInvocationTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionStats" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStats"
+          }
+        }
+      }
+    },
+    "FunctionStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStatus"
+          }
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "object"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "messageId" : {
+          "$ref" : "#/definitions/MessageId"
+        },
+        "sequenceId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "keyBytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "encryptionCtx" : {
+          "$ref" : "#/definitions/EncryptionContext"
+        },
+        "redeliveryCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "schemaVersion" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "publishTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "eventTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.1/swaggersink.json
+++ b/site2/website/static/swagger/2.3.1/swaggersink.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Sink operations",
+    "version" : "v3",
+    "title" : "Pulsar Sink REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "sink"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/sink/builtinsinks" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches a list of supported Pulsar IO sink connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Lists all Pulsar Sinks currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSinks",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches information about a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Creates a new Pulsar Sink in cluster mode",
+        "description" : "",
+        "operationId" : "registerSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "sink" ],
+        "summary" : "Updates a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "sink" ],
+        "summary" : "Deletes a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart all sink instances",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start all sink instances",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop all sink instances",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart sink instance",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start sink instance",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink instance",
+        "description" : "",
+        "operationId" : "getSinkInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop sink instance",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SinkInstanceStatusData"
+        }
+      }
+    },
+    "SinkInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReadFromPulsar" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSinkExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSinkExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWrittenToSink" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SinkStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SinkInstanceStatus"
+          }
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.1/swaggersource.json
+++ b/site2/website/static/swagger/2.3.1/swaggersource.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Source operations",
+    "version" : "v3",
+    "title" : "Pulsar Source REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "source"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/source/builtinsources" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches a list of supported Pulsar IO source connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Lists all Pulsar Sources currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSources",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches information about a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Creates a new Pulsar Source in cluster mode",
+        "description" : "",
+        "operationId" : "registerSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "source" ],
+        "summary" : "Updates a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "source" ],
+        "summary" : "Deletes a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart all source instances",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start all source instances",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop all source instances",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart source instance",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start source instance",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source instance",
+        "description" : "",
+        "operationId" : "getSourceInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop source instance",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SourceInstanceStatusData"
+        }
+      }
+    },
+    "SourceInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceivedFromSource" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSourceExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSourceExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWritten" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SourceInstanceStatus"
+          }
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.2/swagger.json
+++ b/site2/website/static/swagger/2.3.2/swagger.json
@@ -1,0 +1,8191 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for admin operations",
+    "version" : "v2",
+    "title" : "Pulsar Admin REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v2",
+  "tags" : [ {
+    "name" : "bookies"
+  }, {
+    "name" : "broker-stats"
+  }, {
+    "name" : "brokers"
+  }, {
+    "name" : "clusters"
+  }, {
+    "name" : "namespaces"
+  }, {
+    "name" : "non-persistent topic"
+  }, {
+    "name" : "persistent topic"
+  }, {
+    "name" : "resource-quotas"
+  }, {
+    "name" : "schemas"
+  }, {
+    "name" : "tenants"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/bookies/racks-info" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for all the bookies in the cluster",
+        "description" : "",
+        "operationId" : "getBookiesRackInfo",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "$ref" : "#/definitions/BookieInfo"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/bookies/racks-info/{bookie}" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "getBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BookieInfo"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Updates the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "updateBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Removed the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "deleteBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/allocator-stats/{allocator}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get the stats for the Netty allocator. Available allocators are 'default' and 'ml-cache'",
+        "description" : "",
+        "operationId" : "getAllocatorStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "allocator",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AllocatorStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/bookieops" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get pending bookie client op stats by namesapce",
+        "description" : "",
+        "operationId" : "getPendingBookieOpsStats",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/PendingBookieOpsStats"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/broker-resource-availability/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Broker availability report",
+        "description" : "This API gives the current broker availability in percent, each resource percentage usage is calculated and thensum of all of the resource usage percent is called broker-resource-availability<br/><br/>THIS API IS ONLY FOR USE BY TESTING FOR CONFIRMING NAMESPACE ALLOCATION ALGORITHM",
+        "operationId" : "getBrokerResourceAvailability",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/ResourceUnit"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Load-manager doesn't support operation"
+          }
+        }
+      }
+    },
+    "/broker-stats/load-report" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get Load for this broker",
+        "description" : "consists of topics stats & systemResourceUsage",
+        "operationId" : "getLoadReport",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LoadReport"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/mbeans" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the mbean details of this broker JVM",
+        "description" : "",
+        "operationId" : "getMBeans",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/metrics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Gets the metrics for Monitoring",
+        "description" : "Requested should be executed by Monitoring agent on each broker to fetch the metrics",
+        "operationId" : "getMetrics",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/topics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the topic stats by namespace",
+        "description" : "",
+        "operationId" : "getTopics2",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OutputStream"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/brokers/configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all updatable dynamic configurations's name",
+        "description" : "",
+        "operationId" : "getDynamicConfigurationName",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brokers/configuration/values" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get value of all dynamic configurations' value overridden on local config",
+        "description" : "",
+        "operationId" : "getAllDynamicConfigurations",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          }
+        }
+      }
+    },
+    "/brokers/configuration/{configName}/{configValue}" : {
+      "post" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Update dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "updateDynamicConfiguration",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "configName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "configValue",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Service configuration updated successfully"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to update service-configuration"
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          },
+          "412" : {
+            "description" : "Configuration can't be updated dynamically"
+          }
+        }
+      }
+    },
+    "/brokers/health" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Run a healthcheck against the broker",
+        "description" : "",
+        "operationId" : "healthcheck",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Everything is OK"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/internal-configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the internal configuration data",
+        "description" : "",
+        "operationId" : "getInternalConfigurationData",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/InternalConfigurationData"
+            }
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of active brokers (web service addresses) in the cluster.",
+        "description" : "",
+        "operationId" : "getActiveBrokers",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}/{broker}/ownedNamespaces" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of namespaces served by the specific broker",
+        "description" : "",
+        "operationId" : "getOwnedNamespaes",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceOwnershipStatus"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the list of all the Pulsar clusters.",
+        "description" : "",
+        "operationId" : "getClusters",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the configuration data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ClusterData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update the configuration for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Provisions a new cluster. This operation requires Pulsar super-user privileges.",
+        "description" : "The name cannot contain '/' characters.",
+        "operationId" : "createCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been created"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to create the cluster"
+          },
+          "409" : {
+            "description" : "Cluster already exists"
+          },
+          "412" : {
+            "description" : "Cluster name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete an existing cluster",
+        "description" : "",
+        "operationId" : "deleteCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster is not empty"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the cluster failure domains",
+        "description" : "",
+        "operationId" : "getFailureDomains",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/FailureDomain"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains/{domainName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a domain in a cluster",
+        "description" : "",
+        "operationId" : "getDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FailureDomain"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Domain doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set cluster's failure Domain",
+        "description" : "",
+        "operationId" : "setFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Broker already exists in another domain"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete cluster's failure omain",
+        "description" : "",
+        "operationId" : "deleteFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the namespace isolation policies assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicies",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceIsolationData"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get list of brokers with namespace-isolation policies attached to them",
+        "description" : "",
+        "operationId" : "getBrokersWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers/{broker}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a broker with namespace-isolation policies attached to it",
+        "description" : "",
+        "operationId" : "getBrokerWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies/ Broker not found"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/{policyName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a single namespace isolation policy assigned in the cluster",
+        "description" : "",
+        "operationId" : "getNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Policy doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set namespace isolation policy",
+        "description" : "",
+        "operationId" : "setNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete namespace isolation policy",
+        "description" : "",
+        "operationId" : "deleteNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or plicy is read only"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/peers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the peer-cluster data for the specified cluster.",
+        "description" : "",
+        "operationId" : "getPeerCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update peer-cluster-list for a cluster.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "setPeerClusterNames",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "412" : {
+            "description" : "Peer cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{cluster}/antiAffinity/{group}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get all namespaces that are grouped by given anti-affinity group in a given cluster. api can be only accessed by admin of any of the existing tenant",
+        "description" : "",
+        "operationId" : "getAntiAffinityNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tenant",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "412" : {
+            "description" : "Cluster not exist/Anti-affinity group can't be empty."
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the namespaces for a certain tenant.",
+        "description" : "",
+        "operationId" : "getTenantNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the dump all the policies specified for a namespace.",
+        "description" : "",
+        "operationId" : "getPolicies",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Policies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Creates a new namespace with the specified policies",
+        "description" : "",
+        "operationId" : "createNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace already exists"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/antiAffinity" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set anti-affinity group for a namespace",
+        "description" : "",
+        "operationId" : "setNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid antiAffinityGroup"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuota" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a backlog quota for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Specified backlog quota exceeds retention quota. Increase retention quota and retry request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove a backlog quota policy from a namespace.",
+        "description" : "",
+        "operationId" : "removeBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuotaMap" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get backlog quota map on a namespace.",
+        "description" : "",
+        "operationId" : "getBacklogQuotaMap",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/bundles" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the bundles split data.",
+        "description" : "",
+        "operationId" : "getBundlesData",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BundlesData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not setup to split in bundles"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/deduplication" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Enable or disable broker side deduplication for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyDeduplication",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/dispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/encryptionRequired" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Message encryption is required or not for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyEncryptionRequired",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerSubscription" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerSubscription config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerSubscription configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerSubscription value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxProducersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxProducersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxProducersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxProducersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/messageTTL" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the message TTL for the namespace",
+        "description" : "",
+        "operationId" : "getNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set message TTL in seconds for namespace",
+        "description" : "",
+        "operationId" : "setNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid TTL"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Retrieve the permissions for a namespace.",
+        "description" : "",
+        "operationId" : "getPermissions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Grant a new permission to a role on a namespace.",
+        "description" : "",
+        "operationId" : "grantPermissionOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "501" : {
+            "description" : "Authorization is not enabled"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Revoke all permissions to a role on a namespace.",
+        "description" : "",
+        "operationId" : "revokePermissionsOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/persistence" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the persistence configuration for a namespace.",
+        "description" : "",
+        "operationId" : "getPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistencePolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the persistence configuration for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid persistence policies"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/replication" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not global"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Peer-cluster can't be part of replication-cluster"
+          },
+          "412" : {
+            "description" : "Namespace is not global or invalid cluster ids"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/retention" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get retention config on a namespace.",
+        "description" : "",
+        "operationId" : "getRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RetentionPolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set retention configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Retention Quota must exceed backlog quota"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get subscribe-rate configured for the namespace",
+        "description" : "",
+        "operationId" : "getSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SubscribeRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a subscription auth mode for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setSubscriptionAuthMode",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionDispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get Subscription dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set Subscription dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/topics" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the topics under a certain namespace.",
+        "description" : "",
+        "operationId" : "getTopics",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "PERSISTENT",
+          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload namespace",
+        "description" : "Unload an active namespace from the current broker serving it. Performing this operation will let the brokerremoves all producers, consumers, and connections using this namespace, and close all topics (includingtheir persistent store). During that operation, the namespace is marked as tentatively unavailable until thebroker completes the unloading action. This operation requires strictly super user privileges, since it wouldresult in non-persistent message loss and unexpected connection closure to the clients.",
+        "operationId" : "unloadNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is already unloaded or Namespace has bundles activated"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}" : {
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace bundle and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace bundle is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/split" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Split a namespace bundle",
+        "description" : "",
+        "operationId" : "splitNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "unload",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload a namespace bundle",
+        "description" : "",
+        "operationId" : "unloadNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace bundle.",
+        "description" : "",
+        "operationId" : "getListFromBundle",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exists"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NonPersistentTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expire messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/resource-quotas" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get the default quota",
+        "description" : "",
+        "operationId" : "getDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set the default quota",
+        "description" : "",
+        "operationId" : "setDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/resource-quotas/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get resource quota of a namespace bundle.",
+        "description" : "",
+        "operationId" : "getNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ResourceQuota"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set resource quota on a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Remove resource quota for a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Update the schema of a topic",
+        "description" : "",
+        "operationId" : "postSchema",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a schema playload. An example of the expected schema can be found down here.",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/PostSchemaPayload"
+          },
+          "x-examples" : {
+            "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
+          }
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PostSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Delete the schema of a topic",
+        "description" : "",
+        "operationId" : "deleteSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DeleteSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema/{version}" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic at a given version",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/tenants" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the list of tenants.",
+        "description" : "",
+        "operationId" : "getTenants",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/tenants/{tenant}" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the admin configuration for a given tenant.",
+        "description" : "",
+        "operationId" : "getTenantAdmin",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TenantInfo"
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Update the admins for a tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Create a new tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "createTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          },
+          "412" : {
+            "description" : "Tenant name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Delete a tenant and all namespaces and topics under it.",
+        "description" : "",
+        "operationId" : "deleteTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "The tenant still has active namespaces"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "AllocatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "numDirectArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numHeapArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numThreadLocalCaches" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "normalCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "smallCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinyCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "directArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        },
+        "heapArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        }
+      }
+    },
+    "AuthPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "namespace_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume" ]
+            }
+          }
+        },
+        "destination_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string",
+                "enum" : [ "produce", "consume" ]
+              }
+            }
+          }
+        },
+        "subscription_auth_roles" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "AutoFailoverPolicyData" : {
+      "type" : "object",
+      "properties" : {
+        "policy_type" : {
+          "type" : "string",
+          "enum" : [ "min_available" ]
+        },
+        "parameters" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BacklogQuota" : {
+      "type" : "object",
+      "properties" : {
+        "limit" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "policy" : {
+          "type" : "string",
+          "enum" : [ "producer_request_hold", "producer_exception", "consumer_backlog_eviction" ]
+        }
+      }
+    },
+    "BookieInfo" : {
+      "type" : "object",
+      "properties" : {
+        "rack" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        }
+      }
+    },
+    "BrokerNamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "brokerName" : {
+          "type" : "string"
+        },
+        "namespaceRegex" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "BundlesData" : {
+      "type" : "object",
+      "properties" : {
+        "boundaries" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "ClusterData" : {
+      "type" : "object",
+      "properties" : {
+        "serviceUrl" : {
+          "type" : "string"
+        },
+        "serviceUrlTls" : {
+          "type" : "string"
+        },
+        "brokerServiceUrl" : {
+          "type" : "string"
+        },
+        "brokerServiceUrlTls" : {
+          "type" : "string"
+        },
+        "peerClusterNames" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "ConsumerStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerName" : {
+          "type" : "string"
+        },
+        "availablePermits" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "blockedConsumerOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "CursorDetails" : {
+      "type" : "object",
+      "properties" : {
+        "cursorBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "CursorStats" : {
+      "type" : "object",
+      "properties" : {
+        "markDeletePosition" : {
+          "type" : "string"
+        },
+        "readPosition" : {
+          "type" : "string"
+        },
+        "waitingReadOp" : {
+          "type" : "boolean"
+        },
+        "pendingReadOps" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "messagesConsumedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedger" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerLastEntry" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "individuallyDeletedMessages" : {
+          "type" : "string"
+        },
+        "lastLedgerSwitchTimestamp" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "numberOfEntriesSinceFirstNotAckedMessage" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalNonContiguousDeletedMessagesRange" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      }
+    },
+    "DeleteSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "DispatchRate" : {
+      "type" : "object",
+      "properties" : {
+        "dispatchThrottlingRateInMsg" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dispatchThrottlingRateInByte" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "FailureDomain" : {
+      "type" : "object",
+      "properties" : {
+        "brokers" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "GetSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "DATE", "TIME", "TIMESTAMP", "KEY_VALUE", "BYTES", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH" ]
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "data" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "InternalConfigurationData" : {
+      "type" : "object",
+      "properties" : {
+        "zookeeperServers" : {
+          "type" : "string"
+        },
+        "configurationStoreServers" : {
+          "type" : "string"
+        },
+        "ledgersRootPath" : {
+          "type" : "string"
+        },
+        "stateStorageServiceUrl" : {
+          "type" : "string"
+        }
+      }
+    },
+    "LedgerDetails" : {
+      "type" : "object",
+      "properties" : {
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "LedgerInfo" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offloaded" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "LoadReport" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "brokerVersionString" : {
+          "type" : "string"
+        },
+        "webServiceUrl" : {
+          "type" : "string"
+        },
+        "webServiceUrlTls" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrl" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrlTls" : {
+          "type" : "string"
+        },
+        "persistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "nonPersistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "numTopics" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numConsumers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numProducers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "systemResourceUsage" : {
+          "$ref" : "#/definitions/SystemResourceUsage"
+        },
+        "bundleStats" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NamespaceBundleStats"
+          }
+        },
+        "bundleGains" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundleLosses" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "underLoaded" : {
+          "type" : "boolean"
+        },
+        "overLoaded" : {
+          "type" : "boolean"
+        },
+        "loadReportType" : {
+          "type" : "string"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "lastUpdate" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "LongRunningProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageIdImpl" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entryId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "partitionIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "Metrics" : {
+      "type" : "object",
+      "properties" : {
+        "metrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "dimensions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "NamespaceBundleStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "producerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topics" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cacheSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "NamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "namespaces" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "primary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "secondary" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "auto_failover_policy" : {
+          "$ref" : "#/definitions/AutoFailoverPolicyData"
+        }
+      }
+    },
+    "NamespaceOwnershipStatus" : {
+      "type" : "object",
+      "properties" : {
+        "broker_assignment" : {
+          "type" : "string",
+          "enum" : [ "primary", "secondary", "shared" ]
+        },
+        "is_controlled" : {
+          "type" : "boolean"
+        },
+        "is_active" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "NonPersistentPublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NonPersistentReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentSubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NonPersistentPublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentSubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "OffloadProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        },
+        "firstUnoffloadedMessage" : {
+          "$ref" : "#/definitions/MessageIdImpl"
+        }
+      }
+    },
+    "OutputStream" : {
+      "type" : "object"
+    },
+    "PartitionedTopicMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "partitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PartitionedTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "metadata" : {
+          "$ref" : "#/definitions/PartitionedTopicMetadata"
+        },
+        "partitions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/TopicStats"
+          }
+        }
+      }
+    },
+    "PendingBookieOpsStats" : {
+      "type" : "object",
+      "properties" : {
+        "dataLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PersistencePolicies" : {
+      "type" : "object",
+      "properties" : {
+        "bookkeeperEnsemble" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperWriteQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperAckQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "managedLedgerMaxMarkDeleteRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "PersistentOfflineTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "messageBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "brokerName" : {
+          "type" : "string"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "dataLedgerDetails" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerDetails"
+          }
+        },
+        "cursorDetails" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorDetails"
+          }
+        },
+        "statGeneratedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      }
+    },
+    "PersistentTopicInternalStats" : {
+      "type" : "object",
+      "properties" : {
+        "entriesAddedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numberOfEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastLedgerCreatedTimestamp" : {
+          "type" : "string"
+        },
+        "lastLedgerCreationFailureTimestamp" : {
+          "type" : "string"
+        },
+        "waitingCursorsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pendingAddEntriesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastConfirmedEntry" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "ledgers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerInfo"
+          }
+        },
+        "cursors" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorStats"
+          }
+        }
+      }
+    },
+    "Policies" : {
+      "type" : "object",
+      "properties" : {
+        "auth_policies" : {
+          "$ref" : "#/definitions/AuthPolicies"
+        },
+        "replication_clusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundles" : {
+          "$ref" : "#/definitions/BundlesData"
+        },
+        "backlog_quota_map" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/BacklogQuota"
+          }
+        },
+        "clusterDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "subscriptionDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "clusterSubscribeRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscribeRate"
+          }
+        },
+        "persistence" : {
+          "$ref" : "#/definitions/PersistencePolicies"
+        },
+        "deduplicationEnabled" : {
+          "type" : "boolean"
+        },
+        "latency_stats_sample_rate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "message_ttl_in_seconds" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retention_policies" : {
+          "$ref" : "#/definitions/RetentionPolicies"
+        },
+        "deleted" : {
+          "type" : "boolean"
+        },
+        "antiAffinityGroup" : {
+          "type" : "string"
+        },
+        "encryption_required" : {
+          "type" : "boolean"
+        },
+        "subscription_auth_mode" : {
+          "type" : "string",
+          "enum" : [ "None", "Prefix" ]
+        },
+        "max_producers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_subscription" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "compaction_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_deletion_lag_ms" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "schema_auto_update_compatibility_strategy" : {
+          "type" : "string",
+          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible" ]
+        }
+      }
+    },
+    "PoolArenaStats" : {
+      "type" : "object",
+      "properties" : {
+        "numTinySubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numSmallSubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numChunkLists" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinySubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "smallSubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "chunkLists" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkListStats"
+          }
+        },
+        "numAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PoolChunkListStats" : {
+      "type" : "object",
+      "properties" : {
+        "minUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunks" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkStats"
+          }
+        }
+      }
+    },
+    "PoolChunkStats" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunkSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "freeBytes" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PoolSubpageStats" : {
+      "type" : "object",
+      "properties" : {
+        "maxNumElements" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numAvailable" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "elementSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PostSchemaPayload" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "schema" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "PostSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "$ref" : "#/definitions/SchemaVersion"
+        }
+      }
+    },
+    "PublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ResourceDescription" : {
+      "type" : "object",
+      "properties" : {
+        "usagePct" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "resourceUsage" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ResourceUsage"
+          }
+        }
+      }
+    },
+    "ResourceQuota" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "memory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "dynamic" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ResourceUnit" : {
+      "type" : "object",
+      "properties" : {
+        "resourceId" : {
+          "type" : "string"
+        },
+        "availableResource" : {
+          "$ref" : "#/definitions/ResourceDescription"
+        }
+      }
+    },
+    "ResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "limit" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "RetentionPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "retentionTimeInMinutes" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retentionSizeInMB" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SchemaVersion" : {
+      "type" : "object"
+    },
+    "SubscribeRate" : {
+      "type" : "object",
+      "properties" : {
+        "subscribeThrottlingRatePerConsumer" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "SubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        }
+      }
+    },
+    "SystemResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        }
+      }
+    },
+    "TenantInfo" : {
+      "type" : "object",
+      "properties" : {
+        "adminRoles" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allowedClusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "TopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.2/swaggerfunctions.json
+++ b/site2/website/static/swagger/2.3.2/swaggerfunctions.json
@@ -1,0 +1,3431 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Functions operations",
+    "version" : "v3",
+    "title" : "Pulsar Functions REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "functions"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/functions/connectors" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getConnectorsList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Lists all Pulsar Functions currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listFunctions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches information about a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getFunctionInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Creates a new Pulsar Function in cluster mode",
+        "description" : "",
+        "operationId" : "registerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "functions" ],
+        "summary" : "Updates a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "functions" ],
+        "summary" : "Deletes a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart all function instances",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start all function instances",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/state/{key}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetch the current state associated with a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionState",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "key",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The key does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStats"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop all function instances",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/trigger" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Triggers a Pulsar Function with a user-specified value or file data",
+        "description" : "",
+        "operationId" : "triggerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Message"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart function instance",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start function instance",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatsData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop function instance",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EncryptionContext" : {
+      "type" : "object",
+      "properties" : {
+        "keys" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/EncryptionKey"
+          }
+        },
+        "param" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "algorithm" : {
+          "type" : "string"
+        },
+        "compressionType" : {
+          "type" : "string",
+          "enum" : [ "NONE", "LZ4", "ZLIB", "ZSTD" ]
+        },
+        "uncompressedMessageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "batchSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "EncryptionKey" : {
+      "type" : "object",
+      "properties" : {
+        "keyValue" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionInstanceStats" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "metrics" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsData"
+        }
+      }
+    },
+    "FunctionInstanceStatsData" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userMetrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      }
+    },
+    "FunctionInstanceStatsDataBase" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "FunctionInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/FunctionInstanceStatusData"
+        }
+      }
+    },
+    "FunctionInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceived" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSuccessfullyProcessed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numUserExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestUserExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "averageLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "lastInvocationTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionStats" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStats"
+          }
+        }
+      }
+    },
+    "FunctionStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStatus"
+          }
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "object"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "messageId" : {
+          "$ref" : "#/definitions/MessageId"
+        },
+        "sequenceId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "keyBytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "encryptionCtx" : {
+          "$ref" : "#/definitions/EncryptionContext"
+        },
+        "redeliveryCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "schemaVersion" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "publishTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "eventTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.2/swaggersink.json
+++ b/site2/website/static/swagger/2.3.2/swaggersink.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Sink operations",
+    "version" : "v3",
+    "title" : "Pulsar Sink REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "sink"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/sink/builtinsinks" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches a list of supported Pulsar IO sink connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Lists all Pulsar Sinks currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSinks",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Fetches information about a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Creates a new Pulsar Sink in cluster mode",
+        "description" : "",
+        "operationId" : "registerSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "sink" ],
+        "summary" : "Updates a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "sink" ],
+        "summary" : "Deletes a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart all sink instances",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start all sink instances",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop all sink instances",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Restart sink instance",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Start sink instance",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "sink" ],
+        "summary" : "Displays the status of a Pulsar Sink instance",
+        "description" : "",
+        "operationId" : "getSinkInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The sink doesn't exist"
+          }
+        }
+      }
+    },
+    "/sink/{tenant}/{namespace}/{sinkName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "sink" ],
+        "summary" : "Stop sink instance",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SinkInstanceStatusData"
+        }
+      }
+    },
+    "SinkInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReadFromPulsar" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSinkExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSinkExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWrittenToSink" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SinkStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SinkInstanceStatus"
+          }
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.3.2/swaggersource.json
+++ b/site2/website/static/swagger/2.3.2/swaggersource.json
@@ -1,0 +1,3038 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Source operations",
+    "version" : "v3",
+    "title" : "Pulsar Source REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "source"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/source/builtinsources" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches a list of supported Pulsar IO source connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Lists all Pulsar Sources currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSources",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Fetches information about a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionMetaData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Creates a new Pulsar Source in cluster mode",
+        "description" : "",
+        "operationId" : "registerSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "source" ],
+        "summary" : "Updates a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "source" ],
+        "summary" : "Deletes a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart all source instances",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start all source instances",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop all source instances",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Restart source instance",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Start source instance",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "source" ],
+        "summary" : "Displays the status of a Pulsar Source instance",
+        "description" : "",
+        "operationId" : "getSourceInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The source doesn't exist"
+          }
+        }
+      }
+    },
+    "/source/{tenant}/{namespace}/{sourceName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "source" ],
+        "summary" : "Stop source instance",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ByteString" : {
+      "type" : "object",
+      "properties" : {
+        "empty" : {
+          "type" : "boolean"
+        },
+        "validUtf8" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ConsumerSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserConsumerSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ConsumerSpec"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "serdeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isRegexPattern" : {
+          "type" : "boolean"
+        },
+        "receiverQueueSize" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "receiverQueueSizeOrBuilder" : {
+          "$ref" : "#/definitions/ReceiverQueueSizeOrBuilder"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Descriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "nestedTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "oneofs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OneofDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "extendable" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EnumDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumValueDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumOptions"
+        }
+      }
+    },
+    "EnumOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allowAlias" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "EnumValueDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "type" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        }
+      }
+    },
+    "EnumValueOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserEnumValueOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/EnumValueOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FieldDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "jsonName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "extensionScope" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "messageType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "containingOneof" : {
+          "$ref" : "#/definitions/OneofDescriptor"
+        },
+        "enumType" : {
+          "$ref" : "#/definitions/EnumDescriptor"
+        },
+        "defaultValue" : {
+          "type" : "object"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "number" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "required" : {
+          "type" : "boolean"
+        },
+        "optional" : {
+          "type" : "boolean"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "liteType" : {
+          "type" : "string",
+          "enum" : [ "DOUBLE", "FLOAT", "INT64", "UINT64", "INT32", "FIXED64", "FIXED32", "BOOL", "STRING", "GROUP", "MESSAGE", "BYTES", "UINT32", "ENUM", "SFIXED32", "SFIXED64", "SINT32", "SINT64" ]
+        },
+        "liteJavaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "packable" : {
+          "type" : "boolean"
+        },
+        "repeated" : {
+          "type" : "boolean"
+        },
+        "javaType" : {
+          "type" : "string",
+          "enum" : [ "INT", "LONG", "FLOAT", "DOUBLE", "BOOLEAN", "STRING", "BYTE_STRING", "ENUM", "MESSAGE" ]
+        },
+        "mapField" : {
+          "type" : "boolean"
+        },
+        "extension" : {
+          "type" : "boolean"
+        },
+        "packed" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FieldOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFieldOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FieldOptions"
+        },
+        "packed" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "weak" : {
+          "type" : "boolean"
+        },
+        "ctype" : {
+          "type" : "string",
+          "enum" : [ "STRING", "CORD", "STRING_PIECE" ]
+        },
+        "lazy" : {
+          "type" : "boolean"
+        },
+        "jstype" : {
+          "type" : "string",
+          "enum" : [ "JS_NORMAL", "JS_STRING", "JS_NUMBER" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FileDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "messageTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Descriptor"
+          }
+        },
+        "enumTypes" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EnumDescriptor"
+          }
+        },
+        "services" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ServiceDescriptor"
+          }
+        },
+        "extensions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "dependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "publicDependencies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "package" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "options" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "syntax" : {
+          "type" : "string",
+          "enum" : [ "UNKNOWN", "PROTO2", "PROTO3" ]
+        }
+      }
+    },
+    "FileOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFileOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FileOptions"
+        },
+        "javaStringCheckUtf8" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "javaPackage" : {
+          "type" : "string"
+        },
+        "javaPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaOuterClassname" : {
+          "type" : "string"
+        },
+        "javaOuterClassnameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "javaMultipleFiles" : {
+          "type" : "boolean"
+        },
+        "javaGenerateEqualsAndHash" : {
+          "type" : "boolean"
+        },
+        "optimizeFor" : {
+          "type" : "string",
+          "enum" : [ "SPEED", "CODE_SIZE", "LITE_RUNTIME" ]
+        },
+        "goPackage" : {
+          "type" : "string"
+        },
+        "goPackageBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "ccGenericServices" : {
+          "type" : "boolean"
+        },
+        "javaGenericServices" : {
+          "type" : "boolean"
+        },
+        "pyGenericServices" : {
+          "type" : "boolean"
+        },
+        "phpGenericServices" : {
+          "type" : "boolean"
+        },
+        "ccEnableArenas" : {
+          "type" : "boolean"
+        },
+        "objcClassPrefix" : {
+          "type" : "string"
+        },
+        "objcClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "csharpNamespace" : {
+          "type" : "string"
+        },
+        "csharpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "swiftPrefix" : {
+          "type" : "string"
+        },
+        "swiftPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpClassPrefix" : {
+          "type" : "string"
+        },
+        "phpClassPrefixBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "phpNamespace" : {
+          "type" : "string"
+        },
+        "phpNamespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "FunctionDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "FunctionDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "UNRECOGNIZED" ]
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "nameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "source" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "sink" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE", "UNRECOGNIZED" ]
+        },
+        "userConfig" : {
+          "type" : "string"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "namespaceBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "tenantBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "logTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "processingGuaranteesValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userConfigBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "secretsMap" : {
+          "type" : "string"
+        },
+        "secretsMapBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "runtimeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sourceOrBuilder" : {
+          "$ref" : "#/definitions/SourceSpecOrBuilder"
+        },
+        "sinkOrBuilder" : {
+          "$ref" : "#/definitions/SinkSpecOrBuilder"
+        },
+        "resourcesOrBuilder" : {
+          "$ref" : "#/definitions/ResourcesOrBuilder"
+        },
+        "packageUrl" : {
+          "type" : "string"
+        },
+        "packageUrlBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "retryDetails" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "retryDetailsOrBuilder" : {
+          "$ref" : "#/definitions/RetryDetailsOrBuilder"
+        },
+        "runtimeFlagsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "createTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "functionDetails" : {
+          "$ref" : "#/definitions/FunctionDetails"
+        },
+        "functionDetailsOrBuilder" : {
+          "$ref" : "#/definitions/FunctionDetailsOrBuilder"
+        },
+        "packageLocation" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "packageLocationOrBuilder" : {
+          "$ref" : "#/definitions/PackageLocationMetaDataOrBuilder"
+        },
+        "instanceStatesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instanceStates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string",
+            "enum" : [ "RUNNING", "STOPPED", "UNRECOGNIZED" ]
+          }
+        },
+        "instanceStatesValue" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "instanceStatesValueMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserFunctionMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/FunctionMetaData"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessage"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        }
+      }
+    },
+    "MessageLite" : {
+      "type" : "object",
+      "properties" : {
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageLite"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageLite"
+        }
+      }
+    },
+    "MessageOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMessageOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MessageOptions"
+        },
+        "mapEntry" : {
+          "type" : "boolean"
+        },
+        "messageSetWireFormat" : {
+          "type" : "boolean"
+        },
+        "noStandardDescriptorAccessor" : {
+          "type" : "boolean"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "MethodDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "service" : {
+          "$ref" : "#/definitions/ServiceDescriptor"
+        },
+        "inputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "outputType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/MethodOptions"
+        }
+      }
+    },
+    "MethodOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserMethodOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/MethodOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "idempotencyLevel" : {
+          "type" : "string",
+          "enum" : [ "IDEMPOTENCY_UNKNOWN", "NO_SIDE_EFFECTS", "IDEMPOTENT" ]
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "NamePart" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserNamePart"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/NamePart"
+        },
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "NamePartOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "namePart" : {
+          "type" : "string"
+        },
+        "namePartBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "isExtension" : {
+          "type" : "boolean"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "OneofDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "containingType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "fieldCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/OneofOptions"
+        }
+      }
+    },
+    "OneofOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserOneofOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/OneofOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "PackageLocationMetaData" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserPackageLocationMetaData"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/PackageLocationMetaData"
+        },
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "PackageLocationMetaDataOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "originalFileName" : {
+          "type" : "string"
+        },
+        "originalFileNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "packagePath" : {
+          "type" : "string"
+        },
+        "packagePathBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parser" : {
+      "type" : "object"
+    },
+    "ParserConsumerSpec" : {
+      "type" : "object"
+    },
+    "ParserEnumOptions" : {
+      "type" : "object"
+    },
+    "ParserEnumValueOptions" : {
+      "type" : "object"
+    },
+    "ParserFieldOptions" : {
+      "type" : "object"
+    },
+    "ParserFileOptions" : {
+      "type" : "object"
+    },
+    "ParserFunctionDetails" : {
+      "type" : "object"
+    },
+    "ParserFunctionMetaData" : {
+      "type" : "object"
+    },
+    "ParserMessage" : {
+      "type" : "object"
+    },
+    "ParserMessageLite" : {
+      "type" : "object"
+    },
+    "ParserMessageOptions" : {
+      "type" : "object"
+    },
+    "ParserMethodOptions" : {
+      "type" : "object"
+    },
+    "ParserNamePart" : {
+      "type" : "object"
+    },
+    "ParserOneofOptions" : {
+      "type" : "object"
+    },
+    "ParserPackageLocationMetaData" : {
+      "type" : "object"
+    },
+    "ParserReceiverQueueSize" : {
+      "type" : "object"
+    },
+    "ParserResources" : {
+      "type" : "object"
+    },
+    "ParserRetryDetails" : {
+      "type" : "object"
+    },
+    "ParserServiceOptions" : {
+      "type" : "object"
+    },
+    "ParserSinkSpec" : {
+      "type" : "object"
+    },
+    "ParserSourceSpec" : {
+      "type" : "object"
+    },
+    "ParserUninterpretedOption" : {
+      "type" : "object"
+    },
+    "ReceiverQueueSize" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserReceiverQueueSize"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ReceiverQueueSize"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ReceiverQueueSizeOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserResources"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "ResourcesOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "RetryDetails" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserRetryDetails"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/RetryDetails"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "RetryDetailsOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "deadLetterTopicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ServiceDescriptor" : {
+      "type" : "object",
+      "properties" : {
+        "index" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "fullName" : {
+          "type" : "string"
+        },
+        "file" : {
+          "$ref" : "#/definitions/FileDescriptor"
+        },
+        "methods" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/MethodDescriptor"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "options" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        }
+      }
+    },
+    "ServiceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "deprecated" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserServiceOptions"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/ServiceOptions"
+        },
+        "uninterpretedOptionList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOption"
+          }
+        },
+        "uninterpretedOptionOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/UninterpretedOptionOrBuilder"
+          }
+        },
+        "uninterpretedOptionCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "allFieldsRaw" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "SinkSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSinkSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SinkSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SinkSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topic" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "topicBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serDeClassName" : {
+          "type" : "string"
+        },
+        "serDeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "schemaTypeBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SourceInstanceStatusData"
+        }
+      }
+    },
+    "SourceInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceivedFromSource" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSourceExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSourceExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWritten" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SourceSpec" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserSourceSpec"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/SourceSpec"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "SourceSpecOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "classNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "configs" : {
+          "type" : "string"
+        },
+        "configsBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "typeClassName" : {
+          "type" : "string"
+        },
+        "typeClassNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "builtin" : {
+          "type" : "string"
+        },
+        "builtinBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionTypeValue" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "subscriptionType" : {
+          "type" : "string",
+          "enum" : [ "SHARED", "FAILOVER", "UNRECOGNIZED" ]
+        },
+        "topicsToSerDeClassNameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicsToSerDeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsToSerDeClassNameMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inputSpecsMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerSpec"
+          }
+        },
+        "topicsPatternBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "subscriptionName" : {
+          "type" : "string"
+        },
+        "subscriptionNameBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SourceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SourceInstanceStatus"
+          }
+        }
+      }
+    },
+    "UninterpretedOption" : {
+      "type" : "object",
+      "properties" : {
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/ParserUninterpretedOption"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UninterpretedOption"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        }
+      }
+    },
+    "UninterpretedOptionOrBuilder" : {
+      "type" : "object",
+      "properties" : {
+        "nameCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "doubleValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "stringValue" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "nameList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePart"
+          }
+        },
+        "nameOrBuilderList" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NamePartOrBuilder"
+          }
+        },
+        "identifierValue" : {
+          "type" : "string"
+        },
+        "identifierValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "positiveIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "negativeIntValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "aggregateValue" : {
+          "type" : "string"
+        },
+        "aggregateValueBytes" : {
+          "$ref" : "#/definitions/ByteString"
+        },
+        "allFields" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "initializationErrorString" : {
+          "type" : "string"
+        },
+        "descriptorForType" : {
+          "$ref" : "#/definitions/Descriptor"
+        },
+        "unknownFields" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/Message"
+        },
+        "initialized" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "UnknownFieldSet" : {
+      "type" : "object",
+      "properties" : {
+        "initialized" : {
+          "type" : "boolean"
+        },
+        "serializedSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "parserForType" : {
+          "$ref" : "#/definitions/Parser"
+        },
+        "defaultInstanceForType" : {
+          "$ref" : "#/definitions/UnknownFieldSet"
+        },
+        "serializedSizeAsMessageSet" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.4.0/swagger.json
+++ b/site2/website/static/swagger/2.4.0/swagger.json
@@ -1,0 +1,9698 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for admin operations",
+    "version" : "v2",
+    "title" : "Pulsar Admin REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v2",
+  "tags" : [ {
+    "name" : "bookies"
+  }, {
+    "name" : "broker-stats"
+  }, {
+    "name" : "brokers"
+  }, {
+    "name" : "clusters"
+  }, {
+    "name" : "namespaces"
+  }, {
+    "name" : "non-persistent topic"
+  }, {
+    "name" : "persistent topic"
+  }, {
+    "name" : "resource-quotas"
+  }, {
+    "name" : "schemas"
+  }, {
+    "name" : "tenants"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/bookies/racks-info" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for all the bookies in the cluster",
+        "description" : "",
+        "operationId" : "getBookiesRackInfo",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "$ref" : "#/definitions/BookieInfo"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/bookies/racks-info/{bookie}" : {
+      "get" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Gets the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "getBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BookieInfo"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Updates the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "updateBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "bookies" ],
+        "summary" : "Removed the rack placement information for a specific bookie in the cluster",
+        "description" : "",
+        "operationId" : "deleteBookieRackInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "bookie",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/allocator-stats/{allocator}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get the stats for the Netty allocator. Available allocators are 'default' and 'ml-cache'",
+        "description" : "",
+        "operationId" : "getAllocatorStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "allocator",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AllocatorStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/bookieops" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get pending bookie client op stats by namesapce",
+        "description" : "",
+        "operationId" : "getPendingBookieOpsStats",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/PendingBookieOpsStats"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/broker-resource-availability/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Broker availability report",
+        "description" : "This API gives the current broker availability in percent, each resource percentage usage is calculated and thensum of all of the resource usage percent is called broker-resource-availability<br/><br/>THIS API IS ONLY FOR USE BY TESTING FOR CONFIRMING NAMESPACE ALLOCATION ALGORITHM",
+        "operationId" : "getBrokerResourceAvailability",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/ResourceUnit"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Load-manager doesn't support operation"
+          }
+        }
+      }
+    },
+    "/broker-stats/load-report" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get Load for this broker",
+        "description" : "consists of topics stats & systemResourceUsage",
+        "operationId" : "getLoadReport",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LoadReport"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/mbeans" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the mbean details of this broker JVM",
+        "description" : "",
+        "operationId" : "getMBeans",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/metrics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Gets the metrics for Monitoring",
+        "description" : "Requested should be executed by Monitoring agent on each broker to fetch the metrics",
+        "operationId" : "getMetrics",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Metrics"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/broker-stats/topics" : {
+      "get" : {
+        "tags" : [ "broker-stats" ],
+        "summary" : "Get all the topic stats by namespace",
+        "description" : "",
+        "operationId" : "getTopics2",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OutputStream"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/brokers/configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all updatable dynamic configurations's name",
+        "description" : "",
+        "operationId" : "getDynamicConfigurationName",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brokers/configuration/runtime" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get all runtime configurations. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "getRuntimeConfiguration",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/brokers/configuration/values" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get value of all dynamic configurations' value overridden on local config",
+        "description" : "",
+        "operationId" : "getAllDynamicConfigurations",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/brokers/configuration/{configName}/{configValue}" : {
+      "post" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Update dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.",
+        "description" : "",
+        "operationId" : "updateDynamicConfiguration",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "configName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "configValue",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Service configuration updated successfully"
+          },
+          "403" : {
+            "description" : "You don't have admin permission to update service-configuration"
+          },
+          "404" : {
+            "description" : "Configuration not found"
+          },
+          "412" : {
+            "description" : "Invalid dynamic-config value"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/brokers/health" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Run a healthcheck against the broker",
+        "description" : "",
+        "operationId" : "healthcheck",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Everything is OK"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/brokers/internal-configuration" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the internal configuration data",
+        "description" : "",
+        "operationId" : "getInternalConfigurationData",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/InternalConfigurationData"
+            }
+          }
+        }
+      }
+    },
+    "/brokers/{clusterName}/{broker-webserviceurl}/ownedNamespaces" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of namespaces served by the specific broker",
+        "description" : "",
+        "operationId" : "getOwnedNamespaes",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "clusterName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker-webserviceurl",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceOwnershipStatus"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist"
+          }
+        }
+      }
+    },
+    "/brokers/{cluster}" : {
+      "get" : {
+        "tags" : [ "brokers" ],
+        "summary" : "Get the list of active brokers (web service addresses) in the cluster.If authorization is not enabled, any cluster name is valid.",
+        "description" : "",
+        "operationId" : "getActiveBrokers",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Authentication required"
+          },
+          "403" : {
+            "description" : "This operation requires super-user access"
+          },
+          "404" : {
+            "description" : "Cluster does not exist: cluster={clustername}"
+          }
+        }
+      }
+    },
+    "/clusters" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the list of all the Pulsar clusters.",
+        "description" : "",
+        "operationId" : "getClusters",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Return a list of clusters.",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the configuration for the specified cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Return the cluster data.",
+            "schema" : {
+              "$ref" : "#/definitions/ClusterData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update the configuration for a cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "updateCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The cluster data",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/ClusterData"
+          },
+          "x-examples" : {
+            "application/json" : "{\n   'serviceUrl': 'http://pulsar.example.com:8080',\n   'brokerServiceUrl': 'pulsar://pulsar.example.com:6651'\n}"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated."
+          },
+          "403" : {
+            "description" : "Don't have admin permission or policies are read-only."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Create a new cluster.",
+        "description" : "This operation requires Pulsar superuser privileges, and the name cannot contain the '/' characters.",
+        "operationId" : "createCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The cluster data",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/ClusterData"
+          },
+          "x-examples" : {
+            "application/json" : "{\n   'serviceUrl': 'http://pulsar.example.com:8080',\n   'brokerServiceUrl': 'pulsar://pulsar.example.com:6651',\n}"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been created."
+          },
+          "403" : {
+            "description" : "You don't have admin permission to create the cluster."
+          },
+          "409" : {
+            "description" : "Cluster already exists."
+          },
+          "412" : {
+            "description" : "Cluster name is not valid."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete an existing cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "deleteCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been deleted."
+          },
+          "403" : {
+            "description" : "Don't have admin permission or policies are read-only."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "412" : {
+            "description" : "Cluster is not empty."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the cluster failure domains.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getFailureDomains",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/FailureDomain"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/failureDomains/{domainName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a domain in a cluster",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "description" : "The failure domain name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FailureDomain"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "FailureDomain doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set the failure domain of the cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "setFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "description" : "The failure domain name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The configuration data of a failure domain",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/FailureDomain"
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Failure domain doesn't exist."
+          },
+          "409" : {
+            "description" : "Broker already exists in another domain."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete the failure domain of the cluster",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "deleteFailureDomain",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "domainName",
+          "in" : "path",
+          "description" : "The failure domain name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or policy is read only"
+          },
+          "404" : {
+            "description" : "FailureDomain doesn't exist"
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the namespace isolation policies assigned to the cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getNamespaceIsolationPolicies",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "$ref" : "#/definitions/NamespaceIsolationData"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get list of brokers with namespace-isolation policies attached to them.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getBrokersWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies not found."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/brokers/{broker}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get a broker with namespace-isolation policies attached to it.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getBrokerWithNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "broker",
+          "in" : "path",
+          "description" : "The broker name (<broker-hostname>:<web-service-port>)",
+          "required" : true,
+          "type" : "string",
+          "x-example" : "broker1:8080"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BrokerNamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Namespace-isolation policies/ Broker not found."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/namespaceIsolationPolicies/{policyName}" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the single namespace isolation policy assigned to the cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "description" : "The name of the namespace isolation policy",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NamespaceIsolationData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Policy doesn't exist."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Set namespace isolation policy.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "setNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "description" : "The namespace isolation policy name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The namespace isolation policy data",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/NamespaceIsolationData"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Namespace isolation policy data is invalid."
+          },
+          "403" : {
+            "description" : "Don't have admin permission or policies are read-only."
+          },
+          "404" : {
+            "description" : "Namespace isolation policy doesn't exist."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Delete namespace isolation policy.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "deleteNamespaceIsolationPolicy",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "policyName",
+          "in" : "path",
+          "description" : "The namespace isolation policy name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission or policies are read only."
+          },
+          "404" : {
+            "description" : "Namespace isolation policy doesn't exist."
+          },
+          "412" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/peers" : {
+      "get" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Get the peer-cluster data for the specified cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "getPeerCluster",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "clusters" ],
+        "summary" : "Update peer-cluster-list for a cluster.",
+        "description" : "This operation requires Pulsar superuser privileges.",
+        "operationId" : "setPeerClusterNames",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "description" : "The cluster name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The list of peer cluster names",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "x-examples" : {
+            "application/json" : "[\n   'cluster-a',\n   'cluster-b'\n]"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Cluster has been updated."
+          },
+          "403" : {
+            "description" : "Don't have admin permission or policies are read-only."
+          },
+          "404" : {
+            "description" : "Cluster doesn't exist."
+          },
+          "412" : {
+            "description" : "Peer cluster doesn't exist."
+          },
+          "500" : {
+            "description" : "Internal server error."
+          }
+        }
+      }
+    },
+    "/namespaces/{cluster}/antiAffinity/{group}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get all namespaces that are grouped by given anti-affinity group in a given cluster. api can be only accessed by admin of any of the existing tenant",
+        "description" : "",
+        "operationId" : "getAntiAffinityNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "group",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tenant",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "412" : {
+            "description" : "Cluster not exist/Anti-affinity group can't be empty."
+          }
+        }
+      }
+    },
+    "/namespaces/{property}/{namespace}/persistence/bookieAffinity" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the bookie-affinity-group from namespace-local policy.",
+        "description" : "",
+        "operationId" : "getBookieAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BookieAffinityGroupData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete the bookie-affinity-group from namespace-local policy.",
+        "description" : "",
+        "operationId" : "deleteBookieAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "property",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the namespaces for a certain tenant.",
+        "description" : "",
+        "operationId" : "getTenantNamespaces",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the dump all the policies specified for a namespace.",
+        "description" : "",
+        "operationId" : "getPolicies",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Policies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Creates a new namespace with the specified policies",
+        "description" : "",
+        "operationId" : "createNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace already exists"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/antiAffinity" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set anti-affinity group for a namespace",
+        "description" : "",
+        "operationId" : "setNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid antiAffinityGroup"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove anti-affinity group of a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceAntiAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuota" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a backlog quota for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Specified backlog quota exceeds retention quota. Increase retention quota and retry request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Remove a backlog quota policy from a namespace.",
+        "description" : "",
+        "operationId" : "removeBacklogQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "backlogQuotaType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "destination_storage" ]
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/backlogQuotaMap" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get backlog quota map on a namespace.",
+        "description" : "",
+        "operationId" : "getBacklogQuotaMap",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/bundles" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the bundles split data.",
+        "description" : "",
+        "operationId" : "getBundlesData",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/BundlesData"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not setup to split in bundles"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "clearNamespaceBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/compactionThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of uncompacted bytes in topics before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "getCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of uncompacted bytes in a topic before compaction is triggered.",
+        "description" : "The backlog size is compared to the threshold periodically. A threshold of 0 disabled automatic compaction",
+        "operationId" : "setCompactionThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "compactionThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/deduplication" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Enable or disable broker side deduplication for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyDeduplication",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/dispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/encryptionRequired" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Message encryption is required or not for all topics in a namespace",
+        "description" : "",
+        "operationId" : "modifyEncryptionRequired",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerSubscription" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerSubscription config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerSubscription configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerSubscription value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxConsumersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxConsumersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxConsumersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxConsumersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxConsumersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/maxProducersPerTopic" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get maxProducersPerTopic config on a namespace.",
+        "description" : "",
+        "operationId" : "getMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set maxProducersPerTopic configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setMaxProducersPerTopic",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "maxProducersPerTopic value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/messageTTL" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the message TTL for the namespace",
+        "description" : "",
+        "operationId" : "getNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set message TTL in seconds for namespace",
+        "description" : "",
+        "operationId" : "setNamespaceMessageTTL",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Invalid TTL"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadDeletionLagMs" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value denotes that deletion has been completely disabled. 'null' denotes that the topics in the namespace will fall back to the broker default for deletion lag.",
+        "operationId" : "getOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set number of milliseconds to wait before deleting a ledger segment which has been offloaded from the Pulsar cluster's local storage (i.e. BookKeeper)",
+        "description" : "A negative value disables the deletion completely.",
+        "operationId" : "setOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadDeletionLagMs value is not valid"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear the namespace configured offload deletion lag. The topics in the namespace will fallback to using the default configured deletion lag for the broker",
+        "description" : "",
+        "operationId" : "clearOffloadDeletionLag",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/offloadThreshold" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "getOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set maximum number of bytes stored on the pulsar cluster for a topic, before the broker will start offloading to longterm storage",
+        "description" : "A negative value disables automatic offloading",
+        "operationId" : "setOffloadThreshold",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "offloadThreshold value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Retrieve the permissions for a namespace.",
+        "description" : "",
+        "operationId" : "getPermissions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Grant a new permission to a role on a namespace.",
+        "description" : "",
+        "operationId" : "grantPermissionOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "501" : {
+            "description" : "Authorization is not enabled"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Revoke all permissions to a role on a namespace.",
+        "description" : "",
+        "operationId" : "revokePermissionsOnNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/persistence" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the persistence configuration for a namespace.",
+        "description" : "",
+        "operationId" : "getPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistencePolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the persistence configuration for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setPersistence",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid persistence policies"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/persistence/bookieAffinity" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the bookie-affinity-group to namespace-persistent policy.",
+        "description" : "",
+        "operationId" : "setBookieAffinityGroup",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/replication" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "getNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is not global"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set the replication clusters for a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceReplicationClusters",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Peer-cluster can't be part of replication-cluster"
+          },
+          "412" : {
+            "description" : "Namespace is not global or invalid cluster ids"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/replicatorDispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get replicator dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getReplicatorDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set replicator dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setReplicatorDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/retention" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get retention config on a namespace.",
+        "description" : "",
+        "operationId" : "getRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RetentionPolicies"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set retention configuration on a namespace.",
+        "description" : "",
+        "operationId" : "setRetention",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Retention Quota must exceed backlog quota"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/schemaAutoUpdateCompatibilityStrategy" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "The strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "getSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible", "BackwardTransitive", "ForwardTransitive", "FullTransitive" ]
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Update the strategy used to check the compatibility of new schemas, provided by producers, before automatically updating the schema",
+        "description" : "The value AutoUpdateDisabled prevents producers from updating the schema.  If set to AutoUpdateDisabled, schemas must be updated through the REST api",
+        "operationId" : "setSchemaAutoUpdateCompatibilityStrategy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/schemaValidationEnforced" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get schema validation enforced flag for namespace.",
+        "description" : "If the flag is set to true, when a producer without a schema attempts to produce to a topic with schema in this namespace, the producer will be failed to connect. PLEASE be carefully on using this, since non-java clients don't support schema.if you enable this setting, it will cause non-java clients failed to produce.",
+        "operationId" : "getSchemaValidtionEnforced",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenants or Namespace doesn't exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set schema validation enforced flag on namespace.",
+        "description" : "If the flag is set to true, when a producer without a schema attempts to produce to a topic with schema in this namespace, the producer will be failed to connect. PLEASE be carefully on using this, since non-java clients don't support schema.if you enable this setting, it will cause non-java clients failed to produce.",
+        "operationId" : "setSchemaValidtionEnforced",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "schemaValidationEnforced value is not valid"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscribeRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get subscribe-rate configured for the namespace",
+        "description" : "",
+        "operationId" : "getSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SubscribeRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set subscribe-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscribeRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionAuthMode" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : " Set a subscription auth mode for all the topics on a namespace.",
+        "description" : "",
+        "operationId" : "setSubscriptionAuthMode",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/subscriptionDispatchRate" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get Subscription dispatch-rate configured for the namespace, -1 represents not configured yet",
+        "description" : "",
+        "operationId" : "getSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DispatchRate"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Set Subscription dispatch-rate throttling for all topics of the namespace",
+        "description" : "",
+        "operationId" : "setSubscriptionDispatchRate",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/topics" : {
+      "get" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Get the list of all the topics under a certain namespace.",
+        "description" : "",
+        "operationId" : "getTopics",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "PERSISTENT",
+          "enum" : [ "PERSISTENT", "NON_PERSISTENT", "ALL" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload namespace",
+        "description" : "Unload an active namespace from the current broker serving it. Performing this operation will let the brokerremoves all producers, consumers, and connections using this namespace, and close all topics (includingtheir persistent store). During that operation, the namespace is marked as tentatively unavailable until thebroker completes the unloading action. This operation requires strictly super user privileges, since it wouldresult in non-persistent message loss and unexpected connection closure to the clients.",
+        "operationId" : "unloadNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or namespace doesn't exist"
+          },
+          "412" : {
+            "description" : "Namespace is already unloaded or Namespace has bundles activated"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespace",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "cluster",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}" : {
+      "delete" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Delete a namespace bundle and all the topics under it.",
+        "description" : "",
+        "operationId" : "deleteNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant or cluster or namespace doesn't exist"
+          },
+          "409" : {
+            "description" : "Namespace bundle is not empty"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklog",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Clear backlog for a given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "clearNamespaceBundleBacklogForSubscription",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/split" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Split a namespace bundle",
+        "description" : "",
+        "operationId" : "splitNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "unload",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unload" : {
+      "put" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unload a namespace bundle",
+        "description" : "",
+        "operationId" : "unloadNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/namespaces/{tenant}/{namespace}/{bundle}/unsubscribe/{subscription}" : {
+      "post" : {
+        "tags" : [ "namespaces" ],
+        "summary" : "Unsubscribes the given subscription on all topics on a namespace bundle.",
+        "description" : "",
+        "operationId" : "unsubscribeNamespaceBundle",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscription",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of non-persistent topics under a namespace bundle.",
+        "description" : "",
+        "operationId" : "getListFromBundle",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace doesn't exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a non-partitioned topic.",
+        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
+        "operationId" : "createNonPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "description" : "Stop all producer/consumer/replicator and delete topic forcefully",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expiry messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "description" : "Expires beyond the specified number of seconds",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Expiry messages on a non-persistent topic is not allowed"
+          },
+          "412" : {
+            "description" : "Can't find owner for topic"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The number of partitions for the topic",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to adminisActions to be grantedtrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "406" : {
+            "description" : "The number of partitions should be more than 1"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The number of partitions for the topic",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exists"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "description" : "Stop all producer/consumer/replicator and delete topic forcefully",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "description" : "Client role to which grant permissions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Actions to be granted (produce,functions,consume)",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume", "functions" ]
+            }
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "description" : "Client role to which grant permissions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NonPersistentTopicStats"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to be deleted",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Expiry messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to be Expiry messages on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "description" : "Expires beyond the specified number of seconds",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Expiry messages on a non-persistent topic is not allowed"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscribed message expired",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "description" : "The number of messages (default 1)",
+          "required" : true,
+          "type" : "integer",
+          "default" : 1,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          },
+          "405" : {
+            "description" : "Skipping messages on a non-persistent topic is not allowed"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to reset position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "in" : "body",
+          "name" : "messageId",
+          "description" : "messageId to reset back to (ledgerId:entryId)",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/MessageIdImpl"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          },
+          "412" : {
+            "description" : "Unable to find position for position specified"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to reset position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "description" : "time in minutes to reset back to (or minutes, hours,days,weeks eg:100m, 3h, 2d, 5w)",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Method Not Allowed"
+          },
+          "412" : {
+            "description" : "Failed to reset cursor on subscription or Unable to find position for timestamp specified"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skipping messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Name of subscription",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "description" : "The number of messages to skip",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Skipping messages on a partitioned topic is not allowed"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Name of subscription",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          },
+          "412" : {
+            "description" : "Can't find owner for topic"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "description" : "Subscription to create position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "messageId where to create the subscription. It can be 'latest', 'earliest' or (ledgerId:entryId)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : "latest",
+          "enum" : [ "latest", "earliest", "ledgerId:entryId" ]
+        }, {
+          "name" : "replicated",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Termination of a partitioned topic is not allowed"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/non-persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "non-persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of topics under a namespace.",
+        "description" : "",
+        "operationId" : "getList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/partitioned" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of partitioned topics under a namespace.",
+        "description" : "",
+        "operationId" : "getPartitionedTopicList",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Namespace name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a non-partitioned topic.",
+        "description" : "This is the only REST endpoint from which non-partitioned topics could be created.",
+        "operationId" : "createNonPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a topic.",
+        "description" : "The topic cannot be deleted if delete is not forcefully and there's any active subscription or producer connected to the it. Force delete ignores connected clients and deletes topic by explicitly closing them.",
+        "operationId" : "deleteTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "description" : "Stop all producer/consumer/replicator and delete topic forcefully",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic has active producers/subscriptions"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/all_subscription/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expiry messages on all subscriptions of topic.",
+        "description" : "",
+        "operationId" : "expireMessagesForAllSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "description" : "Expires beyond the specified number of seconds",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Expiry messages on a non-persistent topic is not allowed"
+          },
+          "412" : {
+            "description" : "Can't find owner for topic"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/backlog" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get estimated backlog for offline topic.",
+        "description" : "",
+        "operationId" : "getBacklog",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentOfflineTopicStats"
+            }
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/compaction" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the status of a compaction operation for a topic.",
+        "description" : "",
+        "operationId" : "compactionStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/LongRunningProcessStatus"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist, or compaction hasn't run"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Trigger a compaction operation on a topic.",
+        "description" : "",
+        "operationId" : "compact",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "409" : {
+            "description" : "Compaction already running"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internal-info" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getManagedLedgerInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/internalStats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the internal stats for the topic.",
+        "description" : "",
+        "operationId" : "getInternalStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PersistentTopicInternalStats"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/lastMessageId" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Return the last commit message id of topic",
+        "description" : "",
+        "operationId" : "getLastMessageId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/offload" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "offloadStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OffloadProcessStatus"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Offload a prefix of a topic to long term storage",
+        "description" : "",
+        "operationId" : "triggerOffload",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Operation is not allowed on the persistent topic"
+          },
+          "409" : {
+            "description" : "Offload already running"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitioned-stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the partitioned topic.",
+        "description" : "",
+        "operationId" : "getPartitionedStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/partitions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get partitioned topic metadata.",
+        "description" : "",
+        "operationId" : "getPartitionedMetadata",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PartitionedTopicMetadata"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Increment partitons of an existing partitioned topic.",
+        "description" : "It only increments partitions of existing non-global partitioned-topic",
+        "operationId" : "updatePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The number of partitions for the topic",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to adminisActions to be grantedtrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "406" : {
+            "description" : "The number of partitions should be more than 1"
+          },
+          "409" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Create a partitioned topic.",
+        "description" : "It needs to be called before creating a producer on a partitioned topic.",
+        "operationId" : "createPartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The number of partitions for the topic",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Partitioned topic already exist"
+          },
+          "412" : {
+            "description" : "Failed Reason : Name is invalid or Namespace does not have any clusters configured"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a partitioned topic.",
+        "description" : "It will also delete all the partitions of the topic if it exists.",
+        "operationId" : "deletePartitionedTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "force",
+          "in" : "query",
+          "description" : "Stop all producer/consumer/replicator and delete topic forcefully",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Partitioned topic does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Partitioned topic name is invalid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get permissions on a topic.",
+        "description" : "Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at thenamespace level combined (union) with any eventual specific permission set on the topic.",
+        "operationId" : "getPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/permissions/{role}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Grant a new permission to a role on a single topic.",
+        "description" : "",
+        "operationId" : "grantPermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "description" : "Client role to which grant permissions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Actions to be granted (produce,functions,consume)",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume", "functions" ]
+            }
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Revoke permissions on a topic.",
+        "description" : "Revoke permissions to a role on a single topic. If the permission was not set at the topiclevel, but rather at the namespace level, this operation will return an error (HTTP status code 412).",
+        "operationId" : "revokePermissionsOnTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "role",
+          "in" : "path",
+          "description" : "Client role to which grant permissions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "tenant/namespace/topic doesn't exit"
+          },
+          "412" : {
+            "description" : "Permissions are not set at the topic level"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for the topic.",
+        "description" : "",
+        "operationId" : "getStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TopicStats"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
+      "delete" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Delete a subscription.",
+        "description" : "There should not be any active consumers on the subscription.",
+        "operationId" : "deleteSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to be deleted",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Subscription has active consumers"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/expireMessages/{expireTimeInSeconds}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Expiry messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "expireTopicMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to be Expiry messages on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "expireTimeInSeconds",
+          "in" : "path",
+          "description" : "Expires beyond the specified number of seconds",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Expiry messages on a non-persistent topic is not allowed"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Peek nth message on a topic subscription.",
+        "description" : "",
+        "operationId" : "peekNthMessage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscribed message expired",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "messagePosition",
+          "in" : "path",
+          "description" : "The number of messages (default 1)",
+          "required" : true,
+          "type" : "integer",
+          "default" : 1,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic, subscription or the message position does not exist"
+          },
+          "405" : {
+            "description" : "Skipping messages on a non-persistent topic is not allowed"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursorOnPosition",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to reset position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "in" : "body",
+          "name" : "messageId",
+          "description" : "messageId to reset back to (ledgerId:entryId)",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/MessageIdImpl"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          },
+          "412" : {
+            "description" : "Unable to find position for position specified"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor/{timestamp}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to absolute timestamp (in ms).",
+        "description" : "It fence cursor and disconnects all active consumers before reseting cursor.",
+        "operationId" : "resetCursor",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Subscription to reset position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "path",
+          "description" : "time in minutes to reset back to (or minutes, hours,days,weeks eg:100m, 3h, 2d, 5w)",
+          "required" : true,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Method Not Allowed"
+          },
+          "412" : {
+            "description" : "Failed to reset cursor on subscription or Unable to find position for timestamp specified"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip/{numMessages}" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skipping messages on a topic subscription.",
+        "description" : "",
+        "operationId" : "skipMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Name of subscription",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "numMessages",
+          "in" : "path",
+          "description" : "The number of messages to skip",
+          "required" : true,
+          "type" : "integer",
+          "default" : 0,
+          "format" : "int32"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Skipping messages on a partitioned topic is not allowed"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/skip_all" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Skip all messages on a topic subscription.",
+        "description" : "Completely clears the backlog on the subscription.",
+        "operationId" : "skipAllMessages",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subName",
+          "in" : "path",
+          "description" : "Name of subscription",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic or subscription does not exist"
+          },
+          "405" : {
+            "description" : "Operation not allowed on non-persistent topic"
+          },
+          "412" : {
+            "description" : "Can't find owner for topic"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscription/{subscriptionName}" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Reset subscription to message position closest to given position.",
+        "description" : "Creates a subscription on the topic at the specified message id",
+        "operationId" : "createSubscription",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "subscriptionName",
+          "in" : "path",
+          "description" : "Subscription to create position on",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "messageId where to create the subscription. It can be 'latest', 'earliest' or (ledgerId:entryId)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : "latest",
+          "enum" : [ "latest", "earliest", "ledgerId:entryId" ]
+        }, {
+          "name" : "replicated",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic/Subscription does not exist"
+          },
+          "405" : {
+            "description" : "Not supported for partitioned topics"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/subscriptions" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the list of persistent subscriptions for a given topic.",
+        "description" : "",
+        "operationId" : "getSubscriptions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/terminate" : {
+      "post" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Terminate a topic. A topic that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog",
+        "description" : "",
+        "operationId" : "terminate",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/MessageId"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant orsubscriber is not authorized to access this operation"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "405" : {
+            "description" : "Termination of a partitioned topic is not allowed"
+          },
+          "412" : {
+            "description" : "Topic name is not valid"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/persistent/{tenant}/{namespace}/{topic}/unload" : {
+      "put" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Unload a topic",
+        "description" : "",
+        "operationId" : "unloadTopic",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "description" : "Specify topic name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Topic does not exist"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          },
+          "412" : {
+            "description" : "Topic name is not valid or can't find owner for topic"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
+    "/resource-quotas" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get the default quota",
+        "description" : "",
+        "operationId" : "getDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set the default quota",
+        "description" : "",
+        "operationId" : "setDefaultResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          }
+        }
+      }
+    },
+    "/resource-quotas/{tenant}/{namespace}/{bundle}" : {
+      "get" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Get resource quota of a namespace bundle.",
+        "description" : "",
+        "operationId" : "getNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ResourceQuota"
+            }
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "404" : {
+            "description" : "Namespace does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Set resource quota on a namespace.",
+        "description" : "",
+        "operationId" : "setNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "resource-quotas" ],
+        "summary" : "Remove resource quota for a namespace.",
+        "description" : "",
+        "operationId" : "removeNamespaceBundleResourceQuota",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "bundle",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "409" : {
+            "description" : "Concurrent modification"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Update the schema of a topic",
+        "description" : "",
+        "operationId" : "postSchema",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a schema playload. An example of the expected schema can be found down here.",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/PostSchemaPayload"
+          },
+          "x-examples" : {
+            "application/json" : "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }"
+          }
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/PostSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "409" : {
+            "description" : "Incompatible schema"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          },
+          "422" : {
+            "description" : "Invalid schema data"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Delete the schema of a topic",
+        "description" : "",
+        "operationId" : "deleteSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/DeleteSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/schemas/{tenant}/{namespace}/{topic}/schema/{version}" : {
+      "get" : {
+        "tags" : [ "schemas" ],
+        "summary" : "Get the schema of a topic at a given version",
+        "description" : "",
+        "operationId" : "getSchema",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "topic",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GetSchemaResponse"
+            }
+          },
+          "307" : {
+            "description" : "Current broker doesn't serve the namespace of this topic"
+          },
+          "401" : {
+            "description" : "Client is not authorized or Don't have admin permission"
+          },
+          "403" : {
+            "description" : "Client is not authenticated"
+          },
+          "404" : {
+            "description" : "Tenant or Namespace or Topic doesn't exist; or Schema is not found for this topic"
+          },
+          "412" : {
+            "description" : "Failed to find the ownership for the topic"
+          }
+        }
+      }
+    },
+    "/tenants" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the list of existing tenants.",
+        "description" : "",
+        "operationId" : "getTenants",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant doesn't exist"
+          }
+        }
+      }
+    },
+    "/tenants/{tenant}" : {
+      "get" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Get the admin configuration for a given tenant.",
+        "description" : "",
+        "operationId" : "getTenantAdmin",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TenantInfo"
+            }
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Update the admins for a tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "updateTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "TenantInfo",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/TenantInfo"
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          },
+          "412" : {
+            "description" : "Clusters do not exist"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Create a new tenant.",
+        "description" : "This operation requires Pulsar super-user privileges.",
+        "operationId" : "createTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "TenantInfo",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/TenantInfo"
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "409" : {
+            "description" : "Tenant already exists"
+          },
+          "412" : {
+            "description" : "Clusters do not exist"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "tenants" ],
+        "summary" : "Delete a tenant and all namespaces and topics under it.",
+        "description" : "",
+        "operationId" : "deleteTenant",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Tenant does not exist"
+          },
+          "409" : {
+            "description" : "The tenant still has active namespaces"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "AllocatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "numDirectArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numHeapArenas" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numThreadLocalCaches" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "normalCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "smallCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinyCacheSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "directArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        },
+        "heapArenas" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolArenaStats"
+          }
+        }
+      }
+    },
+    "AuthPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "namespace_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "enum" : [ "produce", "consume", "functions" ]
+            }
+          }
+        },
+        "destination_auth" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "uniqueItems" : true,
+              "items" : {
+                "type" : "string",
+                "enum" : [ "produce", "consume", "functions" ]
+              }
+            }
+          }
+        },
+        "subscription_auth_roles" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "AutoFailoverPolicyData" : {
+      "type" : "object",
+      "properties" : {
+        "policy_type" : {
+          "type" : "string",
+          "description" : "The auto failover policy type",
+          "enum" : [ "min_available" ]
+        },
+        "parameters" : {
+          "type" : "object",
+          "example" : "{\n  \"min_limit\": 3,\n  \"usage_threshold\": 80\n}\n",
+          "description" : "The parameters applied to the auto failover policy specified by `policy_type`.\nThe parameters for 'min_available' are :\n  - 'min_limit': the limit of minimal number of available brokers in primary group before auto failover\n  - 'usage_threshold': the resource usage threshold. If the usage of a broker is beyond this value, it would be marked as unavailable\n",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      },
+      "description" : "The auto failover policy configuration data"
+    },
+    "BacklogQuota" : {
+      "type" : "object",
+      "properties" : {
+        "limit" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "policy" : {
+          "type" : "string",
+          "enum" : [ "producer_request_hold", "producer_exception", "consumer_backlog_eviction" ]
+        }
+      }
+    },
+    "BookieAffinityGroupData" : {
+      "type" : "object",
+      "properties" : {
+        "bookkeeperAffinityGroupPrimary" : {
+          "type" : "string"
+        },
+        "bookkeeperAffinityGroupSecondary" : {
+          "type" : "string"
+        }
+      }
+    },
+    "BookieInfo" : {
+      "type" : "object",
+      "properties" : {
+        "rack" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        }
+      }
+    },
+    "BrokerNamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "brokerName" : {
+          "type" : "string",
+          "example" : "broker1:8080",
+          "description" : "The broker name"
+        },
+        "namespaceRegex" : {
+          "type" : "array",
+          "description" : "The namespace-isolation policies attached to this broker",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "description" : "The namespace isolation data for a given broker"
+    },
+    "BundlesData" : {
+      "type" : "object",
+      "properties" : {
+        "boundaries" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "ClusterData" : {
+      "type" : "object",
+      "properties" : {
+        "serviceUrl" : {
+          "type" : "string",
+          "example" : "http://pulsar.example.com:8080",
+          "description" : "The HTTP rest service URL (for admin operations)"
+        },
+        "serviceUrlTls" : {
+          "type" : "string",
+          "example" : "https://pulsar.example.com:8443",
+          "description" : "The HTTPS rest service URL (for admin operations)"
+        },
+        "brokerServiceUrl" : {
+          "type" : "string",
+          "example" : "pulsar://pulsar.example.com:6650",
+          "description" : "The broker service url (for produce and consume operations)"
+        },
+        "brokerServiceUrlTls" : {
+          "type" : "string",
+          "example" : "pulsar+ssl://pulsar.example.com:6651",
+          "description" : "The secured broker service url (for produce and consume operations)"
+        },
+        "peerClusterNames" : {
+          "type" : "array",
+          "description" : "A set of peer cluster names",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "description" : "The configuration data for a cluster"
+    },
+    "ConsumerStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerName" : {
+          "type" : "string"
+        },
+        "availablePermits" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "blockedConsumerOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "CursorDetails" : {
+      "type" : "object",
+      "properties" : {
+        "cursorBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "CursorStats" : {
+      "type" : "object",
+      "properties" : {
+        "markDeletePosition" : {
+          "type" : "string"
+        },
+        "readPosition" : {
+          "type" : "string"
+        },
+        "waitingReadOp" : {
+          "type" : "boolean"
+        },
+        "pendingReadOps" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "messagesConsumedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedger" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerLastEntry" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "individuallyDeletedMessages" : {
+          "type" : "string"
+        },
+        "lastLedgerSwitchTimestamp" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "numberOfEntriesSinceFirstNotAckedMessage" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalNonContiguousDeletedMessagesRange" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      }
+    },
+    "DeleteSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "DispatchRate" : {
+      "type" : "object",
+      "properties" : {
+        "dispatchThrottlingRateInMsg" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dispatchThrottlingRateInByte" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "FailureDomain" : {
+      "type" : "object",
+      "properties" : {
+        "brokers" : {
+          "type" : "array",
+          "example" : "[ 'broker-1', 'broker-2' ]",
+          "description" : "The collection of brokers in the same failure domain",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "description" : "The data of a failure domain configuration in a cluster"
+    },
+    "GetSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "NONE", "STRING", "JSON", "PROTOBUF", "AVRO", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "FLOAT", "DOUBLE", "DATE", "TIME", "TIMESTAMP", "KEY_VALUE", "BYTES", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH" ]
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "data" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "InternalConfigurationData" : {
+      "type" : "object",
+      "properties" : {
+        "zookeeperServers" : {
+          "type" : "string"
+        },
+        "configurationStoreServers" : {
+          "type" : "string"
+        },
+        "ledgersRootPath" : {
+          "type" : "string"
+        },
+        "stateStorageServiceUrl" : {
+          "type" : "string"
+        }
+      }
+    },
+    "LedgerDetails" : {
+      "type" : "object",
+      "properties" : {
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "LedgerInfo" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offloaded" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "LoadReport" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "brokerVersionString" : {
+          "type" : "string"
+        },
+        "webServiceUrl" : {
+          "type" : "string"
+        },
+        "webServiceUrlTls" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrl" : {
+          "type" : "string"
+        },
+        "pulsarServiceUrlTls" : {
+          "type" : "string"
+        },
+        "persistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "nonPersistentTopicsEnabled" : {
+          "type" : "boolean"
+        },
+        "timestamp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "numTopics" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numConsumers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numProducers" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numBundles" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "systemResourceUsage" : {
+          "$ref" : "#/definitions/SystemResourceUsage"
+        },
+        "bundleStats" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NamespaceBundleStats"
+          }
+        },
+        "bundleGains" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundleLosses" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "allocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedCPU" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMemory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedBandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "preAllocatedMsgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "lastUpdate" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "underLoaded" : {
+          "type" : "boolean"
+        },
+        "overLoaded" : {
+          "type" : "boolean"
+        },
+        "loadReportType" : {
+          "type" : "string"
+        }
+      }
+    },
+    "LongRunningProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "MessageIdImpl" : {
+      "type" : "object",
+      "properties" : {
+        "ledgerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "entryId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "partitionIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "Metrics" : {
+      "type" : "object",
+      "properties" : {
+        "metrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "dimensions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "NamespaceBundleStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "producerCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topics" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cacheSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "NamespaceIsolationData" : {
+      "type" : "object",
+      "properties" : {
+        "namespaces" : {
+          "type" : "array",
+          "description" : "The list of namespaces to apply this namespace isolation data",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "primary" : {
+          "type" : "array",
+          "description" : "The list of secondary brokers for serving the list of namespaces in this isolation policy",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "auto_failover_policy" : {
+          "example" : "{  \"policy_type\": \"min_available\"  \"parameters\": {    \"\": \"\"  }}",
+          "description" : "The data of auto-failover policy configuration",
+          "$ref" : "#/definitions/AutoFailoverPolicyData"
+        }
+      },
+      "description" : "The data of namespace isolation configuration"
+    },
+    "NamespaceOwnershipStatus" : {
+      "type" : "object",
+      "properties" : {
+        "broker_assignment" : {
+          "type" : "string",
+          "enum" : [ "primary", "secondary", "shared" ]
+        },
+        "is_controlled" : {
+          "type" : "boolean"
+        },
+        "is_active" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "NonPersistentPublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NonPersistentReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentSubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "msgDelayed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover", "Key_Shared" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        },
+        "isReplicated" : {
+          "type" : "boolean"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "NonPersistentTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NonPersistentPublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentSubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/NonPersistentReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        },
+        "msgDropRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "OffloadProcessStatus" : {
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "NOT_RUN", "RUNNING", "SUCCESS", "ERROR" ]
+        },
+        "lastError" : {
+          "type" : "string"
+        },
+        "firstUnoffloadedMessage" : {
+          "$ref" : "#/definitions/MessageIdImpl"
+        }
+      }
+    },
+    "OutputStream" : {
+      "type" : "object"
+    },
+    "PartitionedTopicMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "partitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PendingBookieOpsStats" : {
+      "type" : "object",
+      "properties" : {
+        "dataLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "dataLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerOpenOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCloseOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerCreateOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "cursorLedgerDeleteOp" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PersistencePolicies" : {
+      "type" : "object",
+      "properties" : {
+        "bookkeeperEnsemble" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperWriteQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "bookkeeperAckQuorum" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "managedLedgerMaxMarkDeleteRate" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "PersistentOfflineTopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "messageBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "brokerName" : {
+          "type" : "string"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "dataLedgerDetails" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerDetails"
+          }
+        },
+        "cursorDetails" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorDetails"
+          }
+        },
+        "statGeneratedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      }
+    },
+    "PersistentTopicInternalStats" : {
+      "type" : "object",
+      "properties" : {
+        "entriesAddedCounter" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numberOfEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "totalSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerEntries" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "currentLedgerSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastLedgerCreatedTimestamp" : {
+          "type" : "string"
+        },
+        "lastLedgerCreationFailureTimestamp" : {
+          "type" : "string"
+        },
+        "waitingCursorsCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pendingAddEntriesCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastConfirmedEntry" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "ledgers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LedgerInfo"
+          }
+        },
+        "cursors" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CursorStats"
+          }
+        }
+      }
+    },
+    "Policies" : {
+      "type" : "object",
+      "properties" : {
+        "auth_policies" : {
+          "$ref" : "#/definitions/AuthPolicies"
+        },
+        "replication_clusters" : {
+          "type" : "array",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "bundles" : {
+          "$ref" : "#/definitions/BundlesData"
+        },
+        "backlog_quota_map" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/BacklogQuota"
+          }
+        },
+        "topicDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "subscriptionDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "replicatorDispatchRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/DispatchRate"
+          }
+        },
+        "clusterSubscribeRate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscribeRate"
+          }
+        },
+        "persistence" : {
+          "$ref" : "#/definitions/PersistencePolicies"
+        },
+        "deduplicationEnabled" : {
+          "type" : "boolean"
+        },
+        "latency_stats_sample_rate" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "message_ttl_in_seconds" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retention_policies" : {
+          "$ref" : "#/definitions/RetentionPolicies"
+        },
+        "deleted" : {
+          "type" : "boolean"
+        },
+        "antiAffinityGroup" : {
+          "type" : "string"
+        },
+        "encryption_required" : {
+          "type" : "boolean"
+        },
+        "subscription_auth_mode" : {
+          "type" : "string",
+          "enum" : [ "None", "Prefix" ]
+        },
+        "max_producers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_topic" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "max_consumers_per_subscription" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "compaction_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_threshold" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "offload_deletion_lag_ms" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "schema_auto_update_compatibility_strategy" : {
+          "type" : "string",
+          "enum" : [ "AutoUpdateDisabled", "Backward", "Forward", "Full", "AlwaysCompatible", "BackwardTransitive", "ForwardTransitive", "FullTransitive" ]
+        },
+        "schema_validation_enforced" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "PoolArenaStats" : {
+      "type" : "object",
+      "properties" : {
+        "numTinySubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numSmallSubpages" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numChunkLists" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "tinySubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "smallSubpages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolSubpageStats"
+          }
+        },
+        "chunkLists" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkListStats"
+          }
+        },
+        "numAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numTinyDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSmallDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numNormalDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numHugeDeallocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveTinyAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveSmallAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveNormalAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numActiveHugeAllocations" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "PoolChunkListStats" : {
+      "type" : "object",
+      "properties" : {
+        "minUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxUsage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunks" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PoolChunkStats"
+          }
+        }
+      }
+    },
+    "PoolChunkStats" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "chunkSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "freeBytes" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PoolSubpageStats" : {
+      "type" : "object",
+      "properties" : {
+        "maxNumElements" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numAvailable" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "elementSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "pageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "PostSchemaPayload" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "schema" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "PostSchemaResponse" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "$ref" : "#/definitions/SchemaVersion"
+        }
+      }
+    },
+    "PublisherStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "producerId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "connectedSince" : {
+          "type" : "string"
+        },
+        "clientVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ReplicatorStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "replicationBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "connected" : {
+          "type" : "boolean"
+        },
+        "replicationDelayInSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "inboundConnection" : {
+          "type" : "string"
+        },
+        "inboundConnectedSince" : {
+          "type" : "string"
+        },
+        "outboundConnection" : {
+          "type" : "string"
+        },
+        "outboundConnectedSince" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ResourceDescription" : {
+      "type" : "object",
+      "properties" : {
+        "usagePct" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "resourceUsage" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ResourceUsage"
+          }
+        }
+      }
+    },
+    "ResourceQuota" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "bandwidthOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "memory" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "dynamic" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ResourceUnit" : {
+      "type" : "object",
+      "properties" : {
+        "resourceId" : {
+          "type" : "string"
+        },
+        "availableResource" : {
+          "$ref" : "#/definitions/ResourceDescription"
+        }
+      }
+    },
+    "ResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "limit" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "RetentionPolicies" : {
+      "type" : "object",
+      "properties" : {
+        "retentionTimeInMinutes" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "retentionSizeInMB" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SchemaVersion" : {
+      "type" : "object"
+    },
+    "SubscribeRate" : {
+      "type" : "object",
+      "properties" : {
+        "subscribeThrottlingRatePerConsumer" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "ratePeriodInSecond" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "SubscriptionStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateRedeliver" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgBacklog" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "blockedSubscriptionOnUnackedMsgs" : {
+          "type" : "boolean"
+        },
+        "msgDelayed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "unackedMessages" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "Exclusive", "Shared", "Failover", "Key_Shared" ]
+        },
+        "activeConsumerName" : {
+          "type" : "string"
+        },
+        "msgRateExpired" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "consumers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsumerStats"
+          }
+        },
+        "isReplicated" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "SystemResourceUsage" : {
+      "type" : "object",
+      "properties" : {
+        "bandwidthIn" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "bandwidthOut" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "cpu" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "memory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        },
+        "directMemory" : {
+          "$ref" : "#/definitions/ResourceUsage"
+        }
+      }
+    },
+    "TenantInfo" : {
+      "type" : "object",
+      "properties" : {
+        "adminRoles" : {
+          "type" : "array",
+          "description" : "Comma separated list of auth principal allowed to administrate the tenant.",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "allowedClusters" : {
+          "type" : "array",
+          "description" : "Comma separated allowed clusters.",
+          "uniqueItems" : true,
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "description" : "Information of adminRoles and allowedClusters for tenant"
+    },
+    "TopicStats" : {
+      "type" : "object",
+      "properties" : {
+        "msgRateIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputIn" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgRateOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "msgThroughputOut" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "averageMsgSize" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "publishers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PublisherStats"
+          }
+        },
+        "subscriptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/SubscriptionStats"
+          }
+        },
+        "replication" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ReplicatorStats"
+          }
+        },
+        "deduplicationStatus" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.4.0/swaggerfunctions.json
+++ b/site2/website/static/swagger/2.4.0/swaggerfunctions.json
@@ -1,0 +1,1496 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Functions operations",
+    "version" : "v3",
+    "title" : "Pulsar Functions REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "functions"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/functions/connectors" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getConnectorsList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/functions/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Lists all Pulsar Functions currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listFunctions",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetches information about a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getFunctionInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionConfig"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Creates a new Pulsar Function in cluster mode",
+        "description" : "",
+        "operationId" : "registerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The functions tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The functions namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The functions name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting functions configuration payload. An example of the expected functions can be found here.  \nautoAck  \n  Whether or not the framework will automatically acknowledge messages.  \nruntime  \n  What is the runtime of the function. Possible Values: [JAVA, PYTHON, GO]  \nresources  \n  The size of the system resources allowed by the function runtime. The resources include: cpu, ram, disk.  \nclassName  \n  The class name of functions.  \ncustomSchemaInputs  \n  The map of input topics to Schema class names (specified as a JSON object).  \ncustomSerdeInputs  \n  The map of input topics to SerDe class names (specified as a JSON object).  \ndeadLetterTopic  \n  Messages that are not processed successfully are sent to `deadLetterTopic`.  \nruntimeFlags  \n  Any flags that you want to pass to the runtime. Note that in thread mode, these flags have no impact.  \nfqfn  \n  The Fully Qualified Function Name (FQFN) for the function.  \ninputSpecs  \n   The map of input topics to its consumer configuration, each configuration has schema of    {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \ninputs  \n  The input topic or topics (multiple topics can be specified as a comma-separated list) of functions.  \njar  \n  Path to the JAR file for the function (if the function is written in Java).   It also supports URL path [http/https/file (file protocol assumes that file   already exists on worker host)] from which worker can download the package.  \npy  \n  Path to the main Python file/Python Wheel file for the function (if the function is written in Python).  \ngo  \n  Path to the main Go executable binary for the function (if the function is written in Go).  \nlogTopic  \n  The topic to which the functions logs are produced.  \nmaxMessageRetries  \n  How many times should we try to process a message before giving up.  \noutput  \n  The functions output topic (If none is specified, no output is written).  \noutputSerdeClassName  \n  The SerDe class to be used for messages output by the function.  \nparallelism  \n  The functions parallelism factor (i.e. the number of function instances to run).  \nprocessingGuarantees  \n  The processing guarantees (that is, delivery semantics) applied to the function.  Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \nretainOrdering  \n  Function consumes and processes messages in order.  \noutputSchemaType  \n   Represents either a builtin schema type (for example: 'avro', 'json', ect) or the class name for a Schema implementation.subName  \n  Pulsar source subscription name. User can specify a subscription-name for the input-topic consumer.  \nwindowConfig  \n  The window functions configuration.  \ntimeoutMs  \n  The message timeout in milliseconds.  \ntopicsPattern  \n  The topic pattern to consume from a list of topics under a namespace that match the pattern.  [input] and [topic-pattern] are mutually exclusive. Add SerDe class name for a   pattern in customSerdeInputs (supported for java fun only)  \nuserConfig  \n  A map of user-defined configurations (specified as a JSON object).  \nsecrets  \n  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the  SecretProviderConfigurator.getSecretObjectType() method. \ncleanupSubscription  \n  Whether the subscriptions the functions created/used should be deleted when the functions are deleted.  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{\n  \"inputs\": persistent://public/default/input-topic,\n  \"parallelism\": 4\n  \"output\": persistent://public/default/output-topic\n  \"log-topic\": persistent://public/default/log-topic\n  \"classname\": org.example.test.ExclamationFunction\n  \"jar\": java-function-1.0-SNAPSHOT.jar\n}"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (function already exists, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "functions" ],
+        "summary" : "Updates a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a functions config playload. An example of the expected functions can be found down here.  \nautoAck  \n  Whether or not the framework will automatically acknowledge messages.  \nruntime  \n  What is the runtime of the function. Possible Values: [JAVA, PYTHON, GO]  \nresources  \n  The size of the system resources allowed by the function runtime. The resources include: cpu, ram, disk.  \nclassName  \n  The class name of functions.  \ncustomSchemaInputs  \n  The map of input topics to Schema class names (specified as a JSON object).  \ncustomSerdeInputs  \n  The map of input topics to SerDe class names (specified as a JSON object).  \ndeadLetterTopic  \n  Messages that are not processed successfully are sent to `deadLetterTopic`.  \nruntimeFlags  \n  Any flags that you want to pass to the runtime. Note that in thread mode, these flags have no impact.  \nfqfn  \n  The Fully Qualified Function Name (FQFN) for the function.  \ninputSpecs  \n   The map of input topics to its consumer configuration, each configuration has schema of    {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \ninputs  \n  The input topic or topics (multiple topics can be specified as a comma-separated list) of functions.  \njar  \n  Path to the JAR file for the function (if the function is written in Java).   It also supports URL path [http/https/file (file protocol assumes that file   already exists on worker host)] from which worker can download the package.  \npy  \n  Path to the main Python file/Python Wheel file for the function (if the function is written in Python).  \ngo  \n  Path to the main Go executable binary for the function (if the function is written in Go).  \nlogTopic  \n  The topic to which the functions logs are produced.  \nmaxMessageRetries  \n  How many times should we try to process a message before giving up.  \noutput  \n  The functions output topic (If none is specified, no output is written).  \noutputSerdeClassName  \n  The SerDe class to be used for messages output by the function.  \nparallelism  \n  The functions parallelism factor (i.e. the number of function instances to run).  \nprocessingGuarantees  \n  The processing guarantees (that is, delivery semantics) applied to the function.  Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \nretainOrdering  \n  Function consumes and processes messages in order.  \noutputSchemaType  \n   Represents either a builtin schema type (for example: 'avro', 'json', ect) or the class name for a Schema implementation.subName  \n  Pulsar source subscription name. User can specify a subscription-name for the input-topic consumer.  \nwindowConfig  \n  The window functions configuration.  \ntimeoutMs  \n  The message timeout in milliseconds.  \ntopicsPattern  \n  The topic pattern to consume from a list of topics under a namespace that match the pattern.  [input] and [topicsPattern] are mutually exclusive. Add SerDe class name for a   pattern in customSerdeInputs (supported for java fun only)  \nuserConfig  \n  A map of user-defined configurations (specified as a JSON object).  \nsecrets  \n  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the  SecretProviderConfigurator.getSecretObjectType() method. \ncleanupSubscription  \n  Whether the subscriptions the functions created/used should be deleted when the functions are deleted.  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{\n  \"inputs\": persistent://public/default/input-topic,\n  \"parallelism\": 4\n  \"output\": persistent://public/default/output-topic\n  \"log-topic\": persistent://public/default/log-topic\n  \"classname\": org.example.test.ExclamationFunction\n  \"jar\": java-function-1.0-SNAPSHOT.jar\n}"
+          }
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The update options is for the Pulsar Function that needs to be updated.",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/UpdateOptions"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (function doesn't exist, etc.)"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "functions" ],
+        "summary" : "Deletes a Pulsar Function currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart all function instances",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start all function instances",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/state/{key}" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Fetch the current state associated with a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionState",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "key",
+          "in" : "path",
+          "description" : "The stats key",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionState"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The key does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Put the state associated with a Pulsar Function",
+        "description" : "",
+        "operationId" : "putFunctionState",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "key",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStats"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function",
+        "description" : "",
+        "operationId" : "getFunctionStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop all function instances",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/trigger" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Triggers a Pulsar Function with a user-specified value or file data",
+        "description" : "",
+        "operationId" : "triggerFunction",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The value with which you want to trigger the function",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The path to the file that contains the data with which you'd like to trigger the function",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/InputStream"
+          }
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The specific topic name that the function consumes from which you want to inject the data to",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Message"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Restart function instance",
+        "description" : "",
+        "operationId" : "restartFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The function instanceId (if instance-id is not provided, all instances are restarted",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Start function instance",
+        "description" : "",
+        "operationId" : "startFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The function instanceId (if instance-id is not provided, all instances sre started. ",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the stats of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStats",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The function instanceId (if instance-id is not provided, the stats of all instances is returned",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatsData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "functions" ],
+        "summary" : "Displays the status of a Pulsar Function instance",
+        "description" : "",
+        "operationId" : "getFunctionInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The function instanceId (if instance-id is not provided, the stats of all instances is returned",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/FunctionInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "The function doesn't exist"
+          }
+        }
+      }
+    },
+    "/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "functions" ],
+        "summary" : "Stop function instance",
+        "description" : "",
+        "operationId" : "stopFunction",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The tenant of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The namespace of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "functionName",
+          "in" : "path",
+          "description" : "The name of functions",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The function instanceId (if instance-id is not provided, all instances are stopped. ",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The function does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ConsumerConfig" : {
+      "type" : "object",
+      "properties" : {
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "receiverQueueSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "regexPattern" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "EncryptionContext" : {
+      "type" : "object",
+      "properties" : {
+        "keys" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/EncryptionKey"
+          }
+        },
+        "param" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "algorithm" : {
+          "type" : "string"
+        },
+        "compressionType" : {
+          "type" : "string",
+          "enum" : [ "NONE", "LZ4", "ZLIB", "ZSTD", "SNAPPY" ]
+        },
+        "uncompressedMessageSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "batchSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "EncryptionKey" : {
+      "type" : "object",
+      "properties" : {
+        "keyValue" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FunctionConfig" : {
+      "type" : "object",
+      "properties" : {
+        "runtimeFlags" : {
+          "type" : "string"
+        },
+        "tenant" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "inputs" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "customSerdeInputs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "customSchemaInputs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerConfig"
+          }
+        },
+        "output" : {
+          "type" : "string"
+        },
+        "outputSchemaType" : {
+          "type" : "string"
+        },
+        "outputSerdeClassName" : {
+          "type" : "string"
+        },
+        "logTopic" : {
+          "type" : "string"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE" ]
+        },
+        "retainOrdering" : {
+          "type" : "boolean"
+        },
+        "userConfig" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "secrets" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "runtime" : {
+          "type" : "string",
+          "enum" : [ "JAVA", "PYTHON", "GO" ]
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "maxMessageRetries" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "deadLetterTopic" : {
+          "type" : "string"
+        },
+        "subName" : {
+          "type" : "string"
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "fqfn" : {
+          "type" : "string"
+        },
+        "windowConfig" : {
+          "$ref" : "#/definitions/WindowConfig"
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "jar" : {
+          "type" : "string"
+        },
+        "py" : {
+          "type" : "string"
+        },
+        "go" : {
+          "type" : "string"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "FunctionInstanceStats" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "metrics" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsData"
+        }
+      }
+    },
+    "FunctionInstanceStatsData" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userMetrics" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      }
+    },
+    "FunctionInstanceStatsDataBase" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      }
+    },
+    "FunctionInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/FunctionInstanceStatusData"
+        }
+      }
+    },
+    "FunctionInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceived" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSuccessfullyProcessed" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numUserExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestUserExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "averageLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "lastInvocationTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "FunctionState" : {
+      "type" : "object",
+      "properties" : {
+        "key" : {
+          "type" : "string"
+        },
+        "stringValue" : {
+          "type" : "string"
+        },
+        "byteValue" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "numberValue" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "FunctionStats" : {
+      "type" : "object",
+      "properties" : {
+        "receivedTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "processedSuccessfullyTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "systemExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "userExceptionsTotal" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "avgProcessLatency" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "1min" : {
+          "$ref" : "#/definitions/FunctionInstanceStatsDataBase"
+        },
+        "lastInvocation" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStats"
+          }
+        }
+      }
+    },
+    "FunctionStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FunctionInstanceStatus"
+          }
+        }
+      }
+    },
+    "InputStream" : {
+      "type" : "object"
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "object"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "keyBytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "redeliveryCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "messageId" : {
+          "$ref" : "#/definitions/MessageId"
+        },
+        "orderingKey" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        },
+        "sequenceId" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "encryptionCtx" : {
+          "$ref" : "#/definitions/EncryptionContext"
+        },
+        "replicated" : {
+          "type" : "boolean"
+        },
+        "publishTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "eventTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "producerName" : {
+          "type" : "string"
+        },
+        "replicatedFrom" : {
+          "type" : "string"
+        },
+        "schemaVersion" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "byte"
+          }
+        }
+      }
+    },
+    "MessageId" : {
+      "type" : "object"
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "UpdateOptions" : {
+      "type" : "object",
+      "properties" : {
+        "update-auth-data" : {
+          "type" : "boolean",
+          "description" : "Whether or not to update the auth data"
+        }
+      },
+      "description" : "Options while updating the sink"
+    },
+    "WindowConfig" : {
+      "type" : "object",
+      "properties" : {
+        "windowLengthCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "windowLengthDurationMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "slidingIntervalCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "slidingIntervalDurationMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lateDataTopic" : {
+          "type" : "string"
+        },
+        "maxLagMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "watermarkEmitIntervalMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timestampExtractorClassName" : {
+          "type" : "string"
+        },
+        "actualWindowFunctionClassName" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/site2/website/static/swagger/2.4.0/swaggersink.json
+++ b/site2/website/static/swagger/2.4.0/swaggersink.json
@@ -1,0 +1,926 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Sink operations",
+    "version" : "v3",
+    "title" : "Pulsar Sink REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "sinks"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/sinks/builtinsinks" : {
+      "get" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Fetches a list of supported Pulsar IO sink connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Get builtin sinks successfully.",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Lists all Pulsar Sinks currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSinks",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid list request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}" : {
+      "get" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Fetches information about a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkConfig"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Creates a new Pulsar Sink in cluster mode",
+        "description" : "",
+        "operationId" : "registerSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a sink config playload. All available configuration options are:  \nclassname  \n   The sink's class name if archive is file-url-path (file://)  \nsourceSubscriptionName  \n   Pulsar source subscription name if user wants a specific  \n   subscription-name for input-topic consumer  \ninputs  \n   The sink's input topic or topics (specified as a JSON array)  \ntopicsPattern  \n   TopicsPattern to consume from list of topics under a namespace that    match the pattern. [input] and [topicsPattern] are mutually    exclusive. Add SerDe class name for a pattern in customSerdeInputs    (supported for java fun only)topicToSerdeClassName  \n   The map of input topics to SerDe class names (specified as a JSON object)  \ntopicToSchemaType  \n   The map of input topics to Schema types or class names (specified as a JSON object)  \ninputSpecs  \n   The map of input topics to its consumer configuration, each configuration has schema of    {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \nconfigs  \n   The map of configs (specified as a JSON object)  \nsecrets  \n   a map of secretName(aka how the secret is going to be \n   accessed in the function via context) to an object that \n   encapsulates how the secret is fetched by the underlying \n   secrets provider. The type of an value here can be found by the \n   SecretProviderConfigurator.getSecretObjectType() method. (specified as a JSON object)  \nparallelism  \n   The sink's parallelism factor (i.e. the number of sink instances to run \nprocessingGuarantees  \n   The processing guarantees (aka delivery semantics) applied to the sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \nretainOrdering  \n   Boolean denotes whether sink consumes and sinks messages in order  \nresources  \n   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per sink instance (applicable only to Docker runtime)  \nautoAck  \n   Boolean denotes whether or not the framework will automatically acknowledge messages  \ntimeoutMs  \n   Long denotes the message timeout in milliseconds  \ncleanupSubscription  \n   Boolean denotes whether the subscriptions the functions created/used should be deleted when the functions is deleted  \nruntimeFlags  \n   Any flags that you want to pass to the runtime as a single string  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{  \n\t\"classname\": \"org.example.MySinkTest\",\n\t\"inputs\": [\"persistent://public/default/sink-input\"],\n\t\"processingGuarantees\": \"EFFECTIVELY_ONCE\",\n\t\"parallelism\": 10\n}"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Sink successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (sink already exists, etc.)"
+          },
+          "401" : {
+            "description" : "Client is not authorized to perform operation"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to authorize, failed to get tenant data, failed to process package, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Updates a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSink",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting a sink config playload. All available configuration options are:  \nclassname  \n   The sink's class name if archive is file-url-path (file://)  \nsourceSubscriptionName  \n   Pulsar source subscription name if user wants a specific  \n   subscription-name for input-topic consumer  \ninputs  \n   The sink's input topic or topics (specified as a JSON array)  \ntopicsPattern  \n   TopicsPattern to consume from list of topics under a namespace that    match the pattern. [input] and [topicsPattern] are mutually    exclusive. Add SerDe class name for a pattern in customSerdeInputs    (supported for java fun only)topicToSerdeClassName  \n   The map of input topics to SerDe class names (specified as a JSON object)  \ntopicToSchemaType  \n   The map of input topics to Schema types or class names (specified as a JSON object)  \ninputSpecs  \n   The map of input topics to its consumer configuration, each configuration has schema of    {\"schemaType\": \"type-x\", \"serdeClassName\": \"name-x\", \"isRegexPattern\": true, \"receiverQueueSize\": 5}  \nconfigs  \n   The map of configs (specified as a JSON object)  \nsecrets  \n   a map of secretName(aka how the secret is going to be \n   accessed in the function via context) to an object that \n   encapsulates how the secret is fetched by the underlying \n   secrets provider. The type of an value here can be found by the \n   SecretProviderConfigurator.getSecretObjectType() method. (specified as a JSON object)  \nparallelism  \n   The sink's parallelism factor (i.e. the number of sink instances to run \nprocessingGuarantees  \n   The processing guarantees (aka delivery semantics) applied to the sink. Possible Values: \"ATLEAST_ONCE\", \"ATMOST_ONCE\", \"EFFECTIVELY_ONCE\"  \nretainOrdering  \n   Boolean denotes whether sink consumes and sinks messages in order  \nresources  \n   {\"cpu\": 1, \"ram\": 2, \"disk\": 3} The CPU (in cores), RAM (in bytes) and disk (in bytes) that needs to be allocated per sink instance (applicable only to Docker runtime)  \nautoAck  \n   Boolean denotes whether or not the framework will automatically acknowledge messages  \ntimeoutMs  \n   Long denotes the message timeout in milliseconds  \ncleanupSubscription  \n   Boolean denotes whether the subscriptions the functions created/used should be deleted when the functions is deleted  \nruntimeFlags  \n   Any flags that you want to pass to the runtime as a single string  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{  \n\t\"classname\": \"org.example.SinkStressTest\",  \n\t\"inputs\": [\"persistent://public/default/sink-input\"],\n\t\"processingGuarantees\": \"EFFECTIVELY_ONCE\",\n\t\"parallelism\": 5\n}"
+          }
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/UpdateOptions"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Sink successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (sink doesn't exist, update contains no change, etc.)"
+          },
+          "401" : {
+            "description" : "Client is not authorized to perform operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to authorize, failed to process package, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Deletes a Pulsar Sink currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The sink was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid deregister request"
+          },
+          "401" : {
+            "description" : "Client is not authorized to perform operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "408" : {
+            "description" : "Got InterruptedException while deregistering the sink"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to authorize, failed to deregister, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/restart" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Restart all sink instances",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid restart request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to restart the sink, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/start" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Start all sink instances",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid start request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to start the sink, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/status" : {
+      "get" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Displays the status of a Pulsar Sink running in cluster mode",
+        "description" : "",
+        "operationId" : "getSinkStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkStatus"
+            }
+          },
+          "400" : {
+            "description" : "Invalid get status request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/stop" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Stop all sink instances",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid stop request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to stop the sink, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Restart sink instance",
+        "description" : "",
+        "operationId" : "restartSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The sink instanceId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid restart request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to restart the sink instance, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Start sink instance",
+        "description" : "",
+        "operationId" : "startSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The sink instanceId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid start request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to start the sink, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Displays the status of a Pulsar Sink instance",
+        "description" : "",
+        "operationId" : "getSinkInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The sink instanceId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SinkInstanceStatusData"
+            }
+          },
+          "400" : {
+            "description" : "The sink instance does not exist"
+          },
+          "404" : {
+            "description" : "The sink does not exist"
+          },
+          "500" : {
+            "description" : "Internal Server Error (got exception while getting status, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sinks/{tenant}/{namespace}/{sinkName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "sinks" ],
+        "summary" : "Stop sink instance",
+        "description" : "",
+        "operationId" : "stopSink",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The sink's tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The sink's namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sinkName",
+          "in" : "path",
+          "description" : "The sink's name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The sink instanceId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid stop request"
+          },
+          "401" : {
+            "description" : "The client is not authorized to perform this operation"
+          },
+          "404" : {
+            "description" : "The sink instance does not exist"
+          },
+          "500" : {
+            "description" : "Internal server error (failed to stop the sink, failed to authorize, etc.)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ConsumerConfig" : {
+      "type" : "object",
+      "properties" : {
+        "schemaType" : {
+          "type" : "string"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "receiverQueueSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "regexPattern" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SinkConfig" : {
+      "type" : "object",
+      "properties" : {
+        "tenant" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "sourceSubscriptionName" : {
+          "type" : "string"
+        },
+        "inputs" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "topicToSerdeClassName" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "topicsPattern" : {
+          "type" : "string"
+        },
+        "topicToSchemaType" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "inputSpecs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/ConsumerConfig"
+          }
+        },
+        "configs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "secrets" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE" ]
+        },
+        "retainOrdering" : {
+          "type" : "boolean"
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "autoAck" : {
+          "type" : "boolean"
+        },
+        "timeoutMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "archive" : {
+          "type" : "string"
+        },
+        "cleanupSubscription" : {
+          "type" : "boolean"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SinkInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SinkInstanceStatusData"
+        }
+      }
+    },
+    "SinkInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReadFromPulsar" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSinkExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSinkExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWrittenToSink" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SinkStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SinkInstanceStatus"
+          }
+        }
+      }
+    },
+    "UpdateOptions" : {
+      "type" : "object",
+      "properties" : {
+        "update-auth-data" : {
+          "type" : "boolean",
+          "description" : "Whether or not to update the auth data"
+        }
+      },
+      "description" : "Options while updating the sink"
+    }
+  }
+}

--- a/site2/website/static/swagger/2.4.0/swaggersource.json
+++ b/site2/website/static/swagger/2.4.0/swaggersource.json
@@ -1,0 +1,860 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "This provides the REST API for Pulsar Source operations",
+    "version" : "v3",
+    "title" : "Pulsar Source REST API",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath" : "/admin/v3",
+  "tags" : [ {
+    "name" : "sources"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/sources/builtinsources" : {
+      "get" : {
+        "tags" : [ "sources" ],
+        "summary" : "Fetches a list of supported Pulsar IO source connectors currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}" : {
+      "get" : {
+        "tags" : [ "sources" ],
+        "summary" : "Lists all Pulsar Sources currently deployed in a given namespace",
+        "description" : "",
+        "operationId" : "listSources",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}" : {
+      "get" : {
+        "tags" : [ "sources" ],
+        "summary" : "Fetches information about a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceConfig"
+            }
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Creates a new Pulsar Source in cluster mode",
+        "description" : "",
+        "operationId" : "registerSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of source",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \nclassname  \n  The source's class name if archive is file-url-path (file://).  \ntopicName  \n  The Pulsar topic to which data is sent.  \nserdeClassName  \n  The SerDe classname for the source.  \nschemaType  \n  The schema type (either a builtin schema like 'avro', 'json', etc.. or    custom Schema class name to be used to encode messages emitted from the source  \nconfigs  \n  Source config key/values  \nsecrets  \n  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the  SecretProviderConfigurator.getSecretObjectType() method. \nparallelism  \n  The source's parallelism factor (i.e. the number of source instances to run).  \nprocessingGuarantees  \n  The processing guarantees (aka delivery semantics) applied to the source    Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \nresources  \n  The size of the system resources allowed by the source runtime. The resources include: cpu, ram, disk.  \narchive  \n  The path to the NAR archive for the Source. It also supports url-path   [http/https/file (file protocol assumes that file already exists on worker host)]   from which worker can download the package.  \nruntimeFlags  \n  Any flags that you want to pass to the runtime.  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{\n  \"tenant\": public\n  \"namespace\": default\n  \"name\": pulsar-io-mysql\n  \"className\": TestSourceMysql\n  \"topicName\": pulsar-io-mysql\n  \"parallelism\": 1\n  \"archive\": /connectors/pulsar-io-mysql-0.0.1.nar\n  \"schemaType\": avro\n}"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully created"
+          },
+          "400" : {
+            "description" : "Invalid request (Function already exists or Tenant, Namespace or Name is not provided, etc.)"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "sources" ],
+        "summary" : "Updates a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "updateSource",
+        "consumes" : [ "multipart/form-data" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of source",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "A JSON value presenting source configuration payload. An example of the expected functions can be found here.  \nclassname  \n  The source's class name if archive is file-url-path (file://).  \ntopicName  \n  The Pulsar topic to which data is sent.  \nserdeClassName  \n  The SerDe classname for the source.  \nschemaType  \n  The schema type (either a builtin schema like 'avro', 'json', etc.. or    custom Schema class name to be used to encode messages emitted from the source  \nconfigs  \n  Source config key/values  \nsecrets  \n  This is a map of secretName(that is how the secret is going to be accessed in the function via context) to an object that  encapsulates how the secret is fetched by the underlying secrets provider. The type of an value here can be found by the  SecretProviderConfigurator.getSecretObjectType() method. \nparallelism  \n  The source's parallelism factor (i.e. the number of source instances to run).  \nprocessingGuarantees  \n  The processing guarantees (aka delivery semantics) applied to the source    Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]  \nresources  \n  The size of the system resources allowed by the source runtime. The resources include: cpu, ram, disk.  \narchive  \n  The path to the NAR archive for the Source. It also supports url-path   [http/https/file (file protocol assumes that file already exists on worker host)]   from which worker can download the package.  \nruntimeFlags  \n  Any flags that you want to pass to the runtime.  \n",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          },
+          "x-examples" : {
+            "application/json" : "{\n  \"tenant\": public\n  \"namespace\": default\n  \"name\": pulsar-io-mysql\n  \"className\": TestSourceMysql\n  \"topicName\": pulsar-io-mysql\n  \"parallelism\": 1\n  \"archive\": /connectors/pulsar-io-mysql-0.0.1.nar\n  \"schemaType\": avro\n}"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Pulsar Function successfully updated"
+          },
+          "400" : {
+            "description" : "Invalid request (Function already exists or Tenant, Namespace or Name is not provided, etc.)"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "403" : {
+            "description" : "The requester doesn't have admin permissions"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "sources" ],
+        "summary" : "Deletes a Pulsar Source currently running in cluster mode",
+        "description" : "",
+        "operationId" : "deregisterSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The function was successfully deleted"
+          },
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "408" : {
+            "description" : "Request timeout"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/restart" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Restart all source instances",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/start" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Start all source instances",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/status" : {
+      "get" : {
+        "tags" : [ "sources" ],
+        "summary" : "Displays the status of a Pulsar Source running in cluster mode",
+        "description" : "",
+        "operationId" : "getSourceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceStatus"
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/stop" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Stop all source instances",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/{instanceId}/restart" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Restart source instance",
+        "description" : "",
+        "operationId" : "restartSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The source instanceId (if instance-id is not provided, the stats of all instances is returned).",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/{instanceId}/start" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Start source instance",
+        "description" : "",
+        "operationId" : "startSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The source instanceId (if instance-id is not provided, the stats of all instances is returned).",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/{instanceId}/status" : {
+      "get" : {
+        "tags" : [ "sources" ],
+        "summary" : "Displays the status of a Pulsar Source instance",
+        "description" : "",
+        "operationId" : "getSourceInstanceStatus",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The source instanceId (if instance-id is not provided, the stats of all instances is returned).",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SourceInstanceStatusData"
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    },
+    "/sources/{tenant}/{namespace}/{sourceName}/{instanceId}/stop" : {
+      "post" : {
+        "tags" : [ "sources" ],
+        "summary" : "Stop source instance",
+        "description" : "",
+        "operationId" : "stopSource",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "The name of tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "The name of namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "sourceName",
+          "in" : "path",
+          "description" : "The name of name",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "instanceId",
+          "in" : "path",
+          "description" : "The source instanceId (if instance-id is not provided, the stats of all instances is returned).",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid request"
+          },
+          "401" : {
+            "description" : "Client is not authorize to perform operation"
+          },
+          "404" : {
+            "description" : "Not Found(The source doesn't exist)"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Function worker service is now initializing. Please try again later."
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ExceptionInformation" : {
+      "type" : "object",
+      "properties" : {
+        "exceptionString" : {
+          "type" : "string"
+        },
+        "timestampMs" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "Resources" : {
+      "type" : "object",
+      "properties" : {
+        "cpu" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "ram" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "disk" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "SourceConfig" : {
+      "type" : "object",
+      "properties" : {
+        "tenant" : {
+          "type" : "string"
+        },
+        "namespace" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "topicName" : {
+          "type" : "string"
+        },
+        "serdeClassName" : {
+          "type" : "string"
+        },
+        "schemaType" : {
+          "type" : "string"
+        },
+        "configs" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "secrets" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "parallelism" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "processingGuarantees" : {
+          "type" : "string",
+          "enum" : [ "ATLEAST_ONCE", "ATMOST_ONCE", "EFFECTIVELY_ONCE" ]
+        },
+        "resources" : {
+          "$ref" : "#/definitions/Resources"
+        },
+        "archive" : {
+          "type" : "string"
+        },
+        "runtimeFlags" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SourceInstanceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "instanceId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "status" : {
+          "$ref" : "#/definitions/SourceInstanceStatusData"
+        }
+      }
+    },
+    "SourceInstanceStatusData" : {
+      "type" : "object",
+      "properties" : {
+        "running" : {
+          "type" : "boolean"
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "numRestarts" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numReceivedFromSource" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "numSystemExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSystemExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numSourceExceptions" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "latestSourceExceptions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExceptionInformation"
+          }
+        },
+        "numWritten" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "lastReceivedTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "workerId" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SourceStatus" : {
+      "type" : "object",
+      "properties" : {
+        "numInstances" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numRunning" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "instances" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SourceInstanceStatus"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION

### Motivation

After multiple versions of rest API are currently supported, a prefix is added to the route of the online environment when it is displayed. resulting in the js file not being available.

![image](https://user-images.githubusercontent.com/1907867/63989496-18a82280-cb13-11e9-84e7-be2baaf0c889.png)


### Modifications

* Change js file search to a relative path

### Verifying this change

Click http://pulsar.apache.org/admin-rest-api/js/getSwaggerByVersion.js 404 not found
Click http://pulsar.apache.org/admin-rest-api/../js/getSwaggerByVersion.js OK
