### PR TITLE
 Fix hangs when type invalid args at command-line

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -45,7 +45,7 @@ public abstract class CmdBase {
             jcommander.usage(chosenCommand);
         } catch (Exception e) {
             // it is caused by an invalid command, the invalid command can not be parsed
-            System.err.println("Invalid command, please use pulsar-admin to check out how to use");
+            System.err.println("Invalid command, please use `pulsar-admin --help` to check out how to use");
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -39,13 +39,23 @@ public abstract class CmdBase {
         jcommander.setProgramName("pulsar-admin " + cmdName);
     }
 
+    private void tryShowCommandUsage() {
+        try {
+            String chosenCommand = jcommander.getParsedCommand();
+            jcommander.usage(chosenCommand);
+        } catch (Exception e) {
+            // it is caused by an invalid command, the invalid command can not be parsed
+            System.err.println("Invalid command, please use pulsar-admin to check out how to use");
+        }
+    }
+
     public boolean run(String[] args) {
         try {
             jcommander.parse(args);
         } catch (Exception e) {
             System.err.println(e.getMessage());
             System.err.println();
-            jcommander.usage();
+            tryShowCommandUsage();
             return false;
         }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -45,8 +45,7 @@ public abstract class CmdBase {
         } catch (Exception e) {
             System.err.println(e.getMessage());
             System.err.println();
-            String chosenCommand = jcommander.getParsedCommand();
-            jcommander.usage(chosenCommand);
+            jcommander.usage();
             return false;
         }
 


### PR DESCRIPTION
Fixes #5533 

*Motivation*

When we using command-line tools, it hangs after type an invalid args.

*Modifications*

We don't need to parse the command, just show the command usage.
