### PR TITLE
[TIEREDSTORAGE] Don't require both region and endpoint to be specified

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1630,6 +1630,7 @@ public class PersistentTopicsBase extends AdminResource {
         } catch (AlreadyRunningException e) {
             throw new RestException(Status.CONFLICT, e.getMessage());
         } catch (Exception e) {
+            log.warn("Unexpected error triggering offload", e);
             throw new RestException(e);
         }
     }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -382,8 +382,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
     public Map<String, String> getOffloadDriverMetadata() {
         return ImmutableMap.of(
             METADATA_FIELD_BUCKET, writeBucket,
-            METADATA_FIELD_REGION, writeRegion,
-            METADATA_FIELD_ENDPOINT, writeEndpoint
+            METADATA_FIELD_REGION, Strings.nullToEmpty(writeRegion),
+            METADATA_FIELD_ENDPOINT, Strings.nullToEmpty(writeEndpoint)
         );
     }
 


### PR DESCRIPTION
There's a bug in how user metadata is attached to a block that if the
user doesn't specify both the region and the endpoint, offloading will
throw an exception, as you can't add a null value to an immutable
map.

This change elides null to the empty string in these cases, so that
offloading can continue.
