### PR TITLE
[pulsar-broker] fix ns-isolation api to fetch policy for specific broker

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BrokerNamespaceIsolationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BrokerNamespaceIsolationData.java
@@ -39,6 +39,18 @@ public class BrokerNamespaceIsolationData {
     )
     public String brokerName;
     @ApiModelProperty(
+            name = "policyName",
+            value = "Policy name",
+            example = "my-policy"
+        )
+    public String policyName;
+    @ApiModelProperty(
+            name = "isPrimary",
+            value = "Is Primary broker",
+            example = "true/false"
+        )
+    public boolean isPrimary;
+    @ApiModelProperty(
         name = "namespaceRegex",
         value = "The namespace-isolation policies attached to this broker"
     )


### PR DESCRIPTION
### Motivation
Right now, 
`./pulsar-admin ns-isolation-policy broker <cluster> --broker <broker-name>` is broken because broker incorrectly validates broker:
- broker validates that given broker is part of `availableBroker` list which is unnecessary and incorrect because `availableBroker` contains `broker:port` which will always fail the validation and this command never gives any correct result.

### Modification
- remove unnecessary validation
- add more ns-isolation data into response. eg: `policyName` and `isPrimary` broker.