### PR TITLE
Fix exception type check order bug

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -231,11 +231,11 @@ public class PulsarClientException extends IOException {
             return (PulsarClientException) t;
         } else if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
+        }  else if (t instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+            return new PulsarClientException(t);
         } else if (!(t instanceof ExecutionException)) {
             // Generic exception
-            return new PulsarClientException(t);
-        } else if (t instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
             return new PulsarClientException(t);
         }
 


### PR DESCRIPTION
If ```!(t instanceof ExecutionException)``` is false, which means t is an instance of ``` ExecutionException```. If ```!(t instanceof ExecutionException)``` is true, then an instance of  ```PulsarClientException ``` will be returned. So the last ```if``` block will never be executed. 