### PR TITLE
[Issue 5484] Python API: fix reader_listener option

### DIFF
--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -156,7 +156,7 @@ void export_config() {
             ;
 
     class_<ReaderConfiguration>("ReaderConfiguration")
-            .def("message_listener", &ReaderConfiguration_setReaderListener, return_self<>())
+            .def("reader_listener", &ReaderConfiguration_setReaderListener, return_self<>())
             .def("schema", &ReaderConfiguration::getSchema, return_value_policy<copy_const_reference>())
             .def("schema", &ReaderConfiguration::setSchema, return_self<>())
             .def("receiver_queue_size", &ReaderConfiguration::getReceiverQueueSize)


### PR DESCRIPTION
Fixes #5484

### Motivation

reader_listener option to create_reader() was broken

### Modifications

Fix typo in ReaderConfiguration class definition

### Verifying this change

(Does not add a new test case for reader_listener)

### Does this pull request potentially affect one of the following parts:

No

### Documentation

  - Does this pull request introduce a new feature? no