### PR TITLE
[broker]Add handle exception KeeperException.BadVersionException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -269,7 +269,8 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 createNewSchema(schemaId, data, hash)
                         .thenAccept(future::complete)
                         .exceptionally(ex -> {
-                            if (ex.getCause() instanceof NodeExistsException) {
+                            if (ex.getCause() instanceof NodeExistsException ||
+                                    ex.getCause() instanceof KeeperException.BadVersionException) {
                                 // There was a race condition on the schema creation. Since it has now been created,
                                 // retry the whole operation so that we have a chance to recover without bubbling error
                                 // back to producer/consumer


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/4790


Master Issue: https://github.com/apache/pulsar/issues/4790

### Motivation
Currently, when the brokerDeleteInactiveTopicsEnabled policy is enabled, the topic pulsar/standalone/127.0.0.1:8080/healthcheck will be deleted periodically, when creating producer and consumer for the second time https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java#L272, because both producer and consumer call putSchema in a short period of time, resulting in race conditions, Throwing exceptions of schema badVersion, only one of them could succeed. therefore, when badVersion exception occurs, call putSchema should be performed again. 
### Modifications

* Add operation to handle exception KeeperException.BadVersionException

### Verifying this change

```
./bin/pulsar standalone -nss -a 127.0.0.1
curl -v http://127.0.0.1:8080/admin/v2/brokers/health

# Waiting for more than 60 seconds, waiting for the topic pulsar/standalone/127.0.0.1:8080/healthcheck to be deleted

curl -v http://127.0.0.1:8080/admin/v2/brokers/health
```