### PR TITLE
[pulsar-broker] retrieve stats for all persistent topics in a single call

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -446,7 +446,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Failed to validate global cluster configuration") })
-    public List<TopicStats> getStats(
+    public List<TopicStats> getAllTopicStats(
             @ApiParam(value = "Specify the tenant", required = true)
             @PathParam("tenant") String tenant,
             @ApiParam(value = "Specify the namespace", required = true)

--- a/site2/website/static/swagger/2.4.1/swagger.json
+++ b/site2/website/static/swagger/2.4.1/swagger.json
@@ -6729,6 +6729,55 @@
         }
       }
     },
+    "/persistent/{tenant}/{namespace}/topics/stats" : {
+      "get" : {
+        "tags" : [ "persistent topic" ],
+        "summary" : "Get the stats for all the topic.",
+        "description" : "",
+        "operationId" : "getallTopicStats",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "description" : "Specify the tenant",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Specify the namespace",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "authoritative",
+          "in" : "query",
+          "description" : "Is authentication required to perform this operation",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TopicStats"
+            }
+          },
+          "401" : {
+            "description" : "Don't have permission to administrate resources on this tenant"
+          },
+          "403" : {
+            "description" : "Don't have admin permission"
+          },
+          "500" : {
+            "description" : "Internal server error"
+          },
+          "503" : {
+            "description" : "Failed to validate global cluster configuration"
+          }
+        }
+      }
+    },
     "/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}" : {
       "delete" : {
         "tags" : [ "persistent topic" ],


### PR DESCRIPTION
### Motivation
Currently users are required to make multiple calls to retrieve individual stats of all persistent topics.

### Modifications

1. Get a complete list of all persistent topics
2. Iterate through the list to get topic's stats based on its topic reference.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

This change is based on all existing functionalities provided by PersistentTopic and its base class.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (yes)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
