### PR TITLE
Fixed flaky tests in ReplicatorRateLimiterTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -87,7 +87,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     public void testReplicatorRateLimiterDynamicallyChange() throws Exception {
         log.info("--- Starting ReplicatorTest::{} --- ", methodName);
 
-        final String namespace = "pulsar/replicatorchange";
+        final String namespace = "pulsar/replicatorchange-" + System.currentTimeMillis();
         final String topicName = "persistent://" + namespace + "/ratechange";
 
         admin1.namespaces().createNamespace(namespace);
@@ -156,11 +156,11 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
-    @Test(dataProvider =  "dispatchRateType", timeOut = 5000)
+    @Test(dataProvider =  "dispatchRateType")
     public void testReplicatorRateLimiterMessageNotReceivedAllMessages(DispatchRateType dispatchRateType) throws Exception {
         log.info("--- Starting ReplicatorTest::{} --- ", methodName);
 
-        final String namespace = "pulsar/replicatorbyteandmsg" + dispatchRateType.toString();
+        final String namespace = "pulsar/replicatorbyteandmsg-" + dispatchRateType.toString() + "-" + System.currentTimeMillis();
         final String topicName = "persistent://" + namespace + "/notReceivedAll";
 
         admin1.namespaces().createNamespace(namespace);
@@ -242,11 +242,11 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 5000)
+    @Test
     public void testReplicatorRateLimiterMessageReceivedAllMessages() throws Exception {
         log.info("--- Starting ReplicatorTest::{} --- ", methodName);
 
-        final String namespace = "pulsar/replicatormsg";
+        final String namespace = "pulsar/replicatormsg-" + System.currentTimeMillis();
         final String topicName = "persistent://" + namespace + "/notReceivedAll";
 
         admin1.namespaces().createNamespace(namespace);


### PR DESCRIPTION
### Motivation

ReplicatorRateLimiterTest is failing from time to time. The 5 secs timeout is possibly too short when running on the shared Jenkins so it's better to use the default 2m timeout. 

Additionally, the retries were also failing due to the namespace already existing. Using unique names instead.