### PR TITLE
added deletion of state for Functions

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -173,6 +173,20 @@ public interface Context {
     CompletableFuture<Void> putStateAsync(String key, ByteBuffer value);
 
     /**
+     * Delete the state value for the key.
+     *
+     * @param key   name of the key
+     */
+    void deleteState(String key);
+
+    /**
+     * Delete the state value for the key, but don't wait for the operation to be completed
+     *
+     * @param key   name of the key
+     */
+    CompletableFuture<Void> deleteStateAsync(String key);
+
+    /**
      * Retrieve the state value for the key.
      *
      * @param key name of the key

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -311,6 +311,22 @@ class ContextImpl implements Context, SinkContext, SourceContext {
     }
 
     @Override
+    public CompletableFuture<Void> deleteStateAsync(String key) {
+        ensureStateEnabled();
+        return stateContext.delete(key);
+    }
+
+    @Override
+    public void deleteState(String key) {
+        ensureStateEnabled();
+        try {
+            result(stateContext.delete(key));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete the state value for key '" + key + "'");
+        }
+    }
+
+    @Override
     public CompletableFuture<ByteBuffer> getStateAsync(String key) {
         ensureStateEnabled();
         return stateContext.get(key);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContext.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContext.java
@@ -48,9 +48,16 @@ public interface StateContext {
      * instead.
      *
      * @param key key to update.
-     * @param value value to update
+     * @param value value to update; if null the key is deleted
      */
     CompletableFuture<Void> put(String key, ByteBuffer value) throws Exception;
+
+    /**
+     * Deletes the <i>value</i> at the given <i>key</i>
+     *
+     * @param key to delete
+     */
+    CompletableFuture<Void> delete(String key);
 
     /**
      * Get the value of a given <i>key</i>.

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContextImpl.java
@@ -22,6 +22,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.api.kv.Table;
+import org.apache.bookkeeper.api.kv.options.DeleteOption;
+import org.apache.bookkeeper.api.kv.options.Option;
+import org.apache.bookkeeper.api.kv.options.Options;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -51,9 +54,23 @@ public class StateContextImpl implements StateContext {
 
     @Override
     public CompletableFuture<Void> put(String key, ByteBuffer value) {
-        return table.put(
-            Unpooled.wrappedBuffer(key.getBytes(UTF_8)),
-            Unpooled.wrappedBuffer(value));
+        if(value != null) {
+            return table.put(
+                    Unpooled.wrappedBuffer(key.getBytes(UTF_8)),
+                    Unpooled.wrappedBuffer(value));
+        } else {
+            return table.put(
+                    Unpooled.wrappedBuffer(key.getBytes(UTF_8)),
+                    null);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String key) {
+        return table.delete(
+                Unpooled.wrappedBuffer(key.getBytes(UTF_8)),
+                Options.delete()
+        ).thenApply(ignored -> null);
     }
 
     @Override

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.bookkeeper.api.kv.Table;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -98,13 +97,17 @@ public class ContextImplTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testGetCounterStateDisabled() {
-
         context.getCounter("test-key");
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testPutStateStateDisabled() {
         context.putState("test-key", ByteBuffer.wrap("test-value".getBytes(UTF_8)));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testDeleteStateStateDisabled() {
+        context.deleteState("test-key");
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
@@ -132,6 +135,14 @@ public class ContextImplTest {
         ByteBuffer buffer = ByteBuffer.wrap("test-value".getBytes(UTF_8));
         context.putStateAsync("test-key", buffer);
         verify(context.stateContext, times(1)).put(eq("test-key"), same(buffer));
+    }
+
+    @Test
+    public void testDeleteStateStateEnabled() throws Exception {
+        context.stateContext = mock(StateContextImpl.class);
+        ByteBuffer buffer = ByteBuffer.wrap("test-value".getBytes(UTF_8));
+        context.deleteStateAsync("test-key");
+        verify(context.stateContext, times(1)).delete(eq("test-key"));
     }
 
     @Test

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/StateContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/StateContextImplTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.instance.state;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.bookkeeper.api.kv.Table;
+import org.apache.bookkeeper.api.kv.options.Options;
+import org.apache.bookkeeper.api.kv.result.DeleteResult;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -72,6 +74,18 @@ public class StateContextImplTest {
         verify(mockTable, times(1)).put(
             eq(Unpooled.copiedBuffer("test-key", UTF_8)),
             eq(Unpooled.copiedBuffer("test-value", UTF_8))
+        );
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        DeleteResult<ByteBuf, ByteBuf> result = mock(DeleteResult.class);
+        when(mockTable.delete(any(ByteBuf.class), eq(Options.delete())))
+                .thenReturn(FutureUtils.value(result));
+        stateContext.delete("test-key");
+        verify(mockTable, times(1)).delete(
+                eq(Unpooled.copiedBuffer("test-key", UTF_8)),
+                eq(Options.delete())
         );
     }
 


### PR DESCRIPTION
### Motivation

Adding support for state deletion for Functions.  Ran into a use-case where it would be nice to be able to let go of state wherein the key is changing but the data itself is ephemeral. 

### Modifications

I've reflected the changes in the bookkeepr API back through in the context and state context API's so that you can delete on a put by passing null or call the new api for delete.

### Verifying this change

This change added tests and can be verified as follows:
 - Running the unit tests available in the ContextImplTest and ContextStateImplTest

### Does this pull request potentially affect one of the following parts:

  - The public API: yes; added deletion to Function context and state context APIs

### Documentation

  - Does this pull request introduce a new feature? - yes
  - If yes, how is the feature documented? - JavaDocs
