### PR TITLE
[pulsar-broker] Fix bug that namespace policies does not take effect due to NPE

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -99,6 +99,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
+import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
@@ -1372,8 +1373,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             forEachTopic(topic -> {
                 topic.getSubscriptions().forEach((subName, persistentSubscription) -> {
                     Dispatcher dispatcher = persistentSubscription.getDispatcher();
-                    if (dispatcher != null && dispatcher.getRateLimiter().isPresent()) {
-                        dispatcher.getRateLimiter().get().updateDispatchRate();
+                    if (dispatcher != null) {
+                        dispatcher.getRateLimiter().ifPresent(DispatchRateLimiter::updateDispatchRate);
                     }
                 });
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1372,7 +1372,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             forEachTopic(topic -> {
                 topic.getSubscriptions().forEach((subName, persistentSubscription) -> {
                     Dispatcher dispatcher = persistentSubscription.getDispatcher();
-                    if (dispatcher.getRateLimiter().isPresent()) {
+                    if (dispatcher != null && dispatcher.getRateLimiter().isPresent()) {
                         dispatcher.getRateLimiter().get().updateDispatchRate();
                     }
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -269,8 +269,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
 
             // dispatch rate limiter for each subscription
-            subscriptions.forEach((name, subscription) ->
-                subscription.getDispatcher().initializeDispatchRateLimiterIfNeeded(policies));
+            subscriptions.forEach((name, subscription) -> {
+                if (subscription.getDispatcher() != null) {
+                    subscription.getDispatcher().initializeDispatchRateLimiterIfNeeded(policies);
+                }
+            });
 
             // dispatch rate limiter for each replicator
             replicators.forEach((name, replicator) ->
@@ -1673,7 +1676,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
         subscriptions.forEach((subName, sub) -> {
             sub.getConsumers().forEach(Consumer::checkPermissions);
-            if (sub.getDispatcher().getRateLimiter().isPresent()) {
+            if (sub.getDispatcher() != null && sub.getDispatcher().getRateLimiter().isPresent()) {
                 sub.getDispatcher().getRateLimiter().get().onPoliciesUpdate(data);
             }
         });


### PR DESCRIPTION
### Motivation

When produce/consume permissions for a role on a namespace are revoked, producers and consumers connected to the topic under the namespace using that role should be disconnected from the broker. However, I noticed that producers/consumers can stay connected in some topics even if the permissions are revoked.

As a result of the investigation, I found that NPE was thrown in the following line:
https://github.com/apache/pulsar/blob/094ebf7af8d0bb27bd9df3bcea2dba4e9ba204fc/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L273

In subscriptions that consumer has never connected to since the broker started, the dispatcher has not been initialized, so `subscription.getDispatcher()` returns null.

As a result, the process of `PersistentTopic#onPoliciesUpdate()` is aborted.
https://github.com/apache/pulsar/blob/094ebf7af8d0bb27bd9df3bcea2dba4e9ba204fc/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L1668-L1682

### Modifications

Before calling a dispatcher method, make sure that the dispatcher is not null.