### PR TITLE
[Issue 5541] cpp and python API: consumer and reader seek

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -301,6 +301,14 @@ class PULSAR_PUBLIC Consumer {
     Result seek(const MessageId& msgId);
 
     /**
+     * Reset the subscription associated with this consumer to a specific message publish time.
+     *
+     * @param timestamp
+     *            the message publish time where to reposition the subscription
+     */
+    Result seek(uint64_t timestamp);
+
+    /**
      * Asynchronously reset the subscription associated with this consumer to a specific message id.
      * The message id can either be a specific message or represent the first or last messages in the topic.
      *
@@ -311,6 +319,14 @@ class PULSAR_PUBLIC Consumer {
      *            the message id where to reposition the subscription
      */
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
+
+    /**
+     * Asynchronously reset the subscription associated with this consumer to a specific message publish time.
+     *
+     * @param timestamp
+     *            the message publish time where to reposition the subscription
+     */
+    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
 
    private:
     ConsumerImplBasePtr impl_;

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -82,6 +82,46 @@ class PULSAR_PUBLIC Reader {
      */
     Result hasMessageAvailable(bool& hasMessageAvailable);
 
+    /**
+     * Reset the this reader to a specific message id.
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+     * seek() on the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     */
+    Result seek(const MessageId& msgId);
+
+    /**
+     * Reset this reader to a specific message publish time.
+     *
+     * @param timestamp
+     *            the message publish time where to reposition the subscription
+     */
+    Result seek(uint64_t timestamp);
+
+    /**
+     * Asynchronously reset this reader to a specific message id.
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+     * seek() on the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     */
+    void seekAsync(const MessageId& msgId, ResultCallback callback);
+
+    /**
+     * Asynchronously reset this reader to a specific message publish time.
+     *
+     * @param timestamp
+     *            the message publish time where to reposition the subscription
+     */
+    void seekAsync(uint64_t timestamp, ResultCallback callback);
+
    private:
     typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
     ReaderImplPtr impl_;

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -393,6 +393,16 @@ SharedBuffer Commands::newSeek(uint64_t consumerId, uint64_t requestId, const Me
     return writeMessageWithSize(cmd);
 }
 
+SharedBuffer Commands::newSeek(uint64_t consumerId, uint64_t requestId, uint64_t timestamp) {
+    BaseCommand cmd;
+    cmd.set_type(BaseCommand::SEEK);
+    CommandSeek* commandSeek = cmd.mutable_seek();
+    commandSeek->set_consumer_id(consumerId);
+    commandSeek->set_request_id(requestId);
+    commandSeek->set_message_publish_time(timestamp);
+    return writeMessageWithSize(cmd);
+}
+
 SharedBuffer Commands::newGetLastMessageId(uint64_t consumerId, uint64_t requestId) {
     BaseCommand cmd;
     cmd.set_type(BaseCommand::GET_LAST_MESSAGE_ID);

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -120,6 +120,7 @@ class Commands {
     static SharedBuffer newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
     static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId);
+    static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, uint64_t timestamp);
     static SharedBuffer newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
     static SharedBuffer newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
 

--- a/pulsar-client-cpp/lib/Consumer.cc
+++ b/pulsar-client-cpp/lib/Consumer.cc
@@ -216,6 +216,14 @@ void Consumer::seekAsync(const MessageId& msgId, ResultCallback callback) {
     impl_->seekAsync(msgId, callback);
 }
 
+void Consumer::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized);
+        return;
+    }
+    impl_->seekAsync(timestamp, callback);
+}
+
 Result Consumer::seek(const MessageId& msgId) {
     if (!impl_) {
         return ResultConsumerNotInitialized;
@@ -223,6 +231,18 @@ Result Consumer::seek(const MessageId& msgId) {
 
     Promise<bool, Result> promise;
     impl_->seekAsync(msgId, WaitForCallback(promise));
+    Result result;
+    promise.getFuture().get(result);
+    return result;
+}
+
+Result Consumer::seek(uint64_t timestamp) {
+    if (!impl_) {
+        return ResultConsumerNotInitialized;
+    }
+
+    Promise<bool, Result> promise;
+    impl_->seekAsync(timestamp, WaitForCallback(promise));
     Result result;
     promise.getFuture().get(result);
     return result;

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -1064,6 +1064,38 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     callback(ResultNotConnected);
 }
 
+void ConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    Lock lock(mutex_);
+    if (state_ == Closed || state_ == Closing) {
+        lock.unlock();
+        LOG_ERROR(getName() << "Client connection already closed.");
+        if (callback) {
+            callback(ResultAlreadyClosed);
+        }
+        return;
+    }
+    lock.unlock();
+
+    ClientConnectionPtr cnx = getCnx().lock();
+    if (cnx) {
+        ClientImplPtr client = client_.lock();
+        uint64_t requestId = client->newRequestId();
+        LOG_DEBUG(getName() << " Sending seek Command for Consumer - " << getConsumerId() << ", requestId - "
+                            << requestId);
+        Future<Result, ResponseData> future =
+            cnx->sendRequestWithId(Commands::newSeek(consumerId_, requestId, timestamp), requestId);
+
+        if (callback) {
+            future.addListener(
+                std::bind(&ConsumerImpl::handleSeek, shared_from_this(), std::placeholders::_1, callback));
+        }
+        return;
+    }
+
+    LOG_ERROR(getName() << " Client Connection not ready for Consumer");
+    callback(ResultNotConnected);
+}
+
 bool ConsumerImpl::isReadCompacted() { return readCompacted_; }
 
 void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -111,6 +111,7 @@ class ConsumerImpl : public ConsumerImplBase,
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
     void handleSeek(Result result, ResultCallback callback);
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
+    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
     virtual bool isReadCompacted();
     virtual void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
     virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback);

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -52,6 +52,7 @@ class ConsumerImplBase {
     virtual int getNumOfPrefetchedMessages() const = 0;
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) = 0;
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback) = 0;
+    virtual void seekAsync(uint64_t timestamp, ResultCallback callback) = 0;
     virtual void negativeAcknowledge(const MessageId& msgId) = 0;
 };
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -726,3 +726,7 @@ std::shared_ptr<TopicName> MultiTopicsConsumerImpl::topicNamesValid(const std::v
 void MultiTopicsConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     callback(ResultOperationNotSupported);
 }
+
+void MultiTopicsConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    callback(ResultOperationNotSupported);
+}

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -79,6 +79,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     Future<Result, Consumer> subscribeOneTopicAsync(const std::string& topic);
     // not supported
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
+    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
 
     virtual void negativeAcknowledge(const MessageId& msgId);
 

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -474,4 +474,8 @@ void PartitionedConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback c
     callback(ResultOperationNotSupported);
 }
 
+void PartitionedConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    callback(ResultOperationNotSupported);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -70,6 +70,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, PartitionedBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
+    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
 
     virtual void negativeAcknowledge(const MessageId& msgId);
 

--- a/pulsar-client-cpp/lib/Reader.cc
+++ b/pulsar-client-cpp/lib/Reader.cc
@@ -83,4 +83,36 @@ Result Reader::hasMessageAvailable(bool& hasMessageAvailable) {
     return promise.getFuture().get(hasMessageAvailable);
 }
 
+void Reader::seekAsync(const MessageId& msgId, ResultCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized);
+        return;
+    }
+    impl_->seekAsync(msgId, callback);
+}
+
+void Reader::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized);
+        return;
+    }
+    impl_->seekAsync(timestamp, callback);
+}
+
+Result Reader::seek(const MessageId& msgId) {
+    Promise<bool, Result> promise;
+    impl_->seekAsync(msgId, WaitForCallback(promise));
+    Result result;
+    promise.getFuture().get(result);
+    return result;
+}
+
+Result Reader::seek(uint64_t timestamp) {
+    Promise<bool, Result> promise;
+    impl_->seekAsync(timestamp, WaitForCallback(promise));
+    Result result;
+    promise.getFuture().get(result);
+    return result;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -104,4 +104,11 @@ void ReaderImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback) 
     consumer_->hasMessageAvailableAsync(callback);
 }
 
+void ReaderImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
+    consumer_->seekAsync(msgId, callback);
+}
+void ReaderImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
+    consumer_->seekAsync(timestamp, callback);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -49,6 +49,9 @@ class ReaderImpl : public std::enable_shared_from_this<ReaderImpl> {
 
     void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
 
+    void seekAsync(const MessageId& msgId, ResultCallback callback);
+    void seekAsync(uint64_t timestamp, ResultCallback callback);
+
    private:
     void handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumer);
 

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1077,7 +1077,7 @@ class Consumer:
         **Args**
 
         * `message`:
-          The message id for seek.
+          The message id for seek, OR an integer event time to seek to
         """
         self._consumer.seek(messageid)
 

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1069,7 +1069,7 @@ class Consumer:
 
     def seek(self, messageid):
         """
-        Reset the subscription associated with this consumer to a specific message id.
+        Reset the subscription associated with this consumer to a specific message id or publish timestamp.
         The message id can either be a specific message or represent the first or last messages in the topic.
         Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
         seek() on the individual partitions.
@@ -1129,6 +1129,20 @@ class Reader:
         Check if there is any message available to read from the current position.
         """
         return self._reader.has_message_available();
+
+    def seek(self, messageid):
+        """
+        Reset this reader to a specific message id or publish timestamp.
+        The message id can either be a specific message or represent the first or last messages in the topic.
+        Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+        seek() on the individual partitions.
+
+        **Args**
+
+        * `message`:
+          The message id for seek, OR an integer event time to seek to
+        """
+        self._reader.seek(messageid)
 
     def close(self):
         """

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -729,6 +729,12 @@ class PulsarTest(TestCase):
         time.sleep(0.5)
         msg = consumer.receive(TM)
         self.assertEqual(msg.data(), b'hello-0')
+
+        # ditto, but seek on timestamp
+        consumer.seek(0)
+        time.sleep(0.5)
+        msg = consumer.receive(TM)
+        self.assertEqual(msg.data(), b'hello-0')
         client.close()
 
     def test_v2_topics(self):

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -760,25 +760,25 @@ class PulsarTest(TestCase):
         reader.seek(MessageId.earliest)
         time.sleep(0.5)
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-0')
+        self.assertEqual(msg.data(), b'hello-0')
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-1')
+        self.assertEqual(msg.data(), b'hello-1')
 
         # seek on messageId
         reader.seek(ids[33])
         time.sleep(0.5)
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-33')
+        self.assertEqual(msg.data(), b'hello-33')
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-34')
+        self.assertEqual(msg.data(), b'hello-34')
 
         # seek on timestamp
         reader.seek(timestamps[79])
         time.sleep(0.5)
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-79')
+        self.assertEqual(msg.data(), b'hello-79')
         msg = reader.read_next(TM)
-        self.assertEqual(msg0.data(), b'hello-80')
+        self.assertEqual(msg.data(), b'hello-80')
 
         reader.close()
         client.close()

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -384,7 +384,7 @@ class PulsarTest(TestCase):
                 'my-python-topic-reader-on-specific-message',
                 MessageId.earliest)
 
-        for i in range(num_of_msgs/2):
+        for i in range(num_of_msgs//2):
             msg = reader1.read_next(TM)
             self.assertTrue(msg)
             self.assertEqual(msg.data(), b'hello-%d' % i)

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -735,6 +735,30 @@ class PulsarTest(TestCase):
         time.sleep(0.5)
         msg = consumer.receive(TM)
         self.assertEqual(msg.data(), b'hello-0')
+
+        # repeat with reader
+        reader = client.create_reader('my-python-topic-seek', MessageId.latest)
+        try:
+            msg = reader.read_next(100)
+            self.assertTrue(False)  # Should not reach this point
+        except:
+            pass  # Exception is expected
+        # seek on messageId
+        reader.seek(MessageId.earliest)
+        time.sleep(0.5)
+        msg = reader.read_next(TM)
+        self.assertEqual(msg0.data(), b'hello-0')
+        msg = reader.read_next(TM)
+        self.assertEqual(msg0.data(), b'hello-1')
+        # seek on timestamp
+        reader.seek(0)
+        time.sleep(0.5)
+        msg = reader.read_next(TM)
+        self.assertEqual(msg0.data(), b'hello-0')
+        msg = reader.read_next(TM)
+        self.assertEqual(msg0.data(), b'hello-1')
+
+        reader.close()
         client.close()
 
     def test_v2_topics(self):

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -116,6 +116,15 @@ void Consumer_seek(Consumer& consumer, const MessageId& msgId) {
     CHECK_RESULT(res);
 }
 
+void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
+    Result res;
+    Py_BEGIN_ALLOW_THREADS
+    res = consumer.seek(timestamp);
+    Py_END_ALLOW_THREADS
+
+    CHECK_RESULT(res);
+}
+
 void export_consumer() {
     using namespace boost::python;
 
@@ -137,5 +146,6 @@ void export_consumer() {
             .def("resume_message_listener", &Consumer_resumeMessageListener)
             .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages)
             .def("seek", &Consumer_seek)
+            .def("seek", &Consumer_seek_timestamp)
             ;
 }

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -77,6 +77,24 @@ void Reader_close(Reader& reader) {
     CHECK_RESULT(res);
 }
 
+void Reader_seek(Reader& reader, const MessageId& msgId) {
+    Result res;
+    Py_BEGIN_ALLOW_THREADS
+    res = reader.seek(msgId);
+    Py_END_ALLOW_THREADS
+
+    CHECK_RESULT(res);
+}
+
+void Reader_seek_timestamp(Reader& reader, uint64_t timestamp) {
+    Result res;
+    Py_BEGIN_ALLOW_THREADS
+    res = reader.seek(timestamp);
+    Py_END_ALLOW_THREADS
+
+    CHECK_RESULT(res);
+}
+
 void export_reader() {
     using namespace boost::python;
 
@@ -86,5 +104,7 @@ void export_reader() {
             .def("read_next", &Reader_readNextTimeout)
             .def("has_message_available", &Reader_hasMessageAvailable)
             .def("close", &Reader_close)
+            .def("seek", &Reader_seek)
+            .def("seek", &Reader_seek_timestamp)
             ;
 }


### PR DESCRIPTION
Updates the cpp and Python APIs:

* Consumer seek(): overload to accept timestamp as well as MessageID
* Reader gains seek()

Fixes #5541

### Motivation

Feature parity between cpp and Python APIs and Java API.  The Java API already has overloaded seek() on both Consumer and Reader.

Some use cases for Reader.seek(timestamp) described in #5537

### Modifications

* cpp Consumer: overload seek() and seekAsync() to accept uint64_t timestamp
* cpp Reader: add overloaded seek() and seekAsync()
* expose these to Python API in the same way

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added basic tests in Python which exercise Consumer seek(timestamp), Reader seek(messageId), Reader seek(timestamp)

~~Note to reviewer: test just uses seek(0) to seek to the first message. It would be better if the messages had distinct publish timestamps so that it would seek to a particular message.  Is there a way to mock these out? Otherwise I'd need a sleep(2) between messages to ensure the timestamps were spaced apart~~ Since publish timestamps have millisecond resolution, I've updated the test to seek to actual times.  Waiting on CI to see if this works as expected, without buffering issues.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: yes: adds overloaded variant of seek() to Consumer, adds new seek() to Reader.  Should be backwards compatible.

Note to reviewer: in python, the single parameter of the seek() function is called "messageid", but this change means it can also be an integer timestamp - that is, it's overloaded on the type of the value provided (just like Java and cpp).  As long as it's used as a positional arg it works, but it might be considered confusing.

An alternative would be to have a separate methods, e.g. `seek()` and `seek_time()`

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs