### PR TITLE
fix: bug in delayed messaging which prevented some messages from getting delivered

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.delayed;
 
 import com.google.common.annotations.Beta;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -33,7 +34,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 public interface DelayedDeliveryTracker extends AutoCloseable {
 
     /**
-     * Add a message to the tracker
+     * Add a message to the tracker if necessary
      *
      * @param ledgerId
      *            the ledgerId
@@ -43,7 +44,19 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
      *            the absolute timestamp at which the message should be tracked
      * @return true if the message was added to the tracker or false if it should be delivered immediately
      */
-    boolean addMessage(long ledgerId, long entryId, long deliveryAt);
+    boolean tryAddMessage(long ledgerId, long entryId, long deliveryAt);
+
+    /**
+     * Add a message to tracker
+     *
+     * @param ledgerId
+     *            the ledgerId
+     * @param entryId
+     *            the entryId
+     * @param deliveryAt
+     *            the absolute timestamp at which the message should be tracked
+     */
+    void addMessage(long ledgerId, long entryId, long deliveryAt);
 
     /**
      * Return true if there's at least a message that is scheduled to be delivered already
@@ -58,7 +71,7 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
     /**
      * Get a set of position of messages that have already reached the delivery time
      */
-    Set<PositionImpl> getScheduledMessages(int maxMessages);
+    Map<PositionImpl, Long> getScheduledMessages(int maxMessages);
 
     /**
      * Close the subscription tracker and release all resources.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -34,6 +34,7 @@ import io.netty.util.TimerTask;
 
 import java.time.Clock;
 import java.util.Collections;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -63,26 +64,26 @@ public class InMemoryDeliveryTrackerTest {
 
         assertFalse(tracker.hasMessageAvailable());
 
-        assertTrue(tracker.addMessage(2, 2, 20));
-        assertTrue(tracker.addMessage(1, 1, 10));
-        assertTrue(tracker.addMessage(3, 3, 30));
-        assertTrue(tracker.addMessage(5, 5, 50));
-        assertTrue(tracker.addMessage(4, 4, 40));
+        assertTrue(tracker.tryAddMessage(2, 2, 20));
+        assertTrue(tracker.tryAddMessage(1, 1, 10));
+        assertTrue(tracker.tryAddMessage(3, 3, 30));
+        assertTrue(tracker.tryAddMessage(5, 5, 50));
+        assertTrue(tracker.tryAddMessage(4, 4, 40));
 
         assertFalse(tracker.hasMessageAvailable());
         assertEquals(tracker.getNumberOfDelayedMessages(), 5);
 
-        assertEquals(tracker.getScheduledMessages(10), Collections.emptySet());
+        assertEquals(tracker.getScheduledMessages(10), Collections.emptyMap());
 
         // Move time forward
         clockTime.set(15);
 
         // Message is rejected by tracker since it's already ready to send
-        assertFalse(tracker.addMessage(6, 6, 10));
+        assertFalse(tracker.tryAddMessage(6, 6, 10));
 
         assertEquals(tracker.getNumberOfDelayedMessages(), 5);
         assertTrue(tracker.hasMessageAvailable());
-        Set<PositionImpl> scheduled = tracker.getScheduledMessages(10);
+        Map<PositionImpl, Long> scheduled = tracker.getScheduledMessages(10);
         assertEquals(scheduled.size(), 1);
 
         // Move time forward
@@ -100,7 +101,7 @@ public class InMemoryDeliveryTrackerTest {
 
         assertEquals(tracker.getNumberOfDelayedMessages(), 0);
         assertFalse(tracker.hasMessageAvailable());
-        assertEquals(tracker.getScheduledMessages(10), Collections.emptySet());
+        assertEquals(tracker.getScheduledMessages(10), Collections.emptyMap());
     }
 
     @Test
@@ -133,15 +134,15 @@ public class InMemoryDeliveryTrackerTest {
         InMemoryDelayedDeliveryTracker tracker = new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock);
 
         assertTrue(tasks.isEmpty());
-        assertTrue(tracker.addMessage(2, 2, 20));
+        assertTrue(tracker.tryAddMessage(2, 2, 20));
         assertEquals(tasks.size(), 1);
         assertEquals(tasks.firstKey().longValue(), 20);
 
-        assertTrue(tracker.addMessage(1, 1, 10));
+        assertTrue(tracker.tryAddMessage(1, 1, 10));
         assertEquals(tasks.size(), 1);
         assertEquals(tasks.firstKey().longValue(), 10);
 
-        assertTrue(tracker.addMessage(3, 3, 30));
+        assertTrue(tracker.tryAddMessage(3, 3, 30));
         assertEquals(tasks.size(), 1);
         assertEquals(tasks.firstKey().longValue(), 10);
 


### PR DESCRIPTION


### Motivation

There is a bug in the delayed messaging delivery code which can skip delivery of messages.
If there is already a pending read i.e. havePendingReplayRead = true, messages are not delivered but never added back into the delayed message tracker, thus causing these messages to never to be delivered.


### Modifications

When there is a pending read in progress, i.e. havePendingReplayRead=true, add the messages back into the delayed message tracker so they will get send the next time around.

