### PR TITLE
[tests] remove redundant check in PulsarFunctionE2ESecurityTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -301,14 +301,15 @@ public abstract class MockedPulsarServiceBaseTest {
         }
     };
 
-    public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
+    public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
         for (int i = 0; i < retryCount; i++) {
             if (predicate.test(null) || i == (retryCount - 1)) {
-                break;
+                return true;
             }
             Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
         }
+        return false;
     }
 
     public static void setFieldValue(Class clazz, Object classObj, String fieldName, Object fieldValue) throws Exception {


### PR DESCRIPTION
*Motivation*

We use `retryStrategically` to wait for a condition being met.
There is no need to check the condition again if the condition is already met.

