### PR TITLE
Add publish rate limit for each broker to avoid OOM

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -186,10 +186,12 @@ topicPublisherThrottlingTickTimeMillis=10
 brokerPublisherThrPottlingTickTimeMillis=50
 
 # Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
-brokerPublisherThrottlingMaxMessageRate=-1
+# (Disable message rate limit with value 0)
+brokerPublisherThrottlingMaxMessageRate=0
 
-# Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled
-brokerPublisherThrottlingMaxByteRate=-1
+# Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled.
+# (Disable byte rate limit with value 0)
+brokerPublisherThrottlingMaxByteRate=0
 
 # Too many subscribe requests from a consumer can cause broker rewinding consumer cursors and loading data from bookies,
 # hence causing high network bandwidth usage

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -175,9 +175,15 @@ maxUnackedMessagesPerBroker=0
 # limit/2 messages
 maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 
-# Tick time to schedule task that checks publish rate limiting across all topics  
-# (Disable publish throttling with value 0)
+# Tick time to schedule task that checks topic publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
+# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
 publisherThrottlingTickTimeMillis=10
+
+# Tick time to schedule task that checks broker publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
+# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
+brokerPublisherThrPottlingTickTimeMillis=500
 
 # Too many subscribe requests from a consumer can cause broker rewinding consumer cursors and loading data from bookies,
 # hence causing high network bandwidth usage
@@ -467,7 +473,7 @@ bookkeeperClientMinAvailableBookiesInIsolationGroups=
 # Disable Sticy Read until {@link https://github.com/apache/bookkeeper/issues/1970} is fixed
 bookkeeperEnableStickyReads=false
 
-# Set the client security provider factory class name. 
+# Set the client security provider factory class name.
 # Default: org.apache.bookkeeper.tls.TLSContextFactory
 bookkeeperTLSProviderFactoryClass=org.apache.bookkeeper.tls.TLSContextFactory
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -178,12 +178,18 @@ maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 # Tick time to schedule task that checks topic publish rate limiting across all topics
 # Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
-publisherThrottlingTickTimeMillis=10
+topicPublisherThrottlingTickTimeMillis=10
 
 # Tick time to schedule task that checks broker publish rate limiting across all topics
 # Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
-brokerPublisherThrPottlingTickTimeMillis=500
+brokerPublisherThrPottlingTickTimeMillis=50
+
+# Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
+brokerPublisherThrottlingMaxMessageRate=-1
+
+# Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled
+brokerPublisherThrottlingMaxByteRate=-1
 
 # Too many subscribe requests from a consumer can cause broker rewinding consumer cursors and loading data from bookies,
 # hence causing high network bandwidth usage

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -154,10 +154,12 @@ topicPublisherThrottlingTickTimeMillis=2
 brokerPublisherThrPottlingTickTimeMillis=50
 
 # Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
-brokerPublisherThrottlingMaxMessageRate=-1
+# (Disable message rate limit with value 0)
+brokerPublisherThrottlingMaxMessageRate=0
 
 # Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled
-brokerPublisherThrottlingMaxByteRate=-1
+# (Disable byte rate limit with value 0)
+brokerPublisherThrottlingMaxByteRate=0
 
 # Default messages per second dispatch throttling-limit for every topic. Using a value of 0, is disabling default
 # message dispatch-throttling

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -143,10 +143,21 @@ maxUnackedMessagesPerBroker=0
 # limit/2 messages
 maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 
-# Tick time to schedule task that checks publish rate limiting across all topics
-# Reducing to lower value can give more accuracy while throttling publish but 
+# Tick time to schedule task that checks topic publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
-publisherThrottlingTickTimeMillis=2
+topicPublisherThrottlingTickTimeMillis=2
+
+# Tick time to schedule task that checks broker publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
+# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
+brokerPublisherThrPottlingTickTimeMillis=50
+
+# Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
+brokerPublisherThrottlingMaxMessageRate=-1
+
+# Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled
+brokerPublisherThrottlingMaxByteRate=-1
 
 # Default messages per second dispatch throttling-limit for every topic. Using a value of 0, is disabling default
 # message dispatch-throttling
@@ -277,7 +288,7 @@ bookkeeperClientReorderReadSequenceEnabled=false
 # outside the specified groups will not be used by the broker
 bookkeeperClientIsolationGroups=
 
-# Enable bookie secondary-isolation group if bookkeeperClientIsolationGroups doesn't 
+# Enable bookie secondary-isolation group if bookkeeperClientIsolationGroups doesn't
 # have enough bookie available.
 bookkeeperClientSecondaryIsolationGroups=
 
