### PR TITLE
[Issue #5234][pulsar-client-cpp] Fix memory leak caused by deadline_timer holding object reference

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1338,11 +1338,14 @@ void ClientConnection::close() {
 
     if (keepAliveTimer_) {
         keepAliveTimer_->cancel();
+        keepAliveTimer_.reset();
     }
 
     if (consumerStatsRequestTimer_) {
         consumerStatsRequestTimer_->cancel();
+        consumerStatsRequestTimer_.reset();
     }
+
     for (ProducersMap::iterator it = producers.begin(); it != producers.end(); ++it) {
         HandlerBase::handleDisconnection(ResultConnectError, shared_from_this(), it->second);
     }
@@ -1381,6 +1384,10 @@ void ClientConnection::close() {
 
     if (tlsSocket_) {
         tlsSocket_->lowest_layer().close();
+    }
+
+    if (executor_) {
+        executor_.reset();
     }
 }
 

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1385,10 +1385,6 @@ void ClientConnection::close() {
     if (tlsSocket_) {
         tlsSocket_->lowest_layer().close();
     }
-
-    if (executor_) {
-        executor_.reset();
-    }
 }
 
 bool ClientConnection::isClosed() const { return state_ == Disconnected; }

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -564,7 +564,6 @@ void ClientImpl::shutdown() {
     ioExecutorProvider_->close();
     listenerExecutorProvider_->close();
     partitionListenerExecutorProvider_->close();
-    pool_.close();
 }
 
 uint64_t ClientImpl::newProducerId() {

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -564,6 +564,7 @@ void ClientImpl::shutdown() {
     ioExecutorProvider_->close();
     listenerExecutorProvider_->close();
     partitionListenerExecutorProvider_->close();
+    pool_.close();
 }
 
 uint64_t ClientImpl::newProducerId() {

--- a/pulsar-client-cpp/lib/ConnectionPool.cc
+++ b/pulsar-client-cpp/lib/ConnectionPool.cc
@@ -44,7 +44,6 @@ ConnectionPool::ConnectionPool(const ClientConfiguration& conf, ExecutorServiceP
 
 ConnectionPool::~ConnectionPool() {
     std::unique_lock<std::mutex> lock(mutex_);
-
     if (poolConnections_) {
         for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {
             ClientConnectionPtr cnx = cnxIt->second.lock();
@@ -54,8 +53,6 @@ ConnectionPool::~ConnectionPool() {
         }
         pool_.clear();
     }
-
-    lock.unlock();
 }
 
 Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(

--- a/pulsar-client-cpp/lib/ConnectionPool.cc
+++ b/pulsar-client-cpp/lib/ConnectionPool.cc
@@ -47,7 +47,7 @@ ConnectionPool::~ConnectionPool() {
 
     if (poolConnections_) {
         for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {
-            ClientConnectionPtr cnx = cnxIt->second.lock();
+            ClientConnectionPtr cnx = cnxIt->second;
             if (cnx && !cnx->isClosed()) {
                 cnx->close();
             }
@@ -65,17 +65,17 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(
     if (poolConnections_) {
         PoolMap::iterator cnxIt = pool_.find(logicalAddress);
         if (cnxIt != pool_.end()) {
-            ClientConnectionPtr cnx = cnxIt->second.lock();
+            ClientConnectionPtr cnx = cnxIt->second;
 
             if (cnx && !cnx->isClosed()) {
                 // Found a valid or pending connection in the pool
                 LOG_DEBUG("Got connection from pool for " << logicalAddress << " use_count: "  //
-                                                          << (cnx.use_count() - 1) << " @ " << cnx.get());
+                                                          << (cnx.use_count() - 2) << " @ " << cnx.get());
                 return cnx->getConnectFuture();
             } else {
                 // Deleting stale connection
                 LOG_INFO("Deleting stale connection from pool for "
-                         << logicalAddress << " use_count: " << (cnx.use_count() - 1) << " @ " << cnx.get());
+                         << logicalAddress << " use_count: " << (cnx.use_count() - 2) << " @ " << cnx.get());
                 pool_.erase(logicalAddress);
             }
         }

--- a/pulsar-client-cpp/lib/ConnectionPool.cc
+++ b/pulsar-client-cpp/lib/ConnectionPool.cc
@@ -80,4 +80,20 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(
     return future;
 }
 
+void ConnectionPool::close() {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    if (poolConnections_) {
+        for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {
+            ClientConnectionPtr cnx = cnxIt->second.lock();
+            if (cnx && !cnx->isClosed()) {
+                cnx->close();
+            }
+        }
+        pool_.clear();
+    }
+
+    lock.unlock();
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -61,7 +61,7 @@ class PULSAR_PUBLIC ConnectionPool {
     ClientConfiguration clientConfiguration_;
     ExecutorServiceProviderPtr executorProvider_;
     AuthenticationPtr authentication_;
-    typedef std::map<std::string, ClientConnectionWeakPtr> PoolMap;
+    typedef std::map<std::string, ClientConnectionPtr> PoolMap;
     PoolMap pool_;
     bool poolConnections_;
     std::mutex mutex_;

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -55,6 +55,8 @@ class PULSAR_PUBLIC ConnectionPool {
     Future<Result, ClientConnectionWeakPtr> getConnectionAsync(const std::string& logicalAddress,
                                                                const std::string& physicalAddress);
 
+    void close();
+
    private:
     ClientConfiguration clientConfiguration_;
     ExecutorServiceProviderPtr executorProvider_;

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -36,6 +36,8 @@ class PULSAR_PUBLIC ConnectionPool {
     ConnectionPool(const ClientConfiguration& conf, ExecutorServiceProviderPtr executorProvider,
                    const AuthenticationPtr& authentication, bool poolConnections = true);
 
+    ~ConnectionPool();
+
     /**
      * Get a connection from the pool.
      * <p>
@@ -54,8 +56,6 @@ class PULSAR_PUBLIC ConnectionPool {
      */
     Future<Result, ClientConnectionWeakPtr> getConnectionAsync(const std::string& logicalAddress,
                                                                const std::string& physicalAddress);
-
-    void close();
 
    private:
     ClientConfiguration clientConfiguration_;

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -61,7 +61,7 @@ class PULSAR_PUBLIC ConnectionPool {
     ClientConfiguration clientConfiguration_;
     ExecutorServiceProviderPtr executorProvider_;
     AuthenticationPtr authentication_;
-    typedef std::map<std::string, ClientConnectionPtr> PoolMap;
+    typedef std::map<std::string, ClientConnectionWeakPtr> PoolMap;
     PoolMap pool_;
     bool poolConnections_;
     std::mutex mutex_;

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -88,9 +88,6 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
 
 ProducerImpl::~ProducerImpl() {
     LOG_DEBUG(getName() << "~ProducerImpl");
-    if (dataKeyGenTImer_) {
-        dataKeyGenTImer_->cancel();
-    }
     closeAsync(ResultCallback());
     printStats();
 }
@@ -473,6 +470,8 @@ void ProducerImpl::printStats() {
 void ProducerImpl::closeAsync(CloseCallback callback) {
     Lock lock(mutex_);
 
+    cancelTimers();
+
     if (state_ != Ready) {
         lock.unlock();
         if (callback) {
@@ -682,10 +681,20 @@ void ProducerImpl::start() { HandlerBase::start(); }
 void ProducerImpl::shutdown() {
     Lock lock(mutex_);
     state_ = Closed;
+    cancelTimers();
+    producerCreatedPromise_.setFailed(ResultAlreadyClosed);
+}
+
+void ProducerImpl::cancelTimers() {
+    if (dataKeyGenTImer_) {
+        dataKeyGenTImer_->cancel();
+        dataKeyGenTImer_.reset();
+    }
+
     if (sendTimer_) {
         sendTimer_->cancel();
+        sendTimer_.reset();
     }
-    producerCreatedPromise_.setFailed(ResultAlreadyClosed);
 }
 
 bool ProducerImplCmp::operator()(const ProducerImplPtr& a, const ProducerImplPtr& b) const {

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -139,6 +139,8 @@ class ProducerImpl : public HandlerBase,
     bool encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
                         SharedBuffer& encryptedPayload);
 
+    void cancelTimers();
+
     typedef std::unique_lock<std::mutex> Lock;
 
     ProducerConfiguration conf_;


### PR DESCRIPTION
Fixes #5234

### Motivation

In the C++ client library, memory usage increases as producers are repeatedly created and closed. This is because `deadline_timer` such as `sendTimer_` holds a reference to the `ProducerImpl` object and the `ProducerImpl` destructor is not executed.

https://github.com/apache/pulsar/blob/822531c072cb608161cef5e9c459ccc5103c9bc0/pulsar-client-cpp/lib/ProducerImpl.cc#L183-L184

`ClientConnection` seems to have the same problem as `ProducerImpl`.

cf. https://stackoverflow.com/questions/27065954/boost-deadline-timer-holds-reference-to-object

### Modifications

The destructor is executed by resetting shared pointers for these `deadline_timer` when closing the `ProducerImpl` object.