### PR TITLE
[Docs] Add putstate, set-replicator-dispatch-rate and get-replicator-dispatch-rate cli docs for pulsar admin

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -391,6 +391,7 @@ Subcommands
 * `stats`
 * `list`
 * `querystate`
+* `putstate`
 * `trigger`
 
 
@@ -696,6 +697,23 @@ Options
 |`--tenant`|The function's tenant||
 |`-w`, `--watch`|Watch for changes in the value associated with a key for a Pulsar Function|false|
 
+### `putstate`
+Put a key/value pair to the state associated with a Pulsar Function
+
+Usage
+```bash
+$ pulsar-admin functions putstate options
+```
+
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+|`--fqfn`|The Fully Qualified Function Name (FQFN) for the Pulsar Function||
+|`--name`|The name of a Pulsar Function||
+|`--namespace`|The namespace of a Pulsar Function||
+|`--tenant`|The tenant of a Pulsar Function||
+|`-s`, `--state`|The FunctionState that needs to be put||
 
 ### `trigger`
 Triggers the specified Pulsar Function with a supplied value

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -775,6 +775,8 @@ Subcommands
 * `split-bundle`
 * `set-dispatch-rate`
 * `get-dispatch-rate`
+* `set-replicator-dispatch-rate`
+* `get-replicator-dispatch-rate`
 * `set-subscribe-rate`
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
@@ -1146,6 +1148,29 @@ Get configured message-dispatch-rate for all topics of the namespace (Disabled i
 Usage
 ```bash
 $ pulsar-admin namespaces get-dispatch-rate tenant/namespace
+```
+
+### set-replicator-dispatch-rate
+Set replicator message-dispatch-rate for all topics of the namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-replicator-dispatch-rate tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-bd`, `--byte-dispatch-rate`|The byte dispatch rate (default -1 will be overwrite if not passed)|-1|
+|`-dt`, `--dispatch-rate-period`|The dispatch rate period in second type (default 1 second will be overwrite if not passed)|1|
+|`-md`, `--msg-dispatch-rate`|The message dispatch rate (default -1 will be overwrite if not passed)|-1|
+
+### get-replicator-dispatch-rate
+Get replicator configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)
+
+Usage
+```bash
+$ pulsar-admin namespaces get-replicator-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscribe-rate`


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

In [pulsar-admin](https://pulsar.apache.org/docs/en/pulsar-admin), we have not listed the document information related to the `putstate`, `set-replicator-dispatch-rate` and `get-replicator-dispatch-rate`command.

### Modifications

*Describe the modifications you've done.*

Add `putstate` command for **pulsar-admin functions**.
Add `set-replicator-dispatch-rate` command for **pulsar-admin namespaces**.
Add `get-replicator-dispatch-rate` command for **pulsar-admin namespaces**.