### PR TITLE
remove redundant condition

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -63,8 +63,7 @@ public class RestException extends WebApplicationException {
     }
 
     private static Response getResponse(Throwable t) {
-        if (t instanceof RestException
-            || t instanceof WebApplicationException) {
+        if (t instanceof WebApplicationException) {
             WebApplicationException e = (WebApplicationException) t;
             return e.getResponse();
         } else {


### PR DESCRIPTION
Signed-off-by: KevenYLi <liyi.changde@gmail.com>

### Motivation

Condition 't instanceof RestException' covered by subsequent condition 't instanceof WebApplicationException', the first condition become redundant,  so the first condition can be removed.

### Modifications

remove the redundant condition: **t instanceof RestException**

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: ( no)
  - **The rest endpoints: (yes)**
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)

