### PR TITLE
Improve PartitionedTopicsSchemaTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.collect.Sets;
+import java.net.URL;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.test.PortManager;
+import org.apache.pulsar.broker.NoOpShutdownService;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * Test base for tests requires a bk ensemble.
+ */
+@Slf4j
+public abstract class BkEnsemblesTestBase {
+
+    protected static int BROKER_SERVICE_PORT = PortManager.nextFreePort();
+
+    protected PulsarService pulsar;
+    protected ServiceConfiguration config;
+
+    protected URL adminUrl;
+    protected PulsarAdmin admin;
+
+    protected LocalBookkeeperEnsemble bkEnsemble;
+
+    protected int BROKER_WEBSERVICE_PORT;
+
+    private final int numberOfBookies;
+
+    public BkEnsemblesTestBase() {
+        this(3);
+    }
+
+    public BkEnsemblesTestBase(int numberOfBookies) {
+        this.numberOfBookies = numberOfBookies;
+    }
+
+    @BeforeMethod
+    protected void setup() throws Exception {
+        try {
+            int ZOOKEEPER_PORT = PortManager.nextFreePort();
+            BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
+            // start local bookie and zookeeper
+            bkEnsemble = new LocalBookkeeperEnsemble(numberOfBookies, ZOOKEEPER_PORT, () -> PortManager.nextFreePort());
+            bkEnsemble.start();
+
+            // start pulsar service
+            config = new ServiceConfiguration();
+            config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
+            config.setAdvertisedAddress("localhost");
+            config.setWebServicePort(Optional.ofNullable(BROKER_WEBSERVICE_PORT));
+            config.setClusterName("usc");
+            config.setBrokerServicePort(Optional.ofNullable(BROKER_SERVICE_PORT));
+            config.setAuthorizationEnabled(false);
+            config.setAuthenticationEnabled(false);
+            config.setManagedLedgerMaxEntriesPerLedger(5);
+            config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+            config.setAdvertisedAddress("127.0.0.1");
+            config.setAllowAutoTopicCreationType("non-partitioned");
+
+            pulsar = new PulsarService(config);
+            pulsar.setShutdownService(new NoOpShutdownService());
+            pulsar.start();
+
+            adminUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
+            admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();
+
+            admin.clusters().createCluster("usc", new ClusterData(adminUrl.toString()));
+            admin.tenants().createTenant("prop",
+                    new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet("usc")));
+        } catch (Throwable t) {
+            log.error("Error setting up broker test", t);
+            Assert.fail("Broker test setup failed");
+        }
+    }
+
+    @AfterMethod
+    protected void shutdown() throws Exception {
+        try {
+            admin.close();
+            pulsar.close();
+            bkEnsemble.stop();
+        } catch (Throwable t) {
+            log.warn("Error cleaning up broker test setup state", t);
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -21,13 +21,9 @@ package org.apache.pulsar.broker.service;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 import static org.testng.Assert.assertEquals;
 
-import com.google.common.collect.Sets;
-
 import java.lang.reflect.Field;
-import java.net.URL;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -38,100 +34,26 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
-import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.StringUtils;
-import org.apache.pulsar.broker.NoOpShutdownService;
-import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.apache.zookeeper.ZooKeeper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
  */
-public class BrokerBkEnsemblesTests {
-    protected static int BROKER_SERVICE_PORT = PortManager.nextFreePort();
-    protected PulsarService pulsar;
-    ServiceConfiguration config;
-
-    URL adminUrl;
-    protected PulsarAdmin admin;
-
-    LocalBookkeeperEnsemble bkEnsemble;
-
-    protected int BROKER_WEBSERVICE_PORT;
-
-    private final int numberOfBookies;
+public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
 
     public BrokerBkEnsemblesTests() {
         this(3);
     }
 
     public BrokerBkEnsemblesTests(int numberOfBookies) {
-        this.numberOfBookies = numberOfBookies;
-    }
-
-    @BeforeMethod
-    protected void setup() throws Exception {
-        try {
-            int ZOOKEEPER_PORT = PortManager.nextFreePort();
-            BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
-            // start local bookie and zookeeper
-            bkEnsemble = new LocalBookkeeperEnsemble(numberOfBookies, ZOOKEEPER_PORT, () -> PortManager.nextFreePort());
-            bkEnsemble.start();
-
-            // start pulsar service
-            config = new ServiceConfiguration();
-            config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
-            config.setAdvertisedAddress("localhost");
-            config.setWebServicePort(Optional.ofNullable(BROKER_WEBSERVICE_PORT));
-            config.setClusterName("usc");
-            config.setBrokerServicePort(Optional.ofNullable(BROKER_SERVICE_PORT));
-            config.setAuthorizationEnabled(false);
-            config.setAuthenticationEnabled(false);
-            config.setManagedLedgerMaxEntriesPerLedger(5);
-            config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
-            config.setAdvertisedAddress("127.0.0.1");
-            config.setAllowAutoTopicCreationType("non-partitioned");
-
-            pulsar = new PulsarService(config);
-            pulsar.setShutdownService(new NoOpShutdownService());
-            pulsar.start();
-
-            adminUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-            admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();
-
-            admin.clusters().createCluster("usc", new ClusterData(adminUrl.toString()));
-            admin.tenants().createTenant("prop",
-                    new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet("usc")));
-        } catch (Throwable t) {
-            LOG.error("Error setting up broker test", t);
-            Assert.fail("Broker test setup failed");
-        }
-    }
-
-    @AfterMethod
-    protected void shutdown() throws Exception {
-        try {
-            admin.close();
-            pulsar.close();
-            bkEnsemble.stop();
-        } catch (Throwable t) {
-            LOG.warn("Error cleaning up broker test setup state", t);
-        }
+        super(numberOfBookies);
     }
 
     /**
@@ -372,5 +294,4 @@ public class BrokerBkEnsemblesTests {
         client.close();
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(BrokerBkEnsemblesTests.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
@@ -26,15 +26,16 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.pulsar.broker.service.BrokerBkEnsemblesTests;
+import org.apache.pulsar.broker.service.BkEnsemblesTestBase;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.testng.annotations.Test;
 
-public class PartitionedTopicsSchemaTest extends BrokerBkEnsemblesTests {
+public class PartitionedTopicsSchemaTest extends BkEnsemblesTestBase {
 
     /**
      * Test that sequence id from a producer is correct when there are send errors
@@ -51,10 +52,14 @@ public class PartitionedTopicsSchemaTest extends BrokerBkEnsemblesTests {
 
         PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:" + BROKER_SERVICE_PORT).build();
 
-        CompletableFuture<Producer<String>> producerFuture = client.newProducer(Schema.STRING).topic(topicName)
-                .createAsync();
-        CompletableFuture<Consumer<String>> consumerFuture = client.newConsumer(Schema.STRING).topic(topicName)
-                .subscriptionName("sub").subscribeAsync();
+        CompletableFuture<Producer<String>> producerFuture = client.newProducer(Schema.STRING)
+            .topic(topicName)
+            .createAsync();
+        CompletableFuture<Consumer<String>> consumerFuture = client.newConsumer(Schema.STRING)
+            .topic(topicName)
+            .subscriptionName("sub")
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+            .subscribeAsync();
 
         CompletableFuture.allOf(producerFuture, consumerFuture).get();
 
@@ -71,8 +76,14 @@ public class PartitionedTopicsSchemaTest extends BrokerBkEnsemblesTests {
         // Force topic reloading to re-open the schema multiple times in parallel
         admin.namespaces().unload("prop/my-test");
 
-        producerFuture = client.newProducer(Schema.STRING).topic(topicName).createAsync();
-        consumerFuture = client.newConsumer(Schema.STRING).topic(topicName).subscriptionName("sub").subscribeAsync();
+        producerFuture = client.newProducer(Schema.STRING)
+            .topic(topicName)
+            .createAsync();
+        consumerFuture = client.newConsumer(Schema.STRING)
+            .topic(topicName)
+            .subscriptionName("sub")
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+            .subscribeAsync();
 
         // Re-opening the topic should succeed
         CompletableFuture.allOf(producerFuture, consumerFuture).get();
@@ -95,13 +106,4 @@ public class PartitionedTopicsSchemaTest extends BrokerBkEnsemblesTests {
         client.close();
     }
 
-    @Test(enabled = false)
-    public void testCrashBrokerWithoutCursorLedgerLeak() throws Exception {
-        // Ignore test
-    }
-
-    @Test(enabled = false)
-    public void testSkipCorruptDataLedger() throws Exception {
-        // Ignore test
-    }
 }


### PR DESCRIPTION
*Modifications*

- Add `SubscriptionInitialPosition` when constructing consumers to provide a predictable consumption
  behavior for testings
- Create a test base for bk ensemble tests `BkEnsemblesTestBase`
- Make PartitionedTopicsSchemaTest extend BkEnsemblesTestBase

