### PR TITLE
Improve response of Rest API for create schema.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
@@ -344,7 +344,8 @@ public class SchemasResource extends AdminResource {
             )
         ).exceptionally(error -> {
             if (error.getCause() instanceof IncompatibleSchemaException) {
-                response.resume(Response.status(Response.Status.CONFLICT).build());
+                response.resume(Response.status(Response.Status.CONFLICT.getStatusCode(),
+                        error.getCause().getMessage()).build());
             } else if (error instanceof InvalidSchemaDataException) {
                 response.resume(Response.status(
                         422, /* Unprocessable Entity */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -70,6 +70,11 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
+    public CompletableFuture<Void> checkCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
+        return completedFuture(null);
+    }
+
+    @Override
     public SchemaVersion versionFromBytes(byte[] version) {
         return null;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/JsonSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/JsonSchemaCompatibilityCheck.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
+import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
 
@@ -40,37 +41,34 @@ public class JsonSchemaCompatibilityCheck extends AvroSchemaBasedCompatibilityCh
     }
 
     @Override
-    public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+    public void checkCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException {
         if (isAvroSchema(from)) {
             if (isAvroSchema(to)) {
                 // if both producer and broker have the schema in avro format
-                return super.isCompatible(from, to, strategy);
+                super.checkCompatible(from, to, strategy);
             } else if (isJsonSchema(to)) {
                 // if broker have the schema in avro format but producer sent a schema in the old json format
                 // allow old schema format for backwards compatiblity
-                return true;
             } else {
                 // unknown schema format
-                return false;
+                throw new IncompatibleSchemaException("Unknown schema format");
             }
         } else if (isJsonSchema(from)){
 
             if (isAvroSchema(to)) {
                 // if broker have the schema in old json format but producer sent a schema in the avro format
                 // return true and overwrite the old format
-                return true;
             } else if (isJsonSchema(to)) {
                 // if both producer and broker have the schema in old json format
-                return isCompatibleJsonSchema(from, to);
+                isCompatibleJsonSchema(from, to);
             } else {
                 // unknown schema format
-                return false;
+                throw new IncompatibleSchemaException("Unknown schema format");
             }
         } else {
             // broker has schema format with unknown format
             // maybe corrupted?
             // return true to overwrite
-            return true;
         }
     }
 
@@ -82,14 +80,17 @@ public class JsonSchemaCompatibilityCheck extends AvroSchemaBasedCompatibilityCh
         return objectMapper;
     }
 
-    private boolean isCompatibleJsonSchema(SchemaData from, SchemaData to) {
+    private void isCompatibleJsonSchema(SchemaData from, SchemaData to) throws IncompatibleSchemaException {
         try {
             ObjectMapper objectMapper = getObjectMapper();
             JsonSchema fromSchema = objectMapper.readValue(from.getData(), JsonSchema.class);
             JsonSchema toSchema = objectMapper.readValue(to.getData(), JsonSchema.class);
-            return fromSchema.getId().equals(toSchema.getId());
+            if (!fromSchema.getId().equals(toSchema.getId())) {
+                throw new IncompatibleSchemaException(String.format("Incompatible Schema from %s + to %s",
+                        new String(from.getData(), UTF_8), new String(to.getData(), UTF_8)));
+            }
         } catch (IOException e) {
-            return false;
+            throw new IncompatibleSchemaException(e);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/KeyValueSchemaCompatibilityCheck.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.schema;
 
+import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
@@ -54,17 +55,17 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
     }
 
     @Override
-    public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
-        return isCompatible(Collections.singletonList(from), to, strategy);
+    public void checkCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException {
+        checkCompatible(Collections.singletonList(from), to, strategy);
     }
 
     @Override
-    public boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+    public void checkCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException  {
         if (strategy == SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE) {
-            return true;
+            return;
         }
         if (to.getType() != SchemaType.KEY_VALUE) {
-            return false;
+            throw new IncompatibleSchemaException("To schema is not a KEY_VALUE schema.");
         }
         LinkedList<SchemaData> fromKeyList = new LinkedList<>();
         LinkedList<SchemaData> fromValueList = new LinkedList<>();
@@ -75,18 +76,23 @@ public class KeyValueSchemaCompatibilityCheck implements SchemaCompatibilityChec
 
         for (SchemaData schemaData : from) {
             if (schemaData.getType() != SchemaType.KEY_VALUE) {
-                return false;
+                throw new IncompatibleSchemaException("From schema is not a KEY_VALUE schema.");
             }
             fromKeyValue = decodeKeyValueSchemaData(schemaData);
             if (fromKeyValue.getKey().getType() != toKeyType || fromKeyValue.getValue().getType() != toValueType) {
-                return false;
+                throw new IncompatibleSchemaException(String.format("Key schemas or Value schemas are different schema type, " +
+                        "from key schema type is %s and to key schema is %s, from value schema is %s and to value schema is %s",
+                        fromKeyValue.getKey().getType(),
+                        toKeyType,
+                        fromKeyValue.getValue().getType(),
+                        toValueType));
             }
             fromKeyList.addFirst(fromKeyValue.getKey());
             fromValueList.addFirst(fromKeyValue.getValue());
         }
         SchemaCompatibilityCheck keyCheck = checkers.getOrDefault(toKeyType, SchemaCompatibilityCheck.DEFAULT);
         SchemaCompatibilityCheck valueCheck = checkers.getOrDefault(toValueType, SchemaCompatibilityCheck.DEFAULT);
-        return keyCheck.isCompatible(fromKeyList, toKeyValue.getKey(), strategy)
-                && valueCheck.isCompatible(fromValueList, toKeyValue.getValue(), strategy);
+        keyCheck.checkCompatible(fromKeyList, toKeyValue.getKey(), strategy);
+        valueCheck.checkCompatible(fromValueList, toKeyValue.getValue(), strategy);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -46,7 +46,12 @@ public interface SchemaCompatibilityCheck {
     void checkCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException;
 
     default boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
-        return isCompatible(Collections.singletonList(from), to, strategy);
+        try {
+            checkCompatible(from, to, strategy);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     default boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityCheck.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pulsar.broker.service.schema;
 
+import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Collections;
 
 public interface SchemaCompatibilityCheck {
 
@@ -30,9 +33,8 @@ public interface SchemaCompatibilityCheck {
      * @param from the current schema i.e. schema that the broker has
      * @param to the future schema i.e. the schema sent by the producer
      * @param strategy the strategy to use when comparing schemas
-     * @return whether the schemas are compatible
      */
-    boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy);
+    void checkCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException;
 
     /**
      *
@@ -41,7 +43,20 @@ public interface SchemaCompatibilityCheck {
      * @param strategy the strategy to use when comparing schemas
      * @return whether the schemas are compatible
      */
-    boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy);
+    void checkCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException;
+
+    default boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        return isCompatible(Collections.singletonList(from), to, strategy);
+    }
+
+    default boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        try {
+            checkCompatible(from, to, strategy);
+            return true;
+        } catch (IncompatibleSchemaException e) {
+            return false;
+        }
+    }
 
     SchemaCompatibilityCheck DEFAULT = new SchemaCompatibilityCheck() {
 
@@ -51,20 +66,16 @@ public interface SchemaCompatibilityCheck {
         }
 
         @Override
-        public boolean isCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        public void checkCompatible(SchemaData from, SchemaData to, SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException {
             if (strategy == SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE) {
-                return false;
-            } else {
-                return true;
+                throw new IncompatibleSchemaException("Schema compatibility strategy is ALWAYS_INCOMPATIBLE");
             }
         }
 
         @Override
-        public boolean isCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy) {
+        public void checkCompatible(Iterable<SchemaData> from, SchemaData to, SchemaCompatibilityStrategy strategy)  throws IncompatibleSchemaException {
             if (strategy == SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE) {
-                return false;
-            } else {
-                return true;
+                throw new IncompatibleSchemaException("Schema compatibility strategy is ALWAYS_INCOMPATIBLE");
             }
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -40,6 +40,9 @@ public interface SchemaRegistry extends AutoCloseable {
     CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user);
 
     CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema,
+                                            SchemaCompatibilityStrategy strategy);
+
+    CompletableFuture<Void> checkCompatible(String schemaId, SchemaData schema,
                                                              SchemaCompatibilityStrategy strategy);
 
     CompletableFuture<List<SchemaAndMetadata>> trimDeletedSchemaAndGetList(String schemaId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -258,7 +258,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 }
                 return result;
             } else {
-                return completedFuture(null);
+                return FutureUtils.exception(new IncompatibleSchemaException("Do not have existing schema."));
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -47,10 +47,8 @@ import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.proto.SchemaRegistryFormat;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
-import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
-import org.apache.pulsar.common.util.FutureUtil;
 
 public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     private static HashFunction hashFunction = Hashing.sha256();
@@ -116,46 +114,46 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
             .thenCompose(
                 (existingSchema) ->
                 {
-                    CompletableFuture<KeyValue<Long, Boolean>> keyValue;
+                    CompletableFuture<Long> maxDeleteVersionFuture;
                     if (existingSchema == null) {
-                        keyValue = completedFuture(new KeyValue<>(NO_DELETED_VERSION, true));
+                        maxDeleteVersionFuture = completedFuture(NO_DELETED_VERSION);
                     } else if (existingSchema.schema.isDeleted()) {
-                        keyValue = completedFuture(new KeyValue<>(((LongSchemaVersion)schemaStorage
-                                .versionFromBytes(existingSchema.version.bytes())).getVersion(), true));
+                        maxDeleteVersionFuture = completedFuture(((LongSchemaVersion)schemaStorage
+                                .versionFromBytes(existingSchema.version.bytes())).getVersion());
                     } else {
                         if (isTransitiveStrategy(strategy)) {
-                            keyValue = checkCompatibilityWithAll(schemaId, schema, strategy);
+                            maxDeleteVersionFuture = checkCompatibilityWithAll(schemaId, schema, strategy);
 
                         } else {
-                            keyValue = trimDeletedSchemaAndGetList(schemaId).thenCompose(schemaAndMetadataList ->
-                                    completedFuture(((LongSchemaVersion)schemaStorage
-                                    .versionFromBytes(schemaAndMetadataList.get(0).version.bytes())).getVersion() - 1L))
-                                    .thenCompose(maxDeleteVersion -> isCompatible(schemaId, schema, strategy)
-                                            .thenCompose(isCompatible -> completedFuture(new KeyValue<>(maxDeleteVersion, isCompatible))));
+                            maxDeleteVersionFuture = new CompletableFuture<>();
+                            trimDeletedSchemaAndGetList(schemaId).thenAccept(schemaAndMetadataList -> {
+                                checkCompatibilityWithLatest(schemaId, schema, strategy).whenComplete((v, ex) -> {
+                                    if (ex == null) {
+                                        Long maxDeleteVersion = ((LongSchemaVersion)schemaStorage
+                                                .versionFromBytes(schemaAndMetadataList.get(0).version.bytes())).getVersion() - 1L;
+                                        maxDeleteVersionFuture.complete(maxDeleteVersion);
+                                    } else {
+                                        maxDeleteVersionFuture.completeExceptionally(ex);
+                                    }
+                                });
+                            });
                         }
                     }
-                    return keyValue;
+                    return maxDeleteVersionFuture;
                 }
-            )
-            .thenCompose(keyValue -> {
-                    if (keyValue.getValue()) {
-                        byte[] context = hashFunction.hashBytes(schema.getData()).asBytes();
-                        SchemaRegistryFormat.SchemaInfo info = SchemaRegistryFormat.SchemaInfo.newBuilder()
-                            .setType(Functions.convertFromDomainType(schema.getType()))
-                            .setSchema(ByteString.copyFrom(schema.getData()))
-                            .setSchemaId(schemaId)
-                            .setUser(schema.getUser())
-                            .setDeleted(false)
-                            .setTimestamp(clock.millis())
-                            .addAllProps(toPairs(schema.getProps()))
-                            .build();
-                        
-                        return schemaStorage.put(schemaId, info.toByteArray(), context, keyValue.getKey());
-
-                    } else {
-                        return FutureUtil.failedFuture(new IncompatibleSchemaException());
-                    }
-                });
+            ).thenCompose(maxDeleteVersion -> {
+                byte[] context = hashFunction.hashBytes(schema.getData()).asBytes();
+                SchemaRegistryFormat.SchemaInfo info = SchemaRegistryFormat.SchemaInfo.newBuilder()
+                        .setType(Functions.convertFromDomainType(schema.getType()))
+                        .setSchema(ByteString.copyFrom(schema.getData()))
+                        .setSchemaId(schemaId)
+                        .setUser(schema.getUser())
+                        .setDeleted(false)
+                        .setTimestamp(clock.millis())
+                        .addAllProps(toPairs(schema.getProps()))
+                        .build();
+                return schemaStorage.put(schemaId, info.toByteArray(), context, maxDeleteVersion);
+            });
     }
 
     @Override
@@ -168,6 +166,11 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
 
     }
 
+    @Override
+    public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
+        return checkCompatible(schemaId, schema, strategy).thenApply(v -> true);
+    }
+
     private static boolean isTransitiveStrategy(SchemaCompatibilityStrategy strategy) {
         if (FORWARD_TRANSITIVE.equals(strategy)
                 || BACKWARD_TRANSITIVE.equals(strategy)
@@ -178,14 +181,13 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     }
 
     @Override
-    public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema,
+    public CompletableFuture<Void> checkCompatible(String schemaId, SchemaData schema,
                                                                     SchemaCompatibilityStrategy strategy) {
         switch (strategy) {
             case FORWARD_TRANSITIVE:
             case BACKWARD_TRANSITIVE:
             case FULL_TRANSITIVE:
-                return checkCompatibilityWithAll(schemaId, schema, strategy)
-                        .thenCompose(keyValue -> completedFuture(keyValue.getValue()));
+                return checkCompatibilityWithAll(schemaId, schema, strategy).thenApply(maxDeleteVersion -> null);
             default:
                 return checkCompatibilityWithLatest(schemaId, schema, strategy);
         }
@@ -212,17 +214,22 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
             .build();
     }
 
-    private boolean isCompatible(SchemaAndMetadata existingSchema, SchemaData newSchema,
-                                 SchemaCompatibilityStrategy strategy) {
+    private void checkCompatible(SchemaAndMetadata existingSchema, SchemaData newSchema,
+                                 SchemaCompatibilityStrategy strategy) throws IncompatibleSchemaException {
         HashCode existingHash = hashFunction.hashBytes(existingSchema.schema.getData());
         HashCode newHash = hashFunction.hashBytes(newSchema.getData());
         SchemaData existingSchemaData = existingSchema.schema;
         if (existingSchemaData.getType().isPrimitive()) {
-            return newSchema.getType() == existingSchemaData.getType();
+            if (newSchema.getType() != existingSchemaData.getType()) {
+                throw new IncompatibleSchemaException(String.format("Incompatible primitive schema: " +
+                        "exists schema type %s, new schema type %s", existingSchemaData.getType(), newSchema.getType()));
+            }
+        } else {
+            if (!newHash.equals(existingHash)) {
+                compatibilityChecks.getOrDefault(newSchema.getType(), SchemaCompatibilityCheck.DEFAULT)
+                        .checkCompatible(existingSchemaData, newSchema, strategy);
+            }
         }
-        return newHash.equals(existingHash) ||
-            compatibilityChecks.getOrDefault(newSchema.getType(), SchemaCompatibilityCheck.DEFAULT)
-            .isCompatible(existingSchemaData, newSchema, strategy);
     }
 
     public CompletableFuture<Long> findSchemaVersion(String schemaId, SchemaData schemaData) {
@@ -238,25 +245,40 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
         });
     }
 
-    private CompletableFuture<Boolean> checkCompatibilityWithLatest(String schemaId, SchemaData schema,
+    private CompletableFuture<Void> checkCompatibilityWithLatest(String schemaId, SchemaData schema,
                                                                     SchemaCompatibilityStrategy strategy) {
-        return getSchema(schemaId)
-            .thenApply(
-                    (existingSchema) ->
-                        !(existingSchema == null || existingSchema.schema.isDeleted())
-                            && isCompatible(existingSchema, schema, strategy));
+        return getSchema(schemaId).thenCompose(existingSchema -> {
+            if (existingSchema != null && !existingSchema.schema.isDeleted()) {
+                CompletableFuture<Void> result = new CompletableFuture<>();
+                try {
+                    checkCompatible(existingSchema, schema, strategy);
+                    result.complete(null);
+                } catch (IncompatibleSchemaException e) {
+                    result.completeExceptionally(e);
+                }
+                return result;
+            } else {
+                return completedFuture(null);
+            }
+        });
     }
 
-    private CompletableFuture<KeyValue<Long, Boolean>> checkCompatibilityWithAll(String schemaId, SchemaData schema,
-                                                                                 SchemaCompatibilityStrategy strategy) {
-        return trimDeletedSchemaAndGetList(schemaId).thenCompose(schemaAndMetadataList ->
-                 completedFuture(new KeyValue<>(((LongSchemaVersion)schemaStorage.versionFromBytes(schemaAndMetadataList.get(0).version.bytes())).getVersion() - 1L,
-                        compatibilityChecks.getOrDefault(schema.getType(), SchemaCompatibilityCheck.DEFAULT)
-                        .isCompatible(schemaAndMetadataList
-                                .stream()
-                                .map(schemaAndMetadata -> schemaAndMetadata.schema)
-                                .collect(Collectors.toList()), schema, strategy)))
-            );
+    private CompletableFuture<Long> checkCompatibilityWithAll(String schemaId, SchemaData schema,
+                                                                     SchemaCompatibilityStrategy strategy) {
+
+        return trimDeletedSchemaAndGetList(schemaId).thenCompose(schemaAndMetadataList -> {
+            CompletableFuture<Long> result = new CompletableFuture<>();
+            try {
+                compatibilityChecks.getOrDefault(schema.getType(), SchemaCompatibilityCheck.DEFAULT).checkCompatible(schemaAndMetadataList
+                        .stream()
+                        .map(schemaAndMetadata -> schemaAndMetadata.schema)
+                        .collect(Collectors.toList()), schema, strategy);
+                result.complete(((LongSchemaVersion)schemaStorage.versionFromBytes(schemaAndMetadataList.get(0).version.bytes())).getVersion());
+            } catch (IncompatibleSchemaException e) {
+                result.completeExceptionally(e);
+            }
+            return result;
+        });
     }
 
     public CompletableFuture<List<SchemaAndMetadata>> trimDeletedSchemaAndGetList(String schemaId) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/exceptions/IncompatibleSchemaException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/exceptions/IncompatibleSchemaException.java
@@ -32,4 +32,8 @@ public class IncompatibleSchemaException extends SchemaException {
     public IncompatibleSchemaException(String message) {
         super(message);
     }
+
+    public IncompatibleSchemaException(Throwable e) {
+        super(e);
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/exceptions/SchemaException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/exceptions/SchemaException.java
@@ -31,6 +31,10 @@ public class SchemaException extends BrokerServiceException {
         super(message);
     }
 
+    public SchemaException(Throwable cause) {
+        super(cause);
+    }
+
     public SchemaException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
@@ -90,7 +90,17 @@ public class SchemaRegistryServiceWithSchemaDataValidator implements SchemaRegis
     }
 
     @Override
-    public CompletableFuture<Boolean> isCompatible(String schemaId,
+    public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
+        try {
+            SchemaDataValidator.validateSchemaData(schema);
+        } catch (InvalidSchemaDataException e) {
+            return FutureUtil.failedFuture(e);
+        }
+        return service.isCompatible(schemaId, schema, strategy);
+    }
+
+    @Override
+    public CompletableFuture<Void> checkCompatible(String schemaId,
                                                    SchemaData schema,
                                                    SchemaCompatibilityStrategy strategy) {
         try {
@@ -98,7 +108,7 @@ public class SchemaRegistryServiceWithSchemaDataValidator implements SchemaRegis
         } catch (InvalidSchemaDataException e) {
             return FutureUtil.failedFuture(e);
         }
-        return service.isCompatible(schemaId, schema, strategy);
+        return service.checkCompatible(schemaId, schema, strategy);
     }
 
     @Override


### PR DESCRIPTION
Fixes #5094
### Motivation

Currently, can't get some detail messages about incompatible while use REST API to create a new schema. This PR let users to get the detail messages.

### Future more
Use pulsar-admin or pulsar-client also can get the detail messages about incompatible. This PR only handle the REST way.
