### PR TITLE
[issues 5698]Handle replicator producer as generated name producer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.MoreObjects;
 
 public abstract class AbstractTopic implements Topic {
@@ -228,7 +227,7 @@ public abstract class AbstractTopic implements Topic {
         PUBLISH_LATENCY.observe(latency, unit);
     }
 
-    protected void setSchemaCompatibilityStrategy(Policies policies) {
+    protected void setSchemaCompatibilityStrategy (Policies policies) {
         if (policies.schema_compatibility_strategy == SchemaCompatibilityStrategy.UNDEFINED) {
             schemaCompatibilityStrategy = SchemaCompatibilityStrategy.fromAutoUpdatePolicy(
                     policies.schema_auto_update_compatibility_strategy);
@@ -236,7 +235,6 @@ public abstract class AbstractTopic implements Topic {
             schemaCompatibilityStrategy = policies.schema_compatibility_strategy;
         }
     }
-
     private static final Summary PUBLISH_LATENCY = Summary.build("pulsar_broker_publish_latency", "-")
             .quantile(0.0)
             .quantile(0.50)
@@ -252,19 +250,19 @@ public abstract class AbstractTopic implements Topic {
         this.publishRateLimiter.checkPublishRate();
     }
 
-    @Override
+     @Override
     public void incrementPublishCount(int numOfMessages, long msgSizeInBytes) {
         this.publishRateLimiter.incrementPublishCount(numOfMessages, msgSizeInBytes);
     }
 
-    @Override
+     @Override
     public void resetPublishCountAndEnableReadIfRequired() {
         if (this.publishRateLimiter.resetPublishCount()) {
             enableProducerRead();
         }
     }
 
-    /**
+     /**
      * it sets cnx auto-readable if producer's cnx is disabled due to publish-throttling
      */
     protected void enableProducerRead() {
@@ -305,7 +303,7 @@ public abstract class AbstractTopic implements Topic {
             canOverwrite = true;
         }
         if (canOverwrite) {
-            if (!producers.replace(newProducer.getProducerName(), oldProducer, newProducer)) {
+            if(!producers.replace(newProducer.getProducerName(), oldProducer, newProducer)) {
                 // Met concurrent update, throw exception here so that client can try reconnect later.
                 throw new BrokerServiceException.NamingException("Producer with name '" + newProducer.getProducerName()
                         + "' replace concurrency error");
@@ -318,27 +316,27 @@ public abstract class AbstractTopic implements Topic {
         }
     }
 
-    private boolean isUserProvidedProducerName(Producer producer) {
+    private boolean isUserProvidedProducerName(Producer producer){
         //considered replicator producer as generated name producer
         return producer.isUserProvidedProducerName() && !producer.getProducerName().startsWith(replicatorPrefix);
     }
 
     protected abstract void handleProducerRemoved(Producer producer);
 
-    @Override
+     @Override
     public boolean isPublishRateExceeded() {
         return this.publishRateLimiter.isPublishRateExceeded();
     }
 
-    public PublishRateLimiter getPublishRateLimiter() {
+     public PublishRateLimiter getPublishRateLimiter() {
         return publishRateLimiter;
     }
 
-    public void updateMaxPublishRate(Policies policies) {
+     public void updateMaxPublishRate(Policies policies) {
         updatePublishDispatcher(policies);
     }
 
-    private void updatePublishDispatcher(Policies policies) {
+     private void updatePublishDispatcher(Policies policies) {
         final String clusterName = brokerService.pulsar().getConfiguration().getClusterName();
         final PublishRate publishRate = policies != null && policies.publishMaxMessageRate != null
                 ? policies.publishMaxMessageRate.get(clusterName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -297,8 +297,8 @@ public abstract class AbstractTopic implements Topic {
     private void tryOverwriteOldProducer(Producer oldProducer, Producer newProducer)
             throws BrokerServiceException {
         boolean canOverwrite = false;
-        if (oldProducer.equals(newProducer) && !oldProducer.isUserProvidedProducerName()
-                && !newProducer.isUserProvidedProducerName() && newProducer.getEpoch() > oldProducer.getEpoch()) {
+        if (oldProducer.equals(newProducer) && !isUserProvidedProducerName(oldProducer)
+                && !isUserProvidedProducerName(newProducer) && newProducer.getEpoch() > oldProducer.getEpoch()) {
             oldProducer.close(false);
             canOverwrite = true;
         }
@@ -314,6 +314,11 @@ public abstract class AbstractTopic implements Topic {
             throw new BrokerServiceException.NamingException(
                     "Producer with name '" + newProducer.getProducerName() + "' is already connected to topic");
         }
+    }
+
+    private boolean isUserProvidedProducerName(Producer producer){
+        //considered replicator producer as generated name producer
+        return   producer.isUserProvidedProducerName() && !producer.getProducerName().startsWith(replicatorPrefix);
     }
 
     protected abstract void handleProducerRemoved(Producer producer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
+
 import com.google.common.base.MoreObjects;
 
 public abstract class AbstractTopic implements Topic {
@@ -80,7 +81,7 @@ public abstract class AbstractTopic implements Topic {
     protected volatile boolean isAllowAutoUpdateSchema = true;
     // schema validation enforced flag
     protected volatile boolean schemaValidationEnforced = false;
-    
+
     protected volatile PublishRateLimiter publishRateLimiter;
 
     public AbstractTopic(String topic, BrokerService brokerService) {
@@ -227,7 +228,7 @@ public abstract class AbstractTopic implements Topic {
         PUBLISH_LATENCY.observe(latency, unit);
     }
 
-    protected void setSchemaCompatibilityStrategy (Policies policies) {
+    protected void setSchemaCompatibilityStrategy(Policies policies) {
         if (policies.schema_compatibility_strategy == SchemaCompatibilityStrategy.UNDEFINED) {
             schemaCompatibilityStrategy = SchemaCompatibilityStrategy.fromAutoUpdatePolicy(
                     policies.schema_auto_update_compatibility_strategy);
@@ -235,6 +236,7 @@ public abstract class AbstractTopic implements Topic {
             schemaCompatibilityStrategy = policies.schema_compatibility_strategy;
         }
     }
+
     private static final Summary PUBLISH_LATENCY = Summary.build("pulsar_broker_publish_latency", "-")
             .quantile(0.0)
             .quantile(0.50)
@@ -250,19 +252,19 @@ public abstract class AbstractTopic implements Topic {
         this.publishRateLimiter.checkPublishRate();
     }
 
-     @Override
+    @Override
     public void incrementPublishCount(int numOfMessages, long msgSizeInBytes) {
         this.publishRateLimiter.incrementPublishCount(numOfMessages, msgSizeInBytes);
     }
 
-     @Override
+    @Override
     public void resetPublishCountAndEnableReadIfRequired() {
         if (this.publishRateLimiter.resetPublishCount()) {
             enableProducerRead();
         }
     }
 
-     /**
+    /**
      * it sets cnx auto-readable if producer's cnx is disabled due to publish-throttling
      */
     protected void enableProducerRead() {
@@ -303,7 +305,7 @@ public abstract class AbstractTopic implements Topic {
             canOverwrite = true;
         }
         if (canOverwrite) {
-            if(!producers.replace(newProducer.getProducerName(), oldProducer, newProducer)) {
+            if (!producers.replace(newProducer.getProducerName(), oldProducer, newProducer)) {
                 // Met concurrent update, throw exception here so that client can try reconnect later.
                 throw new BrokerServiceException.NamingException("Producer with name '" + newProducer.getProducerName()
                         + "' replace concurrency error");
@@ -316,27 +318,27 @@ public abstract class AbstractTopic implements Topic {
         }
     }
 
-    private boolean isUserProvidedProducerName(Producer producer){
+    private boolean isUserProvidedProducerName(Producer producer) {
         //considered replicator producer as generated name producer
-        return   producer.isUserProvidedProducerName() && !producer.getProducerName().startsWith(replicatorPrefix);
+        return producer.isUserProvidedProducerName() && !producer.getProducerName().startsWith(replicatorPrefix);
     }
 
     protected abstract void handleProducerRemoved(Producer producer);
 
-     @Override
+    @Override
     public boolean isPublishRateExceeded() {
         return this.publishRateLimiter.isPublishRateExceeded();
     }
 
-     public PublishRateLimiter getPublishRateLimiter() {
+    public PublishRateLimiter getPublishRateLimiter() {
         return publishRateLimiter;
     }
 
-     public void updateMaxPublishRate(Policies policies) {
+    public void updateMaxPublishRate(Policies policies) {
         updatePublishDispatcher(policies);
     }
 
-     private void updatePublishDispatcher(Policies policies) {
+    private void updatePublishDispatcher(Policies policies) {
         final String clusterName = brokerService.pulsar().getConfiguration().getClusterName();
         final PublishRate publishRate = policies != null && policies.publishMaxMessageRate != null
                 ? policies.publishMaxMessageRate.get(clusterName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -430,6 +430,30 @@ public class PersistentTopicTest {
         Assert.assertEquals(topic.getProducers().size(), 1);
 
         topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 2));
+
+        topic.removeProducer(producer4);
+        Assert.assertEquals(topic.getProducers().size(), 0);
+
+        Producer producer5= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+                role, false, null, SchemaVersion.Latest, 1, false);
+
+        topic.addProducer(producer5);
+        Assert.assertEquals(topic.getProducers().size(), 1);
+
+        Producer producer6= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+                role, false, null, SchemaVersion.Latest, 2, false);
+
+        topic.addProducer(producer6);
+        Assert.assertEquals(topic.getProducers().size(), 1);
+
+        topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 2));
+
+        Producer producer7= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+                role, false, null, SchemaVersion.Latest, 3, true);
+
+        topic.addProducer(producer7);
+        Assert.assertEquals(topic.getProducers().size(), 1);
+        topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 3));
     }
 
     public void testMaxProducers() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -394,7 +394,7 @@ public class PersistentTopicTest {
         String role = "appid1";
         Producer producer1 = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, true);
-        Producer producer2= new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
+        Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, true);
         try {
             topic.addProducer(producer1);
@@ -406,7 +406,7 @@ public class PersistentTopicTest {
 
         Assert.assertEquals(topic.getProducers().size(), 1);
 
-        Producer producer3= new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
+        Producer producer3 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 1, false);
 
         try {
@@ -421,7 +421,7 @@ public class PersistentTopicTest {
         topic.removeProducer(producer1);
         Assert.assertEquals(topic.getProducers().size(), 0);
 
-        Producer producer4= new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
+        Producer producer4 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 2, false);
 
         topic.addProducer(producer3);
@@ -434,13 +434,13 @@ public class PersistentTopicTest {
         topic.removeProducer(producer4);
         Assert.assertEquals(topic.getProducers().size(), 0);
 
-        Producer producer5= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+        Producer producer5 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
                 role, false, null, SchemaVersion.Latest, 1, false);
 
         topic.addProducer(producer5);
         Assert.assertEquals(topic.getProducers().size(), 1);
 
-        Producer producer6= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+        Producer producer6 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
                 role, false, null, SchemaVersion.Latest, 2, false);
 
         topic.addProducer(producer6);
@@ -448,7 +448,7 @@ public class PersistentTopicTest {
 
         topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 2));
 
-        Producer producer7= new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
+        Producer producer7 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
                 role, false, null, SchemaVersion.Latest, 3, true);
 
         topic.addProducer(producer7);


### PR DESCRIPTION
Fixes #5698

### Motivation

Since #5571 handle the generated producer name, the replicator producer was created by broker, only one producer for a replicated topic.

So, we can handle it simple by considered replicator producer as generated name producer.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (yno)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)


