### PR TITLE
[pulsar-client] Avoid leak on publish failure on batch message

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -468,10 +468,13 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             log.debug("[{}] [{}] Closing out batch to accommodate large message with size {}", topic, producerName,
                     msg.getDataBuffer().readableBytes());
         }
-        batchMessageAndSend();
-        batchMessageContainer.add(msg, callback);
-        lastSendFuture = callback.getFuture();
-        payload.release();
+        try {
+            batchMessageAndSend();
+            batchMessageContainer.add(msg, callback);
+            lastSendFuture = callback.getFuture();
+        } finally {
+            payload.release();
+        }
     }
 
     private boolean isValidProducerState(SendCallback callback) {


### PR DESCRIPTION
### Motivation

Right now, producer-client tries to add batch message into batch-message-container and it can throw Error/RuntimeException [BatchMessageContainer::add](https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java#L72) eg: `OutOfDirectMemoryError`. In this case, pulsar-client is not releasing payload which can leak the memory. SO, make sure to release payload even with any error.