### PR TITLE
Expose lastExpireTimestamp for subscription stats.

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -58,7 +58,7 @@ public class SubscriptionStats {
     /** Total rate of messages expired on this subscription (msg/s). */
     public double msgRateExpired;
 
-    /** Last message expire execution timestamp*/
+    /** Last message expire execution timestamp. */
     public long lastExpireTimestamp;
 
     /** List of connected consumers on this subscription w/ their stats. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -58,6 +58,9 @@ public class SubscriptionStats {
     /** Total rate of messages expired on this subscription (msg/s). */
     public double msgRateExpired;
 
+    /** Last message expire execution timestamp*/
+    public long lastExpireTimestamp;
+
     /** List of connected consumers on this subscription w/ their stats. */
     public List<ConsumerStats> consumers;
 
@@ -75,6 +78,7 @@ public class SubscriptionStats {
         msgBacklog = 0;
         unackedMessages = 0;
         msgRateExpired = 0;
+        lastExpireTimestamp = 0L;
         consumers.clear();
     }
 


### PR DESCRIPTION
### Motivation

Expose lastExpireTimestamp for subscription stats. Can be used to troubleshooting TTL related issues

### Verifying this change

Added new unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
