### PR TITLE
Add procps to docker too enable ps command

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=pulsar /pulsar /pulsar
 
 # Install some utilities
 RUN apt-get update \
-     && apt-get install -y netcat dnsutils less \
+     && apt-get install -y netcat dnsutils less procps \
                  python2.7 python-setuptools \
                  python3-setuptools \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \


### PR DESCRIPTION
This adds the procps to the pulsar docker image so commands such as "ps"
are available to use.