### PR TITLE
[docs] Fix link issues in getting-started-standalone.md

### DIFF
--- a/site2/website/versioned_docs/version-2.4.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.4.1/getting-started-standalone.md
@@ -175,7 +175,7 @@ If you have started Pulsar successfully, you will see `INFO`-level log messages 
 > * The service is running on your terminal, which is under your direct control. If you need to run other commands, open a new terminal window.  
 You can also run the service as a background process using the `pulsar-daemon start standalone` command. For more information, see [pulsar-daemon](https://pulsar.apache.org/docs/en/reference-cli-tools/#pulsar-daemon).
 > 
-> * By default, there is no encryption, authentication, or authorization configured. Apache Pulsar can be accessed from remote server without any authorization. Please do check [Security Overview](security-overview.md.md) document to secure your deployment.
+> * By default, there is no encryption, authentication, or authorization configured. Apache Pulsar can be accessed from remote server without any authorization. Please do check [Security Overview](security-overview.md) document to secure your deployment.
 >
 > * When you start a local standalone cluster, a `public/default` [namespace](concepts-messaging.md#namespaces) is created automatically. The namespace is used for development purposes. All Pulsar topics are managed within namespaces. For more information, see [Topics](concepts-messaging.md#topics).
 


### PR DESCRIPTION
### Motivation
There is a link issue in getting-started-standalone.md in version 2.4.1.

### Modifications
Fix the linked file name.