### PR TITLE
Added basic metadata store API and initial ZK implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <module>distribution</module>
     <module>docker</module>
     <module>tests</module>
+    <module>pulsar-metadata</module>
   </modules>
 
   <issueManagement>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -1,0 +1,51 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pulsar</groupId>
+    <artifactId>pulsar</artifactId>
+    <version>2.5.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pulsar-metadata</artifactId>
+  <name>Pulsar Metadata</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/GetResult.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/GetResult.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import lombok.Data;
+
+/**
+ * Represent a result for a {@link MetadataStore#get(String)} operation.
+ */
+@Data
+public class GetResult {
+
+    /**
+     * The value of the key stored.
+     */
+    private final byte[] value;
+
+    /**
+     * The {@link Stat} object associated with the value.
+     */
+    private final Stat stat;
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import com.google.common.annotations.Beta;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+
+/**
+ * Metadata store client interface.
+ *
+ * NOTE: This API is still evolving and will be refactored as needed until all the metadata usages are converted into
+ * using it.
+ */
+@Beta
+public interface MetadataStore extends AutoCloseable {
+
+    /**
+     * Read the value of one key, identified by the path
+     *
+     * The async call will return a future that yields a {@link GetResult} that will contain the value and the
+     * associated {@link Stat} object.
+     *
+     * If the value is not found, the future will yield an empty {@link Optional}.
+     *
+     * @param path
+     *            the path of the key to get from the store
+     * @return a future to track the async request
+     */
+    CompletableFuture<Optional<GetResult>> get(String path);
+
+    /**
+     * Return all the nodes (lexicographically sorted) that are children to the specific path.
+     *
+     * If the path itself does not exist, it will return an empty list.
+     *
+     * @param path
+     *            webSocketProxyEnabled
+     * @return a future to track the async request
+     */
+    CompletableFuture<List<String>> getChildren(String path);
+
+    /**
+     * Read whether a specific path exists.
+     *
+     * Note: In case of keys with multiple levels (eg: '/a/b/c'), checking the existence of a parent (eg. '/a') might
+     * not necessarily return true, unless the key had been explicitly created.
+     *
+     * @param path
+     *            the path of the key to check on the store
+     * @return a future to track the async request
+     */
+    CompletableFuture<Boolean> exists(String path);
+
+    /**
+     * Put a new value for a given key.
+     *
+     * The caller can specify an expected version to be atomically checked against the current version of the stored
+     * data.
+     *
+     * The future will return the {@link Stat} object associated with the newly inserted value.
+     *
+     *
+     * @param path
+     *            the path of the key to delete from the store
+     * @param value
+     *            the value to
+     * @param expectedVersion
+     *            if present, the version will have to match with the currently stored value for the operation to
+     *            succeed. Use -1 to enforce a non-existing value.
+     * @throws BadVersionException
+     *             if the expected version doesn't match the actual version of the data
+     * @return a future to track the async request
+     */
+    CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion);
+
+    /**
+     *
+     * @param path
+     *            the path of the key to delete from the store
+     * @param expectedVersion
+     *            if present, the version will have to match with the currently stored value for the operation to
+     *            succeed
+     * @throws NotFoundException
+     *             if the path is not found
+     * @throws BadVersionException
+     *             if the expected version doesn't match the actual version of the data
+     * @return a future to track the async request
+     */
+    CompletableFuture<Void> delete(String path, Optional<Long> expectedVersion);
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * The configuration builder for a {@link MetadataStore} config.
+ */
+@Builder
+@Getter
+public class MetadataStoreConfig {
+
+    /**
+     * The (implementation specific) session timeout, in milliseconds.
+     */
+    @Builder.Default
+    private final int sessionTimeoutMillis = 30_000;
+
+    /**
+     * Whether we should allow the metadata client to operate in read-only mode, when the backend store is not writable.
+     */
+    @Builder.Default
+    private final boolean allowReadOnlyOperations = false;
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import java.io.IOException;
+
+/**
+ * Generic metadata store exception.
+ */
+public class MetadataStoreException extends IOException {
+
+    public MetadataStoreException(Throwable t) {
+        super(t);
+    }
+
+    /**
+     * Value not found in store.
+     */
+    public static class NotFoundException extends MetadataStoreException {
+        public NotFoundException(Throwable t) {
+            super(t);
+        }
+    }
+
+    /**
+     * Unsuccessful update due to mismatched expected version.
+     */
+    public static class BadVersionException extends MetadataStoreException {
+        public BadVersionException(Throwable t) {
+            super(t);
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import java.io.IOException;
+
+import lombok.experimental.UtilityClass;
+
+import org.apache.pulsar.metadata.impl.zookeeper.ZKMetadataStore;
+
+/**
+ * Factory class for {@link MetadataStore}.
+ */
+@UtilityClass
+public class MetadataStoreFactory {
+    /**
+     * Create a new {@link MetadataStore} instance based on the given configuration.
+     *
+     * @param metadataURL
+     *            the metadataStore URL
+     * @param metadataStoreConfig
+     *            the configuration object
+     * @return a new {@link MetadataStore} instance
+     * @throws IOException
+     *             if the metadata store initialization fails
+     */
+    public static MetadataStore create(String metadataURL, MetadataStoreConfig metadataStoreConfig) throws IOException {
+        return new ZKMetadataStore(metadataURL, metadataStoreConfig);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import lombok.Data;
+
+/**
+ * Represent the information associated with a given value in the store.
+ */
+@Data
+public class Stat {
+    /**
+     * The data version.
+     */
+    final long version;
+
+    /**
+     * When the value was first inserted.
+     */
+    final long creationTimestamp;
+
+    /**
+     * When the value was last modified.
+     */
+    final long modificationTimestamp;
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/zookeeper/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/zookeeper/ZKMetadataStore.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl.zookeeper;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
+import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.Stat;
+import org.apache.zookeeper.AsyncCallback.StatCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+
+public class ZKMetadataStore implements MetadataStore {
+
+    private final ZooKeeper zkc;
+
+    public ZKMetadataStore(String metadataURL, MetadataStoreConfig metadataStoreConfig) throws IOException {
+        try {
+            zkc = ZooKeeperClient.newBuilder()
+                    .connectString(metadataURL)
+                    .connectRetryPolicy(new BoundExponentialBackoffRetryPolicy(100, 60_000, Integer.MAX_VALUE))
+                    .allowReadOnlyMode(metadataStoreConfig.isAllowReadOnlyOperations())
+                    .sessionTimeoutMs(metadataStoreConfig.getSessionTimeoutMillis())
+                    .build();
+        } catch (KeeperException | InterruptedException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @VisibleForTesting
+    public ZKMetadataStore(ZooKeeper zkc) {
+        this.zkc = zkc;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> get(String path) {
+        CompletableFuture<Optional<GetResult>> future = new CompletableFuture<>();
+
+        try {
+            zkc.getData(path, null, (rc, path1, ctx, data, stat) -> {
+                Code code = Code.get(rc);
+                if (code == Code.OK) {
+                    future.complete(Optional.of(new GetResult(data, getStat(stat))));
+                } else if (code == Code.NONODE) {
+                    future.complete(Optional.empty());
+                } else {
+                    future.completeExceptionally(getException(code, path));
+                }
+            }, null);
+        } catch (Throwable t) {
+            future.completeExceptionally(new MetadataStoreException(t));
+        }
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getChildren(String path) {
+        CompletableFuture<List<String>> future = new CompletableFuture<>();
+
+        try {
+            zkc.getChildren(path, null, (rc, path1, ctx, children) -> {
+                Code code = Code.get(rc);
+                if (code == Code.OK) {
+                    Collections.sort(children);
+                    future.complete(children);
+                } else if (code == Code.NONODE) {
+                    // The node we want may not exist yet, so put a watcher on its existence
+                    // before throwing up the exception. Its possible that the node could have
+                    // been created after the call to getChildren, but before the call to exists().
+                    // If this is the case, exists will return true, and we just call getChildren again.
+                    exists(path).thenAccept(exists -> {
+                        if (exists) {
+                            getChildren(path)
+                                    .thenAccept(c -> future.complete(c))
+                                    .exceptionally(ex -> {
+                                        future.completeExceptionally(ex);
+                                        return null;
+                                    });
+                        } else {
+                            // Z-node does not exist
+                            future.complete(Collections.emptyList());
+                        }
+                    }).exceptionally(ex -> {
+                        future.completeExceptionally(ex);
+                        return null;
+                    });
+
+                    future.complete(Collections.emptyList());
+                } else {
+                    future.completeExceptionally(getException(code, path));
+                }
+            }, null);
+        } catch (Throwable t) {
+            future.completeExceptionally(new MetadataStoreException(t));
+        }
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(String path) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        try {
+            zkc.exists(path, null, (StatCallback) (rc, path1, ctx, stat) -> {
+                Code code = Code.get(rc);
+                if (code == Code.OK) {
+                    future.complete(true);
+                } else if (code == Code.NONODE) {
+                    future.complete(false);
+                } else {
+                    future.completeExceptionally(getException(code, path));
+                }
+            }, future);
+        } catch (Throwable t) {
+            future.completeExceptionally(new MetadataStoreException(t));
+        }
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> optExpectedVersion) {
+        boolean hasVersion = optExpectedVersion.isPresent();
+        int expectedVersion = optExpectedVersion.orElse(-1L).intValue();
+
+        CompletableFuture<Stat> future = new CompletableFuture<>();
+
+        try {
+            if (hasVersion && expectedVersion == -1) {
+                ZkUtils.asyncCreateFullPathOptimistic(zkc, path, value, ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT,
+                        (rc, path1, ctx, name) -> {
+                            Code code = Code.get(rc);
+                            if (code == Code.OK) {
+                                future.complete(new Stat(0, 0, 0));
+                            } else if (code == Code.NODEEXISTS) {
+                                // We're emulating a request to create node, so the version is invalid
+                                future.completeExceptionally(getException(Code.BADVERSION, path));
+                            } else {
+                                future.completeExceptionally(getException(code, path));
+                            }
+                        }, null);
+            } else {
+                zkc.setData(path, value, expectedVersion, (rc, path1, ctx, stat) -> {
+                    Code code = Code.get(rc);
+                    if (code == Code.OK) {
+                        future.complete(getStat(stat));
+                    } else if (code == Code.NONODE) {
+                        if (hasVersion) {
+                            // We're emulating here a request to update or create the znode, depending on the version
+                            future.completeExceptionally(getException(Code.BADVERSION, path));
+                        } else {
+                            // The z-node does not exist, let's create it first
+                            put(path, value, Optional.of(-1L))
+                                    .thenAccept(s -> future.complete(s))
+                                    .exceptionally(ex -> {
+                                        future.completeExceptionally(ex.getCause());
+                                        return null;
+                                    });
+                        }
+                    } else {
+                        future.completeExceptionally(getException(code, path));
+                    }
+                }, null);
+            }
+        } catch (Throwable t) {
+            future.completeExceptionally(new MetadataStoreException(t));
+        }
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String path, Optional<Long> optExpectedVersion) {
+        int expectedVersion = optExpectedVersion.orElse(-1L).intValue();
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        try {
+            zkc.delete(path, expectedVersion, (rc, path1, ctx) -> {
+                Code code = Code.get(rc);
+                if (code == Code.OK) {
+                    future.complete(null);
+                } else {
+                    future.completeExceptionally(getException(code, path));
+                }
+            }, null);
+        } catch (Throwable t) {
+            future.completeExceptionally(new MetadataStoreException(t));
+        }
+
+        return future;
+    }
+
+    @Override
+    public void close() throws Exception {
+        zkc.close();
+    }
+
+    private static Stat getStat(org.apache.zookeeper.data.Stat zkStat) {
+        return new Stat(zkStat.getVersion(), zkStat.getCtime(), zkStat.getMtime());
+    }
+
+    private static MetadataStoreException getException(Code code, String path) {
+        KeeperException ex = KeeperException.create(code, path);
+
+        switch (code) {
+        case BADVERSION:
+            return new BadVersionException(ex);
+        case NONODE:
+            return new NotFoundException(ex);
+        default:
+            return new MetadataStoreException(ex);
+        }
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -1,0 +1,250 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+
+import lombok.Cleanup;
+
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class MetadataStoreTest {
+
+    private TestZKServer zks;
+
+    @BeforeClass
+    void setup() throws Exception {
+        zks = new TestZKServer();
+    }
+
+    @AfterClass
+    void teardown() throws Exception {
+        zks.close();
+    }
+
+    @DataProvider(name = "impl")
+    public Object[][] implementations() {
+        return new Object[][] {
+                { "ZooKeeper", zks.getConnectionString() },
+        };
+    }
+
+    @Test(dataProvider = "impl")
+    public void emptyStoreTest(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        assertFalse(store.exists("/non-existing-key").join());
+        assertFalse(store.exists("/non-existing-key/child").join());
+        assertFalse(store.get("/non-existing-key").join().isPresent());
+        assertFalse(store.get("/non-existing-key/child").join().isPresent());
+
+        assertEquals(store.getChildren("/non-existing-key").join(), Collections.emptyList());
+        assertEquals(store.getChildren("/non-existing-key/child").join(), Collections.emptyList());
+
+        try {
+            store.delete("/non-existing-key", Optional.empty()).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+
+        try {
+            store.delete("/non-existing-key", Optional.of(1L)).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void insertionTestWithExpectedVersion(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        String key1 = newKey();
+
+        try {
+            store.put(key1, "value-1".getBytes(), Optional.of(0L)).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), BadVersionException.class);
+        }
+
+        try {
+            store.put(key1, "value-1".getBytes(), Optional.of(1L)).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), BadVersionException.class);
+        }
+
+        store.put(key1, "value-1".getBytes(), Optional.of(-1L)).join();
+
+        assertTrue(store.exists(key1).join());
+        Optional<GetResult> optRes = store.get(key1).join();
+        assertTrue(optRes.isPresent());
+        assertEquals(optRes.get().getValue(), "value-1".getBytes());
+        assertEquals(optRes.get().getStat().getVersion(), 0);
+
+        try {
+            store.put(key1, "value-2".getBytes(), Optional.of(-1L)).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), BadVersionException.class);
+        }
+
+        try {
+            store.put(key1, "value-2".getBytes(), Optional.of(1L)).join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), BadVersionException.class);
+        }
+
+        store.put(key1, "value-2".getBytes(), Optional.of(0L)).join();
+
+        assertTrue(store.exists(key1).join());
+        optRes = store.get(key1).join();
+        assertTrue(optRes.isPresent());
+        assertEquals(optRes.get().getValue(), "value-2".getBytes());
+        assertEquals(optRes.get().getStat().getVersion(), 1);
+    }
+
+    @Test(dataProvider = "impl")
+    public void getChildrenTest(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        String key = newKey();
+        int N = 10;
+        List<String> expectedChildren = new ArrayList<>();
+
+        for (int i = 0; i < N; i++) {
+            store.put(key + "/c-" + i, new byte[0], Optional.empty()).join();
+
+            expectedChildren.add("c-" + i);
+        }
+
+        assertEquals(store.getChildren(key).join(), expectedChildren);
+
+        // Nested children
+        for (int i = 0; i < N; i++) {
+            store.put(key + "/c-0/cc-" + i, new byte[0], Optional.empty()).join();
+        }
+
+        assertEquals(store.getChildren(key).join(), expectedChildren);
+    }
+
+    @Test(dataProvider = "impl")
+    public void deletionTest(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        String key = newKey();
+        int N = 10;
+        List<String> expectedChildren = new ArrayList<>();
+
+        for (int i = 0; i < N; i++) {
+            store.put(key + "/c-" + i, new byte[0], Optional.empty()).join();
+
+            expectedChildren.add("c-" + i);
+        }
+
+        try {
+            store.delete(key, Optional.empty()).join();
+            fail("The key has children");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+
+        for (int i = 0; i < N; i++) {
+            try {
+                store.delete(key + "/c-" + i, Optional.of(1L)).join();
+                fail("The key has children");
+            } catch (CompletionException e) {
+                assertEquals(e.getCause().getClass(), BadVersionException.class);
+            }
+
+            store.delete(key + "/c-" + i, Optional.empty()).join();
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void emptyKeyTest(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        try {
+            store.delete("", Optional.empty()).join();
+            fail("The key cannot be empty");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+
+        try {
+            store.getChildren("").join();
+            fail("The key cannot be empty");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+
+        try {
+            store.get("").join();
+            fail("The key cannot be empty");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+
+        try {
+            store.exists("").join();
+            fail("The key cannot be empty");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+
+        try {
+            store.put("", new byte[0], Optional.empty()).join();
+            fail("The key cannot be empty");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), MetadataStoreException.class);
+        }
+    }
+
+    private static String newKey() {
+        return "/key-" + System.nanoTime();
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.assertj.core.util.Files;
+
+@Slf4j
+public class TestZKServer implements AutoCloseable {
+
+    private final ZooKeeperServer zks;
+    private final File zkDataDir;
+    private final ServerCnxnFactory serverFactory;
+
+    public TestZKServer() throws Exception {
+        this.zkDataDir = Files.newTemporaryFolder();
+        this.zkDataDir.deleteOnExit();
+        this.zks = new ZooKeeperServer(zkDataDir, zkDataDir, ZooKeeperServer.DEFAULT_TICK_TIME);
+        this.serverFactory = new NIOServerCnxnFactory();
+        this.serverFactory.configure(new InetSocketAddress(0), 1000);
+        this.serverFactory.startup(zks);
+
+        log.info("Started test ZK server on port {}", getPort());
+
+        boolean zkServerReady = waitForServerUp(this.getConnectionString(), 30_000);
+        assertTrue(zkServerReady);
+    }
+
+    @Override
+    public void close() throws Exception {
+        zks.shutdown();
+        serverFactory.shutdown();
+        FileUtils.deleteDirectory(zkDataDir);
+
+        log.info("Stopped test ZK server");
+    }
+
+    public int getPort() {
+        return serverFactory.getLocalPort();
+    }
+
+    public String getConnectionString() {
+        return "127.0.0.1:" + getPort();
+    }
+
+    public static boolean waitForServerUp(String hp, long timeout) {
+        long start = System.currentTimeMillis();
+        String split[] = hp.split(":");
+        String host = split[0];
+        int port = Integer.parseInt(split[1]);
+        while (true) {
+            try {
+                Socket sock = new Socket(host, port);
+                BufferedReader reader = null;
+                try {
+                    OutputStream outstream = sock.getOutputStream();
+                    outstream.write("stat".getBytes());
+                    outstream.flush();
+
+                    reader = new BufferedReader(new InputStreamReader(sock.getInputStream()));
+                    String line = reader.readLine();
+                    if (line != null && line.startsWith("Zookeeper version:")) {
+                        log.info("ZK Server UP");
+                        return true;
+                    }
+                } finally {
+                    sock.close();
+                    if (reader != null) {
+                        reader.close();
+                    }
+                }
+            } catch (IOException e) {
+                // ignore as this is expected
+                log.info("ZK server {} not up: {}", hp, e.getMessage());
+            }
+
+            if (System.currentTimeMillis() > start + timeout) {
+                break;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
### Motivation

This PR is the first in a series of changes. The ultimate goal is to have all the metadata accesses to ZooKeeper to be routed through a single interface with a pluggable implementation.

This PR defines the first cut of the `MetadataStore` interface, along with the ZK implementation.

Subsequent PRs will start converting metadata accesses.