### PR TITLE
Fix docs about reset cursor

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -500,7 +500,7 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Reset position for subscription to position closest to timestamp or messageId")
+    @Parameters(commandDescription = "Reset position for subscription to a position that is closest to timestamp or messageId.")
     private class ResetCursor extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1978,7 +1978,7 @@ Options
 
 
 ### `reset-cursor`
-Reset position for subscription to closest to timestamp
+Reset position for subscription to position closest to timestamp or messageId
 
 Usage
 ```bash
@@ -1986,10 +1986,12 @@ $ pulsar-admin topics reset-cursor topic options
 ```
 
 Options
+
 |Flag|Description|Default|
 |---|---|---|
 |`-s`, `--subscription`|Subscription to reset position on||
-|`-t`, `--time`|The time, in minutes, to reset back to (or minutes, hours, days, weeks, etc.). Examples: `100m`, `3h`, `2d`, `5w`.||
+|`-t`, `--time`|The time in minutes to reset back to (or minutes, hours, days, weeks, etc.). Examples: `100m`, `3h`, `2d`, `5w`.||
+|`-m`, `--messageId`| The messageId to reset back to (ledgerId:entryId). ||
 
 
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1978,7 +1978,7 @@ Options
 
 
 ### `reset-cursor`
-Reset position for subscription to position closest to timestamp or messageId
+Reset position for subscription to a position that is closest to timestamp or messageId.
 
 Usage
 ```bash


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

`reset-cursor` docs missing.

### Modifications

It's not documented in the [Pulsar admin CLI](http://pulsar.apache.org/docs/en/next/pulsar-admin/#reset-cursor), but `reset-cursor` also supports a `messageId` option.

```
$ apache-pulsar-2.4.1/bin/pulsar-admin topics reset-cursor -h

Reset position for subscription to position closest to timestamp or messageId
Usage: reset-cursor [options] persistent://tenant/namespace/topic
  Options:
    --messageId, -m
       messageId to reset back to (ledgerId:entryId)
  * -s, --subscription
       Subscription to reset position on
    --time, -t
       time in minutes to reset back to (or minutes, hours,days,weeks eg: 100m,
       3h, 2d, 5w)
```