### PR TITLE
Fix: Netty threads may still linger after client close

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -583,7 +583,6 @@ public class PulsarClientException extends IOException {
         } else if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
         }  else if (t instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
             return new PulsarClientException(t);
         } else if (!(t instanceof ExecutionException)) {
             // Generic exception

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -282,12 +282,8 @@ public class ConnectionPool implements Closeable {
 
     @Override
     public void close() throws IOException {
-        try {
-            eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).await();
-        } catch (InterruptedException e) {
-            log.warn("EventLoopGroup shutdown was interrupted", e);
-        }
         dnsResolver.close();
+        eventLoopGroup.shutdown();
     }
 
     private void cleanupConnection(InetSocketAddress address, int connectionKey,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -40,6 +40,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -281,7 +282,11 @@ public class ConnectionPool implements Closeable {
 
     @Override
     public void close() throws IOException {
-        eventLoopGroup.shutdownGracefully();
+        try {
+            eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).await();
+        } catch (InterruptedException e) {
+            log.warn("EventLoopGroup shutdown was interrupted", e);
+        }
         dnsResolver.close();
     }
 


### PR DESCRIPTION
### Motivation

Even after the synchronous close() method is called on a PulsarClient, netty thread(s) from the EventLoopGroup used in the ConnectionPool may still linger around for another 2 seconds afterwards due to not wait for the the graceful shutdown to complete.

While this usually doesn't cause any problems for a normal use case, it does cause problems in the Pulsar Flink sources and sinks.  Exceptions like the following can happen when the Flink job with a Pulsar source or sink gets closed:

```
Exception in thread "pulsar-client-io-1-1" java.lang.NoClassDefFoundError: org/apache/pulsar/shade/io/netty/buffer/PoolArena$1
	at org.apache.pulsar.shade.io.netty.buffer.PoolArena.freeChunk(PoolArena.java:293)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache$MemoryRegionCache.freeEntry(PoolThreadCache.java:460)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache$MemoryRegionCache.free(PoolThreadCache.java:430)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache$MemoryRegionCache.free(PoolThreadCache.java:422)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache.free(PoolThreadCache.java:279)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache.free(PoolThreadCache.java:270)
	at org.apache.pulsar.shade.io.netty.buffer.PoolThreadCache.free(PoolThreadCache.java:241)
	at org.apache.pulsar.shade.io.netty.buffer.PooledByteBufAllocator$PoolThreadLocalCache.onRemoval(PooledByteBufAllocator.java:450)
	at org.apache.pulsar.shade.io.netty.buffer.PooledByteBufAllocator$PoolThreadLocalCache.onRemoval(PooledByteBufAllocator.java:426)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocal.remove(FastThreadLocal.java:271)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocal.removeAll(FastThreadLocal.java:67)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:32)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.shade.io.netty.buffer.PoolArena$1
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders$ChildFirstClassLoader.loadClass(FlinkUserCodeClassLoaders.java:129)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 13 more
```

This is because threads from the EventLoopGroup lingers after the pulsar client is closed and the Flink job is unloaded.

### Modifications

Shorten the graceful shutdown period and wait for it to complete
