### PR TITLE
[docs] Update some links on Pulsar website

### DIFF
--- a/site2/docs/concepts-overview.md
+++ b/site2/docs/concepts-overview.md
@@ -4,7 +4,7 @@ title: Pulsar Overview
 sidebar_label: Overview
 ---
 
-Pulsar is a multi-tenant, high-performance solution for server-to-server messaging. Pulsar was originally developed by [Yahoo](http://yahoo.github.io/), it is under the stewardship of the [Apache Software Foundation](https://www.apache.org/).
+Pulsar is a multi-tenant, high-performance solution for server-to-server messaging. Pulsar was originally developed by Yahoo, it is under the stewardship of the [Apache Software Foundation](https://www.apache.org/).
 
 Key features of Pulsar are listed below:
 

--- a/site2/docs/deploy-bare-metal-multi-cluster.md
+++ b/site2/docs/deploy-bare-metal-multi-cluster.md
@@ -31,7 +31,7 @@ If you want to deploy a single Pulsar cluster, see [Clusters and Brokers](gettin
 > This guide shows you how to deploy Pulsar in production in a non-Kubernetes environment. If you want to run a standalone Pulsar cluster on a single machine for development purposes, see the [Setting up a local cluster](getting-started-standalone.md) guide. If you want to run Pulsar on [Kubernetes](https://kubernetes.io), see the [Pulsar on Kubernetes](deploy-kubernetes.md) guide, which includes sections on running Pulsar on Kubernetes on [Google Kubernetes Engine](deploy-kubernetes#pulsar-on-google-kubernetes-engine) and on [Amazon Web Services](deploy-kubernetes#pulsar-on-amazon-web-services).
 
 ## System requirement
-Pulsar is currently available for **MacOS** and **Linux**. In order to use Pulsar, you need to install [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+Pulsar is currently available for **MacOS** and **Linux**. In order to use Pulsar, you need to install Java 8 from [Oracle download center](http://www.oracle.com/).
 
 ## Install Pulsar
 

--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -53,7 +53,7 @@ If you implement the classic word count example using Pulsar Functions, it looks
 
 ![Pulsar Functions word count example](assets/pulsar-functions-word-count.png)
 
-To write the function in Java with [Pulsar Functions SDK for Java](functions-develop#available-apis), you can write the function as follows.
+To write the function in Java with [Pulsar Functions SDK for Java](functions-develop.md#available-apis), you can write the function as follows.
 
 ```java
 package org.example.functions;

--- a/site2/docs/getting-started-clients.md
+++ b/site2/docs/getting-started-clients.md
@@ -38,7 +38,7 @@ There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for
 
 For a tutorial on using the Pulsar C++ clent, see [Pulsar C++ client](client-libraries-cpp.md).
 
-There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](/api/cpp).
+There are also [Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client [here](/api/cpp).
 
 ## Feature Matrix
 Pulsar client feature matrix for different languages is listed on [Client Features Matrix](https://github.com/apache/pulsar/wiki/Client-Features-Matrix) page.

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -15,7 +15,7 @@ This tutorial guides you through every step of the installation process.
 
 ### System requirements
 
-Pulsar is currently available for **MacOS** and **Linux**. To use Pulsar, you need to install [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+Pulsar is currently available for **MacOS** and **Linux**. To use Pulsar, you need to install Java 8 from [Oracle download center](http://www.oracle.com/).
 
 > #### Tip
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 


### PR DESCRIPTION
### Motivation

There are some link issues on Pulsar website, check and fix them.

### Modifications
1. Internal links: correct the link address.
2. External links: do not use too detailed links to other website. If the download or introduction links changes, it's hard to maintain those links. We can use general link (only navigate to their main pages) or not use links.