### PR TITLE
[Transaction coordinator]Add transaction metadata store service

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -804,3 +804,4 @@ replicationTlsEnabled=false
 
 # Enable transaction coordinator in broker
 transactionCoordinatorEnabled=true
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStore

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -804,4 +804,4 @@ replicationTlsEnabled=false
 
 # Enable transaction coordinator in broker
 transactionCoordinatorEnabled=true
-transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStore
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -608,3 +608,6 @@ allowAutoTopicCreationType=non-partitioned
 
 # The number of partitioned topics that is allowed to be automatically created if allowAutoTopicCreationType is partitioned.
 defaultNumPartitions=1
+
+### --- Transaction config variables --- ###
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStore

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -610,4 +610,4 @@ allowAutoTopicCreationType=non-partitioned
 defaultNumPartitions=1
 
 ### --- Transaction config variables --- ###
-transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStore
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1329,6 +1329,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean transactionCoordinatorEnabled = true;
 
+    @FieldContext(
+        category = CATEGORY_TRANSACTION,
+            doc = "Class name for transaction metadata store provider"
+    )
+    private String transactionMetadataStoreProviderClassName;
+
     /**
      * @deprecated See {@link #getConfigurationStoreServers}
      */

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1333,7 +1333,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_TRANSACTION,
             doc = "Class name for transaction metadata store provider"
     )
