### PR TITLE
[Doc]to fix syntax err in the sample code: close producer async

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -155,10 +155,10 @@ stringProducer.send("My message");
 > Close operations can also be asynchronous:
 > ```java
 > producer.closeAsync()
->    .thenRun(() -> System.out.println("Producer closed"));
+>    .thenRun(() -> System.out.println("Producer closed"))
 >    .exceptionally((ex) -> {
 >        System.err.println("Failed to close producer: " + ex);
->        return ex;
+>        return null;
 >    });
 > ```
 


### PR DESCRIPTION
### Motivation

* to fix syntax err in the sample code: 'Close operations can also be asynchronous’, the error are as below:
  - Cannot resolve method 'exceptionally(\<lambda expression>)
  - Bad return type in lambda expression: Throwable cannot be converted to Void


### Modifications

- delete the unexpected semicolon
- adjust return clause.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
