### PR TITLE
[pulsar-client] print unknown exception stacktrace

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1303,7 +1303,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 semaphore.release(batchMessageContainer.getNumMessagesInBatch());
             } catch (Throwable t) {
                 semaphore.release(batchMessageContainer.getNumMessagesInBatch());
-                log.warn("[{}] [{}] error while create opSendMsg by batch message container -- {}", topic, producerName, t);
+                log.warn("[{}] [{}] error while create opSendMsg by batch message container", topic, producerName, t);
             }
         }
     }


### PR DESCRIPTION
### Motivation
right now, pulsar-client producer throws unknown exception while publishing messages and it doesn't log stacktrace and it makes very difficult to debug issue with just client log.