@@ -285,7 +296,7 @@ bookkeeperClientSecondaryIsolationGroups=
 # else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.
 bookkeeperClientMinAvailableBookiesInIsolationGroups=
 
-# Set the client security provider factory class name. 
+# Set the client security provider factory class name.
 # Default: org.apache.bookkeeper.tls.TLSContextFactory
 bookkeeperTLSProviderFactoryClass=org.apache.bookkeeper.tls.TLSContextFactory
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -383,19 +383,21 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + "Reducing to lower value can give more accuracy while throttling publish but "
             + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)"
     )
-    private int brokerPublisherThrottlingTickTimeMillis = 500;
+    private int brokerPublisherThrottlingTickTimeMillis = 50;
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
-        doc = "Max Rate(in 1 seconds) of Message allowed to publish for a broker"
+        doc = "Max Rate(in 1 seconds) of Message allowed to publish for a broker "
+            + "when broker publish rate limiting enabled"
     )
     private int brokerPublisherThrottlingMaxMessageRate = -1;
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
-        doc = "Max Rate(in 1 seconds) of Byte allowed to publish for a broker"
+        doc = "Max Rate(in 1 seconds) of Byte allowed to publish for a broker "
+            + "when broker publish rate limiting enabled"
     )
-    private int brokerPublisherThrottlingMaxByteRate = -1;
+    private long brokerPublisherThrottlingMaxByteRate = -1;
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -388,16 +388,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Max Rate(in 1 seconds) of Message allowed to publish for a broker "
-            + "when broker publish rate limiting enabled"
+            + "when broker publish rate limiting enabled. (Disable message rate limit with value 0)"
     )
-    private int brokerPublisherThrottlingMaxMessageRate = -1;
+    private int brokerPublisherThrottlingMaxMessageRate = 0;
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Max Rate(in 1 seconds) of Byte allowed to publish for a broker "
-            + "when broker publish rate limiting enabled"
+            + "when broker publish rate limiting enabled. (Disable byte rate limit with value 0)"
     )
-    private long brokerPublisherThrottlingMaxByteRate = -1;
+    private long brokerPublisherThrottlingMaxByteRate = 0;
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -370,11 +370,33 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_POLICIES,
             dynamic = true,
-            doc = "Tick time to schedule task that checks publish rate limiting across all topics  "
+            doc = "Tick time to schedule task that checks topic publish rate limiting across all topics  "
                     + "Reducing to lower value can give more accuracy while throttling publish but "
-                    + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)" 
+                    + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)"
         )
-    private int publisherThrottlingTickTimeMillis = 5;
+    private int topicPublisherThrottlingTickTimeMillis = 5;
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Tick time to schedule task that checks broker publish rate limiting across all topics  "
+            + "Reducing to lower value can give more accuracy while throttling publish but "
+            + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)"
+    )
+    private int brokerPublisherThrottlingTickTimeMillis = 500;
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Max Rate(in 1 seconds) of Message allowed to publish for a broker"
+    )
+    private int brokerPublisherThrottlingMaxMessageRate = -1;
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Max Rate(in 1 seconds) of Byte allowed to publish for a broker"
+    )
+    private int brokerPublisherThrottlingMaxByteRate = -1;
+
     @FieldContext(
         category = CATEGORY_POLICIES,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1491,11 +1491,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         long currentMaxByteRate = pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate();
         int brokerTickMs = pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis();
 
-        // not enabled
+        // not enable
         if (brokerTickMs <= 0 || (currentMaxByteRate <= 0 && currentMaxMessageRate <= 0)) {
             if (brokerPublishRateLimiter != PublishRateLimiter.DISABLED_RATE_LIMITER) {
-                brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
                 refreshBrokerPublishRate();
+                brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
             }
             return;
         }
@@ -1503,7 +1503,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         final PublishRate publishRate = new PublishRate(currentMaxMessageRate, currentMaxByteRate);
 
         log.info("Update broker publish rate limiting {}", publishRate);
-        // lazy init Publish-rateLimiting monitoring if not initialized yet
+        // lazy init broker Publish-rateLimiting monitoring if not initialized yet
+        this.setupBrokerPublishRateLimiterMonitor();
         if (brokerPublishRateLimiter == null
             || brokerPublishRateLimiter == PublishRateLimiter.DISABLED_RATE_LIMITER) {
             // create new rateLimiter if rate-limiter is disabled

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -30,7 +30,6 @@ import static org.apache.pulsar.broker.web.PulsarWebResource.joinPath;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.AdaptiveRecvByteBufAllocator;
@@ -41,7 +40,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -66,11 +64,9 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
@@ -130,6 +126,7 @@ import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PersistentOfflineTopicStats;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.stats.Metrics;
@@ -189,7 +186,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     private final ScheduledExecutorService inactivityMonitor;
     private final ScheduledExecutorService messageExpiryMonitor;
     private final ScheduledExecutorService compactionMonitor;
-    private ScheduledExecutorService publishRateLimiterMonitor;
+    private ScheduledExecutorService topicPublishRateLimiterMonitor;
+    private ScheduledExecutorService brokerPublishRateLimiterMonitor;
+    protected volatile PublishRateLimiter brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
 
     private DistributedIdGenerator producerNameGenerator;
 
@@ -454,32 +453,75 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      * Schedules and monitors publish-throttling for all owned topics that has publish-throttling configured. It also
      * disables and shutdowns publish-rate-limiter monitor task if broker disables it.
      */
-    public synchronized void setupPublishRateLimiterMonitor() {
-        long tickTimeMs = pulsar().getConfiguration().getPublisherThrottlingTickTimeMillis();
-        if (tickTimeMs > 0) {
-            if (this.publishRateLimiterMonitor == null) {
-                this.publishRateLimiterMonitor = Executors.newSingleThreadScheduledExecutor(
-                        new DefaultThreadFactory("pulsar-publish-rate-limiter-monitor"));
-                if (tickTimeMs > 0) {
+    public synchronized void setupTopicPublishRateLimiterMonitor() {
+        // set topic PublishRateLimiterMonitor
+        long topicTickTimeMs = pulsar().getConfiguration().getTopicPublisherThrottlingTickTimeMillis();
+        if (topicTickTimeMs > 0) {
+            if (this.topicPublishRateLimiterMonitor == null) {
+                this.topicPublishRateLimiterMonitor = Executors.newSingleThreadScheduledExecutor(
+                        new DefaultThreadFactory("pulsar-topic-publish-rate-limiter-monitor"));
+                if (topicTickTimeMs > 0) {
                     // schedule task that sums up publish-rate across all cnx on a topic
-                    publishRateLimiterMonitor.scheduleAtFixedRate(safeRun(() -> checkPublishThrottlingRate()),
-                            tickTimeMs, tickTimeMs, TimeUnit.MILLISECONDS);
+                    topicPublishRateLimiterMonitor.scheduleAtFixedRate(safeRun(() -> checkTopicPublishThrottlingRate()),
+                            topicTickTimeMs, topicTickTimeMs, TimeUnit.MILLISECONDS);
                     // schedule task that refreshes rate-limitting bucket
-                    publishRateLimiterMonitor.scheduleAtFixedRate(safeRun(() -> refreshPublishRate()), 1, 1,
+                    topicPublishRateLimiterMonitor.scheduleAtFixedRate(safeRun(() -> refreshTopicPublishRate()), 1, 1,
                             TimeUnit.SECONDS);
                 }
             }
         } else {
             // disable publish-throttling for all topics
-            if (this.publishRateLimiterMonitor != null) {
+            if (this.topicPublishRateLimiterMonitor != null) {
                 try {
-                    this.publishRateLimiterMonitor.awaitTermination(30, TimeUnit.SECONDS);
+                    this.topicPublishRateLimiterMonitor.awaitTermination(30, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
-                    log.warn("failed to shutdown publishRateLimiterMonitor", e);
+                    log.warn("failed to shutdown topicPublishRateLimiterMonitor", e);
                 }
                 // make sure topics are not being throttled
-                refreshPublishRate();
-                this.publishRateLimiterMonitor = null;
+                refreshTopicPublishRate();
+                this.topicPublishRateLimiterMonitor = null;
+            }
+        }
+    }
+
+    /**
+     * Schedules and monitors publish-throttling for broker that has publish-throttling configured. It also
+     * disables and shutdowns publish-rate-limiter monitor for broker task if broker disables it.
+     */
+    public synchronized void setupBrokerPublishRateLimiterMonitor() {
+        // set broker PublishRateLimiterMonitor
+        long brokerTickTimeMs = pulsar().getConfiguration().getBrokerPublisherThrottlingTickTimeMillis();
+        if (brokerTickTimeMs > 0) {
+            if (this.brokerPublishRateLimiterMonitor == null) {
+                this.brokerPublishRateLimiterMonitor = Executors.newSingleThreadScheduledExecutor(
+                    new DefaultThreadFactory("pulsar-broker-publish-rate-limiter-monitor"));
+                if (brokerTickTimeMs > 0) {
+                    // schedule task that sums up publish-rate across all cnx on a topic,
+                    // and check the rate limit exceeded or not.
+                    brokerPublishRateLimiterMonitor.scheduleAtFixedRate(
+                        safeRun(() -> checkBrokerPublishThrottlingRate()),
+                        brokerTickTimeMs,
+                        brokerTickTimeMs,
+                        TimeUnit.MILLISECONDS);
+                    // schedule task that refreshes rate-limitting bucket
+                    brokerPublishRateLimiterMonitor.scheduleAtFixedRate(
+                        safeRun(() -> refreshBrokerPublishRate()),
+                        1,
+                        1,
+                        TimeUnit.SECONDS);
+                }
+            }
+        } else {
+            // disable publish-throttling for broker.
+            if (this.brokerPublishRateLimiterMonitor != null) {
+                try {
+                    this.brokerPublishRateLimiterMonitor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    log.warn("failed to shutdown brokerPublishRateLimiterMonitor", e);
+                }
+                // make sure topics are not being throttled
+                refreshBrokerPublishRate();
+                this.brokerPublishRateLimiterMonitor = null;
             }
         }
     }
@@ -1067,12 +1109,21 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         forEachTopic(Topic::checkInactiveSubscriptions);
     }
 
-    public void checkPublishThrottlingRate() {
-        forEachTopic(Topic::checkPublishThrottlingRate);
+    public void checkTopicPublishThrottlingRate() {
+        forEachTopic(Topic::checkTopicPublishThrottlingRate);
     }
 
-    private void refreshPublishRate() {
-        forEachTopic(Topic::resetPublishCountAndEnableReadIfRequired);
+    private void refreshTopicPublishRate() {
+        forEachTopic(Topic::resetTopicPublishCountAndEnableReadIfRequired);
+    }
+
+    public void checkBrokerPublishThrottlingRate() {
+        brokerPublishRateLimiter.checkPublishRate();
+    }
+
+    private void refreshBrokerPublishRate() {
+        boolean doneReset = brokerPublishRateLimiter.resetPublishCount();
+        forEachTopic(topic -> topic.resetBrokerPublishCountAndEnableReadIfRequired(doneReset));
     }
 
     /**
@@ -1415,11 +1466,51 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             updateReplicatorMessageDispatchRate();
         });
 
-        // add listener to notify publish-rate monitoring
-        registerConfigurationListener("publisherThrottlingTickTimeMillis", (publisherThrottlingTickTimeMillis) -> {
-            setupPublishRateLimiterMonitor();
+        // add listener to notify broker publish-rate monitoring
+        registerConfigurationListener("brokerPublisherThrottlingTickTimeMillis", (publisherThrottlingTickTimeMillis) -> {
+            setupBrokerPublishRateLimiterMonitor();
         });
+        // add listener to notify broker publish-rate dynamic config
+        registerConfigurationListener("brokerPublisherThrottlingMaxMessageRate",
+            (brokerPublisherThrottlingMaxMessageRate) ->
+                updateBrokerPublisherThrottlingMaxRate());
+        registerConfigurationListener("brokerPublisherThrottlingMaxByteRate",
+            (brokerPublisherThrottlingMaxByteRate) ->
+                updateBrokerPublisherThrottlingMaxRate());
+
+        // add listener to notify topic publish-rate monitoring
+        registerConfigurationListener("topicPublisherThrottlingTickTimeMillis", (publisherThrottlingTickTimeMillis) -> {
+            setupTopicPublishRateLimiterMonitor();
+        });
+
         // add more listeners here
+    }
+
+    private void updateBrokerPublisherThrottlingMaxRate() {
+        int currentMaxMessageRate = pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate();
+        long currentMaxByteRate = pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate();
+        int brokerTickMs = pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis();
+
+        // not enabled
+        if (brokerTickMs <= 0 || (currentMaxByteRate <= 0 && currentMaxMessageRate <= 0)) {
+            if (brokerPublishRateLimiter != PublishRateLimiter.DISABLED_RATE_LIMITER) {
+                brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
+                refreshBrokerPublishRate();
+            }
+            return;
+        }
+
+        final PublishRate publishRate = new PublishRate(currentMaxMessageRate, currentMaxByteRate);
+
+        log.info("Update broker publish rate limiting {}", publishRate);
+        // lazy init Publish-rateLimiting monitoring if not initialized yet
+        if (brokerPublishRateLimiter == null
+            || brokerPublishRateLimiter == PublishRateLimiter.DISABLED_RATE_LIMITER) {
+            // create new rateLimiter if rate-limiter is disabled
+            brokerPublishRateLimiter = new PublishRateLimiterImpl(publishRate);
+        } else {
+            brokerPublishRateLimiter.update(publishRate);
+        }
     }
 
     private void updateTopicMessageDispatchRate() {
@@ -1514,7 +1605,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     /**
-     * Updates pulsar.ServiceConfiguration's dynamic field with value persent into zk-dynamic path. It also validates
+     * Updates pulsar.ServiceConfiguration's dynamic field with value persistent into zk-dynamic path. It also validates
      * dynamic-value before updating it and throws {@code IllegalArgumentException} if validation fails
      */
     private void updateDynamicServiceConfiguration() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -531,7 +531,7 @@ public class Producer {
             msgDrop.calculateRate();
             ((NonPersistentPublisherStats) stats).msgDropRate = msgDrop.getRate();
         }
-        
+
     }
 
     public boolean isRemote() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -131,12 +131,14 @@ public interface Topic {
 
     void checkMessageDeduplicationInfo();
 
-    void checkPublishThrottlingRate();
-    
+    void checkTopicPublishThrottlingRate();
+
     void incrementPublishCount(int numOfMessages, long msgSizeInBytes);
-    
-    void resetPublishCountAndEnableReadIfRequired();
-    
+
+    void resetTopicPublishCountAndEnableReadIfRequired();
+
+    void resetBrokerPublishCountAndEnableReadIfRequired(boolean doneReset);
+
     boolean isPublishRateExceeded();
 
     CompletableFuture<Void> onPoliciesUpdate(Policies data);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -247,7 +247,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // disable throttling
         admin.brokers()
-            .updateDynamicConfiguration("brokerPublisherThrottlingMaxMessageRate", Integer.toString(-1));
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxMessageRate", Integer.toString(0));
         retryStrategically((test) ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
@@ -326,7 +326,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // disable throttling
         admin.brokers()
-            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(0));
         retryStrategically((test) ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
@@ -504,7 +504,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // disable broker throttling, expected no throttling.
         admin.brokers()
-            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(0));
         retryStrategically((test) ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -20,10 +20,19 @@ package org.apache.pulsar.client.impl;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AtomicDouble;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.PublishRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.slf4j.Logger;
@@ -32,8 +41,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Sets;
 
 public class MessagePublishThrottlingTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(MessagePublishThrottlingTest.class);
@@ -45,6 +52,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         super.producerBaseSetup();
         this.conf.setClusterName("test");
         this.conf.setTopicPublisherThrottlingTickTimeMillis(1);
+        this.conf.setBrokerPublisherThrottlingTickTimeMillis(1);
     }
 
     @AfterMethod
@@ -61,18 +69,15 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
      */
     @Test
     public void testSimplePublishMessageThrottling() throws Exception {
-
         log.info("-- Starting {} test --", methodName);
 
         final String namespace = "my-property/throttling_publish";
-        final String topicName = "persistent://" + namespace + "/throttlingBlock";
+        final String topicName = "persistent://" + namespace + "/throttlingMessageBlock";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         PublishRate publishMsgRate = new PublishRate();
         publishMsgRate.publishThrottlingRateInMsg = 10;
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name")
-                .subscribe();
         // create producer and topic
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName)
                 .maxPendingMessages(30000).create();
@@ -115,7 +120,6 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         rateIn = prod.getStats().msgRateIn;
         assertTrue(rateIn > total);
 
-        consumer.close();
         producer.close();
     }
 
@@ -126,18 +130,15 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
      */
     @Test
     public void testSimplePublishByteThrottling() throws Exception {
-
         log.info("-- Starting {} test --", methodName);
 
         final String namespace = "my-property/throttling_publish";
-        final String topicName = "persistent://" + namespace + "/throttlingBlock";
+        final String topicName = "persistent://" + namespace + "/throttlingRateBlock";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         PublishRate publishMsgRate = new PublishRate();
         publishMsgRate.publishThrottlingRateInByte = 400;
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name")
-                .subscribe();
         // create producer and topic
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
@@ -179,8 +180,347 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         rateIn = prod.getStats().msgRateIn;
         assertTrue(rateIn > total);
 
-        consumer.close();
         producer.close();
     }
 
+    /**
+     * Verifies publish rate limiting by setting rate-limiting on number of published messages.
+     * Broker publish throttle enabled / topic publish throttle disabled
+     * @throws Exception
+     */
+    @Test
+    public void testBrokerPublishMessageThrottling() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String namespace = "my-property/throttling_publish";
+        final String topicName = "persistent://" + namespace + "/brokerThrottlingMessageBlock";
+
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        int messageRate = 10;
+
+        // create producer and topic
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+            .topic(topicName)
+            .enableBatching(false)
+            .maxPendingMessages(30000).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        // (1) verify message-rate is -1 initially
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // enable throttling
+        admin.brokers().
+            updateDynamicConfiguration(
+                "brokerPublisherThrottlingMaxMessageRate",
+                Integer.toString(messageRate));
+
+        retryStrategically(
+            (test) ->
+                (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+
+        log.info("Get broker configuration: brokerTick {},  MaxMessageRate {}, MaxByteRate {}",
+            pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate());
+
+        Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        Producer prod = topic.getProducers().values().get(0);
+        // reset counter
+        prod.updateRates();
+        int total = 100;
+        for (int i = 0; i < total; i++) {
+            producer.send(new byte[80]);
+        }
+        // calculate rates and due to throttling rate should be < total per-second
+        prod.updateRates();
+        double rateIn = prod.getStats().msgRateIn;
+        log.info("1-st rate in: {}, total: {} ", rateIn, total);
+        assertTrue(rateIn < total);
+
+        // disable throttling
+        admin.brokers()
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxMessageRate", Integer.toString(-1));
+        retryStrategically((test) ->
+                topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < total; i++) {
+            producer.send(new byte[80]);
+        }
+
+        prod.updateRates();
+        rateIn = prod.getStats().msgRateIn;
+        log.info("2-nd rate in: {}, total: {} ", rateIn, total);
+        assertTrue(rateIn > total);
+
+        producer.close();
+    }
+
+    /**
+     * Verifies publish rate limiting by setting rate-limiting on number of publish bytes.
+     * Broker publish throttle enabled / topic publish throttle disabled
+     * @throws Exception
+     */
+    @Test
+    public void testBrokerPublishByteThrottling() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String namespace = "my-property/throttling_publish";
+        final String topicName = "persistent://" + namespace + "/brokerThrottlingByteBlock";
+
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        long byteRate = 400;
+
+        // create producer and topic
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+            .topic(topicName)
+            .enableBatching(false)
+            .maxPendingMessages(30000).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        // (1) verify byte-rate is -1 disabled
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // enable throttling
+        admin.brokers()
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(byteRate));
+
+        retryStrategically(
+            (test) ->
+                (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+
+        log.info("Get broker configuration after enable: brokerTick {},  MaxMessageRate {}, MaxByteRate {}",
+            pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate());
+
+        Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        Producer prod = topic.getProducers().values().get(0);
+        // reset counter
+        prod.updateRates();
+        int numMessage = 20;
+        int msgBytes = 80;
+
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new byte[msgBytes]);
+        }
+        // calculate rates and due to throttling rate should be < total per-second
+        prod.updateRates();
+        double rateIn = prod.getStats().msgThroughputIn;
+        log.info("1-st byte rate in: {}, total: {} ", rateIn, numMessage * msgBytes);
+        assertTrue(rateIn < numMessage * msgBytes);
+
+        // disable throttling
+        admin.brokers()
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
+        retryStrategically((test) ->
+                topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+
+        log.info("Get broker configuration after disable: brokerTick {},  MaxMessageRate {}, MaxByteRate {}",
+            pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate());
+
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new byte[msgBytes]);
+        }
+
+        prod.updateRates();
+        rateIn = prod.getStats().msgThroughputIn;
+        log.info("2-nd byte rate in: {}, total: {} ", rateIn, numMessage * msgBytes);
+        assertTrue(rateIn > numMessage * msgBytes);
+
+        producer.close();
+    }
+
+    /**
+     * Verifies publish rate limiting by setting rate-limiting on number of publish bytes.
+     * Broker publish throttle / topic publish throttle both enabled.
+     * 1. set brokerByteRate > topicByteRate,
+     * 2. with 1 topic, topicByteRate first take effective, then brokerByteRate take effective, the former rate is less.
+     * 3. create 3 topics with same rate limit, publish should throttle by broker and topic limit.
+     * @throws Exception
+     */
+    @Test
+    public void testBrokerTopicPublishByteThrottling() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String namespace = "my-property/throttling_publish";
+        final String topicName = "persistent://" + namespace + "/brokerTopicThrottlingByteBlock";
+
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        PublishRate topicPublishMsgRate = new PublishRate();
+        long topicByteRate = 400;
+        long brokerByteRate = 800;
+        topicPublishMsgRate.publishThrottlingRateInByte = topicByteRate;
+
+        // create producer and topic
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+            .topic(topicName)
+            .enableBatching(false)
+            .maxPendingMessages(30000).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        // (1) verify both broker and topic limiter is disabled
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // enable broker and topic throttling
+        admin.brokers().updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate",
+            Long.toString(brokerByteRate));
+        admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        retryStrategically((test) ->
+                !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+        retryStrategically(
+            (test) ->
+                (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+
+        log.info("Get broker configuration after enable: brokerTick {},  MaxMessageRate {}, MaxByteRate {}",
+            pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate());
+
+        Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        Producer prod = topic.getProducers().values().get(0);
+        // reset counter
+        prod.updateRates();
+        int numMessage = 40;
+        int msgBytes = 80;
+
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new byte[msgBytes]);
+        }
+        // calculate rates and due to throttling rate should be < total per-second
+        prod.updateRates();
+        double rateIn = prod.getStats().msgThroughputIn;
+        log.info("1-st byte rate in 1: {}, total: {} ", rateIn, numMessage * msgBytes);
+        assertTrue(rateIn < numMessage * msgBytes);
+
+        // create other topics, and count the produce rate, this should be throttle by both topic and broker limit.
+        int topicNumber = 3;
+        final String topicNameBase = "persistent://" + namespace + "/brokerTopicThrottlingByteBlock";
+        List<ProducerImpl<byte[]>> producers = Lists.newArrayListWithExpectedSize(topicNumber);
+        List<PersistentTopic> topics = Lists.newArrayListWithExpectedSize(topicNumber);
+
+        for (int i = 0 ; i < topicNumber; i ++) {
+            String iTopicName = topicNameBase + i;
+            ProducerImpl<byte[]> iProducer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(iTopicName)
+                .enableBatching(false)
+                .maxPendingMessages(30000)
+                .create();
+            PersistentTopic iTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopicIfExists(iTopicName).get().get();
+
+            producers.add(iProducer);
+            topics.add(iTopic);
+
+            // verify both broker and topic limiter is enabled
+            Assert.assertNotEquals(iTopic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+            admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+            retryStrategically((test) ->
+                    !iTopic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+                5,
+                200);
+            Assert.assertNotEquals(iTopic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        }
+
+        List<Callable<Void>> topicRatesCounter = Lists.newArrayListWithExpectedSize(3);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        final AtomicDouble topicsRateIn = new AtomicDouble(0);
+        final AtomicInteger index = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(topicNumber);
+
+        for (int i = 0; i < topicNumber; i ++) {
+            topicRatesCounter.add(() -> {
+                int id = index.incrementAndGet();
+                ProducerImpl<byte[]> iProducer = producers.get(id);
+                PersistentTopic iTopic = topics.get(id);
+                Producer iProd = iTopic.getProducers().values().get(0);
+                // reset counter
+                iProd.updateRates();
+
+                for (int j = 0; j < numMessage; j++) {
+                    iProducer.send(new byte[msgBytes]);
+                }
+                iProd.updateRates();
+                topicsRateIn.addAndGet(iProd.getStats().msgThroughputIn);
+                latch.countDown();
+                return null;
+            });
+        }
+        executor.invokeAll(topicRatesCounter);
+        latch.await(2, TimeUnit.SECONDS);
+        log.info("2-nd rate in: {}, total: {} ", topicsRateIn.get(), topicNumber * numMessage * msgBytes);
+        assertTrue(rateIn < topicsRateIn.get());
+        assertTrue(rateIn < topicNumber * numMessage * msgBytes);
+
+        // disable topic throttling, it will use broker throttling, expected rateIn bigger than before.
+        topicPublishMsgRate.publishThrottlingRateInByte = -1;
+        admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        retryStrategically((test) ->
+                topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new byte[msgBytes]);
+        }
+        // calculate rates and due to use broker throttling, expected rateIn bigger than topic throttling.
+        prod.updateRates();
+        double rateIn2 = prod.getStats().msgThroughputIn;
+        log.info("3-rd byte rate in: {}, rate in 2: {},  total: {} ", rateIn, rateIn2, numMessage * msgBytes);
+        assertTrue(rateIn < rateIn2);
+        assertTrue(rateIn2 < numMessage * msgBytes);
+
+        // disable broker throttling, expected no throttling.
+        admin.brokers().updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
+        retryStrategically((test) ->
+                topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
+
+        log.info("Get broker configuration after disable: brokerTick {},  MaxMessageRate {}, MaxByteRate {}",
+            pulsar.getConfiguration().getBrokerPublisherThrottlingTickTimeMillis(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxMessageRate(),
+            pulsar.getConfiguration().getBrokerPublisherThrottlingMaxByteRate());
+
+        Assert.assertEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new byte[msgBytes]);
+        }
+
+        prod.updateRates();
+        rateIn = prod.getStats().msgThroughputIn;
+        log.info("4-th byte rate in: {}, total: {} ", rateIn, numMessage * msgBytes);
+        assertTrue(rateIn > numMessage * msgBytes);
+
+        producer.close();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -44,7 +44,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         super.internalSetup();
         super.producerBaseSetup();
         this.conf.setClusterName("test");
-        this.conf.setPublisherThrottlingTickTimeMillis(1);
+        this.conf.setTopicPublisherThrottlingTickTimeMillis(1);
     }
 
     @AfterMethod
@@ -56,7 +56,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
     /**
      * Verifies publish rate limiting by setting rate-limiting on number of published messages.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -78,13 +78,13 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
                 .maxPendingMessages(30000).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
         // (1) verify message-rate is -1 initially
-        Assert.assertEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> !topic.getPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
+        retryStrategically((test) -> !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
                 200);
-        Assert.assertNotEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         Producer prod = topic.getProducers().values().iterator().next();
         // reset counter
@@ -101,9 +101,9 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         publishMsgRate.publishThrottlingRateInMsg = -1;
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> topic.getPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
+        retryStrategically((test) -> topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
                 200);
-        Assert.assertEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         // reset counter
         prod.updateRates();
@@ -121,7 +121,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
     /**
      * Verifies publish rate limiting by setting rate-limiting on number of publish bytes.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -142,13 +142,13 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
         // (1) verify message-rate is -1 initially
-        Assert.assertEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> !topic.getPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
+        retryStrategically((test) -> !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
                 200);
-        Assert.assertNotEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         Producer prod = topic.getProducers().values().iterator().next();
         // reset counter
@@ -165,9 +165,9 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         publishMsgRate.publishThrottlingRateInByte = -1;
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> topic.getPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
+        retryStrategically((test) -> topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
                 200);
-        Assert.assertEquals(topic.getPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         // reset counter
         prod.updateRates();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -87,8 +87,10 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
-                200);
+        retryStrategically((test) ->
+                !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
         Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         Producer prod = topic.getProducers().values().iterator().next();
@@ -106,8 +108,10 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         publishMsgRate.publishThrottlingRateInMsg = -1;
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
-                200);
+        retryStrategically((test) ->
+                topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
         Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         // reset counter
@@ -147,8 +151,10 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
-                200);
+        retryStrategically((test) ->
+                !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
+            5,
+            200);
         Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
         Producer prod = topic.getProducers().values().iterator().next();
@@ -226,7 +232,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
-        Producer prod = topic.getProducers().values().get(0);
+        Producer prod = topic.getProducers().values().iterator().next();
         // reset counter
         prod.updateRates();
         int total = 100;
@@ -303,7 +309,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
-        Producer prod = topic.getProducers().values().get(0);
+        Producer prod = topic.getProducers().values().iterator().next();
         // reset counter
         prod.updateRates();
         int numMessage = 20;
@@ -400,7 +406,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         Assert.assertNotEquals(topic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
         Assert.assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
-        Producer prod = topic.getProducers().values().get(0);
+        Producer prod = topic.getProducers().values().iterator().next();
         // reset counter
         prod.updateRates();
         int numMessage = 40;
@@ -456,7 +462,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
                 int id = index.incrementAndGet();
                 ProducerImpl<byte[]> iProducer = producers.get(id);
                 PersistentTopic iTopic = topics.get(id);
-                Producer iProd = iTopic.getProducers().values().get(0);
+                Producer iProd = iTopic.getProducers().values().iterator().next();
                 // reset counter
                 iProd.updateRates();
 
@@ -497,7 +503,8 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         assertTrue(rateIn2 < numMessage * msgBytes);
 
         // disable broker throttling, expected no throttling.
-        admin.brokers().updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
+        admin.brokers()
+            .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(-1));
         retryStrategically((test) ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,


### PR DESCRIPTION
Fixes #5513 

### Motivation

Through #3985, user could set the publish rate for each topic, but the topic number for each broker is not limited, so there is case that a lot of topics served in same broker, and if each topic send too many message, it will cause the messages not able to send to BookKeeper in time,  and messages be hold in the direct memory of broker, and cause Broker out of direct memory.

### Modifications

- add broker publish rate limit base on #3985,
- add unit test.

### Verifying this change
unit test passed.