### PR TITLE
[Issue 5346]bin/pulsar standalone --zookeeper-port 2183 does not work with version 2.4.1

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -76,14 +76,12 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         // Priority: args > conf > default
         if (argsContains(args,"--zookeeper-port")) {
             config.setZookeeperServers(zkServers + ":" + this.getZkPort());
+            config.setConfigurationStoreServers(zkServers + ":" + this.getZkPort());
         } else {
             if (config.getZookeeperServers() != null) {
                 this.setZkPort(Integer.parseInt(config.getZookeeperServers().split(":")[1]));
             }
             config.setZookeeperServers(zkServers + ":" + this.getZkPort());
-        }
-
-        if (config.getConfigurationStoreServers() == null) {
             config.setConfigurationStoreServers(zkServers + ":" + this.getZkPort());
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -95,10 +95,17 @@ public class PrometheusMetricsGenerator {
                 stream.write(sample.name);
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
+                    String labelValue = sample.labelValues.get(j);
+                    if(labelValue != null &&
+                            (labelValue.startsWith("\"") ||
+                            labelValue.endsWith("\""))){
+                        labelValue = labelValue.replace("\"", "\\\"");
+                    }
+
                     stream.write(",");
                     stream.write(sample.labelNames.get(j));
                     stream.write("=\"");
-                    stream.write(sample.labelValues.get(j));
+                    stream.write(labelValue);
                     stream.write('"');
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -96,9 +96,7 @@ public class PrometheusMetricsGenerator {
                 stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
                     String labelValue = sample.labelValues.get(j);
-                    if(labelValue != null &&
-                            (labelValue.startsWith("\"") ||
-                            labelValue.endsWith("\""))){
+                    if(labelValue != null){
                         labelValue = labelValue.replace("\"", "\\\"");
                     }
 


### PR DESCRIPTION
Fixes [#5346](https://github.com/apache/pulsar/issues/5346)

When start pulsar in standalone mode, and specify zookeeper port using `bin/pulsar standalone --zookeeper-port 2183`, the pulsar will start failed if `configurationStoreServers` is set in conf/standalone.conf and the port not same with --zookeeper-port set in command line.

The reason is `--zookeeper-port` set in command line only override zkServer configuration and will not override `configurationStoreServers` in conf/standalone.conf.

In my fix, i will override `configurationStoreServers` if using `--zookeeper-port` to setup pulsar in standalone mode.