-    private String transactionMetadataStoreProviderClassName;
+    private String transactionMetadataStoreProviderClassName =
+            "org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider";
 
     /**
      * @deprecated See {@link #getConfigurationStoreServers}

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -310,6 +310,17 @@
       <groupId>com.sun.activation</groupId>
       <artifactId>javax.activation</artifactId>
     </dependency>
+
+    <!-- transaction related dependencies (begin) -->
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-transaction-coordinator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- transaction related dependencies (end) -->
+
   </dependencies>
 
   <build>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
+import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -315,6 +316,8 @@ public class PulsarStandalone implements AutoCloseable {
         // Start Broker
         broker = new PulsarService(config, Optional.ofNullable(fnWorkerService));
         broker.start();
+
+        broker.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
 
         URL webServiceUrl = new URL(
                 String.format("http://%s:%d", config.getAdvertisedAddress(), config.getWebServicePort().get()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -108,6 +108,8 @@ import org.apache.pulsar.compaction.TwoPhaseCompactor;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
+import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
+import org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider;
 import org.apache.pulsar.websocket.WebSocketConsumerServlet;
 import org.apache.pulsar.websocket.WebSocketProducerServlet;
 import org.apache.pulsar.websocket.WebSocketReaderServlet;
@@ -182,6 +184,7 @@ public class PulsarService implements AutoCloseable {
     private ShutdownService shutdownService;
 
     private MetricsGenerator metricsGenerator;
+    private TransactionMetadataStoreService transactionMetadataStoreService;
 
     public enum State {
         Init, Started, Closed
@@ -396,6 +399,14 @@ public class PulsarService implements AutoCloseable {
             this.loadManager.set(LoadManager.create(this));
 
             this.offloader = createManagedLedgerOffloader(this.getConfiguration());
+
+            if (StringUtils.isNotBlank(config.getTransactionMetadataStoreProviderClassName())) {
+                transactionMetadataStoreService = new TransactionMetadataStoreService(TransactionMetadataStoreProvider
+                        .newProvider(config.getTransactionMetadataStoreProviderClassName()), this);
+            } else {
+                transactionMetadataStoreService = new TransactionMetadataStoreService(TransactionMetadataStoreProvider
+                        .newProvider(InMemTransactionMetadataStoreProvider.class.getName()), this);
+            }
 
             brokerService.start();
 
@@ -914,6 +925,10 @@ public class PulsarService implements AutoCloseable {
 
     public MetricsGenerator getMetricsGenerator() {
         return metricsGenerator;
+    }
+
+    public TransactionMetadataStoreService getTransactionMetadataStoreService() {
+        return transactionMetadataStoreService;
     }
 
     public void setShutdownService(ShutdownService shutdownService) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
+import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
+import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
+import org.apache.pulsar.transaction.coordinator.TxnMeta;
+import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
+import org.apache.pulsar.transaction.impl.common.TxnID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TransactionMetadataStoreService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionMetadataStoreService.class);
+
+    private final Map<TransactionCoordinatorID, TransactionMetadataStore> stores;
+    private final TransactionMetadataStoreProvider transactionMetadataStoreProvider;
+    private final PulsarService pulsarService;
+
+    public TransactionMetadataStoreService(TransactionMetadataStoreProvider transactionMetadataStoreProvider,
+                                           PulsarService pulsarService) {
+        this.pulsarService = pulsarService;
+        this.stores = new ConcurrentHashMap<>();
+        this.transactionMetadataStoreProvider = transactionMetadataStoreProvider;
+    }
+
+    public void addTransactionMetadataStore(TransactionCoordinatorID tcId) {
+        transactionMetadataStoreProvider.openStore(tcId, pulsarService.getManagedLedgerFactory())
+            .whenComplete((store, ex) -> {
+                if (ex != null) {
+                    LOG.error("Add transaction metadata store with id {} error", tcId.getId(), ex);
+                } else {
+                    stores.put(tcId, store);
+                }
+            });
+    }
+
+    public void removeTransactionMetadataStore(TransactionCoordinatorID tcId) {
+        stores.remove(tcId).closeAsync().whenComplete((v, ex) -> {
+           if (ex != null) {
+               LOG.error("Close transaction metadata store with id {} error", ex);
+           }
+        });
+    }
+
+    public CompletableFuture<TxnID> newTransaction(TransactionCoordinatorID tcId) {
+        TransactionMetadataStore store = stores.get(tcId);
+        if (store == null) {
+            return FutureUtil.failedFuture(new CoordinatorException.NotFoundException(tcId));
+        }
+        return store.newTransaction();
+    }
+
+    public CompletableFuture<Void> addProducedPartitionToTxn(TxnID txnId, List<String> partitions) {
+        TransactionCoordinatorID tcId = getTcIdFromTxnId(txnId);
+        TransactionMetadataStore store = stores.get(tcId);
+        if (store == null) {
+            return FutureUtil.failedFuture(new CoordinatorException.NotFoundException(tcId));
+        }
+        return store.addProducedPartitionToTxn(txnId, partitions);
+    }
+
+    public CompletableFuture<Void> addAckedPartitionToTxn(TxnID txnId, List<String> partitions) {
+        TransactionCoordinatorID tcId = getTcIdFromTxnId(txnId);
+        TransactionMetadataStore store = stores.get(tcId);
+        if (store == null) {
+            return FutureUtil.failedFuture(new CoordinatorException.NotFoundException(tcId));
+        }
+        return store.addAckedPartitionToTxn(txnId, partitions);
+    }
+
+    public CompletableFuture<TxnMeta> getTxnMeta(TxnID txnId) {
+        TransactionCoordinatorID tcId = getTcIdFromTxnId(txnId);
+        TransactionMetadataStore store = stores.get(tcId);
+        if (store == null) {
+            return FutureUtil.failedFuture(new CoordinatorException.NotFoundException(tcId));
+        }
+        return store.getTxnMeta(txnId);
+    }
+
+    private TransactionCoordinatorID getTcIdFromTxnId(TxnID txnId) {
+        return new TransactionCoordinatorID(txnId.getMostSigBits());
+    }
+
+    public TransactionMetadataStoreProvider getTransactionMetadataStoreProvider() {
+        return transactionMetadataStoreProvider;
+    }
+
+    @VisibleForTesting
+    public Map<TransactionCoordinatorID, TransactionMetadataStore> getStores() {
+        return Collections.unmodifiableMap(stores);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.broker.TransactionMetadataStoreService;
+import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
+import org.apache.pulsar.transaction.coordinator.TxnMeta;
+import org.apache.pulsar.transaction.impl.common.TxnID;
+import org.apache.pulsar.transaction.impl.common.TxnStatus;
+import org.junit.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.Assert.assertEquals;
+
+public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testAddAndRemoveTransactionMetadataStore() {
+        TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
+        Assert.assertNotNull(transactionMetadataStoreService);
+
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 1);
+
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 0);
+    }
+
+    @Test
+    public void testNewTransaction() throws ExecutionException, InterruptedException {
+        TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(1));
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(2));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 3);
+        TxnID txnID0 = transactionMetadataStoreService.newTransaction(TransactionCoordinatorID.get(0)).get();
+        TxnID txnID1 = transactionMetadataStoreService.newTransaction(TransactionCoordinatorID.get(1)).get();
+        TxnID txnID2 = transactionMetadataStoreService.newTransaction(TransactionCoordinatorID.get(2)).get();
+        Assert.assertEquals(0, txnID0.getMostSigBits());
+        Assert.assertEquals(1, txnID1.getMostSigBits());
+        Assert.assertEquals(2, txnID2.getMostSigBits());
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(1));
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(2));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 0);
+    }
+
+    @Test
+    public void testAddProducedPartitionToTxn() throws ExecutionException, InterruptedException {
+        TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 1);
+        TxnID txnID = transactionMetadataStoreService.newTransaction(TransactionCoordinatorID.get(0)).get();
+        List<String> partitions = new ArrayList<>();
+        partitions.add("ptn-0");
+        partitions.add("ptn-1");
+        partitions.add("ptn-2");
+        transactionMetadataStoreService.addProducedPartitionToTxn(txnID, partitions);
+        TxnMeta txn = transactionMetadataStoreService.getTxnMeta(txnID).get();
+        assertEquals(txn.status(), TxnStatus.OPEN);
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 0);
+    }
+
+    @Test
+    public void testAddAckedPartitionToTxn() throws ExecutionException, InterruptedException {
+        TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
+        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 1);
+        TxnID txnID = transactionMetadataStoreService.newTransaction(TransactionCoordinatorID.get(0)).get();
+        List<String> partitions = new ArrayList<>();
+        partitions.add("ptn-0");
+        partitions.add("ptn-1");
+        partitions.add("ptn-2");
+        transactionMetadataStoreService.addAckedPartitionToTxn(txnID, partitions);
+        TxnMeta txn = transactionMetadataStoreService.getTxnMeta(txnID).get();
+        assertEquals(txn.status(), TxnStatus.OPEN);
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Assert.assertEquals(transactionMetadataStoreService.getStores().size(), 0);
+    }
+}

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -41,6 +41,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>managed-ledger</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionCoordinatorID.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionCoordinatorID.java
@@ -33,4 +33,8 @@ public class TransactionCoordinatorID {
      */
     private final long id;
 
