### PR TITLE
[Issue 5430][pulsar-flink] Flink connector sink should implement consumeDataStream for 1.9.0

### DIFF
--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSink.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSink.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.connectors.pulsar.partitioner.PulsarKeyExtractor;
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
@@ -100,13 +101,17 @@ public abstract class PulsarTableSink implements AppendStreamTableSink<Row> {
 
     @Override
     public void emitDataStream(DataStream<Row> dataStream) {
+        consumeDataStream(dataStream);
+    }
+
+    public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
         checkState(fieldNames != null, "Table sink is not configured");
         checkState(fieldTypes != null, "Table sink is not configured");
         checkState(serializationSchema != null, "Table sink is not configured");
         checkState(keyExtractor != null, "Table sink is not configured");
 
         FlinkPulsarProducer<Row> producer = createFlinkPulsarProducer();
-        dataStream.addSink(producer);
+        return dataStream.addSink(producer);
     }
 
     @Override

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSinkTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSinkTest.java
@@ -40,7 +40,7 @@ import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 /**
  * Unit test of {@link PulsarJsonTableSink}.
  */
-public class PulsarJsonTableSinkTest {
+public class  PulsarJsonTableSinkTest {
 
     private static final String SERVICE_URL = "pulsar://localhost:6650";
     private static final String TOPIC_NAME = "test_topic";
@@ -88,10 +88,12 @@ public class PulsarJsonTableSinkTest {
     @Test
     public void testConsumeDataStream() throws Exception {
         DataStream mockedDataStream = Mockito.mock(DataStream.class);
+        DataStreamSink mockedSink = Mockito.mock(DataStreamSink.class);
+        Mockito.when(mockedDataStream.addSink(Mockito.any(FlinkPulsarProducer.class))).thenReturn(mockedSink);
         PulsarJsonTableSink sink = spySink();
         DataStreamSink<Row> newSink = sink.consumeDataStream(mockedDataStream);
         Mockito.verify(mockedDataStream).addSink(Mockito.any(FlinkPulsarProducer.class));
-        Assert.assertNotNull(newSink);
+        Assert.assertSame(newSink, mockedSink);
     }
 
     private PulsarJsonTableSink spySink() throws Exception {

--- a/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSinkTest.java
+++ b/pulsar-flink/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSinkTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.connectors.pulsar.partitioner.PulsarKeyExtractor;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
@@ -82,6 +83,15 @@ public class PulsarJsonTableSinkTest {
         sink.emitDataStream(mockedDataStream);
 
         Mockito.verify(mockedDataStream).addSink(Mockito.any(FlinkPulsarProducer.class));
+    }
+
+    @Test
+    public void testConsumeDataStream() throws Exception {
+        DataStream mockedDataStream = Mockito.mock(DataStream.class);
+        PulsarJsonTableSink sink = spySink();
+        DataStreamSink<Row> newSink = sink.consumeDataStream(mockedDataStream);
+        Mockito.verify(mockedDataStream).addSink(Mockito.any(FlinkPulsarProducer.class));
+        Assert.assertNotNull(newSink);
     }
 
     private PulsarJsonTableSink spySink() throws Exception {


### PR DESCRIPTION
Fixes #5430 

### Motivation

Should be able to write to Pulsar under Flink 1.9.0 application

### Modifications
Added an implementation for `StreamTableSink#consumeDataStream(DataStream)` in the sink to make it compatible with Flink 1.9.0 blink.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Added unit test that verifies that a DataStreamSink is returned and is not null

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If a feature is not applicable for documentation, explain why? (Covered by Flink APIs)
