### PR TITLE
Update full-width typo in schema-understand.md

### DIFF
--- a/site2/docs/schema-understand.md
+++ b/site2/docs/schema-understand.md
@@ -112,10 +112,10 @@ This is the `SchemaInfo` of a string.
 
 ```text
 {
-    “name”: “test-string-schema”,
-    “type”: “STRING”,
-    “schema”: “”,
-    “properties”: {}
+    "name": "test-string-schema",
+    "type": "STRING",
+    "schema": "",
+    "properties": {}
 }
 ```
 
@@ -252,7 +252,7 @@ This example shows how to construct a key/value schema and then use it to produc
         .create();
 
     final int key = 100;
-    final String value = "value-100”;
+    final String value = "value-100";
 
     // send the key/value message
     producer.newMessage()


### PR DESCRIPTION
fix full-width “” to half-width "

### Motivation

Some typo exists in schema-understand.md

### Modifications

fix full-width “” to half-width "

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:
no

### Documentation
just fix typo in schema-understand.md
