### PR TITLE
Return after triggering callback with empty result

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1046,6 +1046,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         List<Entry> entries = Lists.newArrayListWithExpectedSize(positions.size());
         if (positions.isEmpty()) {
             callback.readEntriesComplete(entries, ctx);
+            return Collections.emptySet();
         }
 
         // filters out messages which are already acknowledged


### PR DESCRIPTION
### Motivation

While this doesn't appear to affect the correctness, we should just return empty after we trigger the callback.