### PR TITLE
[Doc]Fix tenant typo for debezim mysql source

### DIFF
--- a/site2/docs/io-cdc-debezium.md
+++ b/site2/docs/io-cdc-debezium.md
@@ -56,7 +56,7 @@ Here is a JSON configuration example:
 Optionally, you can create a `debezium-mysql-source-config.yaml` file, and copy the [contents] (https://github.com/apache/pulsar/blob/master/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml) below to the `debezium-mysql-source-config.yaml` file.
 
 ```$yaml
-tenant: "pubilc"
+tenant: "public"
 namespace: "default"
 name: "debezium-mysql-source"
 topicName: "debezium-mysql-topic"

--- a/site2/website/versioned_docs/version-2.4.1/io-cdc-debezium.md
+++ b/site2/website/versioned_docs/version-2.4.1/io-cdc-debezium.md
@@ -57,7 +57,7 @@ Here is a JSON configuration example:
 Optionally, you can create a `debezium-mysql-source-config.yaml` file, and copy the [contents] (https://github.com/apache/pulsar/blob/master/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml) below to the `debezium-mysql-source-config.yaml` file.
 
 ```$yaml
-tenant: "pubilc"
+tenant: "public"
 namespace: "default"
 name: "debezium-mysql-source"
 topicName: "debezium-mysql-topic"


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/5189


Master Issue: https://github.com/apache/pulsar/issues/5189

### Motivation

Currently, the tenant name for the new version of the document is incorrectly written, resulting in that the tenant cannot be found.

### Modifications

Fix tenant name from `pubilc` to `public`

