### PR TITLE
Add topic name into reader-sub-name

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -38,7 +38,8 @@ public class ReaderImpl<T> implements Reader<T> {
     public ReaderImpl(PulsarClientImpl client, ReaderConfigurationData<T> readerConfiguration,
                       ExecutorService listenerExecutor, CompletableFuture<Consumer<T>> consumerFuture, Schema<T> schema) {
 
-        String subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+        String subscription = "reader-" + readerConfiguration.getTopicName() + "-"
+            + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
             subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
         }


### PR DESCRIPTION
currently the sub name of each reader is named as "reader-xxxx", it not contains related info with this reader, and hard to identify. This change add the `topicname` into the sub-name
