### PR TITLE
Broker fails to start with function worker enabled and broker client using TLS

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -160,7 +160,9 @@ public class PulsarBrokerStarter {
                     workerConfig = WorkerConfig.load(starterArguments.fnWorkerConfigFile);
                 }
                 // worker talks to local broker
-                boolean useTls = workerConfig.isUseTls();
+                // If the broker client is configured to use TLS, then we
+                // configure the function worker to use TLS
+                boolean useTls = brokerConfig.isBrokerClientTlsEnabled();
                 String pulsarServiceUrl = useTls
                         ? PulsarService.brokerUrlTls(brokerConfig)
                         : PulsarService.brokerUrl(brokerConfig);
@@ -187,7 +189,7 @@ public class PulsarBrokerStarter {
                 workerConfig.setZooKeeperSessionTimeoutMillis(brokerConfig.getZooKeeperSessionTimeoutMillis());
                 workerConfig.setZooKeeperOperationTimeoutSeconds(brokerConfig.getZooKeeperOperationTimeoutSeconds());
 
-                workerConfig.setUseTls(brokerConfig.isTlsEnabled());
+                workerConfig.setUseTls(useTls);
                 workerConfig.setTlsHostnameVerificationEnable(false);
 
                 workerConfig.setTlsAllowInsecureConnection(brokerConfig.isTlsAllowInsecureConnection());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -160,9 +160,7 @@ public class PulsarBrokerStarter {
                     workerConfig = WorkerConfig.load(starterArguments.fnWorkerConfigFile);
                 }
                 // worker talks to local broker
-                // If the broker client is configured to use TLS, then we
-                // configure the function worker to use TLS
-                boolean useTls = brokerConfig.isBrokerClientTlsEnabled();
+                boolean useTls = workerConfig.isUseTls();
                 String pulsarServiceUrl = useTls
                         ? PulsarService.brokerUrlTls(brokerConfig)
                         : PulsarService.brokerUrl(brokerConfig);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -272,9 +272,7 @@ public class PulsarStandalone implements AutoCloseable {
                 workerConfig = WorkerConfig.load(this.getFnWorkerConfigFile());
             }
             // worker talks to local broker
-            // If the broker client is configured to use TLS, then we
-            // configure the function worker to use TLS
-            boolean useTls = config.isBrokerClientTlsEnabled();
+            boolean useTls = workerConfig.isUseTls();
             String pulsarServiceUrl = useTls
                     ? PulsarService.brokerUrlTls(config)
                     : PulsarService.brokerUrl(config);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -272,7 +272,9 @@ public class PulsarStandalone implements AutoCloseable {
                 workerConfig = WorkerConfig.load(this.getFnWorkerConfigFile());
             }
             // worker talks to local broker
-            boolean useTls = workerConfig.isUseTls();
+            // If the broker client is configured to use TLS, then we
+            // configure the function worker to use TLS
+            boolean useTls = config.isBrokerClientTlsEnabled();
             String pulsarServiceUrl = useTls
                     ? PulsarService.brokerUrlTls(config)
                     : PulsarService.brokerUrl(config);
@@ -306,7 +308,7 @@ public class PulsarStandalone implements AutoCloseable {
             workerConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
             workerConfig.setZooKeeperOperationTimeoutSeconds(config.getZooKeeperOperationTimeoutSeconds());
 
-            workerConfig.setUseTls(config.isTlsEnabled());
+            workerConfig.setUseTls(useTls);
             workerConfig.setTlsHostnameVerificationEnable(false);
 
             workerConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());


### PR DESCRIPTION
### Motivation

I have a broker that is configured to run the function worker and for the broker client to use TLS. Here are the settings:

functionsWorkerEnabled=true
brokerClientTlsEnabled=true

After upgrading to 2.4.1, my broker would fail to start. This was working in 2.3.1. The function worker client would fail to connect. The error indicates that it is trying to use TLS on the plaintext port:

12:39:20.691 [main] INFO  org.apache.pulsar.functions.worker.WorkerService - Created Pulsar client
12:39:21.057 [pulsar-io-24-1] INFO  org.apache.pulsar.broker.service.ServerCnx - New connection from /192.168.34.192:60886
12:39:21.045 [pulsar-client-io-47-1] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x688be07c, L:/192.168.34.192:60886 - R:192.168.34.192/192.168.34.192:6650]] Connected to server
12:39:21.080 [pulsar-io-24-1] WARN  org.apache.pulsar.broker.service.ServerCnx - [/192.168.34.192:60886] Got exception TooLongFrameException : Adjusted frame length exceeds 5253120: 369295620 - discarded
io.netty.handler.codec.TooLongFrameException: Adjusted frame length exceeds 5253120: 369295620 - discarded
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.fail(LengthFieldBasedFrameDecoder.java:522) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.failIfNecessary(LengthFieldBasedFrameDecoder.java:500) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.exceededFrameLength(LengthFieldBasedFrameDecoder.java:387) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:430) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:343) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:502) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:441) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:278) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:433) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:330) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:909) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]


### Modifications

Looking at the startup code when running the function worker with the broker, it is checking for TLS enabled in the function_worker.yml file to determine whether or not to use the TLS port, but when setting TLS enabled on the function worker, it is checking the broker.conf. 

Since the function worker is running with the broker, it makes sense to look to the broker.conf as the single source of truth about whether or not to use TLS. I changed the code to check the broker client is configured to use TLS. If it is, then use TLS for the function worker, otherwise use plain text.

The same code exists in the startup path for the normal broker and the standalone version, so I made the change in both places.

### Verifying this change

I ran the broker unit tests on this change and they all passed.

I also built a new docker image with this change and started using it in my cluster. The broker now starts successfully.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

