### PR TITLE
update Maven version to 3.3.9+ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Learn more about Pulsar at https://pulsar.apache.org
 
 Requirements:
  * Java JDK 1.8
- * Maven
+ * Maven 3.3.9+
 
 Compile and install:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1422,6 +1422,29 @@ flexible messaging model and an intuitive client API.</description>
           </gitDescribe>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+            <execution>
+                <id>enforce-maven</id>
+                <goals>
+                    <goal>enforce</goal>
+                </goals>
+                <configuration>
+                    <rules>
+                        <requireJavaVersion>
+                            <version>[1.8.0,)</version>
+                        </requireJavaVersion>
+                        <requireMavenVersion>
+                            <version>[3.3.9,)</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -1492,7 +1515,7 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>3.0.0</version>
-      </plugin>
+        </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>


### PR DESCRIPTION
When compiled with maven version 3.0.4, it failed and report error message as follow: 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project pulsar-client-api: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test failed: Unable to load the mojo 'test' (or one of its required components) from the plugin 'org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3': com.google.inject.ProvisionException: Guice provision errors:
[ERROR] 
[ERROR] 1) No implementation for org.codehaus.plexus.languages.java.jpms.LocationManager was bound.
[ERROR] while locating org.apache.maven.plugin.surefire.SurefirePlugin
[ERROR] at ClassRealm[plugin>org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3, parent: sun.misc.Launcher$AppClassLoader@5c647e05]
[ERROR] while locating org.apache.maven.plugin.Mojo annotated with @com.google.inject.name.Named(value=org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test)
[ERROR] 
[ERROR] 1 error
[ERROR] role: org.apache.maven.plugin.Mojo
[ERROR] roleHint: org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :pulsar-client-api

```

Error reference: 
`https://stackoverflow.com/questions/53211941/unable-to-load-the-mojo-test-org-apache-maven-pluginsmaven-surefire-plugin`

When compiled with maven 3.3.3, it failed and report error message as follow: 
```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.0.1:add-source (default) on project flink: The plugin net.alchim31.maven:scala-maven-plugin:4.0.1 requires Maven version 3.3.9 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginIncompatibleException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :flink

```


Only Maven 3.3.9+, the project can build success.