### PR TITLE
[pulsar-client-cpp] Fix memory leak caused by not being executed ClientConnection destructor

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -561,6 +561,7 @@ void ClientImpl::shutdown() {
         }
     }
 
+    pool_.close();
     ioExecutorProvider_->close();
     listenerExecutorProvider_->close();
     partitionListenerExecutorProvider_->close();

--- a/pulsar-client-cpp/lib/ConnectionPool.cc
+++ b/pulsar-client-cpp/lib/ConnectionPool.cc
@@ -42,7 +42,7 @@ ConnectionPool::ConnectionPool(const ClientConfiguration& conf, ExecutorServiceP
       poolConnections_(poolConnections),
       mutex_() {}
 
-ConnectionPool::~ConnectionPool() {
+void ConnectionPool::close() {
     std::unique_lock<std::mutex> lock(mutex_);
     if (poolConnections_) {
         for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -36,7 +36,7 @@ class PULSAR_PUBLIC ConnectionPool {
     ConnectionPool(const ClientConfiguration& conf, ExecutorServiceProviderPtr executorProvider,
                    const AuthenticationPtr& authentication, bool poolConnections = true);
 
-    ~ConnectionPool();
+    void close();
 
     /**
      * Get a connection from the pool.


### PR DESCRIPTION
### Motivation

Currently, closing a C++ Pulsar client object does not execute the destructor for the generated `ClientConnection` object. As a result, memory usage increases in applications that repeatedly create and close clients.

This pull-request is a continuation of #5246.

### Modifications

The reason why the `ClientConnection` destructor is not executed is that the reference count of the shared pointer does not become 0 even when the `ClientConnection` object is closed. As a result of the investigation, it was found that if the shared pointer `executor_` held by the `ClientConnection` object is reset, the reference count becomes 0 and the destructor is executed.

```diff
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1385,6 +1385,10 @@ void ClientConnection::close() {
     if (tlsSocket_) {
         tlsSocket_->lowest_layer().close();
     }
+
+    if (executor_) {
+        executor_.reset();
+    }
 }

 bool ClientConnection::isClosed() const { return state_ == Disconnected; }
```

However, with this fix alone, executing the following code causes an "Illegal instruction" error and the program crashes.
https://gist.github.com/massakam/ebd169caff3db802eee5001b0d06c980

The exact cause is unknown, but this issue doesn't seem to occur if closing `ClientConnection` before closing `ExecutorServiceProvider`. So, I changed the `ConnectionPool` destructor added in #5246 to the `close()` method and call it before closing `ExecutorServiceProvider`.