### PR TITLE
[Java-Client] Fix producer blocked after send an over size message while batch enabled

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -738,7 +738,7 @@ public class BatchMessageTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "containerBuilder")
-    private void testRetrieveSequenceIdGenerated(BatcherBuilder builder) throws Exception {
+    public void testRetrieveSequenceIdGenerated(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;
         final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdGenerated-" + UUID.randomUUID();
@@ -770,7 +770,7 @@ public class BatchMessageTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "containerBuilder")
-    private void testRetrieveSequenceIdSpecify(BatcherBuilder builder) throws Exception {
+    public void testRetrieveSequenceIdSpecify(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;
         final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdSpecify-" + UUID.randomUUID();
@@ -799,6 +799,34 @@ public class BatchMessageTest extends BrokerTestBase {
 
         producer.close();
         consumer.close();
+    }
+
+    @Test(dataProvider = "codecAndContainerBuilder")
+    public void testSendOverSizeMessage(CompressionType compressionType, BatcherBuilder builder) throws Exception {
+
+        final int numMsgs = 10;
+        final String topicName = "persistent://prop/ns-abc/testSendOverSizeMessage-" + UUID.randomUUID();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS)
+                .batchingMaxMessages(2)
+                .enableBatching(true)
+                .compressionType(compressionType)
+                .batcherBuilder(builder)
+                .create();
+
+        try {
+            producer.send(new byte[1024 * 1024 * 10]);
+        } catch (PulsarClientException e) {
+            assertTrue(e instanceof PulsarClientException.InvalidMessageException);
+        }
+
+        for (int i = 0; i < numMsgs; i++) {
+            producer.send(new byte[1024]);
+        }
+
+        producer.close();
+
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(BatchMessageTest.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -123,7 +123,9 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     public void discard(Exception ex) {
         try {
             // Need to protect ourselves from any exception being thrown in the future handler from the application
-            firstCallback.sendComplete(ex);
+            if (firstCallback != null) {
+                firstCallback.sendComplete(ex);
+            }
         } catch (Throwable t) {
             log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topicName, producerName,
                 sequenceId, t);
@@ -148,9 +150,9 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
         if (encryptedPayload.readableBytes() > ClientCnx.getMaxMessageSize()) {
             cmd.release();
-            if (op != null) {
-                op.callback.sendComplete(new PulsarClientException.InvalidMessageException(
+            discard(new PulsarClientException.InvalidMessageException(
                     "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
+            if (op != null) {
                 op.recycle();
             }
             return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -68,6 +68,8 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
             part.compressionType = compressionType;
             part.compressor = compressor;
             part.maxBatchSize = maxBatchSize;
+            part.topicName = topicName;
+            part.producerName = producerName;
             batches.putIfAbsent(key, part);
         } else {
             part.addMsg(msg, callback);
@@ -118,9 +120,9 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
 
         if (encryptedPayload.readableBytes() > ClientCnx.getMaxMessageSize()) {
             cmd.release();
+            keyedBatch.discard(new PulsarClientException.InvalidMessageException(
+                    "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
             if (op != null) {
-                op.callback.sendComplete(new PulsarClientException.InvalidMessageException(
-                        "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
                 op.recycle();
             }
             return null;
@@ -163,6 +165,8 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         private PulsarApi.CompressionType compressionType;
         private CompressionCodec compressor;
         private int maxBatchSize;
+        private String topicName;
+        private String producerName;
 
         // keep track of callbacks for individual messages being published in a batch
         private SendCallback firstCallback;
@@ -209,6 +213,29 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
             }
             previousCallback = callback;
             messages.add(msg);
+        }
+
+        public void discard(Exception ex) {
+            try {
+                // Need to protect ourselves from any exception being thrown in the future handler from the application
+                if (firstCallback != null) {
+                    firstCallback.sendComplete(ex);
+                }
+            } catch (Throwable t) {
+                log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topicName, producerName,
+                        sequenceId, t);
+            }
+            ReferenceCountUtil.safeRelease(batchedMessageMetadataAndPayload);
+            clear();
+        }
+
+        public void clear() {
+            messages = Lists.newArrayList();
+            firstCallback = null;
+            previousCallback = null;
+            messageMetadata.clear();
+            sequenceId = -1;
+            batchedMessageMetadataAndPayload = null;
         }
     }
 


### PR DESCRIPTION
Master Issue: #5281

### Motivation

Fix producer blocked after send an over size message while batch enabled

### Modifications

Discard the batch message container while cause PulsarClientException.InvalidMessageException

### Verifying this change

Added a unit test to verify the change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
