### PR TITLE
[Transaction Coordinator] Bootstrap pulsar system namespace and create TC assign topic.

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -135,6 +135,7 @@ where command is one of:
     standalone          Run a broker server with local bookies and local zookeeper
 
     initialize-cluster-metadata     One-time metadata initialization
+    initialize-transaction-coordinator-metadata     One-time transaction coordinator metadata initialization
     compact-topic       Run compaction against a topic
     zookeeper-shell     Open a ZK shell client
     tokens              Utility to create authentication tokens
@@ -328,6 +329,8 @@ elif [ $COMMAND == "standalone" ]; then
     exec $JAVA $OPTS $ASPECTJ_AGENT ${ZK_OPTS} -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.PulsarStandaloneStarter --config $PULSAR_STANDALONE_CONF $@
 elif [ $COMMAND == "initialize-cluster-metadata" ]; then
     exec $JAVA $OPTS org.apache.pulsar.PulsarClusterMetadataSetup $@
+elif [ $COMMAND == "initialize-transaction-coordinator-metadata" ]; then
+    exec $JAVA $OPTS org.apache.pulsar.PulsarTransactionCoordinatorMetadataSetup $@
 elif [ $COMMAND == "zookeeper-shell" ]; then
     exec $JAVA $OPTS org.apache.zookeeper.ZooKeeperMain $@
 elif [ $COMMAND == "compact-topic" ]; then

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -799,3 +799,8 @@ globalZookeeperServers=
 
 # Deprecated - Enable TLS when talking with other clusters to replicate messages
 replicationTlsEnabled=false
+
+### --- Transaction config variables --- ###
+
+# Enable transaction coordinator in broker
+transactionCoordinatorEnabled=true

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -83,6 +83,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private static final String CATEGORY_SASL_AUTH = "SASL Authentication Provider";
     @Category
     private static final String CATEGORY_HTTP = "HTTP";
+    @Category
+    private static final String CATEGORY_TRANSACTION = "Transaction";
 
     /***** --- pulsar configuration --- ****/
     @FieldContext(
@@ -1319,6 +1321,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Maximum number of thread pool threads for ledger offloading"
     )
     private int managedLedgerOffloadMaxThreads = 2;
+
+    /**** --- Transaction config variables --- ****/
+    @FieldContext(
+            category = CATEGORY_TRANSACTION,
+            doc = "Enable transaction coordinator in broker"
+    )
+    private boolean transactionCoordinatorEnabled = true;
 
     /**
      * @deprecated See {@link #getConfigurationStoreServers}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -146,6 +146,7 @@ public class PulsarClusterMetadataSetup {
 
         if (arguments.numTransactionCoordinators <= 0) {
             System.err.println("Number of transaction coordinators must greater than 0");
+            System.exit(1);
         }
 
         log.info("Setting up cluster {} with zk={} configuration-store={}", arguments.cluster, arguments.zookeeper,
@@ -238,7 +239,7 @@ public class PulsarClusterMetadataSetup {
         log.info("Cluster metadata for '{}' setup correctly", arguments.cluster);
     }
 
-    private static void createTenantIfAbsent(ZooKeeper configStoreZk, String tenant, String cluster) throws IOException,
+    static void createTenantIfAbsent(ZooKeeper configStoreZk, String tenant, String cluster) throws IOException,
             KeeperException, InterruptedException {
 
         String tenantPath = POLICIES_ROOT + "/" + tenant;
@@ -269,7 +270,7 @@ public class PulsarClusterMetadataSetup {
         }
     }
 
-    private static void createNamespaceIfAbsent(ZooKeeper configStoreZk, NamespaceName namespaceName, String cluster)
+    static void createNamespaceIfAbsent(ZooKeeper configStoreZk, NamespaceName namespaceName, String cluster)
             throws KeeperException, InterruptedException, IOException {
         String namespacePath = POLICIES_ROOT + "/" +namespaceName.toString();
         Policies policies;
@@ -303,7 +304,7 @@ public class PulsarClusterMetadataSetup {
         }
     }
 
-    private static void createPartitionedTopic(ZooKeeper configStoreZk, TopicName topicName, int numPartitions) throws KeeperException, InterruptedException, IOException {
+    static void createPartitionedTopic(ZooKeeper configStoreZk, TopicName topicName, int numPartitions) throws KeeperException, InterruptedException, IOException {
         String partitionedTopicPath = ZkAdminPaths.partitionedTopicPath(topicName);
         Stat stat = configStoreZk.exists(partitionedTopicPath, false);
         PartitionedTopicMetadata metadata = new PartitionedTopicMetadata(numPartitions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -34,7 +34,10 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stream.storage.api.cluster.ClusterInitializer;
 import org.apache.bookkeeper.stream.storage.impl.cluster.ZkClusterInitializer;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.pulsar.broker.admin.ZkAdminPaths;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -45,6 +48,7 @@ import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory.SessionType;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooDefs;
@@ -100,6 +104,11 @@ public class PulsarClusterMetadataSetup {
         }, description = "Num storage containers of BookKeeper stream storage")
         private int numStreamStorageContainers = 16;
 
+        @Parameter(names = {
+                "--initial-num-transaction-coordinators"
+        }, description = "Num transaction coordinators will assigned in cluster")
+        private int numTransactionCoordinators = 16;
+
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
     }
@@ -133,6 +142,10 @@ public class PulsarClusterMetadataSetup {
 
         if (arguments.configurationStore == null) {
             arguments.configurationStore = arguments.globalZookeeper;
+        }
+
+        if (arguments.numTransactionCoordinators <= 0) {
+            System.err.println("Number of transaction coordinators must greater than 0");
         }
 
         log.info("Setting up cluster {} with zk={} configuration-store={}", arguments.cluster, arguments.zookeeper,
@@ -207,14 +220,35 @@ public class PulsarClusterMetadataSetup {
         }
 
         // Create public tenant, whitelisted to use the this same cluster, along with other clusters
-        String publicTenantPath = POLICIES_ROOT + "/" + TopicName.PUBLIC_TENANT;
+        createTenantIfAbsent(configStoreZk, TopicName.PUBLIC_TENANT, arguments.cluster);
 
-        Stat stat = configStoreZk.exists(publicTenantPath, false);
+        // Create system tenant
+        createTenantIfAbsent(configStoreZk, NamespaceName.SYSTEM_NAMESPACE.getTenant(), arguments.cluster);
+
+        // Create default namespace
+        createNamespaceIfAbsent(configStoreZk, NamespaceName.get(TopicName.PUBLIC_TENANT, TopicName.DEFAULT_NAMESPACE),
+                arguments.cluster);
+
+        // Create system namespace
+        createNamespaceIfAbsent(configStoreZk, NamespaceName.SYSTEM_NAMESPACE, arguments.cluster);
+
+        // Create transaction coordinator assign partitioned topic
+        createPartitionedTopic(configStoreZk, TopicName.TRANSACTION_COORDINATOR_ASSIGN, arguments.numTransactionCoordinators);
+
+        log.info("Cluster metadata for '{}' setup correctly", arguments.cluster);
+    }
+
+    private static void createTenantIfAbsent(ZooKeeper configStoreZk, String tenant, String cluster) throws IOException,
+            KeeperException, InterruptedException {
+
+        String tenantPath = POLICIES_ROOT + "/" + tenant;
+
+        Stat stat = configStoreZk.exists(tenantPath, false);
         if (stat == null) {
-            TenantInfo publicTenant = new TenantInfo(Collections.emptySet(), Collections.singleton(arguments.cluster));
+            TenantInfo publicTenant = new TenantInfo(Collections.emptySet(), Collections.singleton(cluster));
 
             try {
-                ZkUtils.createFullPathOptimistic(configStoreZk, publicTenantPath,
+                ZkUtils.createFullPathOptimistic(configStoreZk, tenantPath,
                         ObjectMapperFactory.getThreadLocal().writeValueAsBytes(publicTenant),
                         ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             } catch (NodeExistsException e) {
@@ -222,52 +256,82 @@ public class PulsarClusterMetadataSetup {
             }
         } else {
             // Update existing public tenant with new cluster
-            byte[] content = configStoreZk.getData(publicTenantPath, false, null);
+            byte[] content = configStoreZk.getData(tenantPath, false, null);
             TenantInfo publicTenant = ObjectMapperFactory.getThreadLocal().readValue(content, TenantInfo.class);
 
             // Only update z-node if the list of clusters should be modified
-            if (!publicTenant.getAllowedClusters().contains(arguments.cluster)) {
-                publicTenant.getAllowedClusters().add(arguments.cluster);
+            if (!publicTenant.getAllowedClusters().contains(cluster)) {
+                publicTenant.getAllowedClusters().add(cluster);
 
-                configStoreZk.setData(publicTenantPath, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(publicTenant),
+                configStoreZk.setData(tenantPath, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(publicTenant),
                         stat.getVersion());
             }
         }
+    }
 
-        // Create default namespace
-        String defaultNamespacePath = POLICIES_ROOT + "/" + TopicName.PUBLIC_TENANT + "/" + TopicName.DEFAULT_NAMESPACE;
+    private static void createNamespaceIfAbsent(ZooKeeper configStoreZk, NamespaceName namespaceName, String cluster)
+            throws KeeperException, InterruptedException, IOException {
+        String namespacePath = POLICIES_ROOT + "/" +namespaceName.toString();
         Policies policies;
-
-        stat = configStoreZk.exists(defaultNamespacePath, false);
+        Stat stat = configStoreZk.exists(namespacePath, false);
         if (stat == null) {
             policies = new Policies();
             policies.bundles = getBundles(16);
-            policies.replication_clusters = Collections.singleton(arguments.cluster);
+            policies.replication_clusters = Collections.singleton(cluster);
 
             try {
                 ZkUtils.createFullPathOptimistic(
-                    configStoreZk,
-                    defaultNamespacePath,
-                    ObjectMapperFactory.getThreadLocal().writeValueAsBytes(policies),
-                    ZooDefs.Ids.OPEN_ACL_UNSAFE,
-                    CreateMode.PERSISTENT);
+                        configStoreZk,
+                        namespacePath,
+                        ObjectMapperFactory.getThreadLocal().writeValueAsBytes(policies),
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT);
             } catch (NodeExistsException e) {
                 // Ignore
             }
         } else {
-            byte[] content = configStoreZk.getData(defaultNamespacePath, false, null);
+            byte[] content = configStoreZk.getData(namespacePath, false, null);
             policies = ObjectMapperFactory.getThreadLocal().readValue(content, Policies.class);
 
             // Only update z-node if the list of clusters should be modified
-            if (!policies.replication_clusters.contains(arguments.cluster)) {
-                policies.replication_clusters.add(arguments.cluster);
+            if (!policies.replication_clusters.contains(cluster)) {
+                policies.replication_clusters.add(cluster);
 
-                configStoreZk.setData(defaultNamespacePath, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(policies),
+                configStoreZk.setData(namespacePath, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(policies),
                         stat.getVersion());
             }
         }
+    }
 
-        log.info("Cluster metadata for '{}' setup correctly", arguments.cluster);
+    private static void createPartitionedTopic(ZooKeeper configStoreZk, TopicName topicName, int numPartitions) throws KeeperException, InterruptedException, IOException {
+        String partitionedTopicPath = ZkAdminPaths.partitionedTopicPath(topicName);
+        Stat stat = configStoreZk.exists(partitionedTopicPath, false);
+        PartitionedTopicMetadata metadata = new PartitionedTopicMetadata(numPartitions);
+        if (stat == null) {
+            try {
+                ZkUtils.createFullPathOptimistic(
+                        configStoreZk,
+                        partitionedTopicPath,
+                        ObjectMapperFactory.getThreadLocal().writeValueAsBytes(metadata),
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT
+                );
+            } catch (NodeExistsException e) {
+                // Ignore
+            }
+        } else {
+            byte[] content = configStoreZk.getData(partitionedTopicPath, false, null);
+            PartitionedTopicMetadata existsMeta = ObjectMapperFactory.getThreadLocal().readValue(content, PartitionedTopicMetadata.class);
+
+            // Only update z-node if the partitions should be modified
+            if (existsMeta.partitions < numPartitions) {
+                configStoreZk.setData(
+                        partitionedTopicPath,
+                        ObjectMapperFactory.getThreadLocal().writeValueAsBytes(metadata),
+                        stat.getVersion()
+                );
+            }
+        }
     }
 
     public static ZooKeeper initZk(String connection, int sessionTimeout) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTransactionCoordinatorMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTransactionCoordinatorMetadataSetup.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.zookeeper.ZooKeeper;
+
+/**
+ * Setup the transaction coordinator metadata for a cluster, the setup will create pulsar/system namespace and create
+ * partitioned topic for transaction coordinator assign
+ */
+public class PulsarTransactionCoordinatorMetadataSetup {
+
+    private static class Arguments {
+
+        @Parameter(names = { "-c", "--cluster" }, description = "Cluster name", required = true)
+        private String cluster;
+
+        @Parameter(names = { "-cs",
+                "--configuration-store" }, description = "Configuration Store connection string", required = true)
+        private String configurationStore;
+
+        @Parameter(names = {
+                "--zookeeper-session-timeout-ms"
+        }, description = "Local zookeeper session timeout ms")
+        private int zkSessionTimeoutMillis = 30000;
+
+        @Parameter(names = {
+                "--initial-num-transaction-coordinators"
+        }, description = "Num transaction coordinators will assigned in cluster")
+        private int numTransactionCoordinators = 16;
+
+        @Parameter(names = { "-h", "--help" }, description = "Show this help message")
+        private boolean help = false;
+
+    }
+
+    public static void main(String[] args) throws Exception {
+        Arguments arguments = new Arguments();
+        JCommander jcommander = new JCommander();
+        try {
+            jcommander.addObject(arguments);
+            jcommander.parse(args);
+            if (arguments.help) {
+                jcommander.usage();
+                return;
+            }
+        } catch (Exception e) {
+            jcommander.usage();
+            throw e;
+        }
+
+        if (arguments.configurationStore == null) {
+            System.err.println("Configuration store address argument is required (--configuration-store)");
+            jcommander.usage();
+            System.exit(1);
+        }
+
+        if (arguments.numTransactionCoordinators <= 0) {
+            System.err.println("Number of transaction coordinators must greater than 0");
+            System.exit(1);
+        }
+
+        ZooKeeper configStoreZk = PulsarClusterMetadataSetup
+                .initZk(arguments.configurationStore, arguments.zkSessionTimeoutMillis);
+
+        // Create system tenant
+        PulsarClusterMetadataSetup
+                .createTenantIfAbsent(configStoreZk, NamespaceName.SYSTEM_NAMESPACE.getTenant(), arguments.cluster);
+
+        // Create system namespace
+        PulsarClusterMetadataSetup.createNamespaceIfAbsent(configStoreZk, NamespaceName.SYSTEM_NAMESPACE,
+                arguments.cluster);
+
+        // Create transaction coordinator assign partitioned topic
+        PulsarClusterMetadataSetup.createPartitionedTopic(configStoreZk, TopicName.TRANSACTION_COORDINATOR_ASSIGN,
+                arguments.numTransactionCoordinators);
+
+        System.out.println("Transaction coordinator metadata setup success");
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -472,6 +472,11 @@ public class PulsarService implements AutoCloseable {
             // Register heartbeat and bootstrap namespaces.
             this.nsService.registerBootstrapNamespaces();
 
+            // Register pulsar system namespaces
+            if (config.isTransactionCoordinatorEnabled()) {
+               this.nsService.registerNamespace(NamespaceName.SYSTEM_NAMESPACE.toString(), false);
+            }
+
             this.metricsGenerator = new MetricsGenerator(this);
 
             // By starting the Load manager service, the broker will also become visible

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -266,7 +266,7 @@ public class NamespaceService {
      * @throws PulsarServerException
      * @throws Exception
      */
-    private boolean registerNamespace(String namespace, boolean ensureOwned) throws PulsarServerException {
+    public boolean registerNamespace(String namespace, boolean ensureOwned) throws PulsarServerException {
 
         String myUrl = pulsar.getSafeBrokerServiceUrl();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -162,7 +162,7 @@ public class SLAMonitoringTest {
 
                 Map<String, NamespaceOwnershipStatus> nsMap = pulsarAdmins[i].brokers().getOwnedNamespaces("my-cluster",
                         list.get(0));
-                Assert.assertEquals(2, nsMap.size());
+                Assert.assertEquals(nsMap.size(), 3);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -399,7 +399,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         Map<String, NamespaceOwnershipStatus> nsMap = admin.brokers().getOwnedNamespaces("test", list.get(0));
         // since sla-monitor ns is not created nsMap.size() == 1 (for HeartBeat Namespace)
-        Assert.assertEquals(1, nsMap.size());
+        Assert.assertEquals(nsMap.size(), 2);
         for (String ns : nsMap.keySet()) {
             NamespaceOwnershipStatus nsStatus = nsMap.get(ns);
             if (ns.equals(
@@ -415,7 +415,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(parts.length, 2);
         Map<String, NamespaceOwnershipStatus> nsMap2 = adminTls.brokers().getOwnedNamespaces("test",
                 String.format("%s:%d", parts[0], BROKER_WEBSERVICE_PORT_TLS));
-        Assert.assertEquals(nsMap2.size(), 1);
+        Assert.assertEquals(nsMap2.size(), 2);
 
         admin.namespaces().deleteNamespace("prop-xyz/ns1");
         admin.clusters().deleteCluster("test");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -397,7 +397,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
         Map<String, NamespaceOwnershipStatus> nsMap = admin.brokers().getOwnedNamespaces("use", list.get(0));
         // since sla-monitor ns is not created nsMap.size() == 1 (for HeartBeat Namespace)
-        Assert.assertEquals(1, nsMap.size());
+        Assert.assertEquals(nsMap.size(), 2);
         for (String ns : nsMap.keySet()) {
             NamespaceOwnershipStatus nsStatus = nsMap.get(ns);
             if (ns.equals(
@@ -413,7 +413,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(parts.length, 2);
         Map<String, NamespaceOwnershipStatus> nsMap2 = adminTls.brokers().getOwnedNamespaces("use",
                 String.format("%s:%d", parts[0], BROKER_WEBSERVICE_PORT_TLS));
-        Assert.assertEquals(nsMap2.size(), 1);
+        Assert.assertEquals(nsMap2.size(), 2);
 
         admin.namespaces().deleteNamespace("prop-xyz/use/ns1");
         admin.clusters().deleteCluster("use");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorAssignTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorAssignTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.coordinator;
+
+import com.google.common.hash.Hashing;
+import org.apache.pulsar.broker.BundleData;
+import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Unit tests for transaction coordinator assign
+ */
+public class TransactionCoordinatorAssignTest extends BrokerTestBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testTCAssignTopicNamespaceBootstrap() throws Exception {
+        final List<NamespaceBundle> loadedBundles = new ArrayList<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        pulsar.getNamespaceService().addNamespaceBundleOwnershipListener(new NamespaceBundleOwnershipListener() {
+
+            @Override
+            public void onLoad(NamespaceBundle bundle) {
+                loadedBundles.add(bundle);
+                latch.countDown();
+            }
+
+            @Override
+            public void unLoad(NamespaceBundle bundle) {
+            }
+
+            @Override
+            public boolean test(NamespaceBundle namespaceBundle) {
+                return namespaceBundle.getNamespaceObject().equals(NamespaceName.SYSTEM_NAMESPACE);
+            }
+        });
+
+        Assert.assertEquals(loadedBundles.size(), 1);
+        Assert.assertEquals(loadedBundles.get(0).getNamespaceObject(), NamespaceName.SYSTEM_NAMESPACE);
+        Assert.assertEquals(loadedBundles.get(0),
+                NamespaceBundleFactory.createFactory(pulsar, Hashing.crc32())
+                        .getFullBundle(loadedBundles.get(0).getNamespaceObject()));
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
@@ -47,6 +47,8 @@ public class NamespaceName implements ServiceUnitId {
                 }
             });
 
+    public static final NamespaceName SYSTEM_NAMESPACE = NamespaceName.get("pulsar/system");
+
     public static NamespaceName get(String tenant, String namespace) {
         validateNamespaceName(tenant, namespace);
         return get(tenant + '/' + namespace);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -64,6 +64,9 @@ public class TopicName implements ServiceUnitId {
                 }
             });
 
+    public static final TopicName TRANSACTION_COORDINATOR_ASSIGN = TopicName.get(TopicDomain.persistent.value(),
+            NamespaceName.SYSTEM_NAMESPACE, "transaction_coordinator_assign");
+
     public static TopicName get(String domain, NamespaceName namespaceName, String topic) {
         String name = domain + "://" + namespaceName.toString() + '/' + topic;
         return TopicName.get(name);


### PR DESCRIPTION
### Motivation

Introduce pulsar system namespace and init transaction coordinator assign topic when init pulsar cluster.

Broker will bootstrap the system namespace if broker enable transaction coordinator.

### Verifying this change

Added new unit tests for system namespace Bootstrap

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
