### PR TITLE
Not allow use acknowledgeCumulative on Key_shared subscription.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
@@ -315,9 +316,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             if (i == 9) {
                 try {
                     consumer.acknowledgeCumulative(message);
-                } catch (PulsarClientException e) {
-                    assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
-                }
+                    fail("should have failed");
+                } catch (PulsarClientException.InvalidConfigurationException ignore) {}
             }
         }
     }

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -78,6 +78,8 @@ enum Result
     ResultIncompatibleSchema,   /// Specified schema is incompatible with the topic's schema
     ResultConsumerAssignError,  /// Error when a new consumer connected but can't assign messages to this
                                 /// consumer
+    ResultCumulativeAcknowledgementNotAllowedError,  /// Not allowed to call cumulativeAcknowledgement in
+                                                     /// Shared and Key_Shared subscription mode
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -95,6 +95,7 @@ class ConsumerImpl : public ConsumerImplBase,
     virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback);
 
     virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback);
+    virtual bool isCumulativeAcknowledgementAllowed(ConsumerType consumerType);
 
     virtual void redeliverMessages(const std::set<MessageId>& messageIds);
     virtual void negativeAcknowledge(const MessageId& msgId);

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -135,6 +135,9 @@ const char* pulsar::strResult(Result result) {
 
         case ResultConsumerAssignError:
             return "ResultConsumerAssignError";
+
+        case ResultCumulativeAcknowledgementNotAllowedError:
+            return "ResultCumulativeAcknowledgementNotAllowedError";
     };
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -3047,3 +3047,58 @@ TEST(BasicEndToEndTest, testPartitionedTopicWithOnePartition) {
     ASSERT_EQ(ResultTimeout, res);
     client.shutdown();
 }
+
+TEST(BasicEndToEndTest, testCumulativeAcknowledgeNotAllowed) {
+    ClientConfiguration config;
+    Client client(lookupUrl);
+    std::string topicName = "testCumulativeAcknowledgeNotAllowed";
+    std::string subsName = topicName + "-sub-";
+
+    Consumer consumer1;
+    ConsumerConfiguration consumerConfiguration1;
+    consumerConfiguration1.setConsumerType(ConsumerShared);
+
+    Result result = client.subscribe(topicName, subsName + "1", consumerConfiguration1, consumer1);
+    ASSERT_EQ(ResultOk, result);
+
+    Consumer consumer2;
+    ConsumerConfiguration consumerConfiguration2;
+    consumerConfiguration2.setConsumerType(ConsumerKeyShared);
+
+    result = client.subscribe(topicName, subsName + "2", consumerConfiguration2, consumer2);
+    ASSERT_EQ(ResultOk, result);
+
+    Producer producer;
+    result = client.createProducer(topicName, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    // publish messages
+    int numMessages = 10;
+    for (int i = 0; i < numMessages; i++) {
+        Message msg = MessageBuilder().setContent("test-producer-" + topicName + std::to_string(i)).build();
+        producer.send(msg);
+    }
+
+    // test cannot use acknowledgeCumulative on Shared subscription
+    for (int i = 0; i < numMessages; i++) {
+        Message msg;
+        Result res = consumer1.receive(msg, 100);
+        ASSERT_EQ(ResultOk, res);
+        if (i == 9) {
+            res = consumer1.acknowledgeCumulative(msg);
+            ASSERT_EQ(ResultCumulativeAcknowledgementNotAllowedError, res);
+        }
+    }
+
+    // test cannot use acknowledgeCumulative on Key_Shared subscription
+    for (int i = 0; i < numMessages; i++) {
+        Message msg;
+        Result res = consumer2.receive(msg, 100);
+        ASSERT_EQ(ResultOk, res);
+        if (i == 9) {
+            res = consumer2.acknowledgeCumulative(msg);
+            ASSERT_EQ(ResultCumulativeAcknowledgementNotAllowedError, res);
+        }
+    }
+    client.shutdown();
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -251,7 +251,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     public CompletableFuture<Void> acknowledgeCumulativeAsync(MessageId messageId, Transaction txn) {
         if (!isCumulativeAcknowledgementAllowed(conf.getSubscriptionType())) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidConfigurationException(
-                    "Cannot use cumulative acks on a non-exclusive subscription"));
+                    "Cannot use cumulative acks on a non-exclusive/non-failover subscription"));
         }
 
         TransactionImpl txnImpl = null;
@@ -325,7 +325,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     public abstract CompletableFuture<MessageId> getLastMessageIdAsync();
 
     private boolean isCumulativeAcknowledgementAllowed(SubscriptionType type) {
-        return SubscriptionType.Shared != type;
+        return SubscriptionType.Shared != type && SubscriptionType.Key_Shared != type;
     }
 
     protected SubType getSubType() {


### PR DESCRIPTION
### Motivation

Key_Shared subscription is a enhancement of shared subscription, we should avoid use acknowledgeCumulative on Key_shared subscription

### Modifications

Add allow acknowledgeCumulative check for Key_shared subscription

### Verifying this change

Add new unit test.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: ( no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
