### PR TITLE
[pulsar-client-cpp] Fix bad_weak_ptr error when closing producer

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -120,7 +120,7 @@ class ConsumerImpl : public ConsumerImplBase,
     void handleCreateConsumer(const ClientConnectionPtr& cnx, Result result);
 
     void internalListener();
-    void handleClose(Result result, ResultCallback callback);
+    void handleClose(Result result, ResultCallback callback, ConsumerImplPtr consumer);
     virtual HandlerBaseWeakPtr get_weak_from_this() { return shared_from_this(); }
     virtual const std::string& getName() const;
     virtual int getNumOfPrefetchedMessages() const;

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -78,18 +78,16 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
         std::string logCtx = logCtxStream.str();
         msgCrypto_ = std::make_shared<MessageCrypto>(logCtx, true);
         msgCrypto_->addPublicKeyCipher(conf_.getEncryptionKeys(), conf_.getCryptoKeyReader());
-
-        dataKeyGenTImer_ = executor_->createDeadlineTimer();
-        dataKeyGenTImer_->expires_from_now(boost::posix_time::seconds(dataKeyGenIntervalSec_));
-        dataKeyGenTImer_->async_wait(
-            std::bind(&pulsar::ProducerImpl::refreshEncryptionKey, this, std::placeholders::_1));
     }
 }
 
 ProducerImpl::~ProducerImpl() {
     LOG_DEBUG(getName() << "~ProducerImpl");
-    closeAsync(ResultCallback());
+    cancelTimers();
     printStats();
+    if (state_ == Ready) {
+        LOG_WARN(getName() << "Destroyed producer which was not properly closed");
+    }
 }
 
 const std::string& ProducerImpl::getTopic() const { return topic_; }
@@ -170,6 +168,13 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         state_ = Ready;
         backoff_.reset();
         lock.unlock();
+
+        if (!dataKeyGenTImer_ && conf_.isEncryptionEnabled()) {
+            dataKeyGenTImer_ = executor_->createDeadlineTimer();
+            dataKeyGenTImer_->expires_from_now(boost::posix_time::seconds(dataKeyGenIntervalSec_));
+            dataKeyGenTImer_->async_wait(std::bind(&pulsar::ProducerImpl::refreshEncryptionKey,
+                                                   shared_from_this(), std::placeholders::_1));
+        }
 
         // Initialize the sendTimer only once per producer and only when producer timeout is
         // configured. Set the timeout as configured value and asynchronously wait for the
@@ -470,6 +475,9 @@ void ProducerImpl::printStats() {
 void ProducerImpl::closeAsync(CloseCallback callback) {
     Lock lock(mutex_);
 
+    // Keep a reference to ensure object is kept alive
+    ProducerImplPtr ptr = shared_from_this();
+
     cancelTimers();
 
     if (state_ != Ready) {
@@ -508,12 +516,13 @@ void ProducerImpl::closeAsync(CloseCallback callback) {
     Future<Result, ResponseData> future =
         cnx->sendRequestWithId(Commands::newCloseProducer(producerId_, requestId), requestId);
     if (callback) {
+        // Pass the shared pointer "ptr" to the handler to prevent the object from being destroyed
         future.addListener(
-            std::bind(&ProducerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback));
+            std::bind(&ProducerImpl::handleClose, shared_from_this(), std::placeholders::_1, callback, ptr));
     }
 }
 
-void ProducerImpl::handleClose(Result result, ResultCallback callback) {
+void ProducerImpl::handleClose(Result result, ResultCallback callback, ProducerImplPtr producer) {
     if (result == ResultOk) {
         Lock lock(mutex_);
         state_ = Closed;

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -131,7 +131,7 @@ class ProducerImpl : public HandlerBase,
 
     void statsCallBackHandler(Result, const Message&, SendCallback, boost::posix_time::ptime);
 
-    void handleClose(Result result, ResultCallback callback);
+    void handleClose(Result result, ResultCallback callback, ProducerImplPtr producer);
 
     void resendMessages(ClientConnectionPtr cnx);
 


### PR DESCRIPTION
Master Issue: #5234

### Motivation

The other day, I fixed a memory leak caused by not being executed the destructor of C++ producer in #5246. However, when running a producer application written in Go in an environment with the modified C++ client library installed, the program occasionally crashes due to a "bad_weak_ptr" error.

```
2019/10/01 16:34:30.210 c_client.go:68: [info] INFO  | ProducerImpl:481 | [persistent://massakam/global/test/t1, dc1-904-1012912] Closing producer for topic persistent://massakam/global/test/t1
2019/10/01 16:34:30.211 c_client.go:68: [info] INFO  | ProducerImpl:463 | Producer - [persistent://massakam/global/test/t1, dc1-904-1012912] , [batchMessageContainer = { BatchContainer [size = 0] [batchSizeInBytes_ = 0] [maxAllowedMessageBatchSizeInBytes_ = 131072] [maxAllowedNumMessagesInBatch_ = 1000] [topicName = persistent://massakam/global/test/t1] [producerName_ = dc1-904-1012912] [batchSizeInBytes_ = 0] [numberOfBatchesSent = 1] [averageBatchSize = 1]}]
2019/10/01 16:34:30.211 c_client.go:68: [info] INFO  | BatchMessageContainer:171 | [numberOfBatchesSent = 1] [averageBatchSize = 1]
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  2019/10/01 16:34:30.211 c_client.go:68: [info] INFO  | ProducerImpl:463 | Producer - [persistent://massakam/global/test/t1, dc1-904-1012911] , [batchMessageContainer = { BatchContainer [size = 0] [batchSizeInBytes_ = 0] [maxAllowedMessageBatchSizeInBytes_ = 131072] [maxAllowedNumMessagesInBatch_ = 1000] [topicName = persistent://massakam/global/test/t1] [producerName_ = dc1-904-1012911] [batchSizeInBytes_ = 0] [numberOfBatchesSent = 1] [averageBatchSize = 1]}]
bad_weak_ptr
2019/10/01 16:34:30.211 c_client.go:68: [info] INFO  | BatchMessageContainer:171 | [numberOfBatchesSent = 1] [averageBatchSize = 1]
2019/10/01 16:34:30.211 c_client.go:68: [info] INFO  | ProducerImpl:463 | Producer - [persistent://massakam/global/test/t1, dc1-904-1012910] , [batchMessageContainer = { BatchContainer [size = 0] [batchSizeInBytes_ = 0] [maxAllowedMessageBatchSizeInBytes_ = 131072] [maxAllowedNumMessagesInBatch_ = 1000] [topicName = persistent://massakam/global/test/t1] [producerName_ = dc1-904-1012910] [batchSizeInBytes_ = 0] [numberOfBatchesSent = 1] [averageBatchSize = 1]}]
SIGABRT: abort
PC=0x7fc78d39d2c7 m=0 sigcode=18446744073709551610
```

As a result of the investigation, I found that the destructor was called before the process of closing `ProducerImpl` was completed, and the object was destroyed.

### Modifications

To keep the `ProducerImpl` object alive, get its own shared pointer at the beginning of `ProducerImpl::closeAsync()`. And the pointer must be passed to `ProducerImpl::handleClose()`. Otherwise, the object will be destroyed before `handleClose()` is called.

So far, this issue has not been reproduced in `ConsumerImpl`, but I fixed it in the same way as `ProducerImpl`.