### PR TITLE
[PIP-51] Introduce sticky consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
@@ -103,10 +104,13 @@ public class Consumer {
 
     private final Map<String, String> metadata;
 
+    private final PulsarApi.KeySharedMeta keySharedMeta;
+
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
                     int maxUnackedMessages, ServerCnx cnx, String appId,
-                    Map<String, String> metadata, boolean readCompacted, InitialPosition subscriptionInitialPosition) throws BrokerServiceException {
+                    Map<String, String> metadata, boolean readCompacted, InitialPosition subscriptionInitialPosition,
+                    PulsarApi.KeySharedMeta keySharedMeta) throws BrokerServiceException {
 
         this.subscription = subscription;
         this.subType = subType;
@@ -118,6 +122,7 @@ public class Consumer {
         this.consumerName = consumerName;
         this.maxUnackedMessages = maxUnackedMessages;
         this.subscriptionInitialPosition = subscriptionInitialPosition;
+        this.keySharedMeta = keySharedMeta;
         this.cnx = cnx;
         this.msgOut = new Rate();
         this.msgRedeliver = new Rate();
@@ -442,6 +447,10 @@ public class Consumer {
 
     public int getUnackedMessages() {
         return unackedMessages;
+    }
+
+    public PulsarApi.KeySharedMeta getKeySharedMeta() {
+        return keySharedMeta;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
@@ -55,8 +55,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
  */
 public class HashRangeAutoSplitStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
 
-    public static final int DEFAULT_RANGE_SIZE =  2 << 15;
-
     private final int rangeSize;
 
     private final ConcurrentSkipListMap<Integer, Consumer> rangeMap;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * Select consumer will return the ceiling key of message key hashcode % range size.
  *
  */
-public class HashRangeStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
+public class HashRangeAutoSplitStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
 
     public static final int DEFAULT_RANGE_SIZE =  2 << 15;
 
@@ -62,11 +62,11 @@ public class HashRangeStickyKeyConsumerSelector implements StickyKeyConsumerSele
     private final ConcurrentSkipListMap<Integer, Consumer> rangeMap;
     private final Map<Consumer, Integer> consumerRange;
 
-    public HashRangeStickyKeyConsumerSelector() {
+    public HashRangeAutoSplitStickyKeyConsumerSelector() {
         this(DEFAULT_RANGE_SIZE);
     }
 
-    public HashRangeStickyKeyConsumerSelector(int rangeSize) {
+    public HashRangeAutoSplitStickyKeyConsumerSelector(int rangeSize) {
         if (rangeSize < 2) {
             throw new IllegalArgumentException("range size must greater than 2");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -31,6 +31,10 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
     private final int rangeSize;
     private final ConcurrentSkipListMap<Integer, Consumer> rangeMap;
 
+    public HashRangeExclusiveStickyKeyConsumerSelector() {
+        this(DEFAULT_RANGE_SIZE);
+    }
+
     public HashRangeExclusiveStickyKeyConsumerSelector(int rangeSize) {
         super();
         if (rangeSize < 1) {
@@ -84,7 +88,12 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
         if (ranges.isEmpty()) {
             throw new BrokerServiceException.ConsumerAssignException("Ranges for KeyShared policy must not be empty.");
         }
-        for (PulsarApi.IntRange intRange : consumer.getKeySharedMeta().getHashRangesList()) {
+        for (PulsarApi.IntRange intRange : ranges) {
+
+            if (intRange.getStart() > intRange.getEnd()) {
+                throw new BrokerServiceException.ConsumerAssignException("Fixed hash range start > end");
+            }
+
             Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(intRange.getStart());
             Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(intRange.getEnd());
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.util.Murmur3_32Hash;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
+
+    private final int rangeSize;
+    private final ConcurrentSkipListMap<Integer, Consumer> rangeMap;
+
+    public HashRangeExclusiveStickyKeyConsumerSelector(int rangeSize) {
+        super();
+        if (rangeSize < 1) {
+            throw new IllegalArgumentException("range size must greater than 0");
+        }
+        this.rangeSize = rangeSize;
+        this.rangeMap = new ConcurrentSkipListMap<>();
+    }
+
+    @Override
+    public void addConsumer(Consumer consumer) throws BrokerServiceException.ConsumerAssignException {
+        validateKeySharedMeta(consumer);
+        for (PulsarApi.IntRange intRange : consumer.getKeySharedMeta().getHashRangesList()) {
+            rangeMap.put(intRange.getStart(), consumer);
+            rangeMap.put(intRange.getEnd(), consumer);
+        }
+    }
+
+    @Override
+    public void removeConsumer(Consumer consumer) {
+        rangeMap.entrySet().removeIf(entry -> entry.getValue().equals(consumer));
+    }
+
+    @Override
+    public Consumer select(byte[] stickyKey) {
+        return select(Murmur3_32Hash.getInstance().makeHash(stickyKey));
+    }
+
+    public Consumer select(int hash) {
+        if (rangeMap.size() > 0) {
+            int slot = hash % rangeSize;
+            Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(slot);
+            Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(slot);
+            Consumer ceilingConsumer = ceilingEntry != null ? ceilingEntry.getValue() : null;
+            Consumer floorConsumer = floorEntry != null ? floorEntry.getValue() : null;
+            if (floorConsumer != null && floorConsumer.equals(ceilingConsumer)) {
+                return ceilingConsumer;
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private void validateKeySharedMeta(Consumer consumer) throws BrokerServiceException.ConsumerAssignException {
+        if (consumer.getKeySharedMeta() == null) {
+            throw new BrokerServiceException.ConsumerAssignException("Must specify key shared meta for consumer.");
+        }
+        List<PulsarApi.IntRange> ranges = consumer.getKeySharedMeta().getHashRangesList();
+        if (ranges.isEmpty()) {
+            throw new BrokerServiceException.ConsumerAssignException("Ranges for KeyShared policy must not be empty.");
+        }
+        for (PulsarApi.IntRange intRange : consumer.getKeySharedMeta().getHashRangesList()) {
+            Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(intRange.getStart());
+            Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(intRange.getEnd());
+
+            if (floorEntry != null && floorEntry.getKey() >= intRange.getStart()) {
+                throw new BrokerServiceException.ConsumerAssignException("Range conflict with consumer " + floorEntry.getValue());
+            }
+
+            if (ceilingEntry != null && ceilingEntry.getKey() <= intRange.getEnd()) {
+                throw new BrokerServiceException.ConsumerAssignException("Range conflict with consumer " + ceilingEntry.getValue());
+            }
+
+            if (ceilingEntry != null && floorEntry != null && ceilingEntry.getValue().equals(floorEntry.getValue())) {
+                throw new BrokerServiceException.ConsumerAssignException("Range conflict with consumer " + ceilingEntry.getValue());
+            }
+        }
+    }
+
+    Map<Integer, Consumer> getRangeConsumer() {
+        return Collections.unmodifiableMap(rangeMap);
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -624,6 +624,7 @@ public class ServerCnx extends PulsarHandler {
         final SchemaData schema = subscribe.hasSchema() ? getSchema(subscribe.getSchema()) : null;
         final boolean isReplicated = subscribe.hasReplicateSubscriptionState() && subscribe.getReplicateSubscriptionState();
         final boolean forceTopicCreation = subscribe.getForceTopicCreation();
+        final PulsarApi.KeySharedMeta keySharedMeta = subscribe.hasKeySharedMeta() ? subscribe.getKeySharedMeta() : null;
 
         CompletableFuture<Boolean> isProxyAuthorizedFuture;
         if (service.isAuthorizationEnabled() && originalPrincipal != null) {
@@ -706,13 +707,12 @@ public class ServerCnx extends PulsarHandler {
                                             .thenCompose(v -> topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                                     subType, priorityLevel, consumerName, isDurable,
                                                     startMessageId, metadata,
-                                                    readCompacted, initialPosition, startMessageRollbackDurationSec, isReplicated));
-
+                                                    readCompacted, initialPosition, startMessageRollbackDurationSec, isReplicated, keySharedMeta));
                                     } else {
                                         return topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                             subType, priorityLevel, consumerName, isDurable,
                                             startMessageId, metadata, readCompacted, initialPosition,
-                                            startMessageRollbackDurationSec, isReplicated);
+                                            startMessageRollbackDurationSec, isReplicated, keySharedMeta);
                                     }
                                 })
                                 .thenAccept(consumer -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
@@ -22,6 +22,8 @@ import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerAssignExc
 
 public interface StickyKeyConsumerSelector {
 
+    int DEFAULT_RANGE_SIZE =  2 << 15;
+
     /**
      * Add a new consumer
      * @param consumer new consumer

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -92,7 +93,7 @@ public interface Topic {
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            long startMessageRollbackDurationSec, boolean replicateSubscriptionState);
+            long startMessageRollbackDurationSec, boolean replicateSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta);
 
     CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition,
             boolean replicateSubscriptionState);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
@@ -22,7 +22,6 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.EntryBatchSizes;
-import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.Subscription;
@@ -40,10 +39,10 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
 
     private final StickyKeyConsumerSelector selector;
 
-    public NonPersistentStickyKeyDispatcherMultipleConsumers(NonPersistentTopic topic, Subscription subscription) {
+    public NonPersistentStickyKeyDispatcherMultipleConsumers(NonPersistentTopic topic, Subscription subscription,
+                                                             StickyKeyConsumerSelector selector) {
         super(topic, subscription);
-        //TODO: Consumer selector Pluggable
-        selector = new HashRangeStickyKeyConsumerSelector();
+        this.selector = selector;
     }
 
     @Override
@@ -76,10 +75,7 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
             while (iterator.hasNext()) {
                 final Map.Entry<Integer, List<Entry>> entriesWithSameKey = iterator.next();
                 //TODO: None key policy
-                Consumer consumer = null;
-                if (selector instanceof HashRangeStickyKeyConsumerSelector) {
-                    consumer = ((HashRangeStickyKeyConsumerSelector)selector).select(entriesWithSameKey.getKey());
-                }
+                Consumer consumer = selector.select(entriesWithSameKey.getKey());
                 if (consumer != null) {
                     SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
                     EntryBatchSizes batchSizes = EntryBatchSizes.get(entriesWithSameKey.getValue().size());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -34,6 +34,8 @@ import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyE
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionFencedException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
+import org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector;
+import org.apache.pulsar.broker.service.HashRangeExclusiveStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
@@ -120,7 +122,25 @@ public class NonPersistentSubscription implements Subscription {
             case Key_Shared:
                 if (dispatcher == null || dispatcher.getType() != SubType.Key_Shared) {
                     previousDispatcher = dispatcher;
-                    dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this);
+                    if (consumer.getKeySharedMeta() != null) {
+                        switch (consumer.getKeySharedMeta().getKeySharedMode()) {
+                            case exclusiveHashRange:
+                                dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
+                                        new HashRangeExclusiveStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                break;
+                            case autoSplit:
+                                dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
+                                        new HashRangeAutoSplitStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                break;
+                            default:
+                                dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
+                                        new HashRangeAutoSplitStickyKeyConsumerSelector());
+                                break;
+                        }
+                    } else {
+                        dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
+                                new HashRangeAutoSplitStickyKeyConsumerSelector());
+                    }
                 }
                 break;
             default:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -124,11 +124,11 @@ public class NonPersistentSubscription implements Subscription {
                     previousDispatcher = dispatcher;
                     if (consumer.getKeySharedMeta() != null) {
                         switch (consumer.getKeySharedMeta().getKeySharedMode()) {
-                            case sticky:
+                            case STICKY:
                                 dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
                                         new HashRangeExclusiveStickyKeyConsumerSelector());
                                 break;
-                            case autoSplit:
+                            case AUTO_SPLIT:
                                 dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
                                         new HashRangeAutoSplitStickyKeyConsumerSelector());
                                 break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -124,13 +124,13 @@ public class NonPersistentSubscription implements Subscription {
                     previousDispatcher = dispatcher;
                     if (consumer.getKeySharedMeta() != null) {
                         switch (consumer.getKeySharedMeta().getKeySharedMode()) {
-                            case exclusiveHashRange:
+                            case sticky:
                                 dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
-                                        new HashRangeExclusiveStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                        new HashRangeExclusiveStickyKeyConsumerSelector());
                                 break;
                             case autoSplit:
                                 dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,
-                                        new HashRangeAutoSplitStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                        new HashRangeAutoSplitStickyKeyConsumerSelector());
                                 break;
                             default:
                                 dispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(topic, this,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -64,6 +64,7 @@ import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
@@ -246,7 +247,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            long resetStartMessageBackInSec, boolean replicateSubscriptionState) {
+            long resetStartMessageBackInSec, boolean replicateSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -297,7 +298,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
 
         try {
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName, 0, cnx,
-                                             cnx.getRole(), metadata, readCompacted, initialPosition);
+                                             cnx.getRole(), metadata, readCompacted, initialPosition, keySharedMeta);
             subscription.addConsumer(consumer);
             if (!cnx.isActive()) {
                 consumer.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -213,11 +213,11 @@ public class PersistentSubscription implements Subscription {
                     previousDispatcher = dispatcher;
                     if (consumer.getKeySharedMeta() != null) {
                         switch (consumer.getKeySharedMeta().getKeySharedMode()) {
-                            case sticky:
+                            case STICKY:
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
                                         new HashRangeExclusiveStickyKeyConsumerSelector());
                                 break;
-                            case autoSplit:
+                            case AUTO_SPLIT:
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
                                         new HashRangeAutoSplitStickyKeyConsumerSelector());
                                 break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -213,13 +213,13 @@ public class PersistentSubscription implements Subscription {
                     previousDispatcher = dispatcher;
                     if (consumer.getKeySharedMeta() != null) {
                         switch (consumer.getKeySharedMeta().getKeySharedMode()) {
-                            case exclusiveHashRange:
+                            case sticky:
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
-                                        new HashRangeExclusiveStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                        new HashRangeExclusiveStickyKeyConsumerSelector());
                                 break;
                             case autoSplit:
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
-                                        new HashRangeAutoSplitStickyKeyConsumerSelector(consumer.getKeySharedMeta().getTotalHashRange()));
+                                        new HashRangeAutoSplitStickyKeyConsumerSelector());
                                 break;
                             default:
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -95,6 +95,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
@@ -508,7 +509,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
-            long startMessageRollbackDurationSec, boolean replicatedSubscriptionState) {
+            long startMessageRollbackDurationSec, boolean replicatedSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -595,7 +596,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 ledger.checkBackloggedCursors();
 
                 Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
-                                                 maxUnackedMessages, cnx, cnx.getRole(), metadata, readCompacted, initialPosition);
+                                                 maxUnackedMessages, cnx, cnx.getRole(), metadata, readCompacted, initialPosition, keySharedMeta);
                 subscription.addConsumer(consumer);
 
                 if (!cnx.isActive()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelectorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+import static org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
 import static org.mockito.Mockito.mock;
 
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerAssignException;
@@ -28,12 +28,12 @@ import org.testng.annotations.Test;
 
 import java.util.UUID;
 
-public class HashRangeStickyKeyConsumerSelectorTest {
+public class HashRangeAutoSplitStickyKeyConsumerSelectorTest {
 
     @Test
     public void testConsumerSelect() throws ConsumerAssignException {
 
-        HashRangeStickyKeyConsumerSelector selector = new HashRangeStickyKeyConsumerSelector();
+        HashRangeAutoSplitStickyKeyConsumerSelector selector = new HashRangeAutoSplitStickyKeyConsumerSelector();
         String key1 = "anyKey";
         Assert.assertNull(selector.select(key1.getBytes()));
 
@@ -137,7 +137,7 @@ public class HashRangeStickyKeyConsumerSelectorTest {
 
     @Test(expectedExceptions = ConsumerAssignException.class)
     public void testSplitExceed() throws ConsumerAssignException {
-        StickyKeyConsumerSelector selector = new HashRangeStickyKeyConsumerSelector(16);
+        StickyKeyConsumerSelector selector = new HashRangeAutoSplitStickyKeyConsumerSelector(16);
         for (int i = 0; i <= 16; i++) {
             selector.addConsumer(mock(Consumer.class));
         }
@@ -145,11 +145,11 @@ public class HashRangeStickyKeyConsumerSelectorTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testRangeSizeLessThan2() {
-        new HashRangeStickyKeyConsumerSelector(1);
+        new HashRangeAutoSplitStickyKeyConsumerSelector(1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testRangeSizePower2() {
-        new HashRangeStickyKeyConsumerSelector(6);
+        new HashRangeAutoSplitStickyKeyConsumerSelector(6);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
@@ -37,7 +37,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(0).setEnd(2).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -54,7 +54,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
 
         Consumer consumer2 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta2 = PulsarApi.KeySharedMeta.newBuilder()
-                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(3).setEnd(9).build())
                 .build();
         when(consumer2.getKeySharedMeta()).thenReturn(keySharedMeta2);
@@ -88,7 +88,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                 .build();
         when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
         selector.addConsumer(consumer);
@@ -112,7 +112,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -134,7 +134,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         for (PulsarApi.IntRange testRange : testRanges) {
             Consumer consumer = mock(Consumer.class);
             PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                    .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                     .addHashRanges(testRange)
                     .build();
             when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
@@ -153,7 +153,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -175,7 +175,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         for (List<PulsarApi.IntRange> testRange : testRanges) {
             Consumer consumer = mock(Consumer.class);
             PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                    .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.STICKY)
                     .addAllHashRanges(testRange)
                     .build();
             when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
@@ -37,8 +37,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setTotalHashRange(10)
-                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(0).setEnd(2).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -55,8 +54,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
 
         Consumer consumer2 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta2 = PulsarApi.KeySharedMeta.newBuilder()
-                .setTotalHashRange(10)
-                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(3).setEnd(9).build())
                 .build();
         when(consumer2.getKeySharedMeta()).thenReturn(keySharedMeta2);
@@ -90,8 +88,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                .setTotalHashRange(10)
-                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                 .build();
         when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
         selector.addConsumer(consumer);
@@ -115,8 +112,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setTotalHashRange(10)
-                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -129,12 +125,16 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         testRanges.add(PulsarApi.IntRange.newBuilder().setStart(1).setEnd(3).build());
         testRanges.add(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(2).build());
         testRanges.add(PulsarApi.IntRange.newBuilder().setStart(5).setEnd(5).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(1).setEnd(5).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(6).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(1).setEnd(6).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(8).setEnd(6).build());
 
         for (PulsarApi.IntRange testRange : testRanges) {
             Consumer consumer = mock(Consumer.class);
             PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                    .setTotalHashRange(10)
-                    .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                     .addHashRanges(testRange)
                     .build();
             when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
@@ -153,8 +153,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
         Consumer consumer1 = mock(Consumer.class);
         PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
-                .setTotalHashRange(10)
-                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                 .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
                 .build();
         when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
@@ -176,8 +175,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
         for (List<PulsarApi.IntRange> testRange : testRanges) {
             Consumer consumer = mock(Consumer.class);
             PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
-                    .setTotalHashRange(10)
-                    .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.sticky)
                     .addAllHashRanges(testRange)
                     .build();
             when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelectorTest.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.collect.Lists;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HashRangeExclusiveStickyKeyConsumerSelectorTest {
+
+    @Test
+    public void testConsumerSelect() throws BrokerServiceException.ConsumerAssignException {
+
+        HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
+        Consumer consumer1 = mock(Consumer.class);
+        PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
+                .setTotalHashRange(10)
+                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(0).setEnd(2).build())
+                .build();
+        when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
+        Assert.assertEquals(consumer1.getKeySharedMeta(), keySharedMeta1);
+        selector.addConsumer(consumer1);
+        Assert.assertEquals(selector.getRangeConsumer().size(),2);
+        Consumer selectedConsumer;
+        for (int i = 0; i < 3; i++) {
+            selectedConsumer = selector.select(i);
+            Assert.assertEquals(selectedConsumer, consumer1);
+        }
+        selectedConsumer = selector.select(4);
+        Assert.assertNull(selectedConsumer);
+
+        Consumer consumer2 = mock(Consumer.class);
+        PulsarApi.KeySharedMeta keySharedMeta2 = PulsarApi.KeySharedMeta.newBuilder()
+                .setTotalHashRange(10)
+                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(3).setEnd(9).build())
+                .build();
+        when(consumer2.getKeySharedMeta()).thenReturn(keySharedMeta2);
+        Assert.assertEquals(consumer2.getKeySharedMeta(), keySharedMeta2);
+        selector.addConsumer(consumer2);
+        Assert.assertEquals(selector.getRangeConsumer().size(),4);
+
+        for (int i = 3; i < 10; i++) {
+            selectedConsumer = selector.select(i);
+            Assert.assertEquals(selectedConsumer, consumer2);
+        }
+
+        for (int i = 0; i < 3; i++) {
+            selectedConsumer = selector.select(i);
+            Assert.assertEquals(selectedConsumer, consumer1);
+        }
+
+        selector.removeConsumer(consumer1);
+        Assert.assertEquals(selector.getRangeConsumer().size(),2);
+        selectedConsumer = selector.select(1);
+        Assert.assertNull(selectedConsumer);
+
+        selector.removeConsumer(consumer2);
+        Assert.assertEquals(selector.getRangeConsumer().size(),0);
+        selectedConsumer = selector.select(5);
+        Assert.assertNull(selectedConsumer);
+    }
+
+    @Test(expectedExceptions = BrokerServiceException.ConsumerAssignException.class)
+    public void testEmptyRanges() throws BrokerServiceException.ConsumerAssignException {
+        HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
+        Consumer consumer = mock(Consumer.class);
+        PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
+                .setTotalHashRange(10)
+                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .build();
+        when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
+        selector.addConsumer(consumer);
+    }
+
+    @Test(expectedExceptions = BrokerServiceException.ConsumerAssignException.class)
+    public void testNullKeySharedMeta() throws BrokerServiceException.ConsumerAssignException {
+        HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
+        Consumer consumer = mock(Consumer.class);
+        when(consumer.getKeySharedMeta()).thenReturn(null);
+        selector.addConsumer(consumer);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidRangeTotal() {
+        new HashRangeExclusiveStickyKeyConsumerSelector(0);
+    }
+
+    @Test
+    public void testSingleRangeConflict() throws BrokerServiceException.ConsumerAssignException {
+        HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
+        Consumer consumer1 = mock(Consumer.class);
+        PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
+                .setTotalHashRange(10)
+                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
+                .build();
+        when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
+        Assert.assertEquals(consumer1.getKeySharedMeta(), keySharedMeta1);
+        selector.addConsumer(consumer1);
+        Assert.assertEquals(selector.getRangeConsumer().size(),2);
+
+        final List<PulsarApi.IntRange> testRanges = new ArrayList<>();
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(4).setEnd(6).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(1).setEnd(3).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(2).build());
+        testRanges.add(PulsarApi.IntRange.newBuilder().setStart(5).setEnd(5).build());
+
+        for (PulsarApi.IntRange testRange : testRanges) {
+            Consumer consumer = mock(Consumer.class);
+            PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
+                    .setTotalHashRange(10)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                    .addHashRanges(testRange)
+                    .build();
+            when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
+            Assert.assertEquals(consumer.getKeySharedMeta(), keySharedMeta);
+            try {
+                selector.addConsumer(consumer);
+                Assert.fail("should be failed");
+            } catch (BrokerServiceException.ConsumerAssignException ignore) {
+            }
+            Assert.assertEquals(selector.getRangeConsumer().size(),2);
+        }
+    }
+
+    @Test
+    public void testMultipleRangeConflict() throws BrokerServiceException.ConsumerAssignException {
+        HashRangeExclusiveStickyKeyConsumerSelector selector = new HashRangeExclusiveStickyKeyConsumerSelector(10);
+        Consumer consumer1 = mock(Consumer.class);
+        PulsarApi.KeySharedMeta keySharedMeta1 = PulsarApi.KeySharedMeta.newBuilder()
+                .setTotalHashRange(10)
+                .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                .addHashRanges(PulsarApi.IntRange.newBuilder().setStart(2).setEnd(5).build())
+                .build();
+        when(consumer1.getKeySharedMeta()).thenReturn(keySharedMeta1);
+        Assert.assertEquals(consumer1.getKeySharedMeta(), keySharedMeta1);
+        selector.addConsumer(consumer1);
+        Assert.assertEquals(selector.getRangeConsumer().size(),2);
+
+        final List<List<PulsarApi.IntRange>> testRanges = new ArrayList<>();
+        testRanges.add(Lists.newArrayList(
+                PulsarApi.IntRange.newBuilder().setStart(2).setEnd(2).build(),
+                PulsarApi.IntRange.newBuilder().setStart(3).setEnd(3).build(),
+                PulsarApi.IntRange.newBuilder().setStart(4).setEnd(5).build())
+        );
+        testRanges.add(Lists.newArrayList(
+                PulsarApi.IntRange.newBuilder().setStart(0).setEnd(0).build(),
+                PulsarApi.IntRange.newBuilder().setStart(1).setEnd(2).build())
+        );
+
+        for (List<PulsarApi.IntRange> testRange : testRanges) {
+            Consumer consumer = mock(Consumer.class);
+            PulsarApi.KeySharedMeta keySharedMeta = PulsarApi.KeySharedMeta.newBuilder()
+                    .setTotalHashRange(10)
+                    .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                    .addAllHashRanges(testRange)
+                    .build();
+            when(consumer.getKeySharedMeta()).thenReturn(keySharedMeta);
+            Assert.assertEquals(consumer.getKeySharedMeta(), keySharedMeta);
+            try {
+                selector.addConsumer(consumer);
+                Assert.fail("should be failed");
+            } catch (BrokerServiceException.ConsumerAssignException ignore) {
+            }
+            Assert.assertEquals(selector.getRangeConsumer().size(),2);
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -279,7 +279,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 2. Add old consumer
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0,
-                "Cons1"/* consumer name */, 50000, serverCnxWithOldVersion, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
+                "Cons1"/* consumer name */, 50000, serverCnxWithOldVersion, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest, null);
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertSame(consumers.get(0).consumerName(), consumer1.consumerName());
@@ -290,7 +290,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 3. Add new consumer
         Consumer consumer2 = new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0,
-                "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
+                "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest, null);
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
         assertSame(consumers.get(0).consumerName(), consumer1.consumerName());
@@ -319,7 +319,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 2. Add consumer
         Consumer consumer1 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest));
+                false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertSame(consumers.get(0).consumerName(), consumer1.consumerName());
@@ -343,7 +343,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 5. Add another consumer which does not change active consumer
         Consumer consumer2 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest));
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
         assertSame(pdfc.getActiveConsumer().consumerName(), consumer1.consumerName());
@@ -357,7 +357,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 6. Add a consumer which changes active consumer
         Consumer consumer0 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 0 /* consumer id */, 0,
                 "Cons0"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest));
+                false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer0);
         consumers = pdfc.getConsumers();
         assertSame(pdfc.getActiveConsumer().consumerName(), consumer0.consumerName());
@@ -440,7 +440,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 2. Add a consumer
         Consumer consumer1 = spy(new Consumer(sub, SubType.Failover, topic.getName(), 1 /* consumer id */, 1,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest));
+                false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertEquals(1, consumers.size());
@@ -449,7 +449,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 3. Add a consumer with same priority level and consumer name is smaller in lexicographic order.
         Consumer consumer2 = spy(new Consumer(sub, SubType.Failover, topic.getName(), 2 /* consumer id */, 1,
                 "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest));
+                false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer2);
 
         // 4. Verify active consumer doesn't change
@@ -462,7 +462,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 5. Add another consumer which has higher priority level
         Consumer consumer3 = spy(new Consumer(sub, SubType.Failover, topic.getName(), 3 /* consumer id */, 0, "Cons3"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest));
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null));
         pdfc.addConsumer(consumer3);
         consumers = pdfc.getConsumers();
         assertEquals(3, consumers.size());
@@ -652,7 +652,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     private Consumer createConsumer(int priority, int permit, boolean blocked, int id) throws Exception {
         Consumer consumer =
                 new Consumer(null, SubType.Shared, "test-topic", id, priority, ""+id, 5000,
-                        serverCnx, "appId", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
+                        serverCnx, "appId", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null);
         try {
             consumer.flowPermits(permit);
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -123,7 +123,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -182,7 +182,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -245,7 +245,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -304,7 +304,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -442,7 +442,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false);
+                0 /*avoid reseting cursor*/, false, null);
         try {
             f1.get();
             fail("should fail with exception");
@@ -462,14 +462,13 @@ public class PersistentTopicTest {
         // 1. simple subscribe
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false);
+                0 /*avoid reseting cursor*/,false, null);
         f1.get();
 
         // 2. duplicate subscribe
         Future<Consumer> f2 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false);
-
+                0 /*avoid reseting cursor*/,false, null);
         try {
             f2.get();
             fail("should fail with exception");
@@ -491,7 +490,7 @@ public class PersistentTopicTest {
         PersistentSubscription sub = new PersistentSubscription(topic, "change-sub-type", cursorMock, false);
 
         Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1, 0, "Cons1", 50000, serverCnx,
-                "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
+                "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest, null);
         sub.addConsumer(consumer);
         consumer.close();
 
@@ -501,7 +500,7 @@ public class PersistentTopicTest {
             Dispatcher previousDispatcher = sub.getDispatcher();
 
             consumer = new Consumer(sub, subType, topic.getName(), 1, 0, "Cons1", 50000, serverCnx, "myrole-1",
-                    Collections.emptyMap(), false, InitialPosition.Latest);
+                    Collections.emptyMap(), false, InitialPosition.Latest, null);
             sub.addConsumer(consumer);
 
             assertTrue(sub.getDispatcher().isConsumerConnected());
@@ -524,7 +523,7 @@ public class PersistentTopicTest {
 
         // 1. simple add consumer
         Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer);
         assertTrue(sub.getDispatcher().isConsumerConnected());
 
@@ -557,7 +556,7 @@ public class PersistentTopicTest {
         PersistentSubscription sub = new PersistentSubscription(topic, "non-durable-sub", cursorMock, false);
 
         Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1, 0, "Cons1", 50000, serverCnx,
-                "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
+                "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest, null);
 
         sub.addConsumer(consumer);
         assertFalse(sub.getDispatcher().isClosed());
@@ -589,14 +588,14 @@ public class PersistentTopicTest {
         // 1. add consumer1
         Consumer consumer = new Consumer(sub, SubType.Shared, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer);
         assertEquals(sub.getConsumers().size(), 1);
 
         // 2. add consumer2
         Consumer consumer2 = new Consumer(sub, SubType.Shared, topic.getName(), 2 /* consumer id */, 0,
                 "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer2);
         assertEquals(sub.getConsumers().size(), 2);
 
@@ -604,7 +603,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer3 = new Consumer(sub, SubType.Shared, topic.getName(), 3 /* consumer id */, 0,
                     "Cons3"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */, InitialPosition.Latest);
+                    false /* read compacted */, InitialPosition.Latest, null);
             sub.addConsumer(consumer3);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -617,7 +616,7 @@ public class PersistentTopicTest {
         // 4. add consumer4 to sub2
         Consumer consumer4 = new Consumer(sub2, SubType.Shared, topic.getName(), 4 /* consumer id */, 0,
                 "Cons4"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub2.addConsumer(consumer4);
         assertEquals(sub2.getConsumers().size(), 1);
 
@@ -628,7 +627,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer5 = new Consumer(sub2, SubType.Shared, topic.getName(), 5 /* consumer id */, 0,
                     "Cons5"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */, InitialPosition.Latest);
+                    false /* read compacted */, InitialPosition.Latest, null);
             sub2.addConsumer(consumer5);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -680,14 +679,14 @@ public class PersistentTopicTest {
         // 1. add consumer1
         Consumer consumer = new Consumer(sub, SubType.Failover, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer);
         assertEquals(sub.getConsumers().size(), 1);
 
         // 2. add consumer2
         Consumer consumer2 = new Consumer(sub, SubType.Failover, topic.getName(), 2 /* consumer id */, 0,
                 "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer2);
         assertEquals(sub.getConsumers().size(), 2);
 
@@ -695,7 +694,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer3 = new Consumer(sub, SubType.Failover, topic.getName(), 3 /* consumer id */, 0,
                     "Cons3"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */, InitialPosition.Latest);
+                    false /* read compacted */, InitialPosition.Latest, null);
             sub.addConsumer(consumer3);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -708,7 +707,7 @@ public class PersistentTopicTest {
         // 4. add consumer4 to sub2
         Consumer consumer4 = new Consumer(sub2, SubType.Failover, topic.getName(), 4 /* consumer id */, 0,
                 "Cons4"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */, InitialPosition.Latest);
+                false /* read compacted */, InitialPosition.Latest, null);
         sub2.addConsumer(consumer4);
         assertEquals(sub2.getConsumers().size(), 1);
 
@@ -719,7 +718,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer5 = new Consumer(sub2, SubType.Failover, topic.getName(), 5 /* consumer id */, 0,
                     "Cons5"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */, InitialPosition.Latest);
+                    false /* read compacted */, InitialPosition.Latest, null);
             sub2.addConsumer(consumer5);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -759,7 +758,7 @@ public class PersistentTopicTest {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, "sub-1", cursorMock, false);
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null);
         sub.addConsumer(consumer1);
 
         doAnswer(new Answer<Object>() {
@@ -781,7 +780,7 @@ public class PersistentTopicTest {
         try {
             Thread.sleep(10); /* delay to ensure that the ubsubscribe gets executed first */
             new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
-                    50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
+                    50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest, null);
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);
         }
@@ -812,7 +811,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         f1.get();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -828,7 +827,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -883,7 +882,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -971,8 +970,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
                 0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
-
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         try {
             f.get();
             fail("should have failed");
@@ -1101,7 +1099,7 @@ public class PersistentTopicTest {
         Future<Consumer> f1 = topic1.subscribe(serverCnx, cmd1.getSubscription(), cmd1.getConsumerId(),
                 cmd1.getSubType(), 0, cmd1.getConsumerName(), cmd1.getDurable(), null, Collections.emptyMap(),
                 cmd1.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         f1.get();
 
         // 2. Subscribe with partition topic
@@ -1114,7 +1112,7 @@ public class PersistentTopicTest {
         Future<Consumer> f2 = topic2.subscribe(serverCnx, cmd2.getSubscription(), cmd2.getConsumerId(),
                 cmd2.getSubType(), 0, cmd2.getConsumerName(), cmd2.getDurable(), null, Collections.emptyMap(),
                 cmd2.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f2.get();
 
         // 3. Subscribe and create second consumer
@@ -1125,7 +1123,7 @@ public class PersistentTopicTest {
         Future<Consumer> f3 = topic2.subscribe(serverCnx, cmd3.getSubscription(), cmd3.getConsumerId(),
                 cmd3.getSubType(), 0, cmd3.getConsumerName(), cmd3.getDurable(), null, Collections.emptyMap(),
                 cmd3.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f3.get();
 
         assertEquals(
@@ -1147,7 +1145,7 @@ public class PersistentTopicTest {
         Future<Consumer> f4 = topic2.subscribe(serverCnx, cmd4.getSubscription(), cmd4.getConsumerId(),
                 cmd4.getSubType(), 0, cmd4.getConsumerName(), cmd4.getDurable(), null, Collections.emptyMap(),
                 cmd4.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f4.get();
 
         assertEquals(
@@ -1174,8 +1172,7 @@ public class PersistentTopicTest {
         Future<Consumer> f5 = topic2.subscribe(serverCnx, cmd5.getSubscription(), cmd5.getConsumerId(),
                 cmd5.getSubType(), 0, cmd5.getConsumerName(), cmd5.getDurable(), null, Collections.emptyMap(),
                 cmd5.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/,false /* replicated */);
-
+                0 /*avoid reseting cursor*/,false /* replicated */, null);
         try {
             f5.get();
             fail("should fail with exception");
@@ -1192,7 +1189,7 @@ public class PersistentTopicTest {
         Future<Consumer> f6 = topic2.subscribe(serverCnx, cmd6.getSubscription(), cmd6.getConsumerId(),
                 cmd6.getSubType(), 0, cmd6.getConsumerName(), cmd6.getDurable(), null, Collections.emptyMap(),
                 cmd6.getReadCompacted(), InitialPosition.Latest,
-                0 /*avoid reseting cursor*/, false /* replicated */);
+                0 /*avoid reseting cursor*/, false /* replicated */, null);
         f6.get();
 
         // 7. unsubscribe exclusive sub

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -126,22 +126,17 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_exclusive-" + UUID.randomUUID();
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
@@ -153,10 +148,10 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % 9;
-                if (slot <= 2) {
+                        % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+                if (slot <= 20000) {
                     consumer1ExpectMessages++;
-                } else if (slot <= 5) {
+                } else if (slot <= 40000) {
                     consumer2ExpectMessages++;
                 } else {
                     consumer3ExpectMessages++;
@@ -293,22 +288,17 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_none_key_exclusive-" + UUID.randomUUID();
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
@@ -319,11 +309,11 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .send();
         }
         int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
-                % 9;
+                % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
         List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
-        if (slot <= 2) {
+        if (slot <= 20000) {
             checkList.add(new KeyValue<>(consumer1, 100));
-        } else if (slot <= 5) {
+        } else if (slot <= 40000) {
             checkList.add(new KeyValue<>(consumer2, 100));
         } else {
             checkList.add(new KeyValue<>(consumer3, 100));
@@ -388,22 +378,17 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_exclusive_ordering_key-" + UUID.randomUUID();
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
@@ -415,10 +400,10 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % 9;
-                if (slot <= 2) {
+                        % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+                if (slot <= 20000) {
                     consumer1ExpectMessages++;
-                } else if (slot <= 5) {
+                } else if (slot <= 40000) {
                     consumer2ExpectMessages++;
                 } else {
                     consumer3ExpectMessages++;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.api;
 
 import com.google.common.collect.Sets;
 import lombok.Cleanup;
-import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
+import org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcherMultipleConsumers;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
@@ -71,7 +71,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "batch")
-    public void testSendAndReceiveWithHashRangeStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+    public void testSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared-" + UUID.randomUUID();
 
@@ -87,7 +87,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -98,7 +98,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                    % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                    % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
@@ -122,7 +122,63 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "batch")
-    public void testConsumerCrashSendAndReceiveWithHashRangeStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException, InterruptedException {
+    public void testSendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "persistent://public/default/key_shared_exclusive-" + UUID.randomUUID();
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, enableBatch);
+
+        int consumer1ExpectMessages = 0;
+        int consumer2ExpectMessages = 0;
+        int consumer3ExpectMessages = 0;
+
+        for (int i = 0; i < 10; i++) {
+            for (String key : keys) {
+                int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
+                        % 9;
+                if (slot <= 2) {
+                    consumer1ExpectMessages++;
+                } else if (slot <= 5) {
+                    consumer2ExpectMessages++;
+                } else {
+                    consumer3ExpectMessages++;
+                }
+                producer.newMessage()
+                        .key(key)
+                        .value(i)
+                        .send();
+            }
+        }
+
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        checkList.add(new KeyValue<>(consumer1, consumer1ExpectMessages));
+        checkList.add(new KeyValue<>(consumer2, consumer2ExpectMessages));
+        checkList.add(new KeyValue<>(consumer3, consumer3ExpectMessages));
+
+        receiveAndCheck(checkList);
+
+    }
+
+    @Test(dataProvider = "batch")
+    public void testConsumerCrashSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException, InterruptedException {
 
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_consumer_crash-" + UUID.randomUUID();
@@ -139,7 +195,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -150,7 +206,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                    % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                    % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
@@ -194,7 +250,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
 
     @Test(dataProvider = "batch")
-    public void testNonKeySendAndReceiveWithHashRangeStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+    public void testNonKeySendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_none_key-" + UUID.randomUUID();
 
@@ -210,7 +266,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -220,7 +276,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .send();
         }
         int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
-            % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+            % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
         if (slot < consumer3Slot) {
             checkList.add(new KeyValue<>(consumer3, 100));
@@ -233,7 +289,50 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "batch")
-    public void testOrderingKeyWithHashRangeStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+    public void testNonKeySendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "persistent://public/default/key_shared_none_key_exclusive-" + UUID.randomUUID();
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, enableBatch);
+
+        for (int i = 0; i < 100; i++) {
+            producer.newMessage()
+                    .value(i)
+                    .send();
+        }
+        int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
+                % 9;
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        if (slot <= 2) {
+            checkList.add(new KeyValue<>(consumer1, 100));
+        } else if (slot <= 5) {
+            checkList.add(new KeyValue<>(consumer2, 100));
+        } else {
+            checkList.add(new KeyValue<>(consumer3, 100));
+        }
+        receiveAndCheck(checkList);
+    }
+
+    @Test(dataProvider = "batch")
+    public void testOrderingKeyWithHashRangeAutoSplitStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "persistent://public/default/key_shared_ordering_key-" + UUID.randomUUID();
 
@@ -249,7 +348,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -260,7 +359,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                    % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                    % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
@@ -273,6 +372,62 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .orderingKey(key.getBytes())
                     .value(i)
                     .send();
+            }
+        }
+
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        checkList.add(new KeyValue<>(consumer1, consumer1ExpectMessages));
+        checkList.add(new KeyValue<>(consumer2, consumer2ExpectMessages));
+        checkList.add(new KeyValue<>(consumer3, consumer3ExpectMessages));
+
+        receiveAndCheck(checkList);
+    }
+
+    @Test(dataProvider = "batch")
+    public void testOrderingKeyWithHashRangeExclusiveStickyKeyConsumerSelector(boolean enableBatch) throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "persistent://public/default/key_shared_exclusive_ordering_key-" + UUID.randomUUID();
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, enableBatch);
+
+        int consumer1ExpectMessages = 0;
+        int consumer2ExpectMessages = 0;
+        int consumer3ExpectMessages = 0;
+
+        for (int i = 0; i < 10; i++) {
+            for (String key : keys) {
+                int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
+                        % 9;
+                if (slot <= 2) {
+                    consumer1ExpectMessages++;
+                } else if (slot <= 5) {
+                    consumer2ExpectMessages++;
+                } else {
+                    consumer3ExpectMessages++;
+                }
+                producer.newMessage()
+                        .key("any key")
+                        .orderingKey(key.getBytes())
+                        .value(i)
+                        .send();
             }
         }
 
@@ -340,12 +495,19 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     private Consumer<Integer> createConsumer(String topic) throws PulsarClientException {
-        return pulsarClient.newConsumer(Schema.INT32)
-                .topic(topic)
+        return createConsumer(topic, null);
+    }
+
+    private Consumer<Integer> createConsumer(String topic, KeySharedPolicy keySharedPolicy) throws PulsarClientException {
+        ConsumerBuilder<Integer> builder = pulsarClient.newConsumer(Schema.INT32);
+        builder.topic(topic)
                 .subscriptionName("key_shared")
                 .subscriptionType(SubscriptionType.Key_Shared)
-                .ackTimeout(3, TimeUnit.SECONDS)
-                .subscribe();
+                .ackTimeout(3, TimeUnit.SECONDS);
+        if (keySharedPolicy != null) {
+            builder.keySharedPolicy(keySharedPolicy);
+        }
+        return builder.subscribe();
     }
 
     private void receiveAndCheck(List<KeyValue<Consumer<Integer>, Integer>> checkList) throws PulsarClientException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentKeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentKeySharedSubscriptionTest.java
@@ -116,22 +116,17 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_exclusive";
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE - 1)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
@@ -143,10 +138,10 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % 9;
-                if (slot <= 2) {
+                        % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+                if (slot <= 20000) {
                     consumer1ExpectMessages++;
-                } else if (slot <= 5) {
+                } else if (slot <= 40000) {
                     consumer2ExpectMessages++;
                 } else {
                     consumer3ExpectMessages++;
@@ -282,22 +277,17 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_exclusive_non_key";
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE - 1)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
@@ -308,11 +298,11 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
                     .send();
         }
         int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
-                % 9;
+                % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
         List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
-        if (slot <= 2) {
+        if (slot <= 20000) {
             checkList.add(new KeyValue<>(consumer1, 100));
-        } else if (slot <= 5) {
+        } else if (slot <= 40000) {
             checkList.add(new KeyValue<>(consumer2, 100));
         } else {
             checkList.add(new KeyValue<>(consumer3, 100));
@@ -377,22 +367,17 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_exclusive_ordering_key";
 
-        final int hashRangeTotal = 9;
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 20000)));
 
         @Cleanup
-        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(0, 2)));
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(20001, 40000)));
 
         @Cleanup
-        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(3, 5)));
-
-        @Cleanup
-        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
-                .hashRangeTotal(hashRangeTotal)
-                .ranges(Range.of(6, 8)));
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
@@ -404,10 +389,10 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % 9;
-                if (slot <= 2) {
+                        % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+                if (slot <= 20000) {
                     consumer1ExpectMessages++;
-                } else if (slot <= 5) {
+                } else if (slot <= 40000) {
                     consumer2ExpectMessages++;
                 } else {
                     consumer3ExpectMessages++;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentKeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentKeySharedSubscriptionTest.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.api;
 
 import com.google.common.collect.Sets;
 import lombok.Cleanup;
-import org.apache.pulsar.broker.service.HashRangeStickyKeyConsumerSelector;
+import org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcherMultipleConsumers;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
@@ -61,7 +61,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
     }
 
     @Test
-    public void testSendAndReceiveWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
+    public void testSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector() throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared";
 
@@ -77,7 +77,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -88,7 +88,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                        % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
@@ -112,7 +112,63 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
     }
 
     @Test
-    public void testConsumerCrashSendAndReceiveWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException, InterruptedException {
+    public void testSendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector() throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "non-persistent://public/default/key_shared_exclusive";
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic);
+
+        int consumer1ExpectMessages = 0;
+        int consumer2ExpectMessages = 0;
+        int consumer3ExpectMessages = 0;
+
+        for (int i = 0; i < 10; i++) {
+            for (String key : keys) {
+                int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
+                        % 9;
+                if (slot <= 2) {
+                    consumer1ExpectMessages++;
+                } else if (slot <= 5) {
+                    consumer2ExpectMessages++;
+                } else {
+                    consumer3ExpectMessages++;
+                }
+                producer.newMessage()
+                        .key(key)
+                        .value(i)
+                        .send();
+            }
+        }
+
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        checkList.add(new KeyValue<>(consumer1, consumer1ExpectMessages));
+        checkList.add(new KeyValue<>(consumer2, consumer2ExpectMessages));
+        checkList.add(new KeyValue<>(consumer3, consumer3ExpectMessages));
+
+        receiveAndCheck(checkList);
+
+    }
+
+    @Test
+    public void testConsumerCrashSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector() throws PulsarClientException, InterruptedException {
 
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_consumer_crash";
@@ -129,7 +185,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -140,7 +196,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                        % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
@@ -183,7 +239,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
     }
 
     @Test
-    public void testNonKeySendAndReceiveWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
+    public void testNonKeySendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector() throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_none_key";
 
@@ -199,7 +255,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -209,7 +265,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
                     .send();
         }
         int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
-                % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
         if (slot < consumer3Slot) {
             checkList.add(new KeyValue<>(consumer3, 100));
@@ -222,7 +278,50 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
     }
 
     @Test
-    public void testOrderingKeyWithHashRangeStickyKeyConsumerSelector() throws PulsarClientException {
+    public void testNonKeySendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector() throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "non-persistent://public/default/key_shared_exclusive_non_key";
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic);
+
+        for (int i = 0; i < 100; i++) {
+            producer.newMessage()
+                    .value(i)
+                    .send();
+        }
+        int slot = Murmur3_32Hash.getInstance().makeHash(PersistentStickyKeyDispatcherMultipleConsumers.NONE_KEY.getBytes())
+                % 9;
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        if (slot <= 2) {
+            checkList.add(new KeyValue<>(consumer1, 100));
+        } else if (slot <= 5) {
+            checkList.add(new KeyValue<>(consumer2, 100));
+        } else {
+            checkList.add(new KeyValue<>(consumer3, 100));
+        }
+        receiveAndCheck(checkList);
+    }
+
+    @Test
+    public void testOrderingKeyWithHashRangeAutoSplitStickyKeyConsumerSelector() throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "non-persistent://public/default/key_shared_ordering_key";
 
@@ -238,7 +337,7 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         @Cleanup
         Producer<Integer> producer = createProducer(topic);
 
-        int consumer1Slot = HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+        int consumer1Slot = HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
         int consumer2Slot = consumer1Slot >> 1;
         int consumer3Slot = consumer2Slot >> 1;
 
@@ -249,13 +348,69 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
         for (int i = 0; i < 10; i++) {
             for (String key : keys) {
                 int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
-                        % HashRangeStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
+                        % HashRangeAutoSplitStickyKeyConsumerSelector.DEFAULT_RANGE_SIZE;
                 if (slot < consumer3Slot) {
                     consumer3ExpectMessages++;
                 } else if (slot < consumer2Slot) {
                     consumer2ExpectMessages++;
                 } else {
                     consumer1ExpectMessages++;
+                }
+                producer.newMessage()
+                        .key("any key")
+                        .orderingKey(key.getBytes())
+                        .value(i)
+                        .send();
+            }
+        }
+
+        List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
+        checkList.add(new KeyValue<>(consumer1, consumer1ExpectMessages));
+        checkList.add(new KeyValue<>(consumer2, consumer2ExpectMessages));
+        checkList.add(new KeyValue<>(consumer3, consumer3ExpectMessages));
+
+        receiveAndCheck(checkList);
+    }
+
+    @Test
+    public void testOrderingKeyWithHashRangeExclusiveStickyKeyConsumerSelector() throws PulsarClientException {
+        this.conf.setSubscriptionKeySharedEnable(true);
+        String topic = "non-persistent://public/default/key_shared_exclusive_ordering_key";
+
+        final int hashRangeTotal = 9;
+
+        @Cleanup
+        Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(0, 2)));
+
+        @Cleanup
+        Consumer<Integer> consumer2 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(3, 5)));
+
+        @Cleanup
+        Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.exclusiveHashRange()
+                .hashRangeTotal(hashRangeTotal)
+                .ranges(Range.of(6, 8)));
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic);
+
+        int consumer1ExpectMessages = 0;
+        int consumer2ExpectMessages = 0;
+        int consumer3ExpectMessages = 0;
+
+        for (int i = 0; i < 10; i++) {
+            for (String key : keys) {
+                int slot = Murmur3_32Hash.getInstance().makeHash(key.getBytes())
+                        % 9;
+                if (slot <= 2) {
+                    consumer1ExpectMessages++;
+                } else if (slot <= 5) {
+                    consumer2ExpectMessages++;
+                } else {
+                    consumer3ExpectMessages++;
                 }
                 producer.newMessage()
                         .key("any key")
@@ -293,12 +448,19 @@ public class NonPersistentKeySharedSubscriptionTest extends ProducerConsumerBase
     }
 
     private Consumer<Integer> createConsumer(String topic) throws PulsarClientException {
-        return pulsarClient.newConsumer(Schema.INT32)
-                .topic(topic)
+        return createConsumer(topic, null);
+    }
+
+    private Consumer<Integer> createConsumer(String topic, KeySharedPolicy keySharedPolicy) throws PulsarClientException {
+        ConsumerBuilder<Integer> builder = pulsarClient.newConsumer(Schema.INT32);
+        builder.topic(topic)
                 .subscriptionName("key_shared")
                 .subscriptionType(SubscriptionType.Key_Shared)
-                .ackTimeout(3, TimeUnit.SECONDS)
-                .subscribe();
+                .ackTimeout(3, TimeUnit.SECONDS);
+        if (keySharedPolicy != null) {
+            builder.keySharedPolicy(keySharedPolicy);
+        }
+        return builder.subscribe();
     }
 
     private void receiveAndCheck(List<KeyValue<Consumer<Integer>, Integer>> checkList) throws PulsarClientException {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -522,9 +522,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *          .keySharedPolicy(KeySharedPolicy.exclusiveHashRange().hashRangeTotal(10).ranges(Range.of(0, 10)))
      *          .subscribe();
      * </pre>
-     *
      * Or
-     *
      * <pre>
      * client.newConsumer()
      *          .keySharedPolicy(KeySharedPolicy.autoSplitHashRange().hashRangeTotal(100))

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -519,15 +519,20 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *
      * <pre>
      * client.newConsumer()
-     *          .keySharedPolicy(KeySharedPolicy.exclusiveHashRange().hashRangeTotal(10).ranges(Range.of(0, 10)))
+     *          .keySharedPolicy(KeySharedPolicy.stickyHashRange().ranges(Range.of(0, 10)))
      *          .subscribe();
      * </pre>
+     *
+     * Details about sticky hash range policy, please see {@link KeySharedPolicy.KeySharedPolicySticky}.
+     *
      * Or
      * <pre>
      * client.newConsumer()
      *          .keySharedPolicy(KeySharedPolicy.autoSplitHashRange().hashRangeTotal(100))
      *          .subscribe();
      * </pre>
+     *
+     * Details about auto split hash range policy, please see {@link KeySharedPolicy.KeySharedPolicyAutoSplit}.
      *
      * @param keySharedPolicy The {@link KeySharedPolicy} want to specify
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -522,16 +522,14 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *          .keySharedPolicy(KeySharedPolicy.stickyHashRange().ranges(Range.of(0, 10)))
      *          .subscribe();
      * </pre>
-     *
      * Details about sticky hash range policy, please see {@link KeySharedPolicy.KeySharedPolicySticky}.
      *
-     * Or
+     * <p>Or
      * <pre>
      * client.newConsumer()
      *          .keySharedPolicy(KeySharedPolicy.autoSplitHashRange().hashRangeTotal(100))
      *          .subscribe();
      * </pre>
-     *
      * Details about auto split hash range policy, please see {@link KeySharedPolicy.KeySharedPolicyAutoSplit}.
      *
      * @param keySharedPolicy The {@link KeySharedPolicy} want to specify

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -473,7 +473,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> intercept(ConsumerInterceptor<T> ...interceptors);
 
     /**
-     * Set dead letter policy for consumer
+     * Set dead letter policy for consumer.
      *
      * <p>By default some message will redelivery so many times possible, even to the extent that it can be never stop.
      * By using dead letter mechanism messages will has the max redelivery count, when message exceeding the maximum
@@ -510,4 +510,28 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *            whether to auto update partition increasement
      */
     ConsumerBuilder<T> autoUpdatePartitions(boolean autoUpdate);
+
+    /**
+     * Set KeyShared subscription policy for consumer.
+     *
+     * <p>By default, KeyShared subscription use auto split hash range to maintain consumers. If you want to
+     * set a different KeyShared policy, you can set by following example:
+     *
+     * <pre>
+     * client.newConsumer()
+     *          .keySharedPolicy(KeySharedPolicy.exclusiveHashRange().hashRangeTotal(10).ranges(Range.of(0, 10)))
+     *          .subscribe();
+     * </pre>
+     *
+     * Or
+     *
+     * <pre>
+     * client.newConsumer()
+     *          .keySharedPolicy(KeySharedPolicy.autoSplitHashRange().hashRangeTotal(100))
+     *          .subscribe();
+     * </pre>
+     *
+     * @param keySharedPolicy The {@link KeySharedPolicy} want to specify
+     */
+    ConsumerBuilder<T> keySharedPolicy(KeySharedPolicy keySharedPolicy);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
@@ -18,9 +18,20 @@
  */
 package org.apache.pulsar.client.api;
 
+/**
+ * KeyShared mode of KeyShared subscription.
+ */
 public enum KeySharedMode {
 
+    /**
+     * Auto split while new consumer connected.
+     */
     AUTO_SPLIT,
 
+    /**
+     * New consumer with fixed hash range and each hash range is exclusive,
+     * If new consumer use conflict hash range with exits consumers, new consumer
+     * will be rejected.
+     */
     EXCLUSIVE_HASH_RANGE
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
@@ -16,36 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.service;
+package org.apache.pulsar.client.api;
 
-import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerAssignException;
+public enum KeySharedMode {
 
-public interface StickyKeyConsumerSelector {
+    AUTO_SPLIT,
 
-    /**
-     * Add a new consumer
-     * @param consumer new consumer
-     */
-    void addConsumer(Consumer consumer) throws ConsumerAssignException;
-
-    /**
-     * Remove the consumer
-     * @param consumer consumer to be removed
-     */
-    void removeConsumer(Consumer consumer);
-
-    /**
-     * Select a consumer by sticky key
-     *
-     * @param stickyKey sticky key
-     * @return consumer
-     */
-    Consumer select(byte[] stickyKey);
-
-    /**
-     * Select a consumer by hash of the sticky they
-     * @param keyHash hash of sticky key
-     * @return
-     */
-    Consumer select(int keyHash);
+    EXCLUSIVE_HASH_RANGE
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
@@ -29,9 +29,8 @@ public enum KeySharedMode {
     AUTO_SPLIT,
 
     /**
-     * New consumer with fixed hash range and each hash range is exclusive,
-     * If new consumer use conflict hash range with exits consumers, new consumer
-     * will be rejected.
+     * New consumer with fixed hash range to attach the topic, if new consumer use conflict hash range with
+     * exits consumers, new consumer will be rejected.
      */
-    EXCLUSIVE_HASH_RANGE
+    STICKY
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -52,10 +52,9 @@ public abstract class KeySharedPolicy {
     /**
      * Sticky attach topic with fixed hash range.
      *
-     * Total hash range size is 65536, using the sticky hash range policy should ensure that the provided ranges by
+     * <p>Total hash range size is 65536, using the sticky hash range policy should ensure that the provided ranges by
      * all consumers can cover the total hash range [0, 65535]. If not, while broker dispatcher can't find the consumer
      * for message, the cursor will rewind.
-     *
      */
     public static class KeySharedPolicySticky extends KeySharedPolicy {
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -22,6 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * KeyShared policy for KeyShared subscription.
+ */
 public abstract class KeySharedPolicy {
 
     protected KeySharedMode keySharedMode;
@@ -52,6 +55,9 @@ public abstract class KeySharedPolicy {
         return this.keySharedMode;
     }
 
+    /**
+     * Exclusive hash range key shared policy.
+     */
     public static class KeySharedPolicyExclusiveHashRange extends KeySharedPolicy {
 
         protected List<Range> ranges;
@@ -93,6 +99,9 @@ public abstract class KeySharedPolicy {
         }
     }
 
+    /**
+     * Auto split hash range key shared policy.
+     */
     public static class KeySharedPolicyAutoSplit extends KeySharedPolicy {
 
         KeySharedPolicyAutoSplit() {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class KeySharedPolicy {
+
+    protected KeySharedMode keySharedMode;
+
+    protected int hashRangeTotal = 2 << 15;
+
+    public static KeySharedPolicyAutoSplit autoSplitHashRange() {
+        return new KeySharedPolicyAutoSplit();
+    }
+
+    public static KeySharedPolicyExclusiveHashRange exclusiveHashRange() {
+        return new KeySharedPolicyExclusiveHashRange();
+    }
+
+    public void validate() {
+        if (this.hashRangeTotal <= 0) {
+            throw new IllegalArgumentException("Hash range total for KeyShared policy must > 0.");
+        }
+    }
+
+    abstract KeySharedPolicy hashRangeTotal(int hashRangeTotal);
+
+    public int getHashRangeTotal() {
+        return this.hashRangeTotal;
+    }
+
+    public KeySharedMode getKeySharedMode() {
+        return this.keySharedMode;
+    }
+
+    public static class KeySharedPolicyExclusiveHashRange extends KeySharedPolicy {
+
+        protected List<Range> ranges;
+
+        KeySharedPolicyExclusiveHashRange() {
+            this.keySharedMode = KeySharedMode.EXCLUSIVE_HASH_RANGE;
+            this.ranges = new ArrayList<>();
+        }
+
+        public KeySharedPolicyExclusiveHashRange hashRangeTotal(int hashRangeTotal) {
+            this.hashRangeTotal = hashRangeTotal;
+            return this;
+        }
+
+        public KeySharedPolicyExclusiveHashRange ranges(Range... ranges) {
+            this.ranges.addAll(Arrays.asList(ranges));
+            return this;
+        }
+
+        @Override
+        public void validate() {
+            super.validate();
+            if (ranges.isEmpty()) {
+                throw new IllegalArgumentException("Ranges for KeyShared policy must not be empty.");
+            }
+            for (int i = 0; i < ranges.size(); i++) {
+                for (int j = 0; j < ranges.size(); j++) {
+                    Range range1 = ranges.get(i);
+                    Range range2 = ranges.get(j);
+                    if (i != j && range1.intersect(range2) != null) {
+                        throw new IllegalArgumentException("Ranges for KeyShared policy with overlap.");
+                    }
+                }
+            }
+        }
+
+        public List<Range> getRanges() {
+            return ranges;
+        }
+    }
+
+    public static class KeySharedPolicyAutoSplit extends KeySharedPolicy {
+
+        KeySharedPolicyAutoSplit() {
+            this.keySharedMode = KeySharedMode.AUTO_SPLIT;
+        }
+
+        public KeySharedPolicyAutoSplit hashRangeTotal(int hashRangeTotal) {
+            this.hashRangeTotal = hashRangeTotal;
+            return this;
+        }
+
+        @Override
+        public void validate() {
+            super.validate();
+        }
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+public class Range {
+
+    private final int start;
+    private final int end;
+
+
+    public Range(int start, int end) {
+        if (end < start) {
+            throw new IllegalArgumentException("Range end must >= range start.");
+        }
+        this.start = start;
+        this.end = end;
+    }
+
+    public static Range of(int start, int end) {
+        return new Range(start, end);
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public Range intersect(Range range) {
+        int start = range.getStart() > this.getStart() ? range.getStart() : this.getStart();
+        int end = range.getEnd() < this.getEnd() ? range.getEnd() : this.getEnd();
+        if (end >= start) {
+            return Range.of(start, end);
+        } else {
+            return null;
+        }
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.client.api;
 
+/**
+ * Int range.
+ */
 public class Range {
 
     private final int start;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
@@ -56,4 +56,9 @@ public class Range {
             return null;
         }
     }
+
+    @Override
+    public String toString() {
+        return "[" + start + ", " + end + "]";
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.ConsumerInterceptor;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
@@ -104,6 +105,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             return FutureUtil.failedFuture(
                     new InvalidConfigurationException("Subscription name must be set on the consumer builder"));
         }
+
+        if (conf.getKeySharedPolicy() != null && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
+            return FutureUtil.failedFuture(
+                    new InvalidConfigurationException("KeySharedPolicy must set with KeyShared subscription"));
+        }
+
         return interceptorList == null || interceptorList.size() == 0 ?
                 client.subscribeAsync(conf, schema, null) :
                 client.subscribeAsync(conf, schema, new ConsumerInterceptors<>(interceptorList));
@@ -323,5 +330,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     @Override
     public String toString() {
         return conf != null ? conf.toString() : null;
+    }
+
+    @Override
+    public ConsumerBuilder<T> keySharedPolicy(KeySharedPolicy keySharedPolicy) {
+        keySharedPolicy.validate();
+        conf.setKeySharedPolicy(keySharedPolicy);
+        return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -527,7 +527,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         ByteBuf request = Commands.newSubscribe(topic, subscription, consumerId, requestId, getSubType(), priorityLevel,
                 consumerName, isDurable, startMessageIdData, metadata, readCompacted,
                 conf.isReplicateSubscriptionState(), InitialPosition.valueOf(subscriptionInitialPosition.getValue()),
-                startMessageRollbackDuration, si, createTopicIfDoesNotExist);
+        startMessageRollbackDuration, si, createTopicIfDoesNotExist, conf.getKeySharedPolicy());
         if (startMessageIdData != null) {
             startMessageIdData.recycle();
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -102,6 +103,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private boolean replicateSubscriptionState = false;
 
     private boolean resetIncludeHead = false;
+
+    private KeySharedPolicy keySharedPolicy;
 
     @JsonIgnore
     public String getSingleTopic() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/KeySharedPolicyTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/KeySharedPolicyTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class KeySharedPolicyTest {
+
+    @Test
+    public void testAutoSplit() {
+
+        KeySharedPolicy policy = KeySharedPolicy.autoSplitHashRange();
+        Assert.assertEquals(2 << 15, policy.getHashRangeTotal());
+
+        policy.hashRangeTotal(100);
+        Assert.assertEquals(100, policy.getHashRangeTotal());
+
+        policy.validate();
+    }
+
+    @Test
+    public void testAutoSplitInvalid() {
+
+        try {
+            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(0).validate();
+            Assert.fail("should be failed");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalArgumentException);
+        }
+
+        try {
+            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(-1).validate();
+            Assert.fail("should be failed");
+        } catch (IllegalArgumentException ignore) {
+        }
+
+    }
+
+    @Test
+    public void testExclusiveHashRange() {
+
+        KeySharedPolicy.KeySharedPolicyExclusiveHashRange policy = KeySharedPolicy.exclusiveHashRange();
+        Assert.assertEquals(2 << 15, policy.getHashRangeTotal());
+
+        policy.hashRangeTotal(100);
+        Assert.assertEquals(100, policy.getHashRangeTotal());
+        Assert.assertTrue(policy.getRanges().isEmpty());
+
+        policy.ranges(Range.of(0, 1), Range.of(1, 2));
+        Assert.assertEquals(policy.getRanges().size(), 2);
+    }
+
+    @Test
+    public void testExclusiveHashRangeInvalid() {
+
+        try {
+            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(0).validate();
+            Assert.fail("should be failed");
+        } catch (IllegalArgumentException ignore) {
+        }
+
+        try {
+            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(-1).validate();
+            Assert.fail("should be failed");
+        } catch (IllegalArgumentException ignore) {
+        }
+
+        KeySharedPolicy.KeySharedPolicyExclusiveHashRange policy = KeySharedPolicy.exclusiveHashRange();
+        try {
+            policy.validate();
+            Assert.fail("should be failed");
+        } catch (IllegalArgumentException ignore) {
+        }
+
+        policy.ranges(Range.of(0, 9), Range.of(0, 5));
+        try {
+            policy.validate();
+            Assert.fail("should be failed");
+        } catch (IllegalArgumentException ignore) {
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/KeySharedPolicyTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/KeySharedPolicyTest.java
@@ -29,39 +29,14 @@ public class KeySharedPolicyTest {
         KeySharedPolicy policy = KeySharedPolicy.autoSplitHashRange();
         Assert.assertEquals(2 << 15, policy.getHashRangeTotal());
 
-        policy.hashRangeTotal(100);
-        Assert.assertEquals(100, policy.getHashRangeTotal());
-
         policy.validate();
-    }
-
-    @Test
-    public void testAutoSplitInvalid() {
-
-        try {
-            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(0).validate();
-            Assert.fail("should be failed");
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IllegalArgumentException);
-        }
-
-        try {
-            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(-1).validate();
-            Assert.fail("should be failed");
-        } catch (IllegalArgumentException ignore) {
-        }
-
     }
 
     @Test
     public void testExclusiveHashRange() {
 
-        KeySharedPolicy.KeySharedPolicyExclusiveHashRange policy = KeySharedPolicy.exclusiveHashRange();
+        KeySharedPolicy.KeySharedPolicySticky policy = KeySharedPolicy.stickyHashRange();
         Assert.assertEquals(2 << 15, policy.getHashRangeTotal());
-
-        policy.hashRangeTotal(100);
-        Assert.assertEquals(100, policy.getHashRangeTotal());
-        Assert.assertTrue(policy.getRanges().isEmpty());
 
         policy.ranges(Range.of(0, 1), Range.of(1, 2));
         Assert.assertEquals(policy.getRanges().size(), 2);
@@ -70,19 +45,7 @@ public class KeySharedPolicyTest {
     @Test
     public void testExclusiveHashRangeInvalid() {
 
-        try {
-            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(0).validate();
-            Assert.fail("should be failed");
-        } catch (IllegalArgumentException ignore) {
-        }
-
-        try {
-            KeySharedPolicy.autoSplitHashRange().hashRangeTotal(-1).validate();
-            Assert.fail("should be failed");
-        } catch (IllegalArgumentException ignore) {
-        }
-
-        KeySharedPolicy.KeySharedPolicyExclusiveHashRange policy = KeySharedPolicy.exclusiveHashRange();
+        KeySharedPolicy.KeySharedPolicySticky policy = KeySharedPolicy.stickyHashRange();
         try {
             policy.validate();
             Assert.fail("should be failed");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/RangeTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/RangeTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RangeTest {
+
+    @Test
+    public void testOf() {
+        Range range = Range.of(0, 3);
+        Assert.assertEquals(0, range.getStart());
+        Assert.assertEquals(3, range.getEnd());
+    }
+
+    @Test
+    public void testIntersect() {
+        Range range1 = Range.of(0, 9);
+        Range range2 = Range.of(0, 2);
+        Range intersectRange = range1.intersect(range2);
+        Assert.assertEquals(0, intersectRange.getStart());
+        Assert.assertEquals(2, intersectRange.getEnd());
+
+        range2 = Range.of(10, 20);
+        intersectRange = range1.intersect(range2);
+        Assert.assertNull(intersectRange);
+
+        range2 = Range.of(-10, -1);
+        intersectRange = range1.intersect(range2);
+        Assert.assertNull(intersectRange);
+
+        range2 = Range.of(-5, 5);
+        intersectRange = range1.intersect(range2);
+        Assert.assertEquals(0, intersectRange.getStart());
+        Assert.assertEquals(5, intersectRange.getEnd());
+
+        range2 = Range.of(5, 15);
+        intersectRange = range1.intersect(range2);
+        Assert.assertEquals(5, intersectRange.getStart());
+        Assert.assertEquals(9, intersectRange.getEnd());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalid() {
+        Range.of(0, -5);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -283,11 +283,11 @@ public final class PulsarApi {
   public enum KeySharedMode
       implements org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLite {
     autoSplit(0, 0),
-    exclusiveHashRange(1, 1),
+    sticky(1, 1),
     ;
     
     public static final int autoSplit_VALUE = 0;
-    public static final int exclusiveHashRange_VALUE = 1;
+    public static final int sticky_VALUE = 1;
     
     
     public final int getNumber() { return value; }
@@ -295,7 +295,7 @@ public final class PulsarApi {
     public static KeySharedMode valueOf(int value) {
       switch (value) {
         case 0: return autoSplit;
-        case 1: return exclusiveHashRange;
+        case 1: return sticky;
         default: return null;
       }
     }
@@ -9188,10 +9188,6 @@ public final class PulsarApi {
     boolean hasKeySharedMode();
     org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode getKeySharedMode();
     
-    // required int32 totalHashRange = 2;
-    boolean hasTotalHashRange();
-    int getTotalHashRange();
-    
     // repeated .pulsar.proto.IntRange hashRanges = 3;
     java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> 
         getHashRangesList();
@@ -9243,16 +9239,6 @@ public final class PulsarApi {
       return keySharedMode_;
     }
     
-    // required int32 totalHashRange = 2;
-    public static final int TOTALHASHRANGE_FIELD_NUMBER = 2;
-    private int totalHashRange_;
-    public boolean hasTotalHashRange() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    public int getTotalHashRange() {
-      return totalHashRange_;
-    }
-    
     // repeated .pulsar.proto.IntRange hashRanges = 3;
     public static final int HASHRANGES_FIELD_NUMBER = 3;
     private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> hashRanges_;
@@ -9276,7 +9262,6 @@ public final class PulsarApi {
     
     private void initFields() {
       keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
-      totalHashRange_ = 0;
       hashRanges_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
@@ -9285,10 +9270,6 @@ public final class PulsarApi {
       if (isInitialized != -1) return isInitialized == 1;
       
       if (!hasKeySharedMode()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasTotalHashRange()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -9313,9 +9294,6 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeEnum(1, keySharedMode_.getNumber());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeInt32(2, totalHashRange_);
-      }
       for (int i = 0; i < hashRanges_.size(); i++) {
         output.writeMessage(3, hashRanges_.get(i));
       }
@@ -9330,10 +9308,6 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeEnumSize(1, keySharedMode_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeInt32Size(2, totalHashRange_);
       }
       for (int i = 0; i < hashRanges_.size(); i++) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
@@ -9454,10 +9428,8 @@ public final class PulsarApi {
         super.clear();
         keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
         bitField0_ = (bitField0_ & ~0x00000001);
-        totalHashRange_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         hashRanges_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       
@@ -9495,13 +9467,9 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000001;
         }
         result.keySharedMode_ = keySharedMode_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.totalHashRange_ = totalHashRange_;
-        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
           hashRanges_ = java.util.Collections.unmodifiableList(hashRanges_);
-          bitField0_ = (bitField0_ & ~0x00000004);
+          bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.hashRanges_ = hashRanges_;
         result.bitField0_ = to_bitField0_;
@@ -9513,13 +9481,10 @@ public final class PulsarApi {
         if (other.hasKeySharedMode()) {
           setKeySharedMode(other.getKeySharedMode());
         }
-        if (other.hasTotalHashRange()) {
-          setTotalHashRange(other.getTotalHashRange());
-        }
         if (!other.hashRanges_.isEmpty()) {
           if (hashRanges_.isEmpty()) {
             hashRanges_ = other.hashRanges_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            bitField0_ = (bitField0_ & ~0x00000002);
           } else {
             ensureHashRangesIsMutable();
             hashRanges_.addAll(other.hashRanges_);
@@ -9531,10 +9496,6 @@ public final class PulsarApi {
       
       public final boolean isInitialized() {
         if (!hasKeySharedMode()) {
-          
-          return false;
-        }
-        if (!hasTotalHashRange()) {
           
           return false;
         }
@@ -9578,11 +9539,6 @@ public final class PulsarApi {
               }
               break;
             }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              totalHashRange_ = input.readInt32();
-              break;
-            }
             case 26: {
               org.apache.pulsar.common.api.proto.PulsarApi.IntRange.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.IntRange.newBuilder();
               input.readMessage(subBuilder, extensionRegistry);
@@ -9619,34 +9575,13 @@ public final class PulsarApi {
         return this;
       }
       
-      // required int32 totalHashRange = 2;
-      private int totalHashRange_ ;
-      public boolean hasTotalHashRange() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      public int getTotalHashRange() {
-        return totalHashRange_;
-      }
-      public Builder setTotalHashRange(int value) {
-        bitField0_ |= 0x00000002;
-        totalHashRange_ = value;
-        
-        return this;
-      }
-      public Builder clearTotalHashRange() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        totalHashRange_ = 0;
-        
-        return this;
-      }
-      
       // repeated .pulsar.proto.IntRange hashRanges = 3;
       private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> hashRanges_ =
         java.util.Collections.emptyList();
       private void ensureHashRangesIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
           hashRanges_ = new java.util.ArrayList<org.apache.pulsar.common.api.proto.PulsarApi.IntRange>(hashRanges_);
-          bitField0_ |= 0x00000004;
+          bitField0_ |= 0x00000002;
          }
       }
       
@@ -9718,7 +9653,7 @@ public final class PulsarApi {
       }
       public Builder clearHashRanges() {
         hashRanges_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000002);
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -282,20 +282,20 @@ public final class PulsarApi {
   
   public enum KeySharedMode
       implements org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLite {
-    autoSplit(0, 0),
-    sticky(1, 1),
+    AUTO_SPLIT(0, 0),
+    STICKY(1, 1),
     ;
     
-    public static final int autoSplit_VALUE = 0;
-    public static final int sticky_VALUE = 1;
+    public static final int AUTO_SPLIT_VALUE = 0;
+    public static final int STICKY_VALUE = 1;
     
     
     public final int getNumber() { return value; }
     
     public static KeySharedMode valueOf(int value) {
       switch (value) {
-        case 0: return autoSplit;
-        case 1: return sticky;
+        case 0: return AUTO_SPLIT;
+        case 1: return STICKY;
         default: return null;
       }
     }
@@ -9261,7 +9261,7 @@ public final class PulsarApi {
     }
     
     private void initFields() {
-      keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+      keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.AUTO_SPLIT;
       hashRanges_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
@@ -9426,7 +9426,7 @@ public final class PulsarApi {
       
       public Builder clear() {
         super.clear();
-        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.AUTO_SPLIT;
         bitField0_ = (bitField0_ & ~0x00000001);
         hashRanges_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -9552,7 +9552,7 @@ public final class PulsarApi {
       private int bitField0_;
       
       // required .pulsar.proto.KeySharedMode keySharedMode = 1;
-      private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+      private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.AUTO_SPLIT;
       public boolean hasKeySharedMode() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
@@ -9570,7 +9570,7 @@ public final class PulsarApi {
       }
       public Builder clearKeySharedMode() {
         bitField0_ = (bitField0_ & ~0x00000001);
-        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.AUTO_SPLIT;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -280,6 +280,47 @@ public final class PulsarApi {
     // @@protoc_insertion_point(enum_scope:pulsar.proto.ProtocolVersion)
   }
   
+  public enum KeySharedMode
+      implements org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLite {
+    autoSplit(0, 0),
+    exclusiveHashRange(1, 1),
+    ;
+    
+    public static final int autoSplit_VALUE = 0;
+    public static final int exclusiveHashRange_VALUE = 1;
+    
+    
+    public final int getNumber() { return value; }
+    
+    public static KeySharedMode valueOf(int value) {
+      switch (value) {
+        case 0: return autoSplit;
+        case 1: return exclusiveHashRange;
+        default: return null;
+      }
+    }
+    
+    public static org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLiteMap<KeySharedMode>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLiteMap<KeySharedMode>
+        internalValueMap =
+          new org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLiteMap<KeySharedMode>() {
+            public KeySharedMode findValueByNumber(int number) {
+              return KeySharedMode.valueOf(number);
+            }
+          };
+    
+    private final int value;
+    
+    private KeySharedMode(int index, int value) {
+      this.value = value;
+    }
+    
+    // @@protoc_insertion_point(enum_scope:pulsar.proto.KeySharedMode)
+  }
+  
   public enum TxnAction
       implements org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.EnumLite {
     COMMIT(0, 0),
@@ -2470,6 +2511,399 @@ public final class PulsarApi {
     }
     
     // @@protoc_insertion_point(class_scope:pulsar.proto.KeyLongValue)
+  }
+  
+  public interface IntRangeOrBuilder
+      extends org.apache.pulsar.shaded.com.google.protobuf.v241.MessageLiteOrBuilder {
+    
+    // required int32 start = 1;
+    boolean hasStart();
+    int getStart();
+    
+    // required int32 end = 2;
+    boolean hasEnd();
+    int getEnd();
+  }
+  public static final class IntRange extends
+      org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
+      implements IntRangeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use IntRange.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private IntRange(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<IntRange> RECYCLER = new io.netty.util.Recycler<IntRange>() {
+            protected IntRange newObject(Handle handle) {
+              return new IntRange(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private IntRange(boolean noInit) {}
+    
+    private static final IntRange defaultInstance;
+    public static IntRange getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public IntRange getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required int32 start = 1;
+    public static final int START_FIELD_NUMBER = 1;
+    private int start_;
+    public boolean hasStart() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public int getStart() {
+      return start_;
+    }
+    
+    // required int32 end = 2;
+    public static final int END_FIELD_NUMBER = 2;
+    private int end_;
+    public boolean hasEnd() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public int getEnd() {
+      return end_;
+    }
+    
+    private void initFields() {
+      start_ = 0;
+      end_ = 0;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasStart()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasEnd()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt32(1, start_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt32(2, end_);
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeInt32Size(1, start_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeInt32Size(2, end_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(byte[] data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        byte[] data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.IntRange parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.pulsar.common.api.proto.PulsarApi.IntRange prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite.Builder<
+          org.apache.pulsar.common.api.proto.PulsarApi.IntRange, Builder>
+        implements org.apache.pulsar.common.api.proto.PulsarApi.IntRangeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using org.apache.pulsar.common.api.proto.PulsarApi.IntRange.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        start_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        end_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.IntRange getDefaultInstanceForType() {
+        return org.apache.pulsar.common.api.proto.PulsarApi.IntRange.getDefaultInstance();
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.IntRange build() {
+        org.apache.pulsar.common.api.proto.PulsarApi.IntRange result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.pulsar.common.api.proto.PulsarApi.IntRange buildParsed()
+          throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+        org.apache.pulsar.common.api.proto.PulsarApi.IntRange result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.IntRange buildPartial() {
+        org.apache.pulsar.common.api.proto.PulsarApi.IntRange result = org.apache.pulsar.common.api.proto.PulsarApi.IntRange.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.start_ = start_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.end_ = end_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.common.api.proto.PulsarApi.IntRange other) {
+        if (other == org.apache.pulsar.common.api.proto.PulsarApi.IntRange.getDefaultInstance()) return this;
+        if (other.hasStart()) {
+          setStart(other.getStart());
+        }
+        if (other.hasEnd()) {
+          setEnd(other.getEnd());
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasStart()) {
+          
+          return false;
+        }
+        if (!hasEnd()) {
+          
+          return false;
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+                              org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              start_ = input.readInt32();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              end_ = input.readInt32();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required int32 start = 1;
+      private int start_ ;
+      public boolean hasStart() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public int getStart() {
+        return start_;
+      }
+      public Builder setStart(int value) {
+        bitField0_ |= 0x00000001;
+        start_ = value;
+        
+        return this;
+      }
+      public Builder clearStart() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        start_ = 0;
+        
+        return this;
+      }
+      
+      // required int32 end = 2;
+      private int end_ ;
+      public boolean hasEnd() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public int getEnd() {
+        return end_;
+      }
+      public Builder setEnd(int value) {
+        bitField0_ |= 0x00000002;
+        end_ = value;
+        
+        return this;
+      }
+      public Builder clearEnd() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        end_ = 0;
+        
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.IntRange)
+    }
+    
+    static {
+      defaultInstance = new IntRange(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.IntRange)
   }
   
   public interface EncryptionKeysOrBuilder
@@ -8747,6 +9181,565 @@ public final class PulsarApi {
     // @@protoc_insertion_point(class_scope:pulsar.proto.AuthData)
   }
   
+  public interface KeySharedMetaOrBuilder
+      extends org.apache.pulsar.shaded.com.google.protobuf.v241.MessageLiteOrBuilder {
+    
+    // required .pulsar.proto.KeySharedMode keySharedMode = 1;
+    boolean hasKeySharedMode();
+    org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode getKeySharedMode();
+    
+    // required int32 totalHashRange = 2;
+    boolean hasTotalHashRange();
+    int getTotalHashRange();
+    
+    // repeated .pulsar.proto.IntRange hashRanges = 3;
+    java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> 
+        getHashRangesList();
+    org.apache.pulsar.common.api.proto.PulsarApi.IntRange getHashRanges(int index);
+    int getHashRangesCount();
+  }
+  public static final class KeySharedMeta extends
+      org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
+      implements KeySharedMetaOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use KeySharedMeta.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private KeySharedMeta(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<KeySharedMeta> RECYCLER = new io.netty.util.Recycler<KeySharedMeta>() {
+            protected KeySharedMeta newObject(Handle handle) {
+              return new KeySharedMeta(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private KeySharedMeta(boolean noInit) {}
+    
+    private static final KeySharedMeta defaultInstance;
+    public static KeySharedMeta getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public KeySharedMeta getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required .pulsar.proto.KeySharedMode keySharedMode = 1;
+    public static final int KEYSHAREDMODE_FIELD_NUMBER = 1;
+    private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode keySharedMode_;
+    public boolean hasKeySharedMode() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode getKeySharedMode() {
+      return keySharedMode_;
+    }
+    
+    // required int32 totalHashRange = 2;
+    public static final int TOTALHASHRANGE_FIELD_NUMBER = 2;
+    private int totalHashRange_;
+    public boolean hasTotalHashRange() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public int getTotalHashRange() {
+      return totalHashRange_;
+    }
+    
+    // repeated .pulsar.proto.IntRange hashRanges = 3;
+    public static final int HASHRANGES_FIELD_NUMBER = 3;
+    private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> hashRanges_;
+    public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> getHashRangesList() {
+      return hashRanges_;
+    }
+    public java.util.List<? extends org.apache.pulsar.common.api.proto.PulsarApi.IntRangeOrBuilder> 
+        getHashRangesOrBuilderList() {
+      return hashRanges_;
+    }
+    public int getHashRangesCount() {
+      return hashRanges_.size();
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.IntRange getHashRanges(int index) {
+      return hashRanges_.get(index);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.IntRangeOrBuilder getHashRangesOrBuilder(
+        int index) {
+      return hashRanges_.get(index);
+    }
+    
+    private void initFields() {
+      keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+      totalHashRange_ = 0;
+      hashRanges_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasKeySharedMode()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasTotalHashRange()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      for (int i = 0; i < getHashRangesCount(); i++) {
+        if (!getHashRanges(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, keySharedMode_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt32(2, totalHashRange_);
+      }
+      for (int i = 0; i < hashRanges_.size(); i++) {
+        output.writeMessage(3, hashRanges_.get(i));
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeEnumSize(1, keySharedMode_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeInt32Size(2, totalHashRange_);
+      }
+      for (int i = 0; i < hashRanges_.size(); i++) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeMessageSize(3, hashRanges_.get(i));
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(byte[] data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        byte[] data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite.Builder<
+          org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta, Builder>
+        implements org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMetaOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        totalHashRange_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        hashRanges_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta getDefaultInstanceForType() {
+        return org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance();
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta build() {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta buildParsed()
+          throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta buildPartial() {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta result = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.keySharedMode_ = keySharedMode_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.totalHashRange_ = totalHashRange_;
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          hashRanges_ = java.util.Collections.unmodifiableList(hashRanges_);
+          bitField0_ = (bitField0_ & ~0x00000004);
+        }
+        result.hashRanges_ = hashRanges_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta other) {
+        if (other == org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance()) return this;
+        if (other.hasKeySharedMode()) {
+          setKeySharedMode(other.getKeySharedMode());
+        }
+        if (other.hasTotalHashRange()) {
+          setTotalHashRange(other.getTotalHashRange());
+        }
+        if (!other.hashRanges_.isEmpty()) {
+          if (hashRanges_.isEmpty()) {
+            hashRanges_ = other.hashRanges_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+          } else {
+            ensureHashRangesIsMutable();
+            hashRanges_.addAll(other.hashRanges_);
+          }
+          
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasKeySharedMode()) {
+          
+          return false;
+        }
+        if (!hasTotalHashRange()) {
+          
+          return false;
+        }
+        for (int i = 0; i < getHashRangesCount(); i++) {
+          if (!getHashRanges(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+                              org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode value = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.valueOf(rawValue);
+              if (value != null) {
+                bitField0_ |= 0x00000001;
+                keySharedMode_ = value;
+              }
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              totalHashRange_ = input.readInt32();
+              break;
+            }
+            case 26: {
+              org.apache.pulsar.common.api.proto.PulsarApi.IntRange.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.IntRange.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addHashRanges(subBuilder.buildPartial());
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required .pulsar.proto.KeySharedMode keySharedMode = 1;
+      private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+      public boolean hasKeySharedMode() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode getKeySharedMode() {
+        return keySharedMode_;
+      }
+      public Builder setKeySharedMode(org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        keySharedMode_ = value;
+        
+        return this;
+      }
+      public Builder clearKeySharedMode() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        keySharedMode_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMode.autoSplit;
+        
+        return this;
+      }
+      
+      // required int32 totalHashRange = 2;
+      private int totalHashRange_ ;
+      public boolean hasTotalHashRange() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public int getTotalHashRange() {
+        return totalHashRange_;
+      }
+      public Builder setTotalHashRange(int value) {
+        bitField0_ |= 0x00000002;
+        totalHashRange_ = value;
+        
+        return this;
+      }
+      public Builder clearTotalHashRange() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        totalHashRange_ = 0;
+        
+        return this;
+      }
+      
+      // repeated .pulsar.proto.IntRange hashRanges = 3;
+      private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> hashRanges_ =
+        java.util.Collections.emptyList();
+      private void ensureHashRangesIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          hashRanges_ = new java.util.ArrayList<org.apache.pulsar.common.api.proto.PulsarApi.IntRange>(hashRanges_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+      
+      public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.IntRange> getHashRangesList() {
+        return java.util.Collections.unmodifiableList(hashRanges_);
+      }
+      public int getHashRangesCount() {
+        return hashRanges_.size();
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.IntRange getHashRanges(int index) {
+        return hashRanges_.get(index);
+      }
+      public Builder setHashRanges(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.IntRange value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureHashRangesIsMutable();
+        hashRanges_.set(index, value);
+        
+        return this;
+      }
+      public Builder setHashRanges(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.IntRange.Builder builderForValue) {
+        ensureHashRangesIsMutable();
+        hashRanges_.set(index, builderForValue.build());
+        
+        return this;
+      }
+      public Builder addHashRanges(org.apache.pulsar.common.api.proto.PulsarApi.IntRange value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureHashRangesIsMutable();
+        hashRanges_.add(value);
+        
+        return this;
+      }
+      public Builder addHashRanges(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.IntRange value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureHashRangesIsMutable();
+        hashRanges_.add(index, value);
+        
+        return this;
+      }
+      public Builder addHashRanges(
+          org.apache.pulsar.common.api.proto.PulsarApi.IntRange.Builder builderForValue) {
+        ensureHashRangesIsMutable();
+        hashRanges_.add(builderForValue.build());
+        
+        return this;
+      }
+      public Builder addHashRanges(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.IntRange.Builder builderForValue) {
+        ensureHashRangesIsMutable();
+        hashRanges_.add(index, builderForValue.build());
+        
+        return this;
+      }
+      public Builder addAllHashRanges(
+          java.lang.Iterable<? extends org.apache.pulsar.common.api.proto.PulsarApi.IntRange> values) {
+        ensureHashRangesIsMutable();
+        super.addAll(values, hashRanges_);
+        
+        return this;
+      }
+      public Builder clearHashRanges() {
+        hashRanges_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        
+        return this;
+      }
+      public Builder removeHashRanges(int index) {
+        ensureHashRangesIsMutable();
+        hashRanges_.remove(index);
+        
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.KeySharedMeta)
+    }
+    
+    static {
+      defaultInstance = new KeySharedMeta(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.KeySharedMeta)
+  }
+  
   public interface CommandSubscribeOrBuilder
       extends org.apache.pulsar.shaded.com.google.protobuf.v241.MessageLiteOrBuilder {
     
@@ -8815,6 +9808,10 @@ public final class PulsarApi {
     // optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
     boolean hasStartMessageRollbackDurationSec();
     long getStartMessageRollbackDurationSec();
+    
+    // optional .pulsar.proto.KeySharedMeta keySharedMeta = 17;
+    boolean hasKeySharedMeta();
+    org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta getKeySharedMeta();
   }
   public static final class CommandSubscribe extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -9176,6 +10173,16 @@ public final class PulsarApi {
       return startMessageRollbackDurationSec_;
     }
     
+    // optional .pulsar.proto.KeySharedMeta keySharedMeta = 17;
+    public static final int KEYSHAREDMETA_FIELD_NUMBER = 17;
+    private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta keySharedMeta_;
+    public boolean hasKeySharedMeta() {
+      return ((bitField0_ & 0x00008000) == 0x00008000);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta getKeySharedMeta() {
+      return keySharedMeta_;
+    }
+    
     private void initFields() {
       topic_ = "";
       subscription_ = "";
@@ -9193,6 +10200,7 @@ public final class PulsarApi {
       replicateSubscriptionState_ = false;
       forceTopicCreation_ = true;
       startMessageRollbackDurationSec_ = 0L;
+      keySharedMeta_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -9233,6 +10241,12 @@ public final class PulsarApi {
       }
       if (hasSchema()) {
         if (!getSchema().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasKeySharedMeta()) {
+        if (!getKeySharedMeta().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -9296,6 +10310,9 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x00004000) == 0x00004000)) {
         output.writeUInt64(16, startMessageRollbackDurationSec_);
+      }
+      if (((bitField0_ & 0x00008000) == 0x00008000)) {
+        output.writeMessage(17, keySharedMeta_);
       }
     }
     
@@ -9368,6 +10385,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00004000) == 0x00004000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(16, startMessageRollbackDurationSec_);
+      }
+      if (((bitField0_ & 0x00008000) == 0x00008000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeMessageSize(17, keySharedMeta_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -9514,6 +10535,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00004000);
         startMessageRollbackDurationSec_ = 0L;
         bitField0_ = (bitField0_ & ~0x00008000);
+        keySharedMeta_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x00010000);
         return this;
       }
       
@@ -9612,6 +10635,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00004000;
         }
         result.startMessageRollbackDurationSec_ = startMessageRollbackDurationSec_;
+        if (((from_bitField0_ & 0x00010000) == 0x00010000)) {
+          to_bitField0_ |= 0x00008000;
+        }
+        result.keySharedMeta_ = keySharedMeta_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -9673,6 +10700,9 @@ public final class PulsarApi {
         if (other.hasStartMessageRollbackDurationSec()) {
           setStartMessageRollbackDurationSec(other.getStartMessageRollbackDurationSec());
         }
+        if (other.hasKeySharedMeta()) {
+          mergeKeySharedMeta(other.getKeySharedMeta());
+        }
         return this;
       }
       
@@ -9711,6 +10741,12 @@ public final class PulsarApi {
         }
         if (hasSchema()) {
           if (!getSchema().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasKeySharedMeta()) {
+          if (!getKeySharedMeta().isInitialized()) {
             
             return false;
           }
@@ -9837,6 +10873,16 @@ public final class PulsarApi {
             case 128: {
               bitField0_ |= 0x00008000;
               startMessageRollbackDurationSec_ = input.readUInt64();
+              break;
+            }
+            case 138: {
+              org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.newBuilder();
+              if (hasKeySharedMeta()) {
+                subBuilder.mergeFrom(getKeySharedMeta());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setKeySharedMeta(subBuilder.buildPartial());
+              subBuilder.recycle();
               break;
             }
           }
@@ -10341,6 +11387,49 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00008000);
         startMessageRollbackDurationSec_ = 0L;
         
+        return this;
+      }
+      
+      // optional .pulsar.proto.KeySharedMeta keySharedMeta = 17;
+      private org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta keySharedMeta_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance();
+      public boolean hasKeySharedMeta() {
+        return ((bitField0_ & 0x00010000) == 0x00010000);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta getKeySharedMeta() {
+        return keySharedMeta_;
+      }
+      public Builder setKeySharedMeta(org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        keySharedMeta_ = value;
+        
+        bitField0_ |= 0x00010000;
+        return this;
+      }
+      public Builder setKeySharedMeta(
+          org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.Builder builderForValue) {
+        keySharedMeta_ = builderForValue.build();
+        
+        bitField0_ |= 0x00010000;
+        return this;
+      }
+      public Builder mergeKeySharedMeta(org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta value) {
+        if (((bitField0_ & 0x00010000) == 0x00010000) &&
+            keySharedMeta_ != org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance()) {
+          keySharedMeta_ =
+            org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.newBuilder(keySharedMeta_).mergeFrom(value).buildPartial();
+        } else {
+          keySharedMeta_ = value;
+        }
+        
+        bitField0_ |= 0x00010000;
+        return this;
+      }
+      public Builder clearKeySharedMeta() {
+        keySharedMeta_ = org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta.getDefaultInstance();
+        
+        bitField0_ = (bitField0_ & ~0x00010000);
         return this;
       }
       

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -515,7 +515,8 @@ public class Commands {
                     PulsarApi.KeySharedMeta.Builder builder = PulsarApi.KeySharedMeta.newBuilder()
                             .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
                             .setTotalHashRange(keySharedPolicy.getHashRangeTotal());
-                    List<Range> ranges = ((KeySharedPolicy.KeySharedPolicyExclusiveHashRange) keySharedPolicy).getRanges();
+                    List<Range> ranges = ((KeySharedPolicy.KeySharedPolicyExclusiveHashRange) keySharedPolicy)
+                            .getRanges();
                     for (Range range : ranges) {
                         builder.addHashRanges(PulsarApi.IntRange.newBuilder()
                                 .setStart(range.getStart())

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.api.proto.PulsarApi;
@@ -478,6 +480,16 @@ public class Commands {
             Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
             InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
             boolean createTopicIfDoesNotExist) {
+                return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
+                        isDurable, startMessageId, metadata, readCompacted, isReplicated, subscriptionInitialPosition,
+                        startMessageRollbackDurationInSec, schemaInfo, createTopicIfDoesNotExist, null);
+    }
+
+    public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
+               SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
+               Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
+               InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
+               boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy) {
         CommandSubscribe.Builder subscribeBuilder = CommandSubscribe.newBuilder();
         subscribeBuilder.setTopic(topic);
         subscribeBuilder.setSubscription(subscription);
@@ -491,6 +503,28 @@ public class Commands {
         subscribeBuilder.setInitialPosition(subscriptionInitialPosition);
         subscribeBuilder.setReplicateSubscriptionState(isReplicated);
         subscribeBuilder.setForceTopicCreation(createTopicIfDoesNotExist);
+
+        if (keySharedPolicy != null) {
+            switch (keySharedPolicy.getKeySharedMode()) {
+                case AUTO_SPLIT:
+                    subscribeBuilder.setKeySharedMeta(PulsarApi.KeySharedMeta.newBuilder()
+                            .setKeySharedMode(PulsarApi.KeySharedMode.autoSplit)
+                            .setTotalHashRange(keySharedPolicy.getHashRangeTotal()));
+                    break;
+                case EXCLUSIVE_HASH_RANGE:
+                    PulsarApi.KeySharedMeta.Builder builder = PulsarApi.KeySharedMeta.newBuilder()
+                            .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
+                            .setTotalHashRange(keySharedPolicy.getHashRangeTotal());
+                    List<Range> ranges = ((KeySharedPolicy.KeySharedPolicyExclusiveHashRange) keySharedPolicy).getRanges();
+                    for (Range range : ranges) {
+                        builder.addHashRanges(PulsarApi.IntRange.newBuilder()
+                                .setStart(range.getStart())
+                                .setEnd(range.getEnd()));
+                    }
+                    subscribeBuilder.setKeySharedMeta(builder);
+                    break;
+            }
+        }
 
         if (startMessageId != null) {
             subscribeBuilder.setStartMessageId(startMessageId);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -488,8 +488,8 @@ public class Commands {
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
                SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
                Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
-               InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
-               boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy) {
+               InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec,
+               SchemaInfo schemaInfo, boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy) {
         CommandSubscribe.Builder subscribeBuilder = CommandSubscribe.newBuilder();
         subscribeBuilder.setTopic(topic);
         subscribeBuilder.setSubscription(subscription);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -508,14 +508,12 @@ public class Commands {
             switch (keySharedPolicy.getKeySharedMode()) {
                 case AUTO_SPLIT:
                     subscribeBuilder.setKeySharedMeta(PulsarApi.KeySharedMeta.newBuilder()
-                            .setKeySharedMode(PulsarApi.KeySharedMode.autoSplit)
-                            .setTotalHashRange(keySharedPolicy.getHashRangeTotal()));
+                            .setKeySharedMode(PulsarApi.KeySharedMode.autoSplit));
                     break;
-                case EXCLUSIVE_HASH_RANGE:
+                case STICKY:
                     PulsarApi.KeySharedMeta.Builder builder = PulsarApi.KeySharedMeta.newBuilder()
-                            .setKeySharedMode(PulsarApi.KeySharedMode.exclusiveHashRange)
-                            .setTotalHashRange(keySharedPolicy.getHashRangeTotal());
-                    List<Range> ranges = ((KeySharedPolicy.KeySharedPolicyExclusiveHashRange) keySharedPolicy)
+                            .setKeySharedMode(PulsarApi.KeySharedMode.sticky);
+                    List<Range> ranges = ((KeySharedPolicy.KeySharedPolicySticky) keySharedPolicy)
                             .getRanges();
                     for (Range range : ranges) {
                         builder.addHashRanges(PulsarApi.IntRange.newBuilder()

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -508,11 +508,11 @@ public class Commands {
             switch (keySharedPolicy.getKeySharedMode()) {
                 case AUTO_SPLIT:
                     subscribeBuilder.setKeySharedMeta(PulsarApi.KeySharedMeta.newBuilder()
-                            .setKeySharedMode(PulsarApi.KeySharedMode.autoSplit));
+                            .setKeySharedMode(PulsarApi.KeySharedMode.AUTO_SPLIT));
                     break;
                 case STICKY:
                     PulsarApi.KeySharedMeta.Builder builder = PulsarApi.KeySharedMeta.newBuilder()
-                            .setKeySharedMode(PulsarApi.KeySharedMode.sticky);
+                            .setKeySharedMode(PulsarApi.KeySharedMode.STICKY);
                     List<Range> ranges = ((KeySharedPolicy.KeySharedPolicySticky) keySharedPolicy)
                             .getRanges();
                     for (Range range : ranges) {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -256,8 +256,8 @@ message AuthData {
 }
 
 enum KeySharedMode {
-    autoSplit = 0;
-    sticky = 1;
+    AUTO_SPLIT = 0;
+    STICKY = 1;
 }
 
 message KeySharedMeta {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -62,8 +62,13 @@ message KeyValue {
 }
 
 message KeyLongValue {
-        required string key = 1;
-        required uint64 value = 2;
+    required string key = 1;
+    required uint64 value = 2;
+}
+
+message IntRange {
+    required int32 start = 1;
+    required int32 end = 2;
 }
 
 message EncryptionKeys {
@@ -250,6 +255,17 @@ message AuthData {
     optional bytes auth_data = 2;
 }
 
+enum KeySharedMode {
+    autoSplit = 0;
+    exclusiveHashRange = 1;
+}
+
+message KeySharedMeta {
+    required KeySharedMode keySharedMode = 1;
+    required int32 totalHashRange = 2;
+    repeated IntRange hashRanges = 3;
+}
+
 message CommandSubscribe {
     enum SubType {
         Exclusive = 0;
@@ -304,6 +320,8 @@ message CommandSubscribe {
     // If specified, the subscription will reset cursor's position back 
     // to specified seconds and  will send messages from that point
     optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
+
+    optional KeySharedMeta keySharedMeta = 17;
 }
 
 message CommandPartitionedTopicMetadata {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -257,12 +257,11 @@ message AuthData {
 
 enum KeySharedMode {
     autoSplit = 0;
-    exclusiveHashRange = 1;
+    sticky = 1;
 }
 
 message KeySharedMeta {
     required KeySharedMode keySharedMode = 1;
-    required int32 totalHashRange = 2;
     repeated IntRange hashRanges = 3;
 }
 


### PR DESCRIPTION
### Motivation

Introduce sticky consumer, users can enable it by

```java
client.newConsumer()
         .keySharedPolicy(KeySharedPolicy.exclusiveHashRange().hashRangeTotal(10).ranges(Range.of(0, 10)))
         .subscribe();
```

### Modifications

Add a new consumer selector named HashRangeExclusiveStickyKeyConsumerSelector to support sticky consumer.

This change added tests and can be verified as follows:

Add new unit tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (yes)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
