### PR TITLE
Do not use timed receive in BrokerClientIntegrationTest.testUnsupportedBatchMessageConsumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -384,7 +384,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
 
         messageSet.clear();
         for (int i = 0; i < numMessagesPerBatch; i++) {
-            msg = consumer2.receive(1, TimeUnit.SECONDS);
+            msg = consumer2.receive();
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
             String expectedMessage = "my-batch-message-" + i;


### PR DESCRIPTION
### Motivation

The test is failing because the `receive(1, TimeUnit.SECONDS)` takes more than 1 sec to receive a message.

Also, removing all explicit test timeouts, since we already have a default timeout.

```
Stacktrace
java.lang.NullPointerException
	at org.apache.pulsar.client.impl.BrokerClientIntegrationTest.testUnsupportedBatchMessageConsumer(BrokerClientIntegrationTest.java:383)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```