### PR TITLE
[pulsar-perf] record message failure and avoid exiting from process on publish failure

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -179,6 +179,10 @@ public class PerformanceProducer {
         @Parameter(names = { "-d",
                 "--delay" }, description = "Mark messages with a given delay in seconds")
         public long delay = 0;
+        
+        @Parameter(names = { "-ef",
+                "--exit-on-failure" }, description = "Exit from the process on publish failure (default: disable)")
+        public boolean exitOnFailure = false;
     }
 
     static class EncKeyReader implements CryptoKeyReader {
@@ -501,6 +505,9 @@ public class PerformanceProducer {
                     }).exceptionally(ex -> {
                         log.warn("Write error on message", ex);
                         messagesFailed.increment();
+                        if (arguments.exitOnFailure) {
+                            System.exit(-1);
+                        }
                         return null;
                     });
                 }


### PR DESCRIPTION
### Motivation
- Right now, perf-producer exit when it sees publish-failure. But pulsar-client should be handling any failure and client should not have to exist from the process. So, make perf-producer continue on publish-failure and also record message failure rate.