### PR TITLE
fix bkenv has no effect bug when start bookie using bin/pulsar-daemon

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -44,16 +44,16 @@ FUNCTIONS_EXTRA_DEPS_DIR=${PULSAR_FUNCTIONS_EXTRA_DEPS_DIR:-"${DEFAULT_FUNCTIONS
 SQL_HOME=$PULSAR_HOME/pulsar-sql
 PRESTO_HOME=${PULSAR_HOME}/lib/presto
 
-# Check pulsar env and load pulser_env.sh
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
-then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
-fi
-
 # Check bookkeeper env and load bkenv.sh
 if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
 then
     . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
+# Check pulsar env and load pulser_env.sh
+if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+then
+    . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
 # Check for the java to use

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -44,10 +44,16 @@ FUNCTIONS_EXTRA_DEPS_DIR=${PULSAR_FUNCTIONS_EXTRA_DEPS_DIR:-"${DEFAULT_FUNCTIONS
 SQL_HOME=$PULSAR_HOME/pulsar-sql
 PRESTO_HOME=${PULSAR_HOME}/lib/presto
 
-
+# Check pulsar env and load pulser_env.sh
 if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
 then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
+fi
+
+# Check bookkeeper env and load bkenv.sh
+if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
+then
+    . "$PULSAR_HOME/conf/bkenv.sh"
 fi
 
 # Check for the java to use

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -40,15 +40,15 @@ EOF
 BINDIR=$(dirname "$0")
 PULSAR_HOME=$(cd $BINDIR/..;pwd)
 
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
-then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
-fi
-
 # Check bookkeeper env and load bkenv.sh
 if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
 then
     . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
+if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+then
+    . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
 PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -45,6 +45,12 @@ then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
+# Check bookkeeper env and load bkenv.sh
+if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
+then
+    . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
 PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
 PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"RollingFile"}
 PULSAR_STOP_TIMEOUT=${PULSAR_STOP_TIMEOUT:-30}

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -29,6 +29,12 @@ then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
+# Check bookkeeper env and load bkenv.sh
+if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
+then
+    . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
 # Check for the java to use
 if [[ -z $JAVA_HOME ]]; then
     JAVA=$(which java)

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -24,15 +24,15 @@ PULSAR_HOME=`cd $BINDIR/..;pwd`
 DEFAULT_CLIENT_CONF=${PULSAR_CLIENT_CONF:-"$PULSAR_HOME/conf/client.conf"}
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j2.yaml
 
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
-then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
-fi
-
 # Check bookkeeper env and load bkenv.sh
 if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
 then
     . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
+if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+then
+    . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
 # Check for the java to use

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -59,7 +59,3 @@ PULSAR_EXTRA_OPTS=${PULSAR_EXTRA_OPTS:-" -Dpulsar.allocator.exit_on_oom=true -Di
 #Wait time before forcefully kill the pulser server instance, if the stop is not successful
 #PULSAR_STOP_TIMEOUT=
 
-# Set BOOKIE_EXTRA_OPTS option here to ensure that all pulsar scripts can work seamless with bookkeeper
-
-# Extra options to be passed to the jvm
-BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -95,10 +95,17 @@ public class PrometheusMetricsGenerator {
                 stream.write(sample.name);
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
+                    String labelValue = sample.labelValues.get(j);
+                    if(labelValue != null &&
+                            (labelValue.startsWith("\"") ||
+                            labelValue.endsWith("\""))){
+                        labelValue = labelValue.replace("\"", "\\\"");
+                    }
+
                     stream.write(",");
                     stream.write(sample.labelNames.get(j));
                     stream.write("=\"");
-                    stream.write(sample.labelValues.get(j));
+                    stream.write(labelValue);
                     stream.write('"');
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -96,7 +96,7 @@ public class PrometheusMetricsGenerator {
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
                     String labelValue = sample.labelValues.get(j);
-                    if(labelValue != null){
+                    if (labelValue != null) {
                         labelValue = labelValue.replace("\"", "\\\"");
                     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -96,9 +96,7 @@ public class PrometheusMetricsGenerator {
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
                     String labelValue = sample.labelValues.get(j);
-                    if(labelValue != null &&
-                            (labelValue.startsWith("\"") ||
-                            labelValue.endsWith("\""))){
+                    if(labelValue != null){
                         labelValue = labelValue.replace("\"", "\\\"");
                     }
 

--- a/src/pulsar-io-gen
+++ b/src/pulsar-io-gen
@@ -23,15 +23,15 @@ PULSAR_HOME=`cd $BINDIR/..;pwd`
 
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j2.yaml
 
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
-then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
-fi
-
 # Check bookkeeper env and load bkenv.sh
 if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
 then
     . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
+if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+then
+    . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
 # Check for the java to use

--- a/src/pulsar-io-gen
+++ b/src/pulsar-io-gen
@@ -28,6 +28,12 @@ then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
+# Check bookkeeper env and load bkenv.sh
+if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
+then
+    . "$PULSAR_HOME/conf/bkenv.sh"
+fi
+
 # Check for the java to use
 if [[ -z $JAVA_HOME ]]; then
     JAVA=$(which java)


### PR DESCRIPTION
when i start bookie using `bin/pulsar-daemon start bookie` command, i found the bookie environment variable defined in conf/bkenv.sh has no effect, but using $PULSAR_MEM and $PULSAR_GC instead.

Then i check the bin/pulsar shell script, i found as follow:
```
elif [ $COMMAND == "bookie" ]; then
    PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"bookkeeper.log"}
    # Pass BOOKIE_EXTRA_OPTS option defined in pulsar_env.sh
    OPTS="$OPTS $BOOKIE_EXTRA_OPTS"
    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.bookkeeper.proto.BookieServer --conf $PULSAR_BOOKKEEPER_CONF $@
```
but in pulsar_env.sh, the `$BOOKIE_EXTRA_OPTS` defined as follow:
```
# Set BOOKIE_EXTRA_OPTS option here to ensure that all pulsar scripts can work seamless with bookkeeper

# Extra options to be passed to the jvm
BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
```
`$BOOKIE_EXTRA_OPTS` do not define `$BOOKIE_MEM` and `$BOOKIE_GC`, then the pulsar script will using `$PULSAR_MEM` and `$PULSAR_GC` instead to start bookkeeper.

So, i suggest to load conf/bkenv.sh in bin/pulsar script and using `$BOOKIE_EXTRA_OPTS` in conf/bkenv.sh instread of `$BOOKIE_EXTRA_OPTS` in bin/pulsar_env.sh