### PR TITLE
Fix prometheus access control not enough in kubernetes

### DIFF
--- a/deployment/kubernetes/aws/monitoring.yaml
+++ b/deployment/kubernetes/aws/monitoring.yaml
@@ -17,6 +17,47 @@
 # under the License.
 #
 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+    name: prometheus-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: prometheus-service-account
+    namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+    name: prometheus-cluster-role-binding
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: default
+
+---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -119,6 +160,7 @@ spec:
                 app: pulsar
                 component: prometheus
         spec:
+            serviceAccount: prometheus-service-account
             containers:
               - name: prometheus
                 image: prom/prometheus:v1.6.3

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/monitoring.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/monitoring.yaml
@@ -17,6 +17,47 @@
 # under the License.
 #
 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+    name: prometheus-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: prometheus-service-account
+    namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+    name: prometheus-cluster-role-binding
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: default
+
+---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -97,6 +138,7 @@ spec:
                 app: pulsar
                 component: prometheus
         spec:
+            serviceAccount: prometheus-service-account
             containers:
               - name: prometheus
                 image: prom/prometheus:v1.6.3

--- a/deployment/kubernetes/generic/original/monitoring.yaml
+++ b/deployment/kubernetes/generic/original/monitoring.yaml
@@ -17,6 +17,47 @@
 # under the License.
 #
 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+    name: prometheus-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: prometheus-service-account
+    namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+    name: prometheus-cluster-role-binding
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: default
+
+---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -74,6 +115,7 @@ spec:
                 app: pulsar
                 component: prometheus
         spec:
+            serviceAccount: prometheus-service-account
             containers:
               - name: prometheus
                 image: prom/prometheus:v1.6.3

--- a/deployment/kubernetes/google-kubernetes-engine/monitoring.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/monitoring.yaml
@@ -17,6 +17,47 @@
 # under the License.
 #
 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+    name: prometheus-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: prometheus-service-account
+    namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+    name: prometheus-cluster-role-binding
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: default
+
+---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,6 +132,7 @@ spec:
                 app: pulsar
                 component: prometheus
         spec:
+            serviceAccount: prometheus-service-account
             containers:
               - name: prometheus
                 image: prom/prometheus:v1.6.3


### PR DESCRIPTION
Fixes #5658 

### Motivation
Fix prometheus access control not enough in kubernetes

### Modifications
Add service account for pulsar cluster prometheus, service account binding cluster role, cluster role have  access control.