### PR TITLE
Data is not deleted after expiration due to connected readers

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -148,6 +148,12 @@ public class EntryCacheImpl implements EntryCache {
     public void invalidateEntries(final PositionImpl lastPosition) {
         final PositionImpl firstPosition = PositionImpl.get(-1, 0);
 
+        if (firstPosition.compareTo(lastPosition) > 0) {
+            log.debug("Attempted to invalidate entries in an invalid range : {} ~ {}",
+                firstPosition, lastPosition);
+            return;
+        }
+
         Pair<Integer, Long> removed = entries.removeRange(firstPosition, lastPosition, false);
         int entriesRemoved = removed.getLeft();
         long sizeRemoved = removed.getRight();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.tuple.Pair;
  * care about ledgers to be deleted.
  *
  */
-class ManagedCursorContainer implements Iterable<ManagedCursor> {
+public class ManagedCursorContainer implements Iterable<ManagedCursor> {
 
     private static class Item {
         final ManagedCursor cursor;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -105,7 +105,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     protected volatile PositionImpl markDeletePosition;
     protected volatile PositionImpl readPosition;
-    private volatile MarkDeleteEntry lastMarkDeleteEntry;
+    protected volatile MarkDeleteEntry lastMarkDeleteEntry;
 
     protected static final AtomicReferenceFieldUpdater<ManagedCursorImpl, OpReadEntry> WAITING_READ_OP_UPDATER =
         AtomicReferenceFieldUpdater.newUpdater(ManagedCursorImpl.class, OpReadEntry.class, "waitingReadOp");
@@ -178,7 +178,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private final ArrayDeque<MarkDeleteEntry> pendingMarkDeleteOps = new ArrayDeque<>();
+    protected final ArrayDeque<MarkDeleteEntry> pendingMarkDeleteOps = new ArrayDeque<>();
     private static final AtomicIntegerFieldUpdater<ManagedCursorImpl> PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER =
         AtomicIntegerFieldUpdater.newUpdater(ManagedCursorImpl.class, "pendingMarkDeletedSubmittedCount");
     @SuppressWarnings("unused")

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -829,11 +829,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     @Override
     public ManagedCursor newNonDurableCursor(Position startCursorPosition) throws ManagedLedgerException {
-        checkManagedLedgerIsOpen();
-        checkFenced();
-
-        return new NonDurableCursorImpl(bookKeeper, config, this, null,
-                (PositionImpl) startCursorPosition);
+        return newNonDurableCursor(
+            startCursorPosition,
+            "non-durable-cursor-" + UUID.randomUUID());
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -863,12 +863,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     @Override
-    public Iterable<ManagedCursor> getCursors() {
+    public ManagedCursorContainer getCursors() {
         return cursors;
     }
 
     @Override
-    public Iterable<ManagedCursor> getActiveCursors() {
+    public ManagedCursorContainer getActiveCursors() {
         return activeCursors;
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -607,6 +608,50 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         assertNotNull(c2.getName());
         assertNotNull(c3.getName());
         assertNotNull(c4.getName());
+        ledger.close();
+    }
+
+    @Test
+    public void testGetSlowestConsumer() throws Exception {
+        final String mlName = "test-get-slowest-consumer-ml";
+        final String c1 = "cursor1";
+        final String nc1 = "non-durable-cursor1";
+        final String ncEarliest = "non-durable-cursor-earliest";
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(mlName, new ManagedLedgerConfig());
+        Position p1 = ledger.addEntry(c1.getBytes(UTF_8));
+        log.info("write entry 1 : pos = {}", p1);
+        Position p2 = ledger.addEntry(nc1.getBytes(UTF_8));
+        log.info("write entry 2 : pos = {}", p2);
+        Position p3 = ledger.addEntry(nc1.getBytes(UTF_8));
+        log.info("write entry 3 : pos = {}", p3);
+
+        ManagedCursor cursor1 = ledger.openCursor(c1);
+        cursor1.seek(p3);
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
+
+        ManagedCursor nonCursor1 = ledger.newNonDurableCursor(p2, nc1);
+        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+
+        PositionImpl earliestPos = new PositionImpl(-1, -2);
+
+        ManagedCursor nonCursorEarliest = ledger.newNonDurableCursor(earliestPos, ncEarliest);
+        PositionImpl expectedPos = new PositionImpl(((PositionImpl) p1).getLedgerId(), -1);
+        assertEquals(expectedPos, ledger.getCursors().getSlowestReaderPosition());
+
+        // move non-durable cursor should update the slowest reader position
+        nonCursorEarliest.markDelete(p1);
+        assertEquals(p1, ledger.getCursors().getSlowestReaderPosition());
+
+        nonCursorEarliest.markDelete(p2);
+        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+
+        nonCursorEarliest.markDelete(p3);
+        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+
+        nonCursor1.markDelete(p3);
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
+
         ledger.close();
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -81,7 +81,7 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         ManagedLedger ledger = factory.open("my_test_ledger");
 
         ManagedCursor c1 = ledger.newNonDurableCursor(PositionImpl.earliest);
-        assertTrue(Iterables.isEmpty(ledger.getCursors()));
+        assertFalse(Iterables.isEmpty(ledger.getCursors()));
 
         c1.close();
         ledger.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -683,8 +683,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             long ledgerId = msgId.getLedgerId();
             long entryId = msgId.getEntryId();
             if (ledgerId >= 0
-                && msgId instanceof BatchMessageIdImpl
-                && ((BatchMessageIdImpl) msgId).getBatchIndex() >= 0) {
+                && msgId instanceof BatchMessageIdImpl) {
                 // When the start message is relative to a batch, we need to take one step back on the previous message,
                 // because the "batch" might not have been consumed in its entirety.
                 // The client will then be able to discard the first messages if needed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -682,7 +682,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             long ledgerId = msgId.getLedgerId();
             long entryId = msgId.getEntryId();
-            if (msgId instanceof BatchMessageIdImpl) {
+            if (ledgerId >= 0
+                && msgId instanceof BatchMessageIdImpl
+                && ((BatchMessageIdImpl) msgId).getBatchIndex() >= 0) {
                 // When the start message is relative to a batch, we need to take one step back on the previous message,
                 // because the "batch" might not have been consumed in its entirety.
                 // The client will then be able to discard the first messages if needed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -83,7 +83,8 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
         throws BrokerServiceException.NamingException, ManagedLedgerException {
         super(topic, ledger, brokerService);
         this.txnCursor = new TransactionCursorImpl();
-        this.retentionCursor = ledger.newNonDurableCursor(PositionImpl.earliest);
+        this.retentionCursor = ledger.newNonDurableCursor(
+            PositionImpl.earliest, "txn-buffer-retention");
     }
 
     @Override


### PR DESCRIPTION
*Problem*

A problem is observed when stress testing pulsar using [pulsar-flink](https://github.com/streamnative/pulsar-flink) -
No matter what TTL or retention setting is used, the data is never cleaned up. So the stress test ends up failing due
to disk filled up.

The root cause of the problem is described as below.

when a reader is opened using `MessageId.earliest`, a non-durable cursor with position (-1, -2) is added to the cursor heap.
The position `(-1, -2)` in the heap is never updated because non-durable cursors are never advanced when mark-deletions
happen. So the slowest cursor position is always `(-1, -2)`, thus causing no ledger can be deleted even they are expired
or over quota.

<img width="720" alt="Screen Shot 2019-11-11 at 9 18 00 PM" src="https://user-images.githubusercontent.com/1217863/68605093-cc039f00-04e6-11ea-8796-2232579a1661.png">

```
17:38:50.349 [pulsar-io-22-7] INFO  org.apache.pulsar.broker.service.ServerCnx - New connection from /192.168.0.1:42568
17:38:50.353 [pulsar-io-22-7] INFO  org.apache.pulsar.broker.service.ServerCnx - [/192.168.0.1:42568] Subscribing on topic persistent://flink-      pressure-test/pressure-test-ack-2/topic-1kb-partition-0 / reader-b668b71c03
17:38:50.354 [pulsar-io-22-7] INFO  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://flink-pressure-test/pressure-test-ack- 2/topic-1kb-partition-0][reader-b668b71c03] Creating non-durable subscription at msg id -1:-1:-1:-1
17:38:50.354 [pulsar-io-22-7] INFO  org.apache.bookkeeper.mledger.impl.NonDurableCursorImpl - [flink-pressure-test/pressure-test-ack-2/persistent/     topic-1kb-partition-0] Created non-durable cursor read-position=82042:0 mark-delete-position=-1:-2
17:38:50.354 [pulsar-io-22-7] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [flink-pressure-test/pressure-test-ack-2/persistent/topic-  1kb-partition-0] Opened new cursor: NonDurableCursorImpl{ledger=flink-pressure-test/pressure-test-ack-2/persistent/topic-1kb-partition-0, ackPos=-1:-  2, readPos=82042:0}
17:38:50.354 [pulsar-io-22-7] INFO  org.apache.bookkeeper.mledger.impl.ManagedCursorImpl - [flink-pressure-test/pressure-test-ack-2/persistent/topic-  1kb-partition-0-reader-b668b71c03] Rewind from 82042:0 to 82042:0
```

*Motivation*

Fixes #5558 

Fix the problem to make sure Pulsar honor to TTL and retention settings.

*Modifications*

- Fix the `startPosition` when PersistentTopic opens a non-durable cursor on `MessageId.earliest`.
  So the `startPosition` is (-1, -1) not (-1, -2).

- Fix the `NonDurableCursorImpl` constructor to check if the position in the ledger of `MessageId.earliest`.
  If the provided position is in the `earliest` ledger, the mark-deleted position will be set to the previous
  position of first position.

- Fix the `NonDurableCursorImpl` to advance ledger cursor when mark-deletion happens on a non-durable cursor.

*Verify this change*

Add a unit test to simulate the mixture of durable and non-durable cursors, and verify the fix address the problem.

