### PR TITLE
[pulsar-broker] fix broken custom auth-provider that uses authenticationData

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -549,6 +549,7 @@ public class ServerCnx extends PulsarHandler {
                 sslSession);
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
+            authenticationData = authState.getAuthDataSource();
             doAuthentication(clientData, clientProtocolVersion, clientVersion);
         } catch (Exception e) {
             String msg = "Unable to authenticate";


### PR DESCRIPTION
### Motivation
with #3677,  ServerCnx is not storing client's `authenticationData` which is used by custom authorization provider  and it always receives `authenticationData` as null and custom auth-provider fails with authorization.