### PR TITLE
[Docs] Add delete-dynamic-config command for brokers

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -171,6 +171,21 @@ Usage
 $ pulsar-admin brokers list-dynamic-config
 ```
 
+### `delete-dynamic-config`
+Delete dynamic-serviceConfiguration of broker
+
+Usage
+```bash
+$ pulsar-admin brokers delete-dynamic-config options
+```
+
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+|`--config`|Service configuration parameter name||
+
+
 ### `get-all-dynamic-config`
 Get all overridden dynamic-configuration values
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

`delete-dynamic-config` document missing

### Modifications

Add `delete-dynamic-config` command for **pulsar-admin brokers**.