### PR TITLE
fix prometheusMetrics export contains " bug

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -95,10 +95,17 @@ public class PrometheusMetricsGenerator {
                 stream.write(sample.name);
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
+                    String labelValue = sample.labelValues.get(j);
+                    if(labelValue != null &&
+                            (labelValue.startsWith("\"") ||
+                            labelValue.endsWith("\""))){
+                        labelValue = labelValue.replace("\"", "\\\"");
+                    }
+
                     stream.write(",");
                     stream.write(sample.labelNames.get(j));
                     stream.write("=\"");
-                    stream.write(sample.labelValues.get(j));
+                    stream.write(labelValue);
                     stream.write('"');
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -96,7 +96,7 @@ public class PrometheusMetricsGenerator {
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
                     String labelValue = sample.labelValues.get(j);
-                    if(labelValue != null){
+                    if (labelValue != null) {
                         labelValue = labelValue.replace("\"", "\\\"");
                     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -96,9 +96,7 @@ public class PrometheusMetricsGenerator {
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
                     String labelValue = sample.labelValues.get(j);
-                    if(labelValue != null &&
-                            (labelValue.startsWith("\"") ||
-                            labelValue.endsWith("\""))){
+                    if(labelValue != null){
                         labelValue = labelValue.replace("\"", "\\\"");
                     }
 


### PR DESCRIPTION
when i use Oracle JDK 10.0.2，the broker metrics `jvm_info` will export as follow: 
```
# TYPE jvm_info gauge
jvm_info{cluster="pulsar-cluster-zk",version="10.0.2+13",vendor=""Oracle Corporation"",runtime="Java(TM) SE Runtime Environment"} 1.0
```
and then prometheus will failed when parsing `""Oracle Corporation""`
![image](https://user-images.githubusercontent.com/5436568/68560255-41398a80-047b-11ea-9fcb-b79d748a353d.png)


The Reason is when using `io.prometheus:simpleclient:0.5.0` to collect jvm info, it returns jvm vendor with `"Oracle Corporation"`, and in the Pulsar source code, it adds `"` in both sides, so it comming with `vendor=""Oracle Corporation""`, and prometheus parse failed.