### PR TITLE
[Issue 5380][deployment]Fixing pod anti-affinity rules in Kubernetes files including Helm chart

### DIFF
--- a/deployment/kubernetes/aws/zookeeper.yaml
+++ b/deployment/kubernetes/aws/zookeeper.yaml
@@ -75,6 +75,10 @@ spec:
                                   - key: "app"
                                     operator: In
                                     values:
+                                      - pulsar
+                                  - key: "component"
+                                    operator: In
+                                    values:
                                       - zookeeper
                             topologyKey: "kubernetes.io/hostname"
             containers:

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
@@ -101,6 +101,10 @@ spec:
                                   - key: "app"
                                     operator: In
                                     values:
+                                      - pulsar
+                                  - key: "component"
+                                    operator: In
+                                    values:
                                       - zookeeper
                             topologyKey: "kubernetes.io/hostname"
             containers:

--- a/deployment/kubernetes/generic/original/zookeeper.yaml
+++ b/deployment/kubernetes/generic/original/zookeeper.yaml
@@ -75,6 +75,10 @@ spec:
                                   - key: "app"
                                     operator: In
                                     values:
+                                      - pulsar
+                                  - key: "component"
+                                    operator: In
+                                    values:
                                       - zookeeper
                             topologyKey: "kubernetes.io/hostname"
             containers:

--- a/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
@@ -84,6 +84,10 @@ spec:
                     - key: "app"
                       operator: In
                       values:
+                        - pulsar
+                    - key: "component"
+                      operator: In
+                      values:
                         - bookkeeper
       initContainers:
         - name: bookie-metaformat

--- a/deployment/kubernetes/google-kubernetes-engine/zookeeper.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/zookeeper.yaml
@@ -86,6 +86,10 @@ spec:
                                   - key: "app"
                                     operator: In
                                     values:
+                                      - pulsar
+                                  - key: "component"
+                                    operator: In
+                                    values:
                                       - zookeeper
                             topologyKey: "kubernetes.io/hostname"
             containers:

--- a/deployment/kubernetes/helm/pulsar/templates/autorecovery-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/autorecovery-deployment.yaml
@@ -63,7 +63,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - "{{ template "pulsar.name" . }}-{{ .Values.bookkeeper.component }}"
+                - "{{ template "pulsar.name" . }}"
               - key: "release"
                 operator: In
                 values:

--- a/deployment/kubernetes/helm/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/bookkeeper-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - "{{ template "pulsar.name" . }}-{{ .Values.bookkeeper.component }}"
+                - "{{ template "pulsar.name" . }}"
               - key: "release"
                 operator: In
                 values:

--- a/deployment/kubernetes/helm/pulsar/templates/broker-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/broker-deployment.yaml
@@ -62,7 +62,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - "{{ template "pulsar.name" . }}-{{ .Values.broker.component }}"
+                - "{{ template "pulsar.name" . }}"
               - key: "release"
                 operator: In
                 values:

--- a/deployment/kubernetes/helm/pulsar/templates/proxy-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/proxy-deployment.yaml
@@ -63,7 +63,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - "{{ template "pulsar.name" . }}-{{ .Values.proxy.component }}"
+                - "{{ template "pulsar.name" . }}"
               - key: "release"
                 operator: In
                 values:

--- a/deployment/kubernetes/helm/pulsar/templates/zookeeper-statefulset.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/zookeeper-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - "{{ template "pulsar.name" . }}-{{ .Values.zookeeper.component }}"
+                - "{{ template "pulsar.name" . }}"
               - key: "release"
                 operator: In
                 values:


### PR DESCRIPTION
This PR fixes issue #5380.

I didn't run tests because I am only changing the deployment example files. I have been running with the Helm chart changes on my Kubernetes clusters for a while now, so I am confident they work correctly.

