### PR TITLE
avoid unsafe split when validate hostname which might be ipv6 address

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.google.common.net.HostAndPort;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
@@ -28,6 +28,8 @@ import com.google.common.base.Strings;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.google.common.net.HostAndPort;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -134,21 +136,21 @@ public class ServiceURI {
     private static String validateHostName(String serviceName,
                                            String[] serviceInfos,
                                            String hostname) {
-        String[] parts = hostname.split(":");
-        if (parts.length >= 3) {
+        URI uri = null;
+        try {
+            uri = URI.create("dummyscheme://" + hostname);
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid hostname : " + hostname);
-        } else if (parts.length == 2) {
-            try {
-                Integer.parseUnsignedInt(parts[1]);
-            } catch (NumberFormatException nfe) {
-                throw new IllegalArgumentException("Invalid hostname : " + hostname);
-            }
-            return hostname;
-        } else if (parts.length == 1) {
-            return hostname + ":" + getServicePort(serviceName, serviceInfos);
-        } else {
-            return hostname;
         }
+        String host = uri.getHost();
+        if (host == null) {
+            throw new IllegalArgumentException("Invalid hostname : " + hostname);
+        }
+        int port = uri.getPort();
+        if (port == -1) {
+            port = getServicePort(serviceName, serviceInfos);
+        }
+        return host + ":" + port;
     }
 
     private final String serviceName;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
@@ -135,6 +135,18 @@ public class ServiceURITest {
     }
 
     @Test
+    public void testIpv6UriWithoutPulsarPort() {
+        String serviceUri = "pulsar://[fec0:0:0:ffff::1]/path/to/namespace";
+        assertServiceUri(
+            serviceUri,
+            "pulsar",
+            new String[0],
+            null,
+            new String[] { "[fec0:0:0:ffff::1]:6650" },
+            "/path/to/namespace");
+    }
+
+    @Test
     public void testMultipleHostsSemiColon() {
         String serviceUri = "pulsar://host1:6650;host2:6650;host3:6650/path/to/namespace";
         assertServiceUri(

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
@@ -18,8 +18,7 @@
  */
 package org.apache.pulsar.common.net;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 import java.net.URI;
@@ -55,6 +54,7 @@ public class ServiceURITest {
             "pulsar://localhost:6650:6651/",    // invalid hostname pair
             "pulsar://localhost:xyz/",          // invalid port
             "pulsar://localhost:-6650/",        // negative port
+            "pulsar://fec0:0:0:ffff::1:6650",   // missing brackets
         };
 
         for (String uri : uris) {
@@ -119,6 +119,18 @@ public class ServiceURITest {
             new String[0],
             "pulsaruser",
             new String[] { "localhost:6650" },
+            "/path/to/namespace");
+    }
+
+    @Test
+    public void testIpv6Uri() {
+        String serviceUri = "pulsar://pulsaruser@[fec0:0:0:ffff::1]:6650/path/to/namespace";
+        assertServiceUri(
+            serviceUri,
+            "pulsar",
+            new String[0],
+            "pulsaruser",
+            new String[] { "[fec0:0:0:ffff::1]:6650" },
             "/path/to/namespace");
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
Pulsar doesn't support deploy on IPv6 network environment.
This PR just makes an effort to make it.
The error happens if the client connect to brokers by IPv6 address, like fec0:0:0:ffff::1.
- Wrong format: fec0:0:0:ffff::1:6650
- Correct format: [fec0:0:0:ffff::1]:6650

Cause the split regex is ':', brackets are needed and the ip:port can't split by ':' directly.

### Modifications

validateHostName in ServiceURI
