### PR TITLE
[Issue 5387] Update Netty version for improving memory usage

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -347,8 +347,8 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.4.jar
  * Netty
     - io.netty-netty-3.10.1.Final.jar
-    - io.netty-netty-all-4.1.32.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.20.Final.jar
+    - io.netty-netty-all-4.1.34.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.22.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -347,8 +347,8 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.4.jar
  * Netty
     - io.netty-netty-3.10.1.Final.jar
-    - io.netty-netty-all-4.1.34.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.22.Final.jar
+    - io.netty-netty-all-4.1.42.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.26.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.9.2</bookkeeper.version>
     <zookeeper.version>3.4.13</zookeeper.version>
-    <netty.version>4.1.34.Final</netty.version>
+    <netty.version>4.1.42.Final</netty.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jersey.version>2.27</jersey.version>
@@ -445,7 +445,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.22.Final</version>
+        <version>2.0.26.Final</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.9.2</bookkeeper.version>
     <zookeeper.version>3.4.13</zookeeper.version>
-    <netty.version>4.1.32.Final</netty.version>
+    <netty.version>4.1.34.Final</netty.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jersey.version>2.27</jersey.version>
@@ -445,7 +445,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.20.Final</version>
+        <version>2.0.22.Final</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -235,7 +235,7 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.4.jar
  * Netty
     - netty-3.6.2.Final.jar
-    - netty-all-4.1.32.Final.jar
+    - netty-all-4.1.42.Final.jar
     - netty-buffer-4.1.31.Final.jar
     - netty-codec-4.1.31.Final.jar
     - netty-codec-dns-4.1.33.Final.jar


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Want to improve memory usage to be able to create many PulsarClients and Consumers.
(Fix https://github.com/apache/pulsar/issues/5387)

### Modifications

Update Netty version to `4.1.34.Final` and netty-tcnative-boringssl-static version to `2.0.22.Final`.

In Netty community, memory increase issue(https://github.com/netty/netty/issues/8814) was reported (at `4.1.32.Final`). It was fixed by https://github.com/netty/netty/pull/8825 (at `4.1.34.Final`). 

When I apply `4.1.34.Final` then memory usage was decreased correctly.