### PR TITLE
[functions] Distribute the CA for KubernetesSecretsTokenAuthProvider

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public interface KubernetesFunctionAuthProvider extends FunctionAuthProvider {
 
-    void initialize(CoreV1Api coreClient, String kubeNamespace);
+    void initialize(CoreV1Api coreClient, String kubeNamespace, byte[] caBytes);
 
     /**
      * Configure function statefulset spec based on function auth data

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.auth;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.models.V1DeleteOptions;
@@ -39,6 +40,8 @@ import org.apache.pulsar.functions.utils.FunctionCommon;
 
 import javax.naming.AuthenticationException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -55,14 +58,18 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
     private static final String SECRET_NAME = "function-auth";
     private static final String DEFAULT_SECRET_MOUNT_DIR = "/etc/auth";
     private static final String FUNCTION_AUTH_TOKEN = "token";
+    private static final String FUNCTION_CA_CERT = "ca.pem";
+
 
     private CoreV1Api coreClient;
     private String kubeNamespace;
+    private byte[] caBytes;
 
     @Override
-    public void initialize(CoreV1Api coreClient, String kubeNamespace) {
+    public void initialize(CoreV1Api coreClient, String kubeNamespace, byte[] caBytes) {
         this.coreClient = coreClient;
         this.kubeNamespace = kubeNamespace;
+        this.caBytes = caBytes;
     }
 
     @Override
@@ -99,6 +106,10 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
         } else {
             authConfig.setClientAuthenticationPlugin(AuthenticationToken.class.getName());
             authConfig.setClientAuthenticationParameters(String.format("file://%s/%s", DEFAULT_SECRET_MOUNT_DIR, FUNCTION_AUTH_TOKEN));
+            // if we have ca bytes, update the new path for the CA
+            if (this.caBytes != null) {
+                authConfig.setTlsTrustCertsFilePath(String.format("%s/%s", DEFAULT_SECRET_MOUNT_DIR, FUNCTION_CA_CERT));
+            }
         }
     }
 
@@ -252,6 +263,16 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
         return existingFunctionAuthData;
     }
 
+    @VisibleForTesting
+    Map<String, byte[]> buildSecretMap(String token) {
+        Map<String, byte[]> valueMap = new HashMap<>();
+        valueMap.put(FUNCTION_AUTH_TOKEN, token.getBytes());
+        if (caBytes != null) {
+            valueMap.put(FUNCTION_CA_CERT, caBytes);
+        }
+        return valueMap;
+    }
+
     private void upsertSecret(String token, String tenant, String namespace, String name, String secretName) throws InterruptedException {
 
         Actions.Action createAuthSecret = Actions.Action.builder()
@@ -262,7 +283,7 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
                     String id =  RandomStringUtils.random(5, true, true).toLowerCase();
                     V1Secret v1Secret = new V1Secret()
                             .metadata(new V1ObjectMeta().name(secretName))
-                            .data(Collections.singletonMap(FUNCTION_AUTH_TOKEN, token.getBytes()));
+                            .data(buildSecretMap(token));
 
                     try {
                         coreClient.createNamespacedSecret(kubeNamespace, v1Secret, null);
@@ -315,7 +336,7 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
                     String id =  RandomStringUtils.random(5, true, true).toLowerCase();
                     V1Secret v1Secret = new V1Secret()
                             .metadata(new V1ObjectMeta().name(getSecretName(id)))
-                            .data(Collections.singletonMap(FUNCTION_AUTH_TOKEN, token.getBytes()));
+                            .data(buildSecretMap(token));
                     try {
                         coreClient.createNamespacedSecret(kubeNamespace, v1Secret, "true");
                     } catch (ApiException e) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactory.java
@@ -97,6 +97,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     private Resources functionInstanceMinResources;
     private final boolean authenticationEnabled;
     private Optional<KubernetesFunctionAuthProvider> authProvider;
+    private final byte[] serverCaBytes;
 
     @VisibleForTesting
     public KubernetesRuntimeFactory(String k8Uri,
@@ -117,6 +118,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
                                     String pulsarAdminUri,
                                     String stateStorageServiceUri,
                                     AuthenticationConfig authConfig,
+                                    byte[] serverCaBytes,
                                     Integer expectedMetricsCollectionInterval,
                                     String changeConfigMap,
                                     String changeConfigMapNamespace,
@@ -171,6 +173,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         this.customLabels = customLabels;
         this.stateStorageServiceUri = stateStorageServiceUri;
         this.authConfig = authConfig;
+        this.serverCaBytes = serverCaBytes;
         this.javaInstanceJarFile = this.kubernetesInfo.getPulsarRootDir() + "/instances/java-instance.jar";
         this.pythonInstanceFile = this.kubernetesInfo.getPulsarRootDir() + "/instances/python-instance/python_instance_main.py";
         this.expectedMetricsCollectionInterval = expectedMetricsCollectionInterval == null ? -1 : expectedMetricsCollectionInterval;
@@ -190,7 +193,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
                         + functionAuthProvider.get().getClass().getName() + " must implement KubernetesFunctionAuthProvider");
             } else {
                 KubernetesFunctionAuthProvider kubernetesFunctionAuthProvider = (KubernetesFunctionAuthProvider) functionAuthProvider.get();
-                kubernetesFunctionAuthProvider.initialize(coreClient, jobNamespace);
+                kubernetesFunctionAuthProvider.initialize(coreClient, jobNamespace, serverCaBytes);
                 this.authProvider = Optional.of(kubernetesFunctionAuthProvider);
             }
         } else {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeFactoryTest.java
@@ -158,6 +158,7 @@ public class KubernetesRuntimeFactoryTest {
             null,
             null,
             null,
+            null,
                 minResources,
                 new TestSecretProviderConfigurator(), false, functionAuthProvider));
         doNothing().when(factory).setupClient();
@@ -274,7 +275,7 @@ public class KubernetesRuntimeFactoryTest {
             }
 
             @Override
-            public void initialize(CoreV1Api coreClient, String kubeNamespace) {
+            public void initialize(CoreV1Api coreClient, String kubeNamespace, byte[] caBytes) {
 
             }
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/KubernetesRuntimeTest.java
@@ -176,6 +176,7 @@ public class KubernetesRuntimeTest {
             null,
             null,
             null,
+null,
                 null, new TestSecretProviderConfigurator(), false,
                 Optional.empty()));
         doNothing().when(factory).setupClient();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -180,6 +180,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
                     StringUtils.isEmpty(workerConfig.getKubernetesContainerFactory().getPulsarAdminUrl()) ? workerConfig.getPulsarWebServiceUrl() : workerConfig.getKubernetesContainerFactory().getPulsarAdminUrl(),
                     workerConfig.getStateStorageServiceUrl(),
                     authConfig,
+                    workerConfig.getTlsTrustChainBytes(),
                     workerConfig.getKubernetesContainerFactory().getExpectedMetricsCollectionInterval() == null ? -1 : workerConfig.getKubernetesContainerFactory().getExpectedMetricsCollectionInterval(),
                     workerConfig.getKubernetesContainerFactory().getChangeConfigMap(),
                     workerConfig.getKubernetesContainerFactory().getChangeConfigMapNamespace(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -537,6 +539,18 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             this.workerHostname = unsafeLocalhostResolve();
         }
         return this.workerHostname;
+    }
+
+    public byte[] getTlsTrustChainBytes() {
+        if (StringUtils.isNotEmpty(getTlsTrustCertsFilePath()) && Files.exists(Paths.get(getTlsTrustCertsFilePath()))) {
+            try {
+                return Files.readAllBytes(Paths.get(getTlsTrustCertsFilePath()));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to read CA bytes", e);
+            }
+        } else {
+            return null;
+        }
     }
 
     public String getWorkerWebAddress() {


### PR DESCRIPTION
### Motivation

Currently, if a user has TLS enabled and is using a custom CA that isn't
baked into the image, when the functions worker starts, it won't have
the CA in order to validate the cert presented by the broker.


### Modifications

This adds support to have  the `KubernetesSecretsTokenAuthProvider`
also distribute the CA via the same kubernetes secret used for the
token.

### Verifying this change

- [x ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added tests to ensure that the code paths work with and without a CA
- Added tests to ensure that the filename returned is as expected

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented, but the KubernetesSecretsTokenAuthProvider is missing docs complete
  - If a feature is not applicable for documentation, explain why? It does need docs, but the functionality as a whole is missing docs
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
