### PR TITLE
[doc]Add brokerClient authentication configuration

### DIFF
--- a/site2/docs/security-athenz.md
+++ b/site2/docs/security-athenz.md
@@ -56,6 +56,10 @@ athenzDomainNames=pulsar
 tlsEnabled=true
 tlsCertificateFilePath=/path/to/broker-cert.pem
 tlsKeyFilePath=/path/to/broker-key.pem
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
+brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 ```
 
 > A full listing of parameters is available in the `conf/broker.conf` file, you can also find the default

--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -64,6 +64,15 @@ To configure brokers to authenticate clients, add the following parameters to `b
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+brokerClientAuthenticationParameters=tlsCertFile:/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
 ## Enable TLS authentication on proxies

--- a/site2/docs/security-token-admin.md
+++ b/site2/docs/security-token-admin.md
@@ -122,6 +122,15 @@ tokenSecretKey=file:///path/to/secret.key
 # tokenPublicKey=file:///path/to/public.key
 ```
 
+If you have more than one broker, you need to add the following configuration to `broker.conf`
+
+```bash
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+```
+
 ## Enable token authentication on Proxies
 
 To configure proxies to authenticate clients, add the following parameters to `proxy.conf`:

--- a/site2/docs/security-token-admin.md
+++ b/site2/docs/security-token-admin.md
@@ -120,15 +120,15 @@ tokenSecretKey=file:///path/to/secret.key
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key
-```
 
-If you have more than one broker, you need to add the following configuration to `broker.conf`
+# operations and publish/consume from all topics
+superUserRoles=admin
 
-```bash
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
 brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
 # Or, alternatively, read token from file
-# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+# brokerClientAuthenticationParameters=file:///path/to/admin-token.txt
 ```
 
 ## Enable token authentication on Proxies

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-athenz.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-athenz.md
@@ -57,6 +57,10 @@ athenzDomainNames=pulsar
 tlsEnabled=true
 tlsCertificateFilePath=/path/to/broker-cert.pem
 tlsKeyFilePath=/path/to/broker-key.pem
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
+brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 ```
 
 > A full listing of parameters available in the `conf/broker.conf` file, as well as the default

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-authentication.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-authentication.md
@@ -54,6 +54,15 @@ To configure brokers to authenticate clients, put the following in `broker.conf`
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+brokerClientAuthenticationParameters=tlsCertFile:/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
 ### ... on Proxies

--- a/site2/website/versioned_docs/version-2.2.1/security-tls-authentication.md
+++ b/site2/website/versioned_docs/version-2.2.1/security-tls-authentication.md
@@ -54,6 +54,15 @@ To configure brokers to authenticate clients, put the following in `broker.conf`
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+brokerClientAuthenticationParameters=tlsCertFile:/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
 ### ... on Proxies

--- a/site2/website/versioned_docs/version-2.2.1/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.2.1/security-token-admin.md
@@ -134,6 +134,15 @@ tokenSecretKey=file:///path/to/secret.key
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/admin-token.txt
 ```
 
 ### ... on Proxies

--- a/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
@@ -146,15 +146,6 @@ brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0
 # brokerClientAuthenticationParameters=file:///path/to/admin-token.txt
 ```
 
-If you have more than one broker, you need to add the following configuration to `broker.conf`
-
-```bash
-brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
-brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
-# Or, alternatively, read token from file
-# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
-```
-
 ### ... on Proxies
 
 To configure proxies to authenticate clients, put the following in `proxy.conf`:

--- a/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
@@ -137,6 +137,15 @@ tokenSecretKey=file:///path/to/secret.key
 # tokenPublicKey=file:///path/to/public.key
 ```
 
+If you have more than one broker, you need to add the following configuration to `broker.conf`
+
+```bash
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+```
+
 ### ... on Proxies
 
 To configure proxies to authenticate clients, put the following in `proxy.conf`:

--- a/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-token-admin.md
@@ -135,6 +135,15 @@ tokenSecretKey=file:///path/to/secret.key
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/admin-token.txt
 ```
 
 If you have more than one broker, you need to add the following configuration to `broker.conf`

--- a/site2/website/versioned_docs/version-2.4.0/security-tls-authentication.md
+++ b/site2/website/versioned_docs/version-2.4.0/security-tls-authentication.md
@@ -66,6 +66,15 @@ To configure brokers to authenticate clients, put the following in `broker.conf`
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+brokerClientAuthenticationParameters=tlsCertFile:/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
 ### ... on Proxies

--- a/site2/website/versioned_docs/version-2.4.0/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.4.0/security-token-admin.md
@@ -135,15 +135,15 @@ tokenSecretKey=file:///path/to/secret.key
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key
-```
 
-If you have more than one broker, you need to add the following configuration to `broker.conf`
+# operations and publish/consume from all topics
+superUserRoles=admin
 
-```bash
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
 brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
 # Or, alternatively, read token from file
-# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+# brokerClientAuthenticationParameters=file:///path/to/admin-token.txt
 ```
 
 ### ... on Proxies

--- a/site2/website/versioned_docs/version-2.4.0/security-token-admin.md
+++ b/site2/website/versioned_docs/version-2.4.0/security-token-admin.md
@@ -137,6 +137,15 @@ tokenSecretKey=file:///path/to/secret.key
 # tokenPublicKey=file:///path/to/public.key
 ```
 
+If you have more than one broker, you need to add the following configuration to `broker.conf`
+
+```bash
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+```
+
 ### ... on Proxies
 
 To configure proxies to authenticate clients, put the following in `proxy.conf`:

--- a/site2/website/versioned_docs/version-2.4.1/security-athenz.md
+++ b/site2/website/versioned_docs/version-2.4.1/security-athenz.md
@@ -57,6 +57,10 @@ athenzDomainNames=pulsar
 tlsEnabled=true
 tlsCertificateFilePath=/path/to/broker-cert.pem
 tlsKeyFilePath=/path/to/broker-key.pem
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
+brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 ```
 
 > A full listing of parameters is available in the `conf/broker.conf` file, you can also find the default

--- a/site2/website/versioned_docs/version-2.4.1/security-tls-authentication.md
+++ b/site2/website/versioned_docs/version-2.4.1/security-tls-authentication.md
@@ -65,6 +65,15 @@ To configure brokers to authenticate clients, add the following parameters to `b
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+
+# operations and publish/consume from all topics
+superUserRoles=admin
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+brokerClientAuthenticationParameters=tlsCertFile:/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
 ## Enable TLS authentication on proxies


### PR DESCRIPTION

Fixes https://github.com/apache/pulsar/issues/4560


Master Issue: https://github.com/apache/pulsar/issues/4560

### Motivation

The current document is not clear about authentication between multiple brokers, and users often encounter 401 errors.

### Modifications

* Add document configuration for brokerClient

### Verifying this change

After configuring brokerClientAuthenticationPlugin and brokerClientAuthenticationParameters in `broker.conf` locally, start multiple brokers. Run the following command to test, no 401 returns

```
./bin/pulsar-admin topics create-partitioned-topic test-partitioned -p 4
./bin/pulsar-admin topics delete-partitioned-topic test-partitioned
```