### PR TITLE
Fix zookeeper expose metrics port on kubernetes yaml

### DIFF
--- a/deployment/kubernetes/aws/zookeeper.yaml
+++ b/deployment/kubernetes/aws/zookeeper.yaml
@@ -60,7 +60,7 @@ spec:
             annotations:
                 pod.alpha.kubernetes.io/initialized: "true"
                 prometheus.io/scrape: "true"
-                prometheus.io/port: "8080"
+                prometheus.io/port: "8000"
 
         spec:
             # Make sure multiple pods of ZK don't get scheduled on the

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/zookeeper.yaml
@@ -86,7 +86,7 @@ spec:
             annotations:
                 pod.alpha.kubernetes.io/initialized: "true"
                 prometheus.io/scrape: "true"
-                prometheus.io/port: "8080"
+                prometheus.io/port: "8000"
 
         spec:
             # Make sure multiple pods of ZK don't get scheduled on the

--- a/deployment/kubernetes/generic/original/zookeeper.yaml
+++ b/deployment/kubernetes/generic/original/zookeeper.yaml
@@ -60,7 +60,7 @@ spec:
             annotations:
                 pod.alpha.kubernetes.io/initialized: "true"
                 prometheus.io/scrape: "true"
-                prometheus.io/port: "8080"
+                prometheus.io/port: "8000"
 
         spec:
             # Make sure multiple pods of ZK don't get scheduled on the

--- a/deployment/kubernetes/google-kubernetes-engine/zookeeper.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/zookeeper.yaml
@@ -71,7 +71,7 @@ spec:
             annotations:
                 pod.alpha.kubernetes.io/initialized: "true"
                 prometheus.io/scrape: "true"
-                prometheus.io/port: "8080"
+                prometheus.io/port: "8000"
 
         spec:
             # Make sure multiple pods of ZK don't get scheduled on the


### PR DESCRIPTION
Fixes #5600 

### Motivation
Fix zookeeper kubernetes annotations for prometheus pull metrics from port 8000

### Modifications
1.change deployment/kubernetes/*.yaml file