### PR TITLE
When building docker image, copy tarball at the end to use build cache

### DIFF
--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -26,9 +26,6 @@ FROM apachepulsar/pulsar-dashboard:latest as dashboard
 # Restart from
 FROM openjdk:8-jdk
 
-# Copy pulsar files from pulsar-all
-COPY --from=pulsar /pulsar /pulsar
-
 # Copy dashboard files from pulsar-dashboard
 COPY --from=dashboard /pulsar/django /pulsar/django
 COPY --from=dashboard /pulsar/requirements.txt /pulsar/django
@@ -58,6 +55,9 @@ redirect_stderr=true" >> /etc/supervisor/conf.d/supervisor-app.conf
 # Configure nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 COPY --from=dashboard /etc/nginx/sites-available/default /etc/nginx/sites-available/default
+
+# Copy pulsar files from pulsar-all
+COPY --from=pulsar /pulsar /pulsar
 
 # Copy web-app sources
 # Setup database and create tables

--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -26,11 +26,6 @@ FROM apachepulsar/pulsar-dashboard:latest as dashboard
 # Restart from
 FROM openjdk:8-jdk
 
-# Copy dashboard files from pulsar-dashboard
-COPY --from=dashboard /pulsar/django /pulsar/django
-COPY --from=dashboard /pulsar/requirements.txt /pulsar/django
-COPY --from=dashboard /pulsar/conf/* /pulsar/conf/
-
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update
@@ -58,6 +53,14 @@ COPY --from=dashboard /etc/nginx/sites-available/default /etc/nginx/sites-availa
 
 # Copy pulsar files from pulsar-all
 COPY --from=pulsar /pulsar /pulsar
+
+# Copy web-app sources
+COPY . /pulsar/
+
+# Copy dashboard files from pulsar-dashboard
+COPY --from=dashboard /pulsar/django /pulsar/django
+COPY --from=dashboard /pulsar/requirements.txt /pulsar/django
+COPY --from=dashboard /pulsar/conf/* /pulsar/conf/
 
 # Copy web-app sources
 # Setup database and create tables

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -39,7 +39,6 @@ COPY scripts/install-pulsar-client-37.sh /pulsar/bin
 ### and add Python dependencies (for Pulsar functions)
 
 FROM openjdk:8-jdk-slim
-COPY --from=pulsar /pulsar /pulsar
 
 # Install some utilities
 RUN apt-get update \
@@ -65,8 +64,11 @@ RUN apt-get update \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /pulsar
-
 VOLUME  ["/pulsar/conf", "/pulsar/data"]
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
+
+
+COPY --from=pulsar /pulsar /pulsar
+WORKDIR /pulsar
+

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -56,8 +56,6 @@ RUN python3.7 get-pip.py
 
 ADD target/python-client/ /pulsar/pulsar-client
 ADD target/cpp-client/ /pulsar/cpp-client
-RUN /pulsar/bin/install-pulsar-client-27.sh
-RUN /pulsar/bin/install-pulsar-client-37.sh
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/jre/lib/security/java.security
 RUN apt-get update \
      && apt install -y /pulsar/cpp-client/*.deb \
@@ -71,4 +69,7 @@ ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 
 COPY --from=pulsar /pulsar /pulsar
 WORKDIR /pulsar
+
+RUN /pulsar/bin/install-pulsar-client-27.sh
+RUN /pulsar/bin/install-pulsar-client-37.sh
 


### PR DESCRIPTION
### Motivation

Since the Pulsar tarball is the only part that keeps changing, we should copy it at the very end so that the rest of the build steps can be cached.