### PR TITLE
[pulsar-broker] Fix: race condition : Failed to read-more entries on dispatcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -722,23 +722,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, msgMetadata.getDeliverAtTime());
     }
 
-    /**
-     * Returns whether we have any message that could be immediately replayed.
-     * This could be a message that was requested to be re-delivered or a delayed
-     * delivery.
-     */
-    private boolean hasMessagesToReplay() {
-        if (!messagesToRedeliver.isEmpty()) {
-            return true;
-        }
-
-        if (delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().hasMessageAvailable()) {
-            return true;
-        }
-
-        return false;
-    }
-
     private synchronized Set<PositionImpl> getMessagesToReplayNow(int maxMessagesToRead) {
         if (!messagesToRedeliver.isEmpty()) {
             return messagesToRedeliver.items(maxMessagesToRead,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAG
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -292,13 +293,13 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
             }
 
-            if (hasMessagesToReplay()) {
+            Set<PositionImpl> messagesToReplayNow = getMessagesToReplayNow(messagesToRead);
+
+            if (!messagesToReplayNow.isEmpty()) {
                 if (havePendingReplayRead) {
                     log.debug("[{}] Skipping replay while awaiting previous read to complete", name);
                     return;
                 }
-
-                Set<PositionImpl> messagesToReplayNow = getMessagesToReplayNow(messagesToRead);
 
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule replay of {} messages for {} consumers", name, messagesToReplayNow.size(),
@@ -742,8 +743,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         if (!messagesToRedeliver.isEmpty()) {
             return messagesToRedeliver.items(maxMessagesToRead,
                     (ledgerId, entryId) -> new PositionImpl(ledgerId, entryId));
-        } else {
+        } else if (delayedDeliveryTracker.isPresent()) {
             return delayedDeliveryTracker.get().getScheduledMessages(maxMessagesToRead);
+        } else {
+            return Collections.emptySet();
         }
     }
 


### PR DESCRIPTION
### Motivation

Due to race condition on `messagesToRedeliver`, dispatcher tries to access `delayedDeliveryTracker` which is empty and it is getting below exception so, dispatcher is not able to read entries. 

```
22:05:03.693 [pulsar-io-22-7] WARN  io.netty.util.concurrent.AbstractEventExecutor - A task raised an exception. Task: org.apache.pulsar.broker.service.persisten
t.PersistentDispatcherMultipleConsumers$$Lambda$965/0x0000000800912840@cdfd37a
java.util.NoSuchElementException: No value present
        at java.util.Optional.get(Optional.java:148) ~[?:?]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.getMessagesToReplayNow(PersistentDispatcherMultipleConsumers.java:728) ~[pulsar-broker-2.4.3-yahoo.jar:2.4.3-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.readMoreEntries(PersistentDispatcherMultipleConsumers.java:298) ~[pulsar-broker-2.4.3-yahoo.jar:2.4.3-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$addUnAckedMessages$374(PersistentDispatcherMultipleConsumers.java:646) ~[pulsar-broker-2.4.3-yahoo.jar:2.4.3-yahoo]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:335) [netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:909) [netty-all-4.1.32.Final.jar:4.1.32.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.32.Final.jar:4.1.32.Final]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

With this fix, dispatcher will atomically fetches replay-messages without accessing `delayedDeliveryTracker`.