### PR TITLE
Revert "[Issue 4956]Add default loader for latest pyyaml"

### DIFF
--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -46,7 +46,7 @@ if len(sys.argv) < 2:
 conf_files = sys.argv[1:]
 
 for conf_filename in conf_files:
-    conf = yaml.load(open(conf_filename), Loader=yaml.FullLoader)
+    conf = yaml.load(open(conf_filename))
 
     # update the config
     modified = False


### PR DESCRIPTION
Reverts apache/pulsar#4974

Lets revert this for now because its causing Pulsar Function Workers to fail starting up in our integration tests.

```
2019-10-21T21:03:32.806743794Z + python -V
2019-10-21T21:03:32.809746507Z Python 2.7.16
2019-10-21T21:03:32.979390472Z Traceback (most recent call last):
2019-10-21T21:03:32.979437479Z   File "bin/gen-yml-from-env.py", line 49, in <module>
2019-10-21T21:03:32.979445879Z     conf = yaml.load(open(conf_filename), Loader=yaml.FullLoader)
2019-10-21T21:03:32.979452110Z AttributeError: 'module' object has no attribute 'FullLoader'
```

This seems to be a problem for python 2.7.  Once we move are images to use python 3.7 by default we can bring this change back.


Full log for function worker starting up:

```
2019-10-21T21:03:32.804486087Z ++ echo
2019-10-21T21:03:32.804626995Z ++ tr '[:upper:]' '[:lower:]'
2019-10-21T21:03:32.806562619Z + FLAG=
2019-10-21T21:03:32.806632205Z + '[' '' = true ']'
2019-10-21T21:03:32.806672570Z + echo 'Python Version ...'
2019-10-21T21:03:32.806723034Z Python Version ...
2019-10-21T21:03:32.806743794Z + python -V
2019-10-21T21:03:32.809746507Z Python 2.7.16
2019-10-21T21:03:32.979390472Z Traceback (most recent call last):
2019-10-21T21:03:32.979437479Z   File "bin/gen-yml-from-env.py", line 49, in <module>
2019-10-21T21:03:32.979445879Z     conf = yaml.load(open(conf_filename), Loader=yaml.FullLoader)
2019-10-21T21:03:32.979452110Z AttributeError: 'module' object has no attribute 'FullLoader'
2019-10-21T21:03:33.378413384Z 2019-10-21 21:03:33,377 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2019-10-21T21:03:33.378506024Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/bookie.conf" during parsing
2019-10-21T21:03:33.378518130Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/broker.conf" during parsing
2019-10-21T21:03:33.378527184Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/functions_worker.conf" during parsing
2019-10-21T21:03:33.378535634Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/global-zk.conf" during parsing
2019-10-21T21:03:33.378544050Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/local-zk.conf" during parsing
2019-10-21T21:03:33.378552477Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/presto_worker.conf" during parsing
2019-10-21T21:03:33.378574774Z 2019-10-21 21:03:33,378 INFO Included extra file "/etc/supervisord/conf.d/proxy.conf" during parsing
2019-10-21T21:03:33.390787507Z 2019-10-21 21:03:33,390 INFO RPC interface 'supervisor' initialized
2019-10-21T21:03:33.390874023Z 2019-10-21 21:03:33,390 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2019-10-21T21:03:33.391123089Z 2019-10-21 21:03:33,390 INFO supervisord started with pid 1
2019-10-21T21:03:34.395601299Z 2019-10-21 21:03:34,394 INFO spawned: 'functions-worker' with pid 21
2019-10-21T21:03:35.397666715Z 2019-10-21 21:03:35,397 INFO success: functions-worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2019-10-21T21:04:40.473995238Z 2019-10-21 21:04:40,473 INFO exited: functions-worker (exit status 255; not expected)
2019-10-21T21:04:41.478742777Z 2019-10-21 21:04:41,478 INFO spawned: 'functions-worker' with pid 215
2019-10-21T21:04:42.480653712Z 2019-10-21 21:04:42,480 INFO success: functions-worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2019-10-21T21:05:47.522984806Z 2019-10-21 21:05:47,522 INFO exited: functions-worker (exit status 255; not expected)
2019-10-21T21:05:48.527747430Z 2019-10-21 21:05:48,527 INFO spawned: 'functions-worker' with pid 409
2019-10-21T21:05:49.529612725Z 2019-10-21 21:05:49,529 INFO success: functions-worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2019-10-21T21:06:54.316756347Z 2019-10-21 21:06:54,316 INFO exited: functions-worker (exit status 255; not expected)
2019-10-21T21:06:55.321097684Z 2019-10-21 21:06:55,320 INFO spawned: 'functions-worker' with pid 603
2019-10-21T21:06:56.323222911Z 2019-10-21 21:06:56,322 INFO success: functions-worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2019-10-21T21:08:01.154232192Z 2019-10-21 21:08:01,153 INFO exited: functions-worker (exit status 255; not expected)
2019-10-21T21:08:02.158816137Z 2019-10-21 21:08:02,158 INFO spawned: 'functions-worker' with pid 797
2019-10-21T21:08:03.160892553Z 2019-10-21 21:08:03,160 INFO success: functions-worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```