+    public static TransactionCoordinatorID get(long id) {
+        return new TransactionCoordinatorID(id);
+    }
+
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.transaction.coordinator;
 
 import com.google.common.annotations.Beta;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.transaction.impl.common.TxnID;
@@ -92,5 +93,9 @@ public interface TransactionMetadataStore {
     CompletableFuture<Void> updateTxnStatus(
         TxnID txnid, TxnStatus newStatus, TxnStatus expectedStatus);
 
+    /**
+     * Close the transaction metadata store
+     */
+    CompletableFuture<Void> closeAsync();
 
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
@@ -94,7 +94,7 @@ public interface TransactionMetadataStore {
         TxnID txnid, TxnStatus newStatus, TxnStatus expectedStatus);
 
     /**
-     * Close the transaction metadata store
+     * Close the transaction metadata store.
      */
     CompletableFuture<Void> closeAsync();
 

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.transaction.coordinator;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.Beta;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
@@ -60,5 +62,5 @@ public interface TransactionMetadataStoreProvider {
      *         if the operation succeeds.
      */
     CompletableFuture<TransactionMetadataStore> openStore(
-        TransactionCoordinatorID transactionCoordinatorId);
+            TransactionCoordinatorID transactionCoordinatorId, ManagedLedgerFactory managedLedgerFactory);
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
@@ -63,5 +63,5 @@ public interface TransactionMetadataStoreProvider {
      *         if the operation succeeds.
      */
     CompletableFuture<TransactionMetadataStore> openStore(
-            TransactionCoordinatorID transactionCoordinatorId, ManagedLedgerFactory managedLedgerFactory);
+        TransactionCoordinatorID transactionCoordinatorId, ManagedLedgerFactory managedLedgerFactory);
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
@@ -21,10 +21,11 @@ package org.apache.pulsar.transaction.coordinator;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.Beta;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 
 /**
  * A provider that provides {@link TransactionMetadataStore}.

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
@@ -38,6 +38,9 @@ public abstract class CoordinatorException extends Exception {
         super(cause);
     }
 
+    /**
+     * Transaction coordinator not found exception.
+     */
     public static class NotFoundException extends CoordinatorException {
 
         public NotFoundException(TransactionCoordinatorID tcId) {

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.transaction.coordinator.exceptions;
 
+import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
+
 /**
  * The base exception for exceptions thrown from coordinator.
  */
@@ -34,5 +36,24 @@ public abstract class CoordinatorException extends Exception {
 
     public CoordinatorException(Throwable cause) {
         super(cause);
+    }
+
+    public static class NotFoundException extends CoordinatorException {
+
+        public NotFoundException(TransactionCoordinatorID tcId) {
+            super(String.format("Transaction coordinator with id %s not found!", tcId.getId()));
+        }
+
+        public NotFoundException(String message) {
+            super(message);
+        }
+
+        public NotFoundException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public NotFoundException(Throwable cause) {
+            super(cause);
+        }
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
@@ -111,4 +111,10 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
             }
         });
     }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        transactions.clear();
+        return CompletableFuture.completedFuture(null);
+    }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
@@ -34,6 +34,6 @@ public class InMemTransactionMetadataStoreProvider implements TransactionMetadat
     public CompletableFuture<TransactionMetadataStore> openStore(TransactionCoordinatorID transactionCoordinatorId,
          ManagedLedgerFactory managedLedgerFactory) {
         return CompletableFuture.completedFuture(
-                new InMemTransactionMetadataStore(transactionCoordinatorId));
+            new InMemTransactionMetadataStore(transactionCoordinatorId));
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.transaction.coordinator.impl;
 
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
@@ -29,10 +31,9 @@ import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvide
 public class InMemTransactionMetadataStoreProvider implements TransactionMetadataStoreProvider {
 
     @Override
-    public CompletableFuture<TransactionMetadataStore>
-        openStore(TransactionCoordinatorID transactionCoordinatorId) {
+    public CompletableFuture<TransactionMetadataStore> openStore(TransactionCoordinatorID transactionCoordinatorId,
+         ManagedLedgerFactory managedLedgerFactory) {
         return CompletableFuture.completedFuture(
-            new InMemTransactionMetadataStore(transactionCoordinatorId));
+                new InMemTransactionMetadataStore(transactionCoordinatorId));
     }
-
 }

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProviderTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProviderTest.java
@@ -61,7 +61,7 @@ public class TransactionMetadataStoreProviderTest {
     @BeforeMethod
     public void setup() throws Exception {
         this.tcId = new TransactionCoordinatorID(1L);
-        this.store = this.provider.openStore(tcId).get();
+        this.store = this.provider.openStore(tcId, null).get();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Add transaction metadata store service and auto create 1 transaction metadata store with 
id 0

### Verifying this change

Add new unit tests for transaction metadata store service

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)

This is a internal mechanism for transaction streaming
