### PR TITLE
Throw an error if the key was not specified for querying state

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -550,6 +550,29 @@ public class CmdFunctionsTest {
         verify(functions, times(1)).getFunctionState(eq(tenant), eq(namespace), eq(fnName), eq(key));
     }
 
+    @Test
+    public void testStateGetterWithoutKey() throws Exception {
+        String tenant = TEST_NAME + "-tenant";
+        String namespace = TEST_NAME + "-namespace";
+        String fnName = TEST_NAME + "-function";
+        ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
+        consoleOutputCapturer.start();
+        cmd.run(new String[] {
+                "querystate",
+                "--tenant", tenant,
+                "--namespace", namespace,
+                "--name", fnName,
+        });
+        consoleOutputCapturer.stop();
+        String output = consoleOutputCapturer.getStderr();
+        assertTrue(output.replace("\n", "").contains("State key needs to be specified"));
+        StateGetter stateGetter = cmd.getStateGetter();
+        assertEquals(tenant, stateGetter.getTenant());
+        assertEquals(namespace, stateGetter.getNamespace());
+        assertEquals(fnName, stateGetter.getFunctionName());
+        verify(functions, times(0)).getFunctionState(any(), any(), any(), any());
+    }
+
     private static final String fnName = TEST_NAME + "-function";
     private static final String inputTopicName = TEST_NAME + "-input-topic";
     private static final String outputTopicName = TEST_NAME + "-output-topic";

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -805,7 +805,7 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Fetch the current state associated with a Pulsar Function")
     class StateGetter extends FunctionCommand {
 
-        @Parameter(names = { "-k", "--key" }, description = "key")
+        @Parameter(names = { "-k", "--key" }, description = "Key name of State")
         private String key = null;
 
         @Parameter(names = { "-w", "--watch" }, description = "Watch for changes in the value associated with a key for a Pulsar Function")
@@ -813,6 +813,9 @@ public class CmdFunctions extends CmdBase {
 
         @Override
         void runCmd() throws Exception {
+            if (isBlank(key)) {
+                throw new ParameterException("State key needs to be specified");
+            }
             do {
                 try {
                     FunctionState functionState = admin.functions()


### PR DESCRIPTION
Throw an error explicitly if the key was not specified for querying state.
 
Closes #4943 