### PR TITLE
[Issue 5684] [docs] Add unit for storageSize

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1874,6 +1874,9 @@ Usage
 $ pulsar-admin topics stats topic
 ```
 
+> Note   
+> The unit of `storageSize` and `averageMsgSize` is Byte.
+
 ### `stats-internal`
 Get the internal stats for the topic
 


### PR DESCRIPTION
Fixes #5684 

### Motivation
The unit for `storageSize` is not specified in the documentation or API files.

### Modifications
Add a note in the pulsar-admin documents.