### PR TITLE
[Issue 5589][pulsar-function-go] Fix a memory leak of pulsar-function-go library

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -271,7 +271,7 @@ func getIdleTimeout(timeoutMilliSecond time.Duration) time.Duration {
 func (gi *goInstance) setupLogHandler() error {
 	if gi.context.instanceConf.funcDetails.GetLogTopic() != "" {
 		gi.context.logAppender = NewLogAppender(
-			gi.client,                                         //pulsar client
+			gi.client, //pulsar client
 			gi.context.instanceConf.funcDetails.GetLogTopic(), //log topic
 			getDefaultSubscriptionName(gi.context.instanceConf.funcDetails.Tenant, //fqn
 				gi.context.instanceConf.funcDetails.Namespace,
@@ -283,6 +283,11 @@ func (gi *goInstance) setupLogHandler() error {
 }
 
 func (gi *goInstance) addLogTopicHandler() {
+	// Clear StrEntry regardless gi.context.logAppender is set or not
+	defer func() {
+		log.StrEntry = nil
+	}()
+
 	if gi.context.logAppender == nil {
 		log.Error("the logAppender is nil, if you want to use it, please specify `--log-topic` at startup.")
 		return


### PR DESCRIPTION
### Motivation

Fixes #5589 

It seems that there is a memory leak in the pulsar-function-go library.

I implemented a simple pulsar function worker that just write logs using pulsar-function-go/logutil for sending logs to log topic. I tried to long-term test by sending request messages consecutively to the input topic to check the feasibility.

During the test, I faced `ProducerQueueIsFull` error with `--log-topic` option. And I observed indefinitely grown memory usage of the pulsar function worker process.

Please refer to the issue for more detail. (#5589)


### Modifications

Clear the `StrEntry` variable after finish addLogTopicHandler() function regardless of the log messages are appended to logger or not. If it is not cleared, it causes memory leak because StrEntry has grown indefinitely. Moreover, if the function set --log-topic, then the topic could get accumulated huge messages that cause ProducerQueueIsFull error.

### Verifying this change

Verified it by reproducing step described in the issue #5589.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)