### PR TITLE
[pulsar-broker] Make some member variables of Dispatcher volatile

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -40,7 +40,7 @@ public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDi
 
     protected final CopyOnWriteArrayList<Consumer> consumerList = new CopyOnWriteArrayList<>();
     protected final ObjectSet<Consumer> consumerSet = new ObjectHashSet<>();
-    protected int currentConsumerRoundRobinIndex = 0;
+    protected volatile int currentConsumerRoundRobinIndex = 0;
 
     protected static final int FALSE = 0;
     protected static final int TRUE = 1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -82,13 +82,13 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     private Optional<DelayedDeliveryTracker> delayedDeliveryTracker = Optional.empty();
     private final boolean isDelayedDeliveryEnabled;
 
-    private boolean havePendingRead = false;
-    private boolean havePendingReplayRead = false;
+    private volatile boolean havePendingRead = false;
+    private volatile boolean havePendingReplayRead = false;
     private boolean shouldRewindBeforeReadingOrReplaying = false;
     protected final String name;
 
-    protected int totalAvailablePermits = 0;
-    private int readBatchSize;
+    protected volatile int totalAvailablePermits = 0;
+    private volatile int readBatchSize;
     private final Backoff readFailureBackoff = new Backoff(15, TimeUnit.SECONDS, 1, TimeUnit.MINUTES, 0, TimeUnit.MILLISECONDS);
     private static final AtomicIntegerFieldUpdater<PersistentDispatcherMultipleConsumers> TOTAL_UNACKED_MESSAGES_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(PersistentDispatcherMultipleConsumers.class, "totalUnackedMessages");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -60,11 +60,11 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
     private final PersistentTopic topic;
     private final ManagedCursor cursor;
     private final String name;
-    private Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();;
+    private Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
 
     private volatile boolean havePendingRead = false;
 
-    private int readBatchSize;
+    private volatile int readBatchSize;
     private final Backoff readFailureBackoff = new Backoff(15, TimeUnit.SECONDS, 1, TimeUnit.MINUTES, 0, TimeUnit.MILLISECONDS);
     private final ServiceConfiguration serviceConfig;
     private volatile ScheduledFuture<?> readOnActiveConsumerTask = null;


### PR DESCRIPTION
Some of the variables of the `Dispatcher` classes seem to should be volatile, so I fixed them. For example, the variable `havePendingRead` is corrently volatile in `PersistentDispatcherSingleActiveConsumer` but not in` PersistentDispatcherMultipleConsumers`.