### PR TITLE
Added missing enum value KeyShared on the python wrapper

### DIFF
--- a/pulsar-client-cpp/python/src/enums.cc
+++ b/pulsar-client-cpp/python/src/enums.cc
@@ -40,6 +40,7 @@ void export_enums() {
             .value("Exclusive", ConsumerExclusive)
             .value("Shared", ConsumerShared)
             .value("Failover", ConsumerFailover)
+            .value("KeyShared", ConsumerKeyShared)
             ;
 
     enum_<Result >("Result", "Collection of return codes")


### PR DESCRIPTION
The KeyShared feature is currently not available for python wrapper.