### PR TITLE
[Schema] [Pulsar Functions] Fix schema def build error with protobuf schema 

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -151,7 +151,7 @@ public class TopicSchema {
             return (Schema<T>)Schema.KV_BYTES();
 
         case PROTOBUF:
-            return ProtobufSchema.ofGenericClass(clazz, Collections.emptyMap());
+            return ProtobufSchema.ofGenericClass(clazz, new HashMap<>());
 
         default:
             throw new RuntimeException("Unsupported schema type" + type);


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Fixes #5566 

### Motivation

In `newSchemaInstance` func, the properties param is `Collections.emptyMap()`

```
case PROTOBUF:
    return ProtobufSchema.ofGenericClass(clazz, Collections.emptyMap());
```

but in `build` of `SchemaDefinition`, we want put some things to map:

```
properties.put(ALWAYS_ALLOW_NULL, this.alwaysAllowNull ? "true" : "false");
```



### Modifications

Use `HashMap` instead of `Collections.emptyMap()`.

