### PR TITLE
Fix documentation: how to start server for cpp tests

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -202,11 +202,13 @@ ${PULSAR_PATH}/pulsar-client-cpp/tests/
 
 # Execution
 # Start standalone broker
-export PULSAR_STANDALONE_CONF=${PULSAR_PATH}/pulsar-client-cpp/tests/standalone.conf
-${PULSAR_PATH}/bin/pulsar standalone
+${PULSAR_PATH}/pulsar-test-service-start.sh
 
 # Run the tests
 ${PULSAR_PATH}/pulsar-client-cpp/tests/main
+
+# When no longer needed, stop standalone broker
+${PULSAR_PATH}/pulsar-test-service-stop.sh
 ```
 
 ## Requirements for Contributors


### PR DESCRIPTION
### Modifications

Out-of-date instructions in pulsar-client-cpp/README.md about how to start test server