### PR TITLE
Update version of dockerfile-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
-    <dockerfile-maven.version>1.4.9</dockerfile-maven.version>
+    <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.5.1</protobuf3.version>


### PR DESCRIPTION
### Motivation

Errors in integration tests seems to be caused by older version of docker client lib.

```
2019-10-18\T\02:38:26.361 [ERROR] no status provided on response: unknown
2019-10-18\T\02:38:26.365 [WARNING] An attempt failed, will retry 1 more times
org.apache.maven.plugin.MojoExecutionException: Could not build image
    at com.spotify.plugin.dockerfile.BuildMojo.buildImage (BuildMojo.java:208)
    at com.spotify.plugin.dockerfile.BuildMojo.execute (BuildMojo.java:110)
    at com.spotify.plugin.dockerfile.AbstractDockerMojo.tryExecute (AbstractDockerMojo.java:259)
```