### PR TITLE
Add support for partitioned topic consumer seek by time.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -321,9 +321,6 @@ public interface Consumer<T> extends Closeable {
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
      *
-     * <p>Note: this operation can only be done on non-partitioned topics. For these, one can rather perform
-     * the seek() on the individual partitions.
-     *
      * @param timestamp
      *            the message publish time where to reposition the subscription
      */
@@ -349,9 +346,6 @@ public interface Consumer<T> extends Closeable {
 
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
-     *
-     * <p>Note: this operation can only be done on non-partitioned topics. For these, one can rather
-     * perform the seek() on the individual partitions.
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -595,7 +595,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public CompletableFuture<Void> seekAsync(long timestamp) {
-        return FutureUtil.failedFuture(new PulsarClientException("Seek operation not supported on topics consumer"));
+        List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
+        consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(timestamp)));
+        return FutureUtil.waitForAll(futures);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Add support for partitioned topic consumer seek by time.

### Modifications

Call each partition consumer seekAsync() while call partitioned consumer seekAsync()

### Verifying this change

Update unit tests for consumer.seek().

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
