### PR TITLE
Doc: add missing functions from Python context object

### DIFF
--- a/site2/docs/functions-api.md
+++ b/site2/docs/functions-api.md
@@ -572,7 +572,11 @@ The [`Context`](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/p
 Method | What it provides
 :------|:----------------
 `get_message_id` | The message ID of the message being processed
+`get_message_key` | The key of the message being processed
+`get_message_eventtime` | The eventtime of the message being processed
+`get_message_properties` | The properties hash of the message being processed
 `get_current_message_topic_name` | The topic of the message being currently being processed
+`get_partition_key` | The partition key of the message being processed
 `get_function_tenant` | The tenant under which the current Pulsar Function runs under
 `get_function_namespace` | The namespace under which the current Pulsar Function runs under
 `get_function_name` | The name of the current Pulsar Function
@@ -584,8 +588,14 @@ Method | What it provides
 `get_user_config_map` | Returns the entire user-defined config as a dict
 `record_metric` | Records a per-key [metric](#python-metrics)
 `publish` | Publishes a message to the specified Pulsar topic
+`get_output_topic` | The name of the output topic
 `get_output_serde_class_name` | The name of the output [SerDe](#python-serde) class
 `ack` | [Acks](reference-terminology.md#acknowledgment-ack) the message being processed to Pulsar
+`incr_counter` | Increment counter by N in BookKeeper table service
+`get_counter` | Get counter value
+`del_counter` | Delete counter
+`put_state` | Put value into BookKeeper table service
+`get_state` | Get value from BookKeeper table service
 
 ### Python SerDe
 

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -247,6 +247,7 @@ Java, Python and Go SDKs provide access to a **context object** that can be used
 
 * The name and ID of a Pulsar Function.
 * The message ID of each message. Each Pulsar message is automatically assigned with an ID.
+* The key, event time, properties and partition key of each message.
 * The name of the topic to which the message is sent.
 * The names of all input topics as well as the output topic associated with the function.
 * The name of the class used for [SerDe](#serde).
@@ -257,6 +258,8 @@ Java, Python and Go SDKs provide access to a **context object** that can be used
 * Access to arbitrary [user configuration](#user-config) values supplied via the CLI.
 * An interface for recording [metrics](#metrics).
 * An interface for storing and retrieving state in [state storage](#state-storage).
+* A function to publish new messages onto arbitrary topics.
+* A function to ack the message being processed (if auto-ack is disabled).
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Java-->
@@ -278,6 +281,7 @@ public interface Context {
     void incrCounter(String key, long amount);
     long getCounter(String key);
     void putState(String key, ByteBuffer value);
+    void deleteState(String key);
     ByteBuffer getState(String key);
     Map<String, Object> getUserConfigMap();
     Optional<Object> getUserConfigValue(String key);
@@ -315,6 +319,68 @@ public class ContextFunction implements Function<String, Void> {
         return null;
     }
 }
+```
+
+<!--Python-->
+```
+class ContextImpl(pulsar.Context):
+  def get_message_id(self):
+    ...
+  def get_message_key(self):
+    ...
+  def get_message_eventtime(self):
+    ...
+  def get_message_properties(self):
+    ...
+  def get_current_message_topic_name(self):
+    ...
+  def get_partition_key(self):
+    ...
+  def get_function_name(self):
+    ...
+  def get_function_tenant(self):
+    ...
+  def get_function_namespace(self):
+    ...
+  def get_function_id(self):
+    ...
+  def get_instance_id(self):
+    ...
+  def get_function_version(self):
+    ...
+  def get_logger(self):
+    ...
+  def get_user_config_value(self, key):
+    ...
+  def get_user_config_map(self):
+    ...
+  def record_metric(self, metric_name, metric_value):
+    ...
+  def get_output_topic(self):
+    ...
+  def get_output_serde_class_name(self):
+    ...
+  def publish(self, topic_name, message, serde_class_name="serde.IdentitySerDe",
+              properties=None, compression_type=None, callback=None, message_conf=None):
+    ...
+  def ack(self, msgid, topic):
+    ...
+  def get_and_reset_metrics(self):
+    ...
+  def reset_metrics(self):
+    ...
+  def get_metrics(self):
+    ...
+  def incr_counter(self, key, amount):
+    ...
+  def get_counter(self, key):
+    ...
+  def del_counter(self, key):
+    ...
+  def put_state(self, key, value):
+    ...
+  def get_state(self, key):
+    ...
 ```
 
 <!--Go-->


### PR DESCRIPTION
### Motivation

Improve documentation

### Modifications

* At [functions-api/#python-context-object](https://pulsar.apache.org/docs/en/next/functions-api/#python-context-object), list the python methods which were missing
* Add Python tab to [functions-develop/#context](https://pulsar.apache.org/docs/en/next/functions-develop/#context)
* In description of context, mention that you can retrieve message metadata (e.g. eventtime, key, properties), and do publish and ack
* Add `deleteState` to Java API for completeness

NOTE: functions-api is not linked from the nav bar, that probably should be fixed too

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

N/A

### Documentation

Doc update only