### PR TITLE
Avoid exiting on OOM in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1141,6 +1141,7 @@ flexible messaging model and an intuitive client API.</description>
           <argLine> -Xmx2G
             -Dpulsar.allocator.pooled=false
             -Dpulsar.allocator.leak_detection=Advanced
+            -Dpulsar.allocator.exit_on_oom=false
             -Dlog4j.configurationFile=log4j2.xml
           </argLine>
           <reuseForks>false</reuseForks>


### PR DESCRIPTION
### Motivation

There are several unit tests run that are failing because the JVM suddenly exists.

```
2019-10-08\T\02:16:12.005 [ERROR] Error occurred in starting fork, check output in log
2019-10-08\T\02:16:12.006 [ERROR] Process Exit Code: 255
2019-10-08\T\02:16:12.006 [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```

One possible reason for that could be that we're exiting through the `OutOfMemory` exception handler. 

### Modifications

Do not exit when OOM is triggered in the tests, so that we can actually see the (eventual) exception. 