### PR TITLE
Fixed StringSchema static initialization

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
@@ -36,10 +36,22 @@ import java.nio.charset.StandardCharsets;
  */
 public class StringSchema extends AbstractSchema<String> {
 
-    static final String CHARSET_KEY = "__charset";
+    static final String CHARSET_KEY;
 
-    public static StringSchema utf8() {
-        return UTF8;
+    private static final SchemaInfo DEFAULT_SCHEMA_INFO;
+    private static final Charset DEFAULT_CHARSET;
+    private static final StringSchema UTF8;
+
+    static {
+        // Ensure the ordering of the static initialization
+        CHARSET_KEY = "__charset";
+        DEFAULT_CHARSET = StandardCharsets.UTF_8;
+        DEFAULT_SCHEMA_INFO = new SchemaInfo()
+                .setName("String")
+                .setType(SchemaType.STRING)
+                .setSchema(new byte[0]);
+
+        UTF8 = new StringSchema(StandardCharsets.UTF_8);
     }
 
     private static final FastThreadLocal<byte[]> tmpBuffer = new FastThreadLocal<byte[]>() {
@@ -59,14 +71,10 @@ public class StringSchema extends AbstractSchema<String> {
         }
     }
 
-    private static final SchemaInfo DEFAULT_SCHEMA_INFO = new SchemaInfo()
-        .setName("String")
-        .setType(SchemaType.STRING)
-        .setSchema(new byte[0]);
-    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+    public static StringSchema utf8() {
+        return UTF8;
+    }
 
-    // make sure other static fields are initialized before this field
-    private static final StringSchema UTF8 = new StringSchema(StandardCharsets.UTF_8);
     private final Charset charset;
     private final SchemaInfo schemaInfo;
 
@@ -80,10 +88,10 @@ public class StringSchema extends AbstractSchema<String> {
         Map<String, String> properties = new HashMap<>();
         properties.put(CHARSET_KEY, charset.name());
         this.schemaInfo = new SchemaInfo()
-            .setName(DEFAULT_SCHEMA_INFO.getName())
-            .setType(SchemaType.STRING)
-            .setSchema(DEFAULT_SCHEMA_INFO.getSchema())
-            .setProperties(properties);
+                .setName(DEFAULT_SCHEMA_INFO.getName())
+                .setType(SchemaType.STRING)
+                .setSchema(DEFAULT_SCHEMA_INFO.getSchema())
+                .setProperties(properties);
     }
 
     public byte[] encode(String message) {


### PR DESCRIPTION
### Motivation

Java doesn't guarantee the initialization order of the static fields of a class. Depending on the JVM version and race conditions, the StringSchema could be initialized with a null `DEFAULT_SCHEMA_INFO`. 

Eg: 

```
-------------------------------------------------------------------------------
Tests run: 6, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 1.444 s <<< FAILURE! - in org.apache.pulsar.client.impl.schema.SchemaInfoTest
testSchemaInfoToString(org.apache.pulsar.client.impl.schema.SchemaInfoTest)  Time elapsed: 0.03 s  <<< FAILURE!
java.lang.NullPointerException
	at org.apache.pulsar.client.impl.schema.SchemaInfoTest.testSchemaInfoToString(SchemaInfoTest.java:276)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```