### PR TITLE
[pulsar-client-cpp]Change state_ to closed when resultOk is returned

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -837,8 +837,12 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
         return;
     }
 
+    LOG_INFO(getName() << "Closing consumer for topic " << topic_);
+    state_ = Closing;
+
     ClientConnectionPtr cnx = getCnx().lock();
     if (!cnx) {
+        state_ = Closed;
         lock.unlock();
         // If connection is gone, also the consumer is closed on the broker side
         if (callback) {
@@ -847,9 +851,9 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
         return;
     }
 
-    LOG_INFO(getName() << "Closing consumer for topic " << topic_);
     ClientImplPtr client = client_.lock();
     if (!client) {
+        state_ = Closed;
         lock.unlock();
         // Client was already destroyed
         if (callback) {


### PR DESCRIPTION
### Motivation
* Consumer retry the connection forever even though `Consumer::close()` is called in following case.
```
1. Consumer connects to broker
2. Revoke the consumer's permission to consume(e.g. pulsar-admin namespaces revoke-permission --role "consumer.role" public/global/n1)
3. Execute Consumer.Close()
```
* Closed seems to be better when ResultOk is returned in `{ProducerImpl,ConsumerImpl}::closeAsync()`.

### Modifications
* Change `state_` to Closing at the start of closing process in `ConsumerImpl::closeAsync()`.
* Change `state_` to Closed when ResultOk is returned in `{ProducerImpl,ConsumerImpl}::closeAsync()`