### PR TITLE
fix behavior when getting a key from functions state that doesn't exist

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -322,7 +322,7 @@ class ContextImpl implements Context, SinkContext, SourceContext {
         try {
             return result(stateContext.get(key));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to retrieve the state value for key '" + key + "'");
+            throw new RuntimeException("Failed to retrieve the state value for key '" + key + "'", e);
         }
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContextImpl.java
@@ -18,14 +18,15 @@
  */
 package org.apache.pulsar.functions.instance.state;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.bookkeeper.api.kv.Table;
+
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.bookkeeper.api.kv.Table;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This class accumulates the state updates from one function.
@@ -60,11 +61,14 @@ public class StateContextImpl implements StateContext {
         return table.get(Unpooled.wrappedBuffer(key.getBytes(UTF_8))).thenApply(
                 data -> {
                     try {
-                        ByteBuffer result = ByteBuffer.allocate(data.readableBytes());
-                        data.readBytes(result);
-                        return result;
+                        if (data != null) {
+                            ByteBuffer result = ByteBuffer.allocate(data.readableBytes());
+                            data.readBytes(result);
+                            return result;
+                        }
+                        return null;
                     } finally {
-                        data.release();
+                        ReferenceCountUtil.safeRelease(data);
                     }
                 }
         );

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/StateContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/StateContextImplTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.any;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Unit test {@link StateContextImpl}.
@@ -93,6 +95,16 @@ public class StateContextImplTest {
         verify(mockTable, times(1)).getNumber(
             eq(Unpooled.copiedBuffer("test-key", UTF_8))
         );
+    }
+
+    @Test
+    public void testGetKeyNotPresent() throws Exception {
+        when(mockTable.get(any(ByteBuf.class)))
+                .thenReturn(FutureUtils.value(null));
+        CompletableFuture<ByteBuffer> result = stateContext.get("test-key");
+        assertTrue(result != null);
+        assertEquals(result.get(), null);
+
     }
 
 }


### PR DESCRIPTION

### Motivation
Currently, when a user attempts to fetch from function state a key that doesn't exist, an NPE will happen.

### Modifications

Add the correct error handling for keys that don't exist.


