### PR TITLE
Fix Postgres debezium test

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgresqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgresqlSourceTester.java
@@ -66,6 +66,7 @@ public class DebeziumPostgresqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("database.server.name", "dbserver1");
         sourceConfig.put("database.dbname", "postgres");
         sourceConfig.put("schema.whitelist", "inventory");
+        sourceConfig.put("table.blacklist", "inventory.spatial_ref_sys,inventory.geom");
         sourceConfig.put("pulsar.service.url", pulsarServiceUrl);
     }
 


### PR DESCRIPTION
We need to exclude the meta tables from cdc tracking to make the test deterministic and consistently pass.