### PR TITLE
Revert default topic type to non-partitioned

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -89,7 +89,7 @@ ttlDurationDefaultInSeconds=0
 allowAutoTopicCreation=true
 
 # The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)
-allowAutoTopicCreationType=partitioned
+allowAutoTopicCreationType=non-partitioned
 
 # The number of partitioned topics that is allowed to be automatically created if allowAutoTopicCreationType is partitioned.
 defaultNumPartitions=1

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -905,7 +905,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_STORAGE_ML,
             doc = "The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)"
     )
-    private String allowAutoTopicCreationType = "partitioned";
+    private String allowAutoTopicCreationType = "non-partitioned";
     @FieldContext(
             category = CATEGORY_STORAGE_ML,
             doc = "The number of partitioned topics that is allowed to be automatically created"


### PR DESCRIPTION
### Motivation

The changes in #4963 did change the default topic type to be "partitioned". This is a breaking change (so far it has not been released yet). 

### Modifications

Change the default to "non-partitioned"

