### PR TITLE
[kinesis-source] Improvements to kinesis-source

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -94,6 +94,18 @@
       <artifactId>amazon-kinesis-producer</artifactId>
       <version>0.13.1</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>1.11.619</version>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.8.5</version>
+    </dependency>
 	<!-- /kinesis dependencies -->
 
     <dependency>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -65,6 +65,13 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
 
+    <!-- add cbor for kinesis-client to fix dep conflict -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
@@ -77,15 +84,15 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
+      <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>1.9.0</version>
+      <version>2.2.3</version>
     </dependency>
 
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.12.9</version>
+      <version>0.13.1</version>
     </dependency>
 	<!-- /kinesis dependencies -->
 

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
@@ -55,7 +55,8 @@ public interface AwsCredentialProviderPlugin extends Closeable {
      * Defaults to an implementation that pulls credentials from a v1 provider
      */
     default software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getV2CredentialsProvider() {
-        // make a small wrapper to forward requests to v1, this alows
+        // make a small wrapper to forward requests to v1, this allows
+        // for this interface to not "break" for implementers
         AWSCredentialsProvider v1Provider = getCredentialProvider();
         return () -> {
             AWSCredentials creds = v1Provider.getCredentials();

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
@@ -21,7 +21,9 @@ package org.apache.pulsar.io.kinesis;
 
 import java.io.Closeable;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 
 /**
@@ -46,5 +48,28 @@ public interface AwsCredentialProviderPlugin extends Closeable {
      * @return
      */
     AWSCredentialsProvider getCredentialProvider();
+
+    /**
+     * Returns a V2 credential provider for use with the v2 SDK.
+     *
+     * Defaults to an implementation that pulls credentials from a v1 provider
+     */
+    default software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getV2CredentialsProvider() {
+        // make a small wrapper to forward requests to v1, this alows
+        AWSCredentialsProvider v1Provider = getCredentialProvider();
+        return () -> {
+            AWSCredentials creds = v1Provider.getCredentials();
+            if (creds instanceof AWSSessionCredentials) {
+                return software.amazon.awssdk.auth.credentials.AwsSessionCredentials.create(
+                        creds.getAWSAccessKeyId(),
+                        creds.getAWSSecretKey(),
+                        ((AWSSessionCredentials) creds).getSessionToken());
+            } else {
+                return software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create(
+                        creds.getAWSAccessKeyId(),
+                        creds.getAWSSecretKey());
+            }
+        };
+    }
 
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsDefaultProviderChainPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsDefaultProviderChainPlugin.java
@@ -1,0 +1,30 @@
+package org.apache.pulsar.io.kinesis;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
+
+import java.io.IOException;
+
+public class AwsDefaultProviderChainPlugin implements AwsCredentialProviderPlugin {
+    @Override
+    public void init(String param) {
+
+    }
+
+    @Override
+    public AWSCredentialsProvider getCredentialProvider() {
+        return new DefaultAWSCredentialsProviderChain();
+    }
+
+    @Override
+    public software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getV2CredentialsProvider() {
+        return DefaultCredentialsProvider.create();
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsDefaultProviderChainPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsDefaultProviderChainPlugin.java
@@ -1,9 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.io.kinesis;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
 
 import java.io.IOException;
 

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
+import software.amazon.awssdk.regions.Region;
+
 import lombok.Data;
 
 @Data
@@ -34,22 +36,22 @@ public abstract class BaseKinesisConfig implements Serializable {
         defaultValue = "",
         help = "Kinesis end-point url. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
     )
-    private String awsEndpoint;
-    
+    private String awsEndpoint = "";
+
     @FieldDoc(
         required = false,
         defaultValue = "",
         help = "Appropriate aws region. E.g. us-west-1, us-west-2"
     )
-    private String awsRegion;
-    
+    private String awsRegion = "";
+
     @FieldDoc(
         required = true,
         defaultValue = "",
         help = "Kinesis stream name"
     )
-    private String awsKinesisStreamName;
-    
+    private String awsKinesisStreamName = "";
+
     @FieldDoc(
         required = false,
         defaultValue = "",
@@ -57,12 +59,15 @@ public abstract class BaseKinesisConfig implements Serializable {
             + " It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Sink."
             + " If it is empty then KinesisSink will create a default AWSCredentialsProvider which accepts json-map"
             + " of credentials in `awsCredentialPluginParam`")
-    private String awsCredentialPluginName;
-    
+    private String awsCredentialPluginName = "";
+
     @FieldDoc(
         required = false,
         defaultValue = "",
         help = "json-parameters to initialize `AwsCredentialsProviderPlugin`")
-    private String awsCredentialPluginParam;
-    
+    private String awsCredentialPluginParam = "";
+
+    protected Region regionAsV2Region() {
+        return Region.of(this.getAwsRegion());
+    }
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
@@ -18,71 +18,38 @@
  */
 package org.apache.pulsar.io.kinesis;
 
-import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.amazonaws.services.kinesis.clientlibrary.exceptions.InvalidStateException;
-import com.amazonaws.services.kinesis.clientlibrary.exceptions.KinesisClientLibDependencyException;
-import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException;
-import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException;
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
-import com.amazonaws.services.kinesis.model.Record;
+import software.amazon.kinesis.exceptions.InvalidStateException;
+import software.amazon.kinesis.exceptions.KinesisClientLibDependencyException;
+import software.amazon.kinesis.exceptions.ShutdownException;
+import software.amazon.kinesis.exceptions.ThrottlingException;
+import software.amazon.kinesis.lifecycle.events.*;
+import software.amazon.kinesis.processor.RecordProcessorCheckpointer;
+import software.amazon.kinesis.processor.ShardRecordProcessor;
 
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 @Slf4j
-public class KinesisRecordProcessor implements IRecordProcessor {
-    
+public class KinesisRecordProcessor implements ShardRecordProcessor {
+
     private final int numRetries;
     private final long checkpointInterval;
     private final long backoffTime;
-    
+
     private final LinkedBlockingQueue<KinesisRecord> queue;
     private long nextCheckpointTimeInNanos;
     private String kinesisShardId;
     
     public KinesisRecordProcessor(LinkedBlockingQueue<KinesisRecord> queue, KinesisSourceConfig config) {
         this.queue = queue;
-        this.backoffTime = config.getBackoffTime();
         this.checkpointInterval = config.getCheckpointInterval();
         this.numRetries = config.getNumRetries();
+        this.backoffTime = config.getBackoffTime();
     }
 
-    @Override
-    public void initialize(String shardId) {
-        kinesisShardId = shardId;
-    }
-
-    @Override
-    public void processRecords(List<Record> records, IRecordProcessorCheckpointer checkpointer) {
-        log.info("Processing " + records.size() + " records from " + kinesisShardId);
-        
-        for (Record record : records) {
-           try {
-               queue.put(new KinesisRecord(record));
-           } catch (InterruptedException e) {
-               log.warn("unable to create KinesisRecord ", e);
-           }
-        }
-
-       // Checkpoint once every checkpoint interval.
-        if (System.nanoTime() > nextCheckpointTimeInNanos) {
-            checkpoint(checkpointer);
-            nextCheckpointTimeInNanos = System.nanoTime() + checkpointInterval;
-        }
-    }
-
-    @Override
-    public void shutdown(IRecordProcessorCheckpointer checkpointer, ShutdownReason reason) {
-        log.info("Shutting down record processor for shard: " + kinesisShardId);
-        if (reason == ShutdownReason.TERMINATE) {
-            checkpoint(checkpointer);
-        }
-    }
-    
-    private void checkpoint(IRecordProcessorCheckpointer checkpointer) {
+    private void checkpoint(RecordProcessorCheckpointer checkpointer) {
         log.info("Checkpointing shard " + kinesisShardId);
         
         for (int i = 0; i < numRetries; i++) {
@@ -96,14 +63,14 @@ public class KinesisRecordProcessor implements IRecordProcessor {
             } catch (InvalidStateException e) {
                 log.error("Cannot save checkpoint to the DynamoDB table.", e);
                 break;
-            } catch (ThrottlingException e) {
+            } catch (ThrottlingException | KinesisClientLibDependencyException e) {
                 // Back off and re-attempt checkpoint upon transient failures
                 if (i >= (numRetries - 1)) {
                     log.error("Checkpoint failed after " + (i + 1) + "attempts.", e);
                     break;
                 }
             }
-            
+
             try {
                 Thread.sleep(backoffTime);
             } catch (InterruptedException e) {
@@ -112,4 +79,45 @@ public class KinesisRecordProcessor implements IRecordProcessor {
         }
     }
 
+    @Override
+    public void initialize(InitializationInput initializationInput) {
+        kinesisShardId = initializationInput.shardId();
+    }
+
+    @Override
+    public void processRecords(ProcessRecordsInput processRecordsInput) {
+
+        log.info("Processing " + processRecordsInput.records().size() + " records from " + kinesisShardId);
+
+        for (KinesisClientRecord record : processRecordsInput.records()) {
+            try {
+                queue.put(new KinesisRecord(record));
+            } catch (InterruptedException e) {
+                log.warn("unable to create KinesisRecord ", e);
+            }
+        }
+
+        // Checkpoint once every checkpoint interval.
+        if (System.nanoTime() > nextCheckpointTimeInNanos) {
+            checkpoint(processRecordsInput.checkpointer());
+            nextCheckpointTimeInNanos = System.nanoTime() + checkpointInterval;
+        }
+    }
+
+    @Override
+    public void leaseLost(LeaseLostInput leaseLostInput) {
+        log.info("lease lost, will terminate soon");
+    }
+
+    @Override
+    public void shardEnded(ShardEndedInput shardEndedInput) {
+        log.info("reached end of shard, will checkpoint");
+        checkpoint(shardEndedInput.checkpointer());
+    }
+
+    @Override
+    public void shutdownRequested(ShutdownRequestedInput shutdownRequestedInput) {
+        log.info("Shutting down record processor for shard: " + kinesisShardId);
+        checkpoint(shutdownRequestedInput.checkpointer());
+    }
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pulsar.io.kinesis;
 
+import software.amazon.kinesis.processor.ShardRecordProcessor;
+import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
+
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
-
-public class KinesisRecordProcessorFactory implements IRecordProcessorFactory {
+public class KinesisRecordProcessorFactory implements ShardRecordProcessorFactory {
 
     private final LinkedBlockingQueue<KinesisRecord> queue;
     private final KinesisSourceConfig config;
@@ -35,8 +35,7 @@ public class KinesisRecordProcessorFactory implements IRecordProcessorFactory {
     }
 
     @Override
-    public IRecordProcessor createProcessor() {
+    public ShardRecordProcessor shardRecordProcessor() {
         return new KinesisRecordProcessor(queue, config);
     }
-
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -164,7 +164,9 @@ public class KinesisSink extends AbstractKinesisConnector implements Sink<byte[]
         kinesisConfig.setThreadPoolSize(4);
         kinesisConfig.setCollectionMaxCount(1);
         AWSCredentialsProvider credentialsProvider = createCredentialProvider(
-                kinesisSinkConfig.getAwsCredentialPluginName(), kinesisSinkConfig.getAwsCredentialPluginParam());
+                kinesisSinkConfig.getAwsCredentialPluginName(),
+                kinesisSinkConfig.getAwsCredentialPluginParam())
+            .getCredentialProvider();
         kinesisConfig.setCredentialsProvider(credentialsProvider);
 
         this.streamName = kinesisSinkConfig.getAwsKinesisStreamName();

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
@@ -21,12 +21,21 @@ package org.apache.pulsar.io.kinesis;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.KinesisClientUtil;
+import software.amazon.kinesis.common.InitialPositionInStream;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -40,26 +49,26 @@ public class KinesisSourceConfig extends BaseKinesisConfig implements Serializab
     private static final long serialVersionUID = 1L;
 
     @FieldDoc(
-       required = false,
-       defaultValue = "LATEST",
-       help = "Used to specify the position in the stream where the connector should start from.\n" 
-               + "  #\n"
-               + "  # The available options are: \n"
-               + "  #\n"
-               + "  # - AT_TIMESTAMP \n"
-               + "  #\n"
-               + "  #   Start from the record at or after the specified timestamp. \n"
-               + "  #\n"
-               + "  # - LATEST \n"
-               + "  #\n"
-               + "  #   Start after the most recent data record (fetch new data). \n"
-               + "  #\n"
-               + "  # - TRIM_HORIZON \n"
-               + "  #\n"
-               + "  #   Start from the oldest available data record. \n"
+        required = false,
+        defaultValue = "LATEST",
+        help = "Used to specify the position in the stream where the connector should start from.\n"
+                + "  #\n"
+                + "  # The available options are: \n"
+                + "  #\n"
+                + "  # - AT_TIMESTAMP \n"
+                + "  #\n"
+                + "  #   Start from the record at or after the specified timestamp. \n"
+                + "  #\n"
+                + "  # - LATEST \n"
+                + "  #\n"
+                + "  #   Start after the most recent data record (fetch new data). \n"
+                + "  #\n"
+                + "  # - TRIM_HORIZON \n"
+                + "  #\n"
+                + "  #   Start from the oldest available data record. \n"
     )
     private InitialPositionInStream initialPositionInStream = InitialPositionInStream.LATEST;
-    
+
     @FieldDoc(
         required = false,
         defaultValue = "",
@@ -67,55 +76,125 @@ public class KinesisSourceConfig extends BaseKinesisConfig implements Serializab
                 + " property specifies the point in time to start consumption."
     )
     private Date startAtTime;
-    
+
     @FieldDoc(
-      required = false,
-      defaultValue = "Apache Pulsar IO Connector",
-      help = "Name of the Amazon Kinesis application. By default the application name is included "
-              + "in the user agent string used to make AWS requests. This can assist with troubleshooting "
-              + "(e.g. distinguish requests made by separate connectors instances)."
+        required = false,
+        defaultValue = "Apache Pulsar IO Connector",
+        help = "Name of the Amazon Kinesis application. By default the application name is included "
+                + "in the user agent string used to make AWS requests. This can assist with troubleshooting "
+                + "(e.g. distinguish requests made by separate connectors instances)."
     )
     private String applicationName = "Apache Pulsar IO Connector";
-    
+
     @FieldDoc(
-       required = false,
-       defaultValue = "60000",
-       help = "The frequency of the Kinesis stream checkpointing (in milliseconds)"
+        required = false,
+        defaultValue = "60000",
+        help = "The frequency of the Kinesis stream checkpointing (in milliseconds)"
     )
     private long checkpointInterval = 60000L;
 
     @FieldDoc(
-       required = false,
-       defaultValue = "3000",
-       help = "The amount of time to delay between requests when the connector encounters a Throttling"
-               + "exception from AWS Kinesis (in milliseconds)"
+        required = false,
+        defaultValue = "3000",
+        help = "The amount of time to delay between requests when the connector encounters a Throttling"
+                + "exception from AWS Kinesis (in milliseconds)"
     )
     private long backoffTime = 3000L;
-    
+
     @FieldDoc(
-       required = false,
-       defaultValue = "3",
-       help = "The number of re-attempts to make when the connector encounters an "
-               + "exception while trying to set a checkpoint"
-    )    
-    private int numRetries;
-    
+        required = false,
+        defaultValue = "3",
+        help = "The number of re-attempts to make when the connector encounters an "
+                + "exception while trying to set a checkpoint"
+    )
+    private int numRetries = 3;
+
     @FieldDoc(
         required = false,
         defaultValue = "1000",
         help = "The maximum number of AWS Records that can be buffered inside the connector. "
                 + "Once this is reached, the connector will not consume any more messages from "
                 + "Kinesis until some of the messages in the queue have been successfully consumed."
-    )  
+    )
     private int receiveQueueSize = 1000;
-    
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "Dynamo end-point url. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
+    )
+    private String dynamoEndpoint = "";
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "Cloudwatch end-point url. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
+    )
+    private String cloudwatchEndpoint = "";
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "true",
+        help = "When true, uses Kinesis enhanced fan-out, when false, uses polling"
+    )
+    private boolean useEnhancedFanOut = true;
+
+
     public static KinesisSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), KinesisSourceConfig.class);
     }
-    
+
     public static KinesisSourceConfig load(Map<String, Object> map) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(new ObjectMapper().writeValueAsString(map), KinesisSourceConfig.class);
+    }
+
+    public KinesisAsyncClient buildKinesisAsyncClient(AwsCredentialProviderPlugin credPlugin) {
+        KinesisAsyncClientBuilder builder = KinesisAsyncClient.builder();
+
+        if (!this.getAwsEndpoint().isEmpty()) {
+            builder.endpointOverride(URI.create(this.getAwsEndpoint()));
+        }
+        if (!this.getAwsRegion().isEmpty()) {
+            builder.region(this.regionAsV2Region());
+        }
+        builder.credentialsProvider(credPlugin.getV2CredentialsProvider());
+        return KinesisClientUtil.createKinesisAsyncClient(builder);
+    }
+
+    public DynamoDbAsyncClient buildDynamoAsyncClient(AwsCredentialProviderPlugin credPlugin) {
+        DynamoDbAsyncClientBuilder builder = DynamoDbAsyncClient.builder();
+
+        if (!this.getDynamoEndpoint().isEmpty()) {
+            builder.endpointOverride(URI.create(this.getDynamoEndpoint()));
+        }
+        if (!this.getAwsRegion().isEmpty()) {
+            builder.region(this.regionAsV2Region());
+        }
+        builder.credentialsProvider(credPlugin.getV2CredentialsProvider());
+        return builder.build();
+    }
+
+    public CloudWatchAsyncClient buildCloudwatchAsyncClient(AwsCredentialProviderPlugin credPlugin) {
+        CloudWatchAsyncClientBuilder builder = CloudWatchAsyncClient.builder();
+
+        if (!this.getCloudwatchEndpoint().isEmpty()) {
+            builder.endpointOverride(URI.create(this.getCloudwatchEndpoint()));
+        }
+        if (!this.getAwsRegion().isEmpty()) {
+            builder.region(this.regionAsV2Region());
+        }
+        builder.credentialsProvider(credPlugin.getV2CredentialsProvider());
+        return builder.build();
+    }
+
+    public InitialPositionInStreamExtended getStreamStartPosition() {
+        if (initialPositionInStream == InitialPositionInStream.AT_TIMESTAMP) {
+            return InitialPositionInStreamExtended.newInitialPositionAtTimestamp(getStartAtTime());
+        }
+        else {
+            return InitialPositionInStreamExtended.newInitialPosition(this.getInitialPositionInStream());
+        }
     }
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
@@ -84,7 +84,7 @@ public class KinesisSourceConfig extends BaseKinesisConfig implements Serializab
                 + "in the user agent string used to make AWS requests. This can assist with troubleshooting "
                 + "(e.g. distinguish requests made by separate connectors instances)."
     )
-    private String applicationName = "Apache Pulsar IO Connector";
+    private String applicationName = "pulsar-kinesis";
 
     @FieldDoc(
         required = false,

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/STSAssumeRoleProviderPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/STSAssumeRoleProviderPlugin.java
@@ -1,0 +1,47 @@
+package org.apache.pulsar.io.kinesis;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class STSAssumeRoleProviderPlugin implements AwsCredentialProviderPlugin {
+    public static final String ASSUME_ROLE_ARN = "roleArn";
+    public static final String ASSUME_ROLE_SESSION_NAME = "roleSessionName";
+
+    private String roleArn;
+    private String roleSessionName;
+
+    @Override
+    public void init(String param) {
+        Map<String, String> credentialMap = new Gson().fromJson(param,
+                new TypeToken<Map<String, String>>() {
+                }.getType());
+
+        roleArn = credentialMap.get(ASSUME_ROLE_ARN);
+        roleSessionName = credentialMap.get(ASSUME_ROLE_SESSION_NAME);
+    }
+
+    @Override
+    public AWSCredentialsProvider getCredentialProvider() {
+        return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName).build();
+    }
+
+    @Override
+    public software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getV2CredentialsProvider() {
+        StsClient client = StsClient.create();
+        return StsAssumeRoleCredentialsProvider.builder().stsClient(client).refreshRequest((req) -> {
+            req.roleArn(roleArn).roleSessionName(roleSessionName).build();
+        }).build();
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/STSAssumeRoleProviderPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/STSAssumeRoleProviderPlugin.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.io.kinesis;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -6,7 +24,6 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
-import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
 
 import java.io.IOException;
 import java.util.Map;

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -52,7 +52,8 @@ public class KinesisSinkTest {
         credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
         credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
         awsCredentialPluginParam = new Gson().toJson(credentialParam);
-        AWSCredentialsProvider credentialProvider = sink.defaultCredentialProvider(awsCredentialPluginParam);
+        AWSCredentialsProvider credentialProvider = sink.defaultCredentialProvider(awsCredentialPluginParam)
+                .getCredentialProvider();
         Assert.assertNotNull(credentialProvider);
         Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
         Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
@@ -70,11 +71,13 @@ public class KinesisSinkTest {
         credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
         credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
         String awsCredentialPluginParam = new Gson().toJson(credentialParam);
-        AWSCredentialsProvider credentialProvider = sink.createCredentialProvider(null, awsCredentialPluginParam);
+        AWSCredentialsProvider credentialProvider = sink.createCredentialProvider(null, awsCredentialPluginParam)
+                .getCredentialProvider();
         Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
         Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
 
-        credentialProvider = sink.createCredentialProvider(AwsCredentialProviderPluginImpl.class.getName(), "{}");
+        credentialProvider = sink.createCredentialProvider(AwsCredentialProviderPluginImpl.class.getName(), "{}")
+                .getCredentialProvider();
         Assert.assertNotNull(credentialProvider);
         Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
                 AwsCredentialProviderPluginImpl.accessKey);
@@ -91,7 +94,8 @@ public class KinesisSinkTest {
         KinesisSink sink = new KinesisSink();
 
         AWSCredentialsProvider credentialProvider = sink
-                .createCredentialProviderWithPlugin(AwsCredentialProviderPluginImpl.class.getName(), "{}");
+                .createCredentialProviderWithPlugin(AwsCredentialProviderPluginImpl.class.getName(), "{}")
+                .getCredentialProvider();
         Assert.assertNotNull(credentialProvider);
         Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
                 AwsCredentialProviderPluginImpl.accessKey);

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
@@ -32,8 +31,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.testng.annotations.Test;
+import software.amazon.kinesis.common.InitialPositionInStream;
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
 
 public class KinesisSourceConfigTests {
 

--- a/site2/docs/io-connectors.md
+++ b/site2/docs/io-connectors.md
@@ -4,7 +4,7 @@ title: Built-in connector
 sidebar_label: Built-in connector
 ---
 
-Pulsar distribution includes a set of common connectors that have been packaged and tested with the rest of Apache Pulsar. These connectors import and export data from some of the most commonly used data systems. 
+Pulsar distribution includes a set of common connectors that have been packaged and tested with the rest of Apache Pulsar. These connectors import and export data from some of the most commonly used data systems.
 
 Using any of these connectors is as easy as writing a simple connector and running the connector locally or submitting the connector to a Pulsar Functions cluster.
 
@@ -13,15 +13,15 @@ Using any of these connectors is as easy as writing a simple connector and runni
 Pulsar has various source connectors, which are sorted alphabetically as below.
 
 - [Canal source connector](io-cdc-canal.md)
-  
+
 - [Data-generator source connector](io-data-generator.md)
-  
+
 - [Debezium MySQL source connector](io-cdc-debezium.md)
-  
+
 - [Debezium PostgreSQL source Connector](io-postgresql-debezium.md)
-  
+
 - [File source connector](io-file-source.md)
-  
+
 - [Flume source connector](io-flume-source.md)
 
 - [Twitter firehose source connector](io-twitter-source.md)
@@ -41,7 +41,7 @@ Pulsar has various source connectors, which are sorted alphabetically as below.
 Pulsar has various sink connectors, which are sorted alphabetically as below.
 
 - [Aerospike sink connector](io-aerospike-sink.md)
-  
+
 - [Cassandra sink connector](io-cassandra-sink.md)
 
 - [ElasticSearch sink connector](io-elasticsearch.md)

--- a/site2/docs/io-kinesis-sink.md
+++ b/site2/docs/io-kinesis-sink.md
@@ -12,7 +12,7 @@ The configuration of the Kinesis sink connector has the following parameters.
 
 ### Parameter
 
-| Name | Type|Required | Default | Description 
+| Name | Type|Required | Default | Description
 |------|----------|----------|---------|-------------|
 `messageFormat`|MessageFormat|true|ONLY_RAW_PAYLOAD|Message format in which Kinesis sink converts Pulsar messages and publishes to Kinesis streams.<br/><br/>Below are the available options:<br/><br/><li>`ONLY_RAW_PAYLOAD`: Kinesis sink directly publishes Pulsar message payload as a message into the configured Kinesis stream. <br/><br/><li>`FULL_MESSAGE_IN_JSON`: Kinesis sink creates a JSON payload with Pulsar message payload, properties and encryptionCtx, and publishes JSON payload into the configured Kinesis stream.<br/><br/><li>`FULL_MESSAGE_IN_FB`: Kinesis sink creates a flatbuffer serialized payload with Pulsar message payload, properties and encryptionCtx, and publishes flatbuffer payload into the configured Kinesis stream.
 `retainOrdering`|boolean|false|false|Whether Pulsar connectors to retain ordering when moving messages from Pulsar to Kinesis or not.
@@ -26,7 +26,7 @@ The configuration of the Kinesis sink connector has the following parameters.
 
 Before using the Kinesis sink connector, you need to create a configuration file through one of the following methods.
 
-* JSON 
+* JSON
 
     ```json
     {
@@ -51,4 +51,15 @@ Before using the Kinesis sink connector, you need to create a configuration file
         retainOrdering: "true"
     ```
 
+### Built-in `AwsCredentialProviderPlugin` plugins
 
+#### `org.apache.pulsar.io.kinesis.AwsDefaultProviderChainPlugin`
+This plugin takes no configuration, it uses the default AWS provider chain. See the [AWS documentation](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default) for more details
+
+#### `org.apache.pulsar.io.kinesis.STSAssumeRoleProviderPlugin`
+This plugin takes a configuration (via the `awsCredentialPluginParam`) that describes a role to assume when running the KCL.
+
+This configuration takes the form of a small json document like:
+```Json
+{"roleArn": "arn...", "roleSessionName": "name"}
+```

--- a/site2/docs/io-kinesis-source.md
+++ b/site2/docs/io-kinesis-source.md
@@ -1,0 +1,49 @@
+---
+id: io-kinesis-source
+title: Kinesis source connector
+sidebar_label: Kinesis source connector
+---
+
+The Kinesis source connector pulls data from Amazon Kinesis and persists data into Pulsar.
+
+Under the hood, it uses the [Kinesis Consumer Library](https://github.com/awslabs/amazon-kinesis-client) (KCL) to do the actual consuming of messages. The KCL uses dynamodb to track state for consumers.
+
+## Configuration
+
+The configuration of the Kinesis source connector has the following parameters.
+
+### Parameter
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| applicationName | `false` | `pulsar-kinesis` | This is the application-name passed to the KCL and is used as the name to create dynamo tables. This should be overriden if you plan on having multiple instances of this source |
+| awsEndpoint | `true` | null | kinesis end-point url can be found at : https://docs.aws.amazon.com/general/latest/gr/rande.html |
+| awsRegion | `true` | null | appropriate aws region eg: us-west-1, us-west-2 |
+| awsKinesisStreamName | `true` | null | kinesis stream name |
+| awsCredentialPluginName | `false` | null | Fully-Qualified class name of implementation of {@inject: github:`AwsCredentialProviderPlugin`:/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java}. It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Source. If it is empty then KinesisSource will create a default AWSCredentialsProvider which accepts json-map of credentials in `awsCredentialPluginParam` |
+| awsCredentialPluginParam | `false` | null | json-parameters to initialize `AwsCredentialsProviderPlugin` |
+| backoffTime | `false` | 3000 | The interval (in ms) of how long to wait for throttles or other errors |
+| checkpointInterval | `false` | 60000 | The interval (in ms) of how often to checkpoint the position of consumers to dynamodb |
+| cloudwatchEndpoint | `false` | `` | The endpoint to use for cloudwatch, defaults to regional endpoint if not provided |
+| dynamoEndpoint | `false` | `` | The endpoint to use for dynamodb, defaults to regional endpoint if not provided |
+| initialPositionInStream | `false` | `LATEST` | Where to start in the stream, valid values are `AT_TIMESTAMAP`, `LATEST`, and `TRIM_HORIZON` |
+| numRetries | `false` | `3` | How many times to retries before failing the source |
+| startAtTime | `false` | `` | When using `AT_TIMESTAMAP` for `initialPositionInStream`, this sets the timestamp to start at, must be a valid string representing a java date |
+| useEnhancedFanOut | `false` | `true` | Defaults to using push-bashed enhanced fan out, set to false to fall back to polling, note that enhanced fan-out has an additional cost |
+
+### Encrypted Messages
+
+Currently, this source only supports raw messages. if you use KMS encrypted messages, the encrypted messages will be sent downstream. A future version of this connector should support being able to decrypt the messages.
+
+### Built-in `AwsCredentialProviderPlugin` plugins
+
+#### `org.apache.pulsar.io.kinesis.AwsDefaultProviderChainPlugin`
+This plugin takes no configuration, it uses the default AWS provider chain. See the [AWS documentation](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default) for more details
+
+#### `org.apache.pulsar.io.kinesis.STSAssumeRoleProviderPlugin`
+This plugin takes a configuration (via the `awsCredentialPluginParam`) that describes a role to assume when running the KCL.
+
+This configuration takes the form of a small json document like:
+```Json
+{"roleArn": "arn...", "roleSessionName": "name"}
+```

--- a/site2/docs/io-overview.md
+++ b/site2/docs/io-overview.md
@@ -4,7 +4,7 @@ title: Pulsar connector overview
 sidebar_label: Overview
 ---
 
-Messaging systems are most powerful when you can easily use them with external systems like databases and other messaging systems. 
+Messaging systems are most powerful when you can easily use them with external systems like databases and other messaging systems.
 
 **Pulsar IO connectors** enable you to easily create, deploy, and manage connectors that interact with external systems, such as [Apache Cassandra](https://cassandra.apache.org), [Aerospike](https://www.aerospike.com), and many others.
 
@@ -20,7 +20,7 @@ This diagram illustrates the relationship between source, Pulsar, and sink:
 
 ### Source
 
-> Sources **feed data from external systems into Pulsar**. 
+> Sources **feed data from external systems into Pulsar**.
 
 Common sources include other messaging systems and firehose-style data pipeline APIs.
 
@@ -28,7 +28,7 @@ For the complete list of Pulsar built-in source connectors, see [source connecto
 
 ### Sink
 
-> Sinks **feed data from Pulsar into external systems**. 
+> Sinks **feed data from Pulsar into external systems**.
 
 Common sinks include other messaging systems and SQL and NoSQL databases.
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/io-kinesis.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/io-kinesis.md
@@ -17,7 +17,7 @@ AWS Kinesis.
 | awsEndpoint | `true` | null | kinesis end-point url can be found at : https://docs.aws.amazon.com/general/latest/gr/rande.html |
 | awsRegion | `true` | null | appropriate aws region eg: us-west-1, us-west-2 |
 | awsKinesisStreamName | `true` | null | kinesis stream name |
-| awsCredentialPluginName | `false` | null | Fully-Qualified class name of implementation of {@inject: github:`AwsCredentialProviderPlugin`:/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java}. It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Sink. If it is empty then KinesisSink will create a default AWSCredentialsProvider which accepts json-map of credentials in `awsCredentialPluginParam` | 
+| awsCredentialPluginName | `false` | null | Fully-Qualified class name of implementation of {@inject: github:`AwsCredentialProviderPlugin`:/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java}. It is a factory class which creates an AWSCredentialsProvider that will be used by Kinesis Sink. If it is empty then KinesisSink will create a default AWSCredentialsProvider which accepts json-map of credentials in `awsCredentialPluginParam` |
 | awsCredentialPluginParam | `false` | null | json-parameters to initialize `AwsCredentialsProviderPlugin` |
 | messageFormat | `true` | `ONLY_RAW_PAYLOAD` | Message format in which kinesis sink converts pulsar messages and publishes to kinesis streams |
 
@@ -35,3 +35,4 @@ Kinesis sink creates a json payload with pulsar message payload, properties and 
 #### **FULL_MESSAGE_IN_FB**
 
 Kinesis sink creates a flatbuffer serialized paylaod with pulsar message payload, properties and encryptionCtx, and publishes flatbuffer payload into the configured kinesis stream.
+


### PR DESCRIPTION
### Motivation

This pull request improves the kinesis-source (and sink to some extent). Currently, the kinesis-source is actually broken, it never starts reading. This fixes that, but also does upgrades to make it more functionality. it also adds a few other features that clean up the kinesis integrations.

Primarily:
- Ports the kinesis-source to use v2 of the kinesis consumer library (kcl), kcl v2 adds supports for enhanced fan-out, which greatly enhances the ability of multiple consumers to not compete for resources. An option is provided to fall back to polling as well. 
- Adds a few default plugins for the AWS credential plugin, these can be used for both the source and the sink. This allows for using either the default provider chain or to assume a role
- Updates the kinesis-producer-library to 0.13. This release has no functionality changes, but updates the library to be published under the Apache license, which should reduce some concerns about linking against the library.

### Modifications

- Adds kcl v2 library as well as other dependency changes, this brings in some v2 version of the AWS SDK
- Reworks the record processor to the new v2 APIs of the KCL
- Changes the credential provider plugin to support the v2 of the AWS SDK via a new method with a default implementation for any existing providers (i.e. no breaking API changes)
- Adds two new credential provider plugins, one for the default provider change and one for the STS assume role

One annoying bit here is that the jar gets a fair bit bigger as we have both v1 and v2 of the aws sdk here. Eventually, the kinesis producer library should move to v2 of the SDK and then we can have only the v2 of the aws sdk.

### Verifying this change

- Some tests cover this functionality, however, an integration test is still needed.
- this does some improvements to make that easier (allow you to use local dynamo for example)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: no
  - The schema: no
  - The default values of configurations:  yes (adds new config vals)
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not yet documented
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation

The default provider plugins should be documented

@david-streamlio if you want to take a look at this

Fixes #5170 