### PR TITLE
Ensure consumer background tasks are cancelled after subscribe failures

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -217,7 +217,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     @Override
     public void close() {
         flush();
-        if (scheduledTask != null) {
+        if (scheduledTask != null && !scheduledTask.isCancelled()) {
             scheduledTask.cancel(true);
         }
     }


### PR DESCRIPTION
### Motivation

Some of the background consumer tasks are being started in the `ConsumerImpl` constructor though these are not being cancelled if the consumer creation fails, leaving active refs to these objects.