### PR TITLE
Fix schema static initialization sequence

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BooleanSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BooleanSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class BooleanSchema extends AbstractSchema<Boolean> {
 
-    public static BooleanSchema of() {
-        return INSTANCE;
-    }
-
     private static final BooleanSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class BooleanSchema extends AbstractSchema<Boolean> {
                 .setType(SchemaType.BOOLEAN)
                 .setSchema(new byte[0]);
         INSTANCE = new BooleanSchema();
+    }
+
+    public static BooleanSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
@@ -29,10 +29,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class ByteBufSchema extends AbstractSchema<ByteBuf> {
 
-    public static ByteBufSchema of() {
-        return INSTANCE;
-    }
-
     private static final ByteBufSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -42,6 +38,10 @@ public class ByteBufSchema extends AbstractSchema<ByteBuf> {
             .setType(SchemaType.BYTES)
             .setSchema(new byte[0]);
         INSTANCE = new ByteBufSchema();
+    }
+
+    public static ByteBufSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufferSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufferSchema.java
@@ -30,10 +30,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class ByteBufferSchema extends AbstractSchema<ByteBuffer> {
 
-    public static ByteBufferSchema of() {
-        return INSTANCE;
-    }
-
     private static final ByteBufferSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -43,6 +39,10 @@ public class ByteBufferSchema extends AbstractSchema<ByteBuffer> {
             .setType(SchemaType.BYTES)
             .setSchema(new byte[0]);
         INSTANCE = new ByteBufferSchema();
+    }
+
+    public static ByteBufferSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class ByteSchema extends AbstractSchema<Byte> {
 
-    public static ByteSchema of() {
-        return INSTANCE;
-    }
-
     private static final ByteSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class ByteSchema extends AbstractSchema<Byte> {
             .setType(SchemaType.INT8)
             .setSchema(new byte[0]);
         INSTANCE = new ByteSchema();
+    }
+
+    public static ByteSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
@@ -27,10 +27,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class BytesSchema extends AbstractSchema<byte[]> {
 
-    public static BytesSchema of() {
-        return INSTANCE;
-    }
-
     private static final BytesSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -42,6 +38,9 @@ public class BytesSchema extends AbstractSchema<byte[]> {
         INSTANCE = new BytesSchema();
     }
 
+    public static BytesSchema of() {
+        return INSTANCE;
+    }
 
     @Override
     public byte[] encode(byte[] message) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DateSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DateSchema.java
@@ -28,9 +28,6 @@ import java.util.Date;
  * A schema for `java.util.Date` or `java.sql.Date`.
  */
 public class DateSchema extends AbstractSchema<Date> {
-   public static DateSchema of() {
-      return INSTANCE;
-   }
 
    private static final DateSchema INSTANCE;
    private static final SchemaInfo SCHEMA_INFO;
@@ -41,6 +38,10 @@ public class DateSchema extends AbstractSchema<Date> {
              .setType(SchemaType.DATE)
              .setSchema(new byte[0]);
        INSTANCE = new DateSchema();
+   }
+
+   public static DateSchema of() {
+      return INSTANCE;
    }
 
    @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DoubleSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DoubleSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class DoubleSchema extends AbstractSchema<Double> {
 
-    public static DoubleSchema of() {
-        return INSTANCE;
-    }
-
     private static final DoubleSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -43,6 +39,9 @@ public class DoubleSchema extends AbstractSchema<Double> {
         INSTANCE = new DoubleSchema();
     }
 
+    public static DoubleSchema of() {
+        return INSTANCE;
+    }
 
     @Override
     public void validate(byte[] message) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FloatSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FloatSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class FloatSchema extends AbstractSchema<Float> {
 
-    public static FloatSchema of() {
-        return INSTANCE;
-    }
-
     private static final FloatSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class FloatSchema extends AbstractSchema<Float> {
                 .setType(SchemaType.FLOAT)
                 .setSchema(new byte[0]);
         INSTANCE = new FloatSchema();
+    }
+
+    public static FloatSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/IntSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/IntSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class IntSchema extends AbstractSchema<Integer> {
 
-    public static IntSchema of() {
-        return INSTANCE;
-    }
-
     private static final IntSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class IntSchema extends AbstractSchema<Integer> {
             .setType(SchemaType.INT32)
             .setSchema(new byte[0]);
         INSTANCE = new IntSchema();
+    }
+
+    public static IntSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LongSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LongSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class LongSchema extends AbstractSchema<Long> {
 
-    public static LongSchema of() {
-        return INSTANCE;
-    }
-
     private static final LongSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class LongSchema extends AbstractSchema<Long> {
             .setType(SchemaType.INT64)
             .setSchema(new byte[0]);
         INSTANCE = new LongSchema();
+    }
+
+    public static LongSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ShortSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ShortSchema.java
@@ -28,10 +28,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 public class ShortSchema extends AbstractSchema<Short> {
 
-    public static ShortSchema of() {
-        return INSTANCE;
-    }
-
     private static final ShortSchema INSTANCE;
     private static final SchemaInfo SCHEMA_INFO;
 
@@ -41,6 +37,10 @@ public class ShortSchema extends AbstractSchema<Short> {
             .setType(SchemaType.INT16)
             .setSchema(new byte[0]);
         INSTANCE = new ShortSchema();
+    }
+
+    public static ShortSchema of() {
+        return INSTANCE;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimeSchema.java
@@ -28,9 +28,6 @@ import java.sql.Time;
  * A schema for `java.sql.Time`.
  */
 public class TimeSchema extends AbstractSchema<Time> {
-   public static TimeSchema of() {
-      return INSTANCE;
-   }
 
    private static final TimeSchema INSTANCE;
    private static final SchemaInfo SCHEMA_INFO;
@@ -41,6 +38,10 @@ public class TimeSchema extends AbstractSchema<Time> {
              .setType(SchemaType.TIME)
              .setSchema(new byte[0]);
        INSTANCE = new TimeSchema();
+   }
+
+   public static TimeSchema of() {
+      return INSTANCE;
    }
 
    @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimestampSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimestampSchema.java
@@ -28,9 +28,6 @@ import java.sql.Timestamp;
  * A schema for `java.sql.Timestamp`.
  */
 public class TimestampSchema extends AbstractSchema<Timestamp> {
-   public static TimestampSchema of() {
-      return INSTANCE;
-   }
 
    private static final TimestampSchema INSTANCE;
    private static final SchemaInfo SCHEMA_INFO;
@@ -41,6 +38,10 @@ public class TimestampSchema extends AbstractSchema<Timestamp> {
              .setType(SchemaType.TIMESTAMP)
              .setSchema(new byte[0]);
        INSTANCE = new TimestampSchema();
+   }
+
+   public static TimestampSchema of() {
+      return INSTANCE;
    }
 
    @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
@@ -91,12 +91,16 @@ public class PrimitiveSchemaTest {
         for (Schema<?> schema : testData.keySet()) {
             byte[] bytes = null;
             ByteBuf byteBuf =  null;
-            assertNull(schema.encode(null),
-                "Should support null in " + schema.getSchemaInfo().getName() + " serialization");
-            assertNull(schema.decode(bytes),
-                "Should support null in " + schema.getSchemaInfo().getName() + " deserialization");
-            assertNull(((AbstractSchema)schema).decode(byteBuf),
+            try {
+                assertNull(schema.encode(null),
+                    "Should support null in " + schema.getSchemaInfo().getName() + " serialization");
+                assertNull(schema.decode(bytes),
                     "Should support null in " + schema.getSchemaInfo().getName() + " deserialization");
+                assertNull(((AbstractSchema) schema).decode(byteBuf),
+                    "Should support null in " + schema.getSchemaInfo().getName() + " deserialization");
+            } catch (NullPointerException npe) {
+                throw new NullPointerException("NPE when using schema " + schema + " : " + npe.getMessage());
+            }
         }
     }
 
@@ -106,10 +110,15 @@ public class PrimitiveSchemaTest {
             log.info("Test schema {}", test.getKey());
             for (Object value : test.getValue()) {
                 log.info("Encode : {}", value);
-                assertEquals(value,
-                    test.getKey().decode(test.getKey().encode(value)),
-                    "Should get the original " + test.getKey().getSchemaInfo().getName() +
-                        " after serialization and deserialization");
+                try {
+                    assertEquals(value,
+                        test.getKey().decode(test.getKey().encode(value)),
+                        "Should get the original " + test.getKey().getSchemaInfo().getName() +
+                            " after serialization and deserialization");
+                } catch (NullPointerException npe) {
+                    throw new NullPointerException("NPE when using schema " + test.getKey()
+                        + " : " + npe.getMessage());
+                }
             }
         }
     }


### PR DESCRIPTION
*Motivation*

Java doesn't guarantee the initialization order of the static fields of a class.
It depends on the JVM version and race conditions.

