### PR TITLE
[Issue 5365] Add is_read_compacted to create_reader() in python API

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -594,6 +594,8 @@ class Client:
         * `broker_consumer_stats_cache_time_ms`:
           Sets the time duration for which the broker-side consumer stats will
           be cached in the client.
+        * `is_read_compacted`:
+          Selects whether to read the compacted version of the topic
         * `properties`:
           Sets the properties for the consumer. The properties associated with a consumer
           can be used for identify a consumer at broker side.
@@ -663,7 +665,8 @@ class Client:
                       reader_listener=None,
                       receiver_queue_size=1000,
                       reader_name=None,
-                      subscription_role_prefix=None
+                      subscription_role_prefix=None,
+                      is_read_compacted=False
                       ):
         """
         Create a reader on a particular topic
@@ -711,6 +714,8 @@ class Client:
           Sets the reader name.
         * `subscription_role_prefix`:
           Sets the subscription role prefix.
+        * `is_read_compacted`:
+          Selects whether to read the compacted version of the topic
         """
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
@@ -718,6 +723,7 @@ class Client:
         _check_type(int, receiver_queue_size, 'receiver_queue_size')
         _check_type_or_none(str, reader_name, 'reader_name')
         _check_type_or_none(str, subscription_role_prefix, 'subscription_role_prefix')
+        _check_type(bool, is_read_compacted, 'is_read_compacted')
 
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:
@@ -728,6 +734,7 @@ class Client:
         if subscription_role_prefix:
             conf.subscription_role_prefix(subscription_role_prefix)
         conf.schema(schema.schema_info())
+        conf.read_compacted(is_read_compacted)
 
         c = Reader()
         c._reader = self._client.create_reader(topic, start_message_id, conf)


### PR DESCRIPTION
Fixes #5365

### Motivation

`create_reader` in python API is missing is_read_compacted option (although `subscribe` has it)

### Modifications

Add the option and pass it through to ReaderConfiguration

### Verifying this change

Test TBD

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: yes - adds missing option which already exists in Java API and part of python API

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Python API docs
