### PR TITLE
[Doc] Add configuration of Flume source connector

### DIFF
--- a/site2/docs/io-flume-source.md
+++ b/site2/docs/io-flume-source.md
@@ -16,6 +16,6 @@ The configuration of Flume source connector has the following parameters.
 |------|----------|----------|---------|-------------|
 `name`|String|true|"" (empty string)|Name of the agent
 `confFile`|String|true|"" (empty string)|Configuration file
-`noReloadConf`|Boolean||false|Whether to reload configuration file if changed
+`noReloadConf`|Boolean|false|false|Whether to reload configuration file if changed
 `zkConnString`|String|true|"" (empty string)|ZooKeeper connection 
 `zkBasePath`|String|true|"" (empty string)|Base path in ZooKeeper for agent configuration

--- a/site2/docs/io-flume-source.md
+++ b/site2/docs/io-flume-source.md
@@ -1,0 +1,21 @@
+---
+id: io-flume-source
+title: Flume source connector
+sidebar_label: Flume source connector
+---
+
+The Flume source connector pulls messages from logs to Pulsar topics.
+
+## Configuration
+
+The configuration of Flume source connector has the following parameters.
+
+### Parameter
+
+| Name | Type|Required | Default | Description 
+|------|----------|----------|---------|-------------|
+`name`|String|true|"" (empty string)|Name of the agent
+`confFile`|String|true|"" (empty string)|Configuration file
+`noReloadConf`|Boolean||false|Whether to reload configuration file if changed
+`zkConnString`|String|true|"" (empty string)|ZooKeeper connection 
+`zkBasePath`|String|true|"" (empty string)|Base path in ZooKeeper for agent configuration


### PR DESCRIPTION
1. Currently, Pulsar does not have any explanations for Flume source and sink connectors. This PR adds configuration of Flume source connector.

2. Fix https://github.com/apache/pulsar/issues/5015.