### PR TITLE
Avoid rethrowing exception during test teardown

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -174,7 +174,6 @@ public abstract class MockedPulsarServiceBaseTest {
             }
         } catch (Exception e) {
             log.warn("Failed to clean up mocked pulsar service:", e);
-            throw e;
         }
     }
 
@@ -304,6 +303,6 @@ public abstract class MockedPulsarServiceBaseTest {
         field.setAccessible(true);
         field.set(classObj, fieldValue);
     }
-    
+
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -74,10 +74,10 @@ public abstract class MockedPulsarServiceBaseTest {
 
     protected URI lookupUrl;
 
-    protected final int BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
-    protected final int BROKER_WEBSERVICE_PORT_TLS = PortManager.nextFreePort();
-    protected final int BROKER_PORT = PortManager.nextFreePort();
-    protected final int BROKER_PORT_TLS = PortManager.nextFreePort();
+    protected int BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
+    protected int BROKER_WEBSERVICE_PORT_TLS = PortManager.nextFreePort();
+    protected int BROKER_PORT = PortManager.nextFreePort();
+    protected int BROKER_PORT_TLS = PortManager.nextFreePort();
 
     protected MockZooKeeper mockZookKeeper;
     protected NonClosableMockBookKeeper mockBookKeeper;
@@ -92,6 +92,11 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected void resetConfig() {
+        BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
+        BROKER_WEBSERVICE_PORT_TLS = PortManager.nextFreePort();
+        BROKER_PORT = PortManager.nextFreePort();
+        BROKER_PORT_TLS = PortManager.nextFreePort();
+
         this.conf = new ServiceConfiguration();
         this.conf.setAdvertisedAddress("localhost");
         this.conf.setBrokerServicePort(Optional.ofNullable(BROKER_PORT));
@@ -108,6 +113,7 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected final void internalSetup() throws Exception {
+        resetConfig();
         init();
         lookupUrl = new URI(brokerUrl.toString());
         if (isTcpLookup) {
@@ -121,6 +127,7 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected final void internalSetupForStatsTest() throws Exception {
+        resetConfig();
         init();
         String lookupUrl = brokerUrl.toString();
         if (isTcpLookup) {


### PR DESCRIPTION
### Motivation

In several cases, the test get stuck on the broker teardown. Do not re-throw the exception here, since the test logic itself was already successful.


```
20:18:36.507 [main:org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest@176] WARN  org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest - Failed to clean up mocked pulsar service:
org.apache.pulsar.broker.PulsarServerException: org.apache.pulsar.broker.PulsarServerException: java.util.concurrent.TimeoutException
	at org.apache.pulsar.broker.PulsarService.close(PulsarService.java:319) ~[classes/:?]
	at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.internalCleanup(MockedPulsarServiceBaseTest.java:161) [test-classes/:?]
	at org.apache.pulsar.broker.admin.NamespacesTest.cleanup(NamespacesTest.java:173) [test-classes/:?]
```