### PR TITLE
[functions] Add log level in a property for log topic

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
@@ -46,7 +46,10 @@ public class LogAppender implements Appender {
 
     @Override
     public void append(LogEvent logEvent) {
-        producer.sendAsync(logEvent.getMessage().getFormattedMessage().getBytes());
+        producer.newMessage()
+                .value(logEvent.getMessage().getFormattedMessage().getBytes())
+                .property("loglevel", logEvent.getLevel().name())
+                .sendAsync();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

By default, in a function, the messages in the log topic only contain the raw message of the log, we loose the log level. The consumer of this topic could be interested by this information.

### Modifications

Change the LogAppender class by adding a property "loglevel" to the messages sent in the log topic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
