### PR TITLE
[functions] Allow functions to pass runtime specific options

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -300,6 +300,8 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--max-message-retries", description = "How many times should we try to process a message before giving up")
         protected Integer maxMessageRetries;
         @Parameter(names = "--dead-letter-topic", description = "The topic where messages that are not processed successfully are sent to")
+        protected String customRuntimeOptions;
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
         protected String deadLetterTopic;
         protected FunctionConfig functionConfig;
         protected String userCodeFile;
@@ -435,6 +437,10 @@ public class CmdFunctions extends CmdBase {
 
             if (timeoutMs != null) {
                 functionConfig.setTimeoutMs(timeoutMs);
+            }
+
+            if (customRuntimeOptions != null) {
+                functionConfig.setCustomRuntimeOptions(customRuntimeOptions);
             }
 
             // window configs

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -314,6 +314,8 @@ public class CmdSinks extends CmdBase {
         protected Boolean autoAck;
         @Parameter(names = "--timeout-ms", description = "The message timeout in milliseconds")
         protected Long timeoutMs;
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        protected String customRuntimeOptions;
 
         protected SinkConfig sinkConfig;
 
@@ -444,6 +446,10 @@ public class CmdSinks extends CmdBase {
             
             if (null != sinkConfigString) {
                 sinkConfig.setConfigs(parseConfigs(sinkConfigString));
+            }
+
+            if (customRuntimeOptions != null) {
+                sinkConfig.setCustomRuntimeOptions(customRuntimeOptions);
             }
 
             // check if configs are valid

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -299,6 +299,8 @@ public class CmdSources extends CmdBase {
         protected String DEPRECATED_sourceConfigString;
         @Parameter(names = "--source-config", description = "Source config key/values")
         protected String sourceConfigString;
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        protected String customRuntimeOptions;
 
         protected SourceConfig sourceConfig;
 
@@ -392,6 +394,9 @@ public class CmdSources extends CmdBase {
                 sourceConfig.setConfigs(parseConfigs(sourceConfigString));
             }
 
+            if (customRuntimeOptions != null) {
+                sourceConfig.setCustomRuntimeOptions(customRuntimeOptions);
+            }
             // check if source configs are valid
             validateSourceConfigs(sourceConfig);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -116,4 +116,8 @@ public class FunctionConfig {
     private String go;
     // Whether the subscriptions the functions created/used should be deleted when the functions is deleted
     private Boolean cleanupSubscription;
+    // This is an arbitrary string that can be interpreted by the function runtime
+    // to change behavior at runtime. Currently, this primarily used by the KubernetesManifestCustomizer
+    // interface
+    private String customRuntimeOptions;
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -83,4 +83,8 @@ public class SinkConfig {
 
     // Any flags that you want to pass to the runtime.
     private String runtimeFlags;
+    // This is an arbitrary string that can be interpreted by the function runtime
+    // to change behavior at runtime. Currently, this primarily used by the KubernetesManifestCustomizer
+    // interface
+    private String customRuntimeOptions;
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -67,4 +67,8 @@ public class SourceConfig {
     private String archive;
     // Any flags that you want to pass to the runtime.
     private String runtimeFlags;
+    // This is an arbitrary string that can be interpreted by the function runtime
+    // to change behavior at runtime. Currently, this primarily used by the KubernetesManifestCustomizer
+    // interface
+    private String customRuntimeOptions;
 }

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -346,7 +346,7 @@ public class LocalRunner {
                 null, /* python instance file */
                 null, /* log directory */
                 null, /* extra dependencies dir */
-                new DefaultSecretsProviderConfigurator(), false, Optional.empty())) {
+                new DefaultSecretsProviderConfigurator(), false, Optional.empty(), Optional.empty())) {
 
             for (int i = 0; i < parallelism; ++i) {
                 InstanceConfig instanceConfig = new InstanceConfig();

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -80,6 +80,7 @@ message FunctionDetails {
     RetryDetails retryDetails = 15;
     string runtimeFlags = 17;
     ComponentType componentType = 18;
+    string customRuntimeOptions = 19;
 }
 
 message ConsumerSpec {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProvider.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.auth;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
+import org.apache.pulsar.functions.proto.Function;
 
 import java.util.Optional;
 
@@ -40,7 +41,7 @@ public class ClearTextFunctionTokenAuthProvider implements FunctionAuthProvider 
     }
 
     @Override
-    public Optional<FunctionAuthData> cacheAuthData(String tenant, String namespace, String name, AuthenticationDataSource authenticationDataSource) throws Exception {
+    public Optional<FunctionAuthData> cacheAuthData(Function.FunctionDetails funcDetails, AuthenticationDataSource authenticationDataSource) throws Exception {
         String token = null;
         try {
             token = getToken(authenticationDataSource);
@@ -55,13 +56,13 @@ public class ClearTextFunctionTokenAuthProvider implements FunctionAuthProvider 
     }
 
     @Override
-    public Optional<FunctionAuthData> updateAuthData(String tenant, String namespace, String name,
+    public Optional<FunctionAuthData> updateAuthData(Function.FunctionDetails funcDetails,
                                                      Optional<FunctionAuthData> existingFunctionAuthData, AuthenticationDataSource authenticationDataSource) throws Exception {
-        return cacheAuthData(tenant, namespace, name, authenticationDataSource);
+        return cacheAuthData(funcDetails, authenticationDataSource);
     }
 
     @Override
-    public void cleanUpAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> functionAuthData) throws Exception {
+    public void cleanUpAuthData(Function.FunctionDetails funcDetails, Optional<FunctionAuthData> functionAuthData) throws Exception {
         //no-op
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/FunctionAuthProvider.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.auth;
 
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
+import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.utils.Reflections;
 
 import java.util.Optional;
@@ -39,29 +40,22 @@ public interface FunctionAuthProvider {
 
     /**
      * Cache auth data in as part of function metadata for function that runtime may need to configure authentication
-     * @param tenant tenant that the function is running under
-     * @param namespace namespace that is the function is running under
-     * @param name name of the function
+     * @param funcDetails the function details
      * @param authenticationDataSource auth data
      * @return
      * @throws Exception
      */
-    Optional<FunctionAuthData> cacheAuthData(String tenant, String namespace, String name, AuthenticationDataSource authenticationDataSource) throws Exception;
+    Optional<FunctionAuthData> cacheAuthData(Function.FunctionDetails funcDetails, AuthenticationDataSource authenticationDataSource) throws Exception;
 
-
-
-    Optional<FunctionAuthData> updateAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> existingFunctionAuthData, AuthenticationDataSource authenticationDataSource) throws Exception;
-
+    Optional<FunctionAuthData> updateAuthData(Function.FunctionDetails funcDetails, Optional<FunctionAuthData> existingFunctionAuthData, AuthenticationDataSource authenticationDataSource) throws Exception;
 
     /**
      * Clean up operation for auth when function is terminated
-     * @param tenant tenant that the function is running under
-     * @param namespace namespace that is the function is running under
-     * @param name name of the function
+     * @param funcDetails the function details
      * @param functionAuthData function auth data
      * @throws Exception
      */
-    void cleanUpAuthData(String tenant, String namespace, String name, Optional<FunctionAuthData> functionAuthData) throws Exception;
+    void cleanUpAuthData(Function.FunctionDetails funcDetails, Optional<FunctionAuthData> functionAuthData) throws Exception;
 
     static FunctionAuthProvider getAuthProvider(String className) {
         return Reflections.createInstance(className, FunctionAuthProvider.class, Thread.currentThread().getContextClassLoader());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesFunctionAuthProvider.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.auth;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1StatefulSet;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.utils.Reflections;
 
 import java.util.Optional;
@@ -30,7 +32,21 @@ import java.util.Optional;
  */
 public interface KubernetesFunctionAuthProvider extends FunctionAuthProvider {
 
-    void initialize(CoreV1Api coreClient, String kubeNamespace, byte[] caBytes);
+    void initialize(CoreV1Api coreClient);
+
+    default void initialize(CoreV1Api coreClient, byte[] caBytes, java.util.function.Function<Function.FunctionDetails, String> namespaceCustomizerFunc) {
+        setCaBytes(caBytes);
+        setNamespaceProviderFunc(namespaceCustomizerFunc);
+        initialize(coreClient);
+    }
+
+    default void setCaBytes(byte[] caBytes) {
+
+    }
+
+    default void setNamespaceProviderFunc(java.util.function.Function<Function.FunctionDetails, String> funcDetails) {
+
+    }
 
     /**
      * Configure function statefulset spec based on function auth data

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeCustomizer.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.runtime;
+
+import org.apache.pulsar.functions.utils.Reflections;
+
+import java.util.Map;
+
+public interface RuntimeCustomizer {
+    void initialize(final Map<String, Object> runtimeCustomizerConfig);
+
+    static RuntimeCustomizer getRuntimeCustomizer(String className) {
+        return Reflections.createInstance(className, RuntimeCustomizer.class, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeFactory.java
@@ -37,7 +37,8 @@ public interface RuntimeFactory extends AutoCloseable {
     void initialize(WorkerConfig workerConfig,
                     AuthenticationConfig authenticationConfig,
                     SecretsProviderConfigurator secretsProviderConfigurator,
-                    Optional<FunctionAuthProvider> functionAuthProvider) throws Exception;
+                    Optional<FunctionAuthProvider> authProvider,
+                    Optional<RuntimeCustomizer> runtimeCustomizer) throws Exception;
 
     /**
      * Create a function container to execute a java instance.
@@ -55,7 +56,11 @@ public interface RuntimeFactory extends AutoCloseable {
 
     default void doAdmissionChecks(Function.FunctionDetails functionDetails) { }
 
-    default Optional<FunctionAuthProvider> getAuthProvider() {
+    default Optional<? extends FunctionAuthProvider> getAuthProvider() {
+        return Optional.empty();
+    }
+
+    default Optional<? extends RuntimeCustomizer> getRuntimeCustomizer() {
         return Optional.empty();
     }
 
@@ -67,4 +72,4 @@ public interface RuntimeFactory extends AutoCloseable {
     }
 
 }
- 
+

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.runtime.kubernetes;
+
+import io.kubernetes.client.models.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.runtime.kubernetes.KubernetesManifestCustomizer;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of the {@link KubernetesManifestCustomizer} that allows
+ * for some basic customization of namespace, labels, annotations, node selectors,
+ * and tolerations.
+ *
+ * With the right RBAC permissions for the functions worker, these should be safe to
+ * modify (for example, a service account must have permissions in the specified jobNamespace)
+ *
+ */
+public class BasicKubernetesManifestCustomizer implements KubernetesManifestCustomizer {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    static private class RuntimeOpts {
+        private String jobNamespace;
+        private Map<String, String> extraLabels;
+        private Map<String, String> extraAnnotations;
+        private Map<String, String> nodeSelectorLabels;
+        private List<V1Toleration> tolerations;
+    }
+
+    @Override
+    public void initialize(Map<String, Object> config) {
+    }
+
+    @Override
+    public String customizeNamespace(Function.FunctionDetails funcDetails, String currentNamespace) {
+        RuntimeOpts opts = getOptsFromDetails(funcDetails);
+        if (!StringUtils.isEmpty(opts.getJobNamespace())) {
+            return opts.getJobNamespace();
+        } else {
+            return currentNamespace;
+        }
+    }
+
+    @Override
+    public V1Service customizeService(Function.FunctionDetails funcDetails, V1Service service) {
+        RuntimeOpts opts = getOptsFromDetails(funcDetails);
+        service.setMetadata(updateMeta(opts, service.getMetadata()));
+        return service;
+    }
+
+    @Override
+    public V1StatefulSet customizeStatefulSet(Function.FunctionDetails funcDetails, V1StatefulSet statefulSet) {
+        RuntimeOpts opts = getOptsFromDetails(funcDetails);
+        statefulSet.setMetadata(updateMeta(opts, statefulSet.getMetadata()));
+        V1PodTemplateSpec pt = statefulSet.getSpec().getTemplate();
+        pt.setMetadata(updateMeta(opts, pt.getMetadata()));
+        V1PodSpec ps = pt.getSpec();
+        if (opts.getNodeSelectorLabels() != null && opts.getNodeSelectorLabels().size() > 0) {
+            opts.getNodeSelectorLabels().forEach(ps::putNodeSelectorItem);
+        }
+        if (opts.getTolerations() != null && opts.getTolerations().size() > 0) {
+            opts.getTolerations().forEach(ps::addTolerationsItem);
+        }
+        return statefulSet;
+    }
+
+    private RuntimeOpts getOptsFromDetails(Function.FunctionDetails funcDetails) {
+        String customRuntimeOptions = funcDetails.getCustomRuntimeOptions();
+        RuntimeOpts opts = new Gson().fromJson(customRuntimeOptions, RuntimeOpts.class);
+        // ensure that we always have at least the default
+        if (opts == null) {
+            opts = new RuntimeOpts();
+        }
+        return opts;
+    }
+
+    private V1ObjectMeta updateMeta(RuntimeOpts opts, V1ObjectMeta meta) {
+        if (opts.getExtraAnnotations() != null && opts.getExtraAnnotations().size() > 0) {
+            opts.getExtraAnnotations().forEach(meta::putAnnotationsItem);
+        }
+        if (opts.getExtraLabels() != null && opts.getExtraLabels().size() > 0) {
+            opts.getExtraLabels().forEach(meta::putLabelsItem);
+        }
+        return meta;
+    }
+
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesManifestCustomizer.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.runtime.kubernetes;
+
+import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1StatefulSet;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.runtime.RuntimeCustomizer;
+
+public interface KubernetesManifestCustomizer extends RuntimeCustomizer {
+
+    default V1StatefulSet customizeStatefulSet(Function.FunctionDetails funcDetails, V1StatefulSet statefulSet) {
+        return statefulSet;
+    }
+
+    default V1Service customizeService(Function.FunctionDetails funcDetails, V1Service service) {
+        return service;
+    }
+
+    default String customizeNamespace(Function.FunctionDetails funcDetails, String currentNamespace) {
+        return currentNamespace;
+    }
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -144,6 +144,7 @@ public class KubernetesRuntime implements Runtime {
     private double memoryOverCommitRatio;
     private final Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider;
     private final AuthenticationConfig authConfig;
+    private final Optional<KubernetesManifestCustomizer> manifestCustomizer;
 
     KubernetesRuntime(AppsV1Api appsClient,
                       CoreV1Api coreClient,
@@ -171,7 +172,8 @@ public class KubernetesRuntime implements Runtime {
                       double cpuOverCommitRatio,
                       double memoryOverCommitRatio,
                       Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider,
-                      boolean authenticationEnabled) throws Exception {
+                      boolean authenticationEnabled,
+                      Optional<KubernetesManifestCustomizer> manifestCustomizer) throws Exception {
         this.appsClient = appsClient;
         this.coreClient = coreClient;
         this.instanceConfig = instanceConfig;
@@ -188,6 +190,7 @@ public class KubernetesRuntime implements Runtime {
         this.cpuOverCommitRatio = cpuOverCommitRatio;
         this.memoryOverCommitRatio = memoryOverCommitRatio;
         this.authenticationEnabled = authenticationEnabled;
+        this.manifestCustomizer = manifestCustomizer;
         String logConfigFile = null;
         String secretsProviderClassName = secretsProviderConfigurator.getSecretsProviderClassName(instanceConfig.getFunctionDetails());
         String secretsProviderConfig = null;
@@ -435,7 +438,8 @@ public class KubernetesRuntime implements Runtime {
         }
     }
 
-    private V1Service createService() {
+    @VisibleForTesting
+    V1Service createService() {
         final String jobName = createJobName(instanceConfig.getFunctionDetails());
 
         final V1Service service = new V1Service();
@@ -444,6 +448,8 @@ public class KubernetesRuntime implements Runtime {
         final V1ObjectMeta objectMeta = new V1ObjectMeta();
         objectMeta.name(jobName);
         objectMeta.setLabels(getLabels(instanceConfig.getFunctionDetails()));
+        // we don't technically need to set this, but it is useful for testing
+        objectMeta.setNamespace(jobNamespace);
         service.metadata(objectMeta);
 
         // create the stateful set spec
@@ -459,7 +465,11 @@ public class KubernetesRuntime implements Runtime {
 
         service.spec(serviceSpec);
 
-        return service;
+        // let the customizer run but ensure it doesn't change the name so we can find it again
+        final V1Service overridden = manifestCustomizer.map((customizer) -> customizer.customizeService(instanceConfig.getFunctionDetails(), service)).orElse(service);
+        overridden.getMetadata().name(jobName);
+
+        return overridden;
     }
 
     private void submitStatefulSet() throws Exception {
@@ -829,7 +839,8 @@ public class KubernetesRuntime implements Runtime {
         return String.format("%s=${POD_NAME##*-} && echo shardId=${%s}", ENV_SHARD_ID, ENV_SHARD_ID);
     }
 
-    private V1StatefulSet createStatefulSet() {
+    @VisibleForTesting
+    V1StatefulSet createStatefulSet() {
         final String jobName = createJobName(instanceConfig.getFunctionDetails());
 
         final V1StatefulSet statefulSet = new V1StatefulSet();
@@ -838,6 +849,8 @@ public class KubernetesRuntime implements Runtime {
         final V1ObjectMeta objectMeta = new V1ObjectMeta();
         objectMeta.name(jobName);
         objectMeta.setLabels(getLabels(instanceConfig.getFunctionDetails()));
+        // we don't technically need to set this, but it is useful for testing
+        objectMeta.setNamespace(jobNamespace);
         statefulSet.metadata(objectMeta);
 
         // create the stateful set spec
@@ -871,6 +884,9 @@ public class KubernetesRuntime implements Runtime {
 
         statefulSet.spec(statefulSetSpec);
 
+        // let the customizer run but ensure it doesn't change the name so we can find it again
+        final V1StatefulSet overridden = manifestCustomizer.map((customizer) -> customizer.customizeStatefulSet(instanceConfig.getFunctionDetails(), statefulSet)).orElse(statefulSet);
+        overridden.getMetadata().name(jobName);
 
         return statefulSet;
     }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
@@ -125,4 +125,5 @@ public class KubernetesRuntimeFactoryConfig {
                     "  The formula for memory request is memoryRequest = userRequestMemory / memoryOverCommitRatio"
     )
     protected double memoryOverCommitRatio = 1.0;
+
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntimeFactory.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.functions.auth.FunctionAuthProvider;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceCache;
 import org.apache.pulsar.functions.instance.InstanceConfig;
+import org.apache.pulsar.functions.runtime.RuntimeCustomizer;
 import org.apache.pulsar.functions.runtime.RuntimeFactory;
 import org.apache.pulsar.functions.runtime.RuntimeUtils;
 import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
@@ -115,7 +116,8 @@ public class ThreadRuntimeFactory implements RuntimeFactory {
     @Override
     public void initialize(WorkerConfig workerConfig, AuthenticationConfig authenticationConfig,
                            SecretsProviderConfigurator secretsProviderConfigurator,
-                           Optional<FunctionAuthProvider> functionAuthProvider) throws Exception {
+                           Optional<FunctionAuthProvider> functionAuthProvider,
+                           Optional<RuntimeCustomizer> runtimeCustomizer) throws Exception {
         ThreadRuntimeFactoryConfig factoryConfig = RuntimeUtils.getRuntimeFunctionConfig(
                 workerConfig.getFunctionRuntimeFactoryConfigs(), ThreadRuntimeFactoryConfig.class);
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -30,6 +30,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -371,6 +372,20 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
                     " authentication information to individual functions e.g. user tokens"
     )
     private String functionAuthProviderClassName;
+
+    @FieldContext(
+            doc = "The full class-name of an instance of RuntimeCustomizer." +
+                    " This class receives the 'customRuntimeOptions string and can customize" +
+                    " details of how the runtime operates"
+    )
+    protected String runtimeCustomizerClassName;
+
+    @FieldContext(
+            doc = "A map of config passed to the RuntimeCustomizer." +
+                    " This config is distinct from the `customRuntimeOptions` provided by functions" +
+                    " as this config is the the same across all functions"
+    )
+    private Map<String, Object> runtimeCustomizerConfig = Collections.emptyMap();
 
     public String getFunctionMetadataTopic() {
         return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionMetadataTopicName);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProviderTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/ClearTextFunctionTokenAuthProviderTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.auth;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
+import org.apache.pulsar.functions.proto.Function;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,9 +33,9 @@ public class ClearTextFunctionTokenAuthProviderTest {
     public void testClearTextAuth() throws Exception {
 
         ClearTextFunctionTokenAuthProvider clearTextFunctionTokenAuthProvider = new ClearTextFunctionTokenAuthProvider();
+        Function.FunctionDetails funcDetails = Function.FunctionDetails.newBuilder().setTenant("test-tenant").setNamespace("test-ns").setName("test-func").build();
 
-        Optional<FunctionAuthData> functionAuthData = clearTextFunctionTokenAuthProvider.cacheAuthData("test-tenant",
-                "test-ns", "test-func", new AuthenticationDataSource() {
+        Optional<FunctionAuthData> functionAuthData = clearTextFunctionTokenAuthProvider.cacheAuthData(funcDetails, new AuthenticationDataSource() {
                     @Override
                     public boolean hasDataFromCommand() {
                         return true;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
+import org.apache.pulsar.functions.proto.Function;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -51,7 +52,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
 
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", testBytes);
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, testBytes, (fd) -> "default");
 
 
         V1StatefulSet statefulSet = new V1StatefulSet();
@@ -77,7 +78,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
     public void testConfigureAuthDataStatefulSetNoCa() {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", null);
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, null, (fd) -> "default");
 
 
         V1StatefulSet statefulSet = new V1StatefulSet();
@@ -104,9 +105,9 @@ public class KubernetesSecretsTokenAuthProviderTest {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         doReturn(new V1Secret()).when(coreV1Api).createNamespacedSecret(anyString(), any(), anyString());
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", null);
-        Optional<FunctionAuthData> functionAuthData = kubernetesSecretsTokenAuthProvider.cacheAuthData("test-tenant",
-                "test-ns", "test-func", new AuthenticationDataSource() {
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api,  null, (fd) -> "default");
+        Function.FunctionDetails funcDetails = Function.FunctionDetails.newBuilder().setTenant("test-tenant").setNamespace("test-ns").setName("test-func").build();
+        Optional<FunctionAuthData> functionAuthData = kubernetesSecretsTokenAuthProvider.cacheAuthData(funcDetails, new AuthenticationDataSource() {
                     @Override
                     public boolean hasDataFromCommand() {
                         return true;
@@ -127,7 +128,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
         byte[] testBytes = new byte[]{0, 1, 2, 3, 4};
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", testBytes);
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, testBytes, (fd) -> "default");
         AuthenticationConfig authenticationConfig = AuthenticationConfig.builder().build();
         FunctionAuthData functionAuthData = FunctionAuthData.builder().data("foo".getBytes()).build();
         kubernetesSecretsTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, Optional.of(functionAuthData));
@@ -141,7 +142,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
     public void configureAuthenticationConfigNoCa() {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", null);
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, null, (fd) -> "default");
         AuthenticationConfig authenticationConfig = AuthenticationConfig.builder().build();
         FunctionAuthData functionAuthData = FunctionAuthData.builder().data("foo".getBytes()).build();
         kubernetesSecretsTokenAuthProvider.configureAuthenticationConfig(authenticationConfig, Optional.of(functionAuthData));
@@ -156,11 +157,11 @@ public class KubernetesSecretsTokenAuthProviderTest {
     public void testUpdateAuthData() throws Exception {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
         KubernetesSecretsTokenAuthProvider kubernetesSecretsTokenAuthProvider = new KubernetesSecretsTokenAuthProvider();
-        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, "default", null);
+        kubernetesSecretsTokenAuthProvider.initialize(coreV1Api, null, (fd) -> "default");
         // test when existingFunctionAuthData is empty
         Optional<FunctionAuthData> existingFunctionAuthData = Optional.empty();
-        Optional<FunctionAuthData> functionAuthData = kubernetesSecretsTokenAuthProvider.updateAuthData("test-tenant",
-                "test-ns", "test-func", existingFunctionAuthData, new AuthenticationDataSource() {
+        Function.FunctionDetails funcDetails = Function.FunctionDetails.newBuilder().setTenant("test-tenant").setNamespace("test-ns").setName("test-func").build();
+        Optional<FunctionAuthData> functionAuthData = kubernetesSecretsTokenAuthProvider.updateAuthData(funcDetails, existingFunctionAuthData, new AuthenticationDataSource() {
                     @Override
                     public boolean hasDataFromCommand() {
                         return true;
@@ -178,8 +179,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
 
         // test when existingFunctionAuthData is NOT empty
         existingFunctionAuthData = Optional.of(new FunctionAuthData("pf-secret-z7mxx".getBytes(), null));
-        functionAuthData = kubernetesSecretsTokenAuthProvider.updateAuthData("test-tenant",
-                "test-ns", "test-func", existingFunctionAuthData, new AuthenticationDataSource() {
+        functionAuthData = kubernetesSecretsTokenAuthProvider.updateAuthData(funcDetails, existingFunctionAuthData, new AuthenticationDataSource() {
                     @Override
                     public boolean hasDataFromCommand() {
                         return true;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -158,7 +158,7 @@ public class ProcessRuntimeTest {
         workerConfig.setFunctionRuntimeFactoryClassName(ProcessRuntimeFactory.class.getName());
         workerConfig.setFunctionRuntimeFactoryConfigs(
                 ObjectMapperFactory.getThreadLocal().convertValue(processRuntimeFactoryConfig, Map.class));
-        processRuntimeFactory.initialize(workerConfig, null, new TestSecretsProviderConfigurator(), Optional.empty());
+        processRuntimeFactory.initialize(workerConfig, null, new TestSecretsProviderConfigurator(), Optional.empty(), Optional.empty());
 
         return processRuntimeFactory;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -234,6 +234,10 @@ public class FunctionConfigUtils {
 
         functionDetailsBuilder.setComponentType(FunctionDetails.ComponentType.FUNCTION);
 
+        if (!StringUtils.isEmpty(functionConfig.getCustomRuntimeOptions())) {
+            functionDetailsBuilder.setCustomRuntimeOptions(functionConfig.getCustomRuntimeOptions());
+        }
+
         return functionDetailsBuilder.build();
     }
 
@@ -332,6 +336,10 @@ public class FunctionConfigUtils {
 
         if (!isEmpty(functionDetails.getRuntimeFlags())) {
             functionConfig.setRuntimeFlags(functionDetails.getRuntimeFlags());
+        }
+
+        if (!isEmpty(functionDetails.getCustomRuntimeOptions())) {
+            functionConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
         }
 
         return functionConfig;
@@ -774,6 +782,9 @@ public class FunctionConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getRuntimeFlags())) {
             mergedConfig.setRuntimeFlags(newConfig.getRuntimeFlags());
+        }
+        if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
+            mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -216,6 +216,10 @@ public class SinkConfigUtils {
 
         functionDetailsBuilder.setComponentType(FunctionDetails.ComponentType.SINK);
 
+        if (!StringUtils.isEmpty(sinkConfig.getCustomRuntimeOptions())) {
+            functionDetailsBuilder.setCustomRuntimeOptions(sinkConfig.getCustomRuntimeOptions());
+        }
+
         return functionDetailsBuilder.build();
     }
 
@@ -288,6 +292,10 @@ public class SinkConfigUtils {
 
         if (isNotBlank(functionDetails.getRuntimeFlags())) {
             sinkConfig.setRuntimeFlags(functionDetails.getRuntimeFlags());
+        }
+
+        if (!isEmpty(functionDetails.getCustomRuntimeOptions())) {
+            sinkConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
         }
 
         return sinkConfig;
@@ -566,6 +574,9 @@ public class SinkConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getRuntimeFlags())) {
             mergedConfig.setRuntimeFlags(newConfig.getRuntimeFlags());
+        }
+        if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
+            mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -144,6 +144,10 @@ public class SourceConfigUtils {
 
         functionDetailsBuilder.setComponentType(FunctionDetails.ComponentType.SOURCE);
 
+        if (!StringUtils.isEmpty(sourceConfig.getCustomRuntimeOptions())) {
+            functionDetailsBuilder.setCustomRuntimeOptions(sourceConfig.getCustomRuntimeOptions());
+        }
+
         return functionDetailsBuilder.build();
     }
 
@@ -194,9 +198,14 @@ public class SourceConfigUtils {
             sourceConfig.setResources(resources);
         }
 
-        if (!org.apache.commons.lang3.StringUtils.isEmpty(functionDetails.getRuntimeFlags())) {
-            sourceConfig .setRuntimeFlags(functionDetails.getRuntimeFlags());
+        if (!isEmpty(functionDetails.getRuntimeFlags())) {
+            sourceConfig.setRuntimeFlags(functionDetails.getRuntimeFlags());
         }
+
+        if (!isEmpty(functionDetails.getCustomRuntimeOptions())) {
+            sourceConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
+        }
+
         return sourceConfig;
     }
 
@@ -370,6 +379,9 @@ public class SourceConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getRuntimeFlags())) {
             mergedConfig.setRuntimeFlags(newConfig.getRuntimeFlags());
+        }
+        if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
+            mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.worker;
 
-import com.google.common.io.MoreFiles;	
+import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 
 import lombok.Data;
@@ -288,6 +288,7 @@ public class FunctionActioner {
         FunctionDetails details = functionRuntimeInfo.getFunctionInstance().getFunctionMetaData().getFunctionDetails();
         String fqfn = FunctionCommon.getFullyQualifiedName(details);
         log.info("{}-{} Terminating function...", fqfn,functionRuntimeInfo.getFunctionInstance().getInstanceId());
+        FunctionDetails funcDetails = functionRuntimeInfo.getFunctionInstance().getFunctionMetaData().getFunctionDetails();
 
         if (functionRuntimeInfo.getRuntimeSpawner() != null) {
             functionRuntimeInfo.getRuntimeSpawner().close();
@@ -300,7 +301,7 @@ public class FunctionActioner {
                                 log.info("{}-{} Cleaning up authentication data for function...", fqfn,functionRuntimeInfo.getFunctionInstance().getInstanceId());
                                 functionAuthProvider
                                         .cleanUpAuthData(
-                                                details.getTenant(), details.getNamespace(), details.getName(),
+                                                details,
                                                 Optional.ofNullable(getFunctionAuthData(
                                                         Optional.ofNullable(
                                                                 functionRuntimeInfo.getRuntimeSpawner().getInstanceConfig().getFunctionAuthenticationSpec()))));

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -188,6 +188,7 @@ public class FunctionsImpl extends ComponentImpl {
 
             // cache auth if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -195,7 +196,7 @@ public class FunctionsImpl extends ComponentImpl {
 
                         try {
                             Optional<FunctionAuthData> functionAuthData = functionAuthProvider
-                                    .cacheAuthData(tenant, namespace, functionName, clientAuthenticationDataHttps);
+                                    .cacheAuthData(finalFunctionDetails, clientAuthenticationDataHttps);
 
                             if (functionAuthData.isPresent()) {
                                 functionMetaDataBuilder.setFunctionAuthSpec(
@@ -369,6 +370,7 @@ public class FunctionsImpl extends ComponentImpl {
 
             // update auth data if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -381,9 +383,7 @@ public class FunctionsImpl extends ComponentImpl {
 
                                 try {
                                     Optional<FunctionAuthData> newFunctionAuthData = functionAuthProvider
-                                            .updateAuthData(
-                                                    tenant, namespace,
-                                                    functionName, existingFunctionAuthData,
+                                            .updateAuthData(finalFunctionDetails, existingFunctionAuthData,
                                                     clientAuthenticationDataHttps);
 
                                     if (newFunctionAuthData.isPresent()) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -188,6 +188,7 @@ public class SinksImpl extends ComponentImpl {
 
             // cache auth if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -195,7 +196,7 @@ public class SinksImpl extends ComponentImpl {
 
                         try {
                             Optional<FunctionAuthData> functionAuthData = functionAuthProvider
-                                    .cacheAuthData(tenant, namespace, sinkName, clientAuthenticationDataHttps);
+                                    .cacheAuthData(finalFunctionDetails, clientAuthenticationDataHttps);
 
                             if (functionAuthData.isPresent()) {
                                 functionMetaDataBuilder.setFunctionAuthSpec(
@@ -372,6 +373,7 @@ public class SinksImpl extends ComponentImpl {
 
             // update auth data if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -384,9 +386,7 @@ public class SinksImpl extends ComponentImpl {
 
                         try {
                             Optional<FunctionAuthData> newFunctionAuthData = functionAuthProvider
-                                    .updateAuthData(
-                                            tenant, namespace,
-                                            sinkName, existingFunctionAuthData,
+                                    .updateAuthData(finalFunctionDetails, existingFunctionAuthData,
                                             clientAuthenticationDataHttps);
 
                             if (newFunctionAuthData.isPresent()) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
@@ -188,6 +188,7 @@ public class SourcesImpl extends ComponentImpl {
 
             // cache auth if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -195,7 +196,7 @@ public class SourcesImpl extends ComponentImpl {
 
                         try {
                             Optional<FunctionAuthData> functionAuthData = functionAuthProvider
-                                    .cacheAuthData(tenant, namespace, sourceName, clientAuthenticationDataHttps);
+                                    .cacheAuthData(finalFunctionDetails, clientAuthenticationDataHttps);
 
                             if (functionAuthData.isPresent()) {
                                 functionMetaDataBuilder.setFunctionAuthSpec(
@@ -369,6 +370,7 @@ public class SourcesImpl extends ComponentImpl {
 
             // update auth data if need
             if (worker().getWorkerConfig().isAuthenticationEnabled()) {
+                Function.FunctionDetails finalFunctionDetails = functionDetails;
                 worker().getFunctionRuntimeManager()
                         .getRuntimeFactory()
                         .getAuthProvider().ifPresent(functionAuthProvider -> {
@@ -381,9 +383,7 @@ public class SourcesImpl extends ComponentImpl {
 
                         try {
                             Optional<FunctionAuthData> newFunctionAuthData = functionAuthProvider
-                                    .updateAuthData(
-                                            tenant, namespace,
-                                            sourceName, existingFunctionAuthData,
+                                    .updateAuthData(finalFunctionDetails, existingFunctionAuthData,
                                             clientAuthenticationDataHttps);
 
                             if (newFunctionAuthData.isPresent()) {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionActionerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionActionerTest.java
@@ -217,7 +217,7 @@ public class FunctionActionerTest {
         actioner.terminateFunction(functionRuntimeInfo);
 
         // make sure cache
-        verify(functionAuthProvider.get(), times(0)).cleanUpAuthData(any(), any(), any(), any());
+        verify(functionAuthProvider.get(), times(0)).cleanUpAuthData(any(), any());
     }
 
 }

--- a/site2/docs/functions-cli.md
+++ b/site2/docs/functions-cli.md
@@ -10,12 +10,12 @@ The following tables list Pulsar Functions command-line tools. You can learn Pul
 
 Run Pulsar Functions locally, rather than deploying it to the Pulsar cluster.
 
-Name | Description | Default 
+Name | Description | Default
 ---|---|---
 auto-ack | Whether or not the framework acknowledges messages automatically. | false |
 broker-service-url | The URL for the Pulsar broker. | |
-classname | The class name of a Pulsar Function.| | 
-client-auth-params | Client authentication parameter. | | 
+classname | The class name of a Pulsar Function.| |
+client-auth-params | Client authentication parameter. | |
 client-auth-plugin | Client authentication plugin using which function-process can connect to broker. |  |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime).| |
 custom-schema-inputs | The map of input topics to Schema class names (as a JSON string). | |
@@ -39,8 +39,8 @@ parallelism | The parallelism factor of  a Pulsar Function (i.e. the number of f
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
 py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
-retain-ordering | Function consumes and processes messages in order. | | 
-schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string> 
+retain-ordering | Function consumes and processes messages in order. | |
+schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
 sliding-interval-count | The number of messages after which the window slides. |  |
 sliding-interval-duration-ms | The time duration after which the window slides. |  |
 subs-name | Pulsar source subscription name if user wants a specific subscription-name for the input-topic consumer. |  |
@@ -59,11 +59,12 @@ window-length-duration-ms | The time duration of the window in milliseconds. | |
 
 Create and deploy a Pulsar Function in cluster mode.
 
-Name | Description | Default 
+Name | Description | Default
 ---|---|---
 auto-ack | Whether or not the framework acknowledges messages automatically. | false |
 classname | The class name of a Pulsar Function. |  |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime).| |
+custom-runtime-options | A string that encodes options to customize the runtime, see docs for configured runtime for details | |
 custom-schema-inputs | The map of input topics to Schema class names (as a JSON string). | |
 custom-serde-inputs | The map of input topics to SerDe class names (as a JSON string). | |
 dead-letter-topic | The topic where all messages that were not processed successfully are sent. | |
@@ -84,7 +85,7 @@ processing-guarantees | The processing guarantees (delivery semantics) applied t
 py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
-schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string> 
+schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
 sliding-interval-count | The number of messages after which the window slides. |  |
 sliding-interval-duration-ms | The time duration after which the window slides. |  |
 subs-name | Pulsar source subscription name if user wants a specific subscription-name for the input-topic consumer. |  |
@@ -115,6 +116,7 @@ Name | Description | Default
 auto-ack | Whether or not the framework acknowledges messages automatically. | false
 classname | The class name of a Pulsar Function. | |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime). | |
+custom-runtime-options | A string that encodes options to customize the runtime, see docs for configured runtime for details | |
 custom-schema-inputs | The map of input topics to Schema class names (as a JSON string). | |
 custom-serde-inputs | The map of input topics to SerDe class names (as a JSON string). | |
 dead-letter-topic | The topic where all messages that were not processed successfully are sent. | |
@@ -135,7 +137,7 @@ processing-guarantees | The processing guarantees (delivery semantics) applied t
 py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
-schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string> 
+schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
 sliding-interval-count | The number of messages after which the window slides. |  |
 sliding-interval-duration-ms | The time duration after which the window slides. |  |
 subs-name | Pulsar source subscription name if user wants a specific subscription-name for the input-topic consumer. |  |
@@ -186,8 +188,8 @@ tenant | The tenant of a Pulsar Function. |  |
 
 Starts a stopped function instance.
 
-Name | Description | Default 
----|---|--- 
+Name | Description | Default
+---|---|---
 fqfn | The Fully Qualified Function Name (FQFN) for the function. | |
 instance-id | The function instanceId (restart all instances if instance-id is not provided. |  |
 name | The name of a Pulsar Function. |  |

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -10,8 +10,8 @@ Pulsar Functions support the following methods to run functions.
 - *Process*: Invoke functions in processes forked by Functions Worker.
 - *Kubernetes*: Submit functions as Kubernetes StatefulSets by Functions Worker.
 
-The differences of the thread and process modes are:   
-- Thread mode: when a function runs in thread mode, it runs on the same Java virtual machine (JVM) with Functions worker.   
+The differences of the thread and process modes are:
+- Thread mode: when a function runs in thread mode, it runs on the same Java virtual machine (JVM) with Functions worker.
 - Process mode: when a function runs in process mode, it runs on the same machine that Functions worker runs.
 
 ## Configure thread runtime
@@ -60,7 +60,7 @@ kubernetesContainerFactory:
   # setting this to true is let function worker to submit functions to the same k8s cluster as function worker
   # is running. setting this to false if your function worker is not running as a k8 pod.
   submittingInsidePod: false
-  # setting the pulsar service url that pulsar function should use to connect to pulsar 
+  # setting the pulsar service url that pulsar function should use to connect to pulsar
   # if it is not set, it will use the pulsar service url configured in worker service
   pulsarServiceUrl:
   # setting the pulsar admin url that pulsar function should use to connect to pulsar
@@ -81,7 +81,7 @@ However, if you enable RBAC on deploying your Pulsar cluster, make sure the serv
 running Functions Workers (or brokers, if Functions Workers run along with brokers) have permissions on the following
 kubernetes APIs.
 
-- services 
+- services
 - configmaps
 - pods
 - apps.statefulsets
@@ -106,7 +106,7 @@ If this happens, you need to grant the required permissions to the service accou
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: functions-worker 
+  name: functions-worker
 rules:
 - apiGroups: [""]
   resources:
@@ -138,4 +138,35 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: functions-worker
+```
+
+### Kubernetes CustomRuntimeOptions
+
+The functions (and sinks/sources) API provides a flag, `customRuntimeOptions` which can be used to pass options to the runtime to customize how the runtime operates.
+
+In the case of case of kubernetes, this is passed to an instance of the `org.apache.pulsar.functions.runtime.kubernetes.KubernetesManifestCustomizer`. This interface can be overridden
+and allows for a high degree of customization over how the K8S manifests are generated. The interface is injected by passing the class name to the `runtimeCustomizerClassName` in the `functions-worker.yaml`
+
+To use the basic implementation, set `org.apache.pulsar.functions.runtime.kubernetes.BasicKubernetesManifestCustomizer`
+for the `runtimeCustomerClassName` property. This implementation takes the following `customRuntimeOptions`
+```Json
+{
+  "jobNamespace": "namespace", // the k8s namespace to run this function in
+  "extractLabels": {           // extra labels to attach to the statefulSet, service, and pods
+    "extraLabel": "value"
+  },
+  "extraAnnotations": {        // extra annotations to attach to the statefulSet, service, and pods
+    "extraAnnotation": "value"
+  },
+  "nodeSelectorLabels": {      // node selector labels to add on to the pod spec
+    "customLabel": "value"
+  },
+  "tolerations": [             // tolerations to add to the pod spec
+    {
+      "key": "custom-key",
+      "value": "value",
+      "effect": "NoSchedule"
+    }
+  ]
+}
 ```


### PR DESCRIPTION

### Motivation

This commit adds a new argument for functions, customRuntimeOptions, which is passed to
funcions (as well as sources/sinks) that enables the ability to
customize the runtime.

This is added primarily to support the `KubernetesManifestCustomizer`
interface. This interface is intended, as the name indicates, allows for
customizing how the kubernetes manifests are generated before they
are sent off to the k8s cluster. 

This interface has a default implementation, which allows for
changing the namespace, labels, nodeSelector labels, and toleratations per function.

This interface is also pluggable, allowing for more customized
implementations. For example, the functions for a given tenant could be
mapped to different pools of compute for isolation.

### Modifications

For the CLI and protobufs, the modifications just involve plumbing through the new option, `customRuntimeOptions` through the relevant code. 

For kubernetes runtime, the modifications are fairly straight forward, adding a new configuration option, `kubernetesManifestCustomizerClassName` and `kubernetesManifestCustomizerConfig` which are options under the kubernetes runtime.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This commit adds some tests:

  - Adds tests for the kubernetes runtime with the default and custom implementation that validates the manifest files generated
- passes existing unit tests 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations:  no
  - The wire protocol: yes, only of functions protobufs, adds a new field, customRuntimeOptions, which is a simple string
  - The rest endpoints: no
  - The admin cli options: yes, adds `custom-runtime-options` flags to the create/update commands for functions, sources, and sinks, which populates the above protobuf field
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented? yes, docs
  - If a feature is not applicable for documentation, explain why? 
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
