### PR TITLE
Fix ConsumerRedeliveryTest by ensure clean state on each run

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
+
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.testng.annotations.AfterClass;
@@ -64,14 +66,16 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
      */
     @Test
     public void testOrderedRedelivery() throws Exception {
-        String topic = "persistent://my-property/my-ns/redelivery";
+        String topic = "persistent://my-property/my-ns/redelivery-" + System.currentTimeMillis();
 
         conf.setManagedLedgerMaxEntriesPerLedger(2);
         conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
 
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic)
-                .producerName("my-producer-name");
-        Producer<byte[]> producer = producerBuilder.create();
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .producerName("my-producer-name")
+                .create();
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topic).subscriptionName("s1")
                 .subscriptionType(SubscriptionType.Shared);
         ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) consumerBuilder.subscribe();
@@ -113,6 +117,7 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
         // close consumer so, this consumer's unack messages will be redelivered to new consumer
         consumer1.close();
 
+        @Cleanup
         Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
         lastMsgId = null;
         for (int i = 0; i < totalMsgs / 2; i++) {
@@ -123,9 +128,6 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
             }
             lastMsgId = msgId;
         }
-
-        producer.close();
-        consumer2.close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The test retries are failing because the state for the prev execution lingers on.

```
2019-10-07\T\21:21:48.362 [ERROR] org.apache.pulsar.client.api.ConsumerRedeliveryTest.testOrderedRedelivery(org.apache.pulsar.client.api.ConsumerRedeliveryTest)
2019-10-07\T\21:21:48.363 [INFO]   Run 1: PASS
2019-10-07\T\21:21:48.363 [ERROR]   Run 2: ConsumerRedeliveryTest.testOrderedRedelivery:74 » ProducerBusy Producer with n...
```