### PR TITLE
[Issue 5287][docs] Add documentation on how to configure multiple broker services

### DIFF
--- a/site2/docs/sql-deployment-configurations.md
+++ b/site2/docs/sql-deployment-configurations.md
@@ -26,6 +26,14 @@ pulsar.entry-read-batch-size=100
 pulsar.target-num-splits=4
 ```
 
+You can connect Presto to a Pulsar cluster with multiple hosts. To configure multiple hosts for brokers or ZooKeepers, you can add multiple URLs to `pulsar.broker-service-url`. The following is an example.
+  
+```
+pulsar.broker-service-url=http://localhost:8080,localhost:8081,localhost:8082
+
+```
+
+
 ## Query data from existing Presto clusters
 
 If you already have a Presto cluster, you can copy the Presto Pulsar connector plugin to your existing cluster. Download the archived plugin package with the following command.

--- a/site2/docs/sql-deployment-configurations.md
+++ b/site2/docs/sql-deployment-configurations.md
@@ -26,13 +26,12 @@ pulsar.entry-read-batch-size=100
 pulsar.target-num-splits=4
 ```
 
-You can connect Presto to a Pulsar cluster with multiple hosts. To configure multiple hosts for brokers or ZooKeepers, you can add multiple URLs to `pulsar.broker-service-url`. The following is an example.
+You can connect Presto to a Pulsar cluster with multiple hosts. To configure multiple hosts for brokers, add multiple URLs to `pulsar.broker-service-url`. To configure multiple hosts for ZooKeeper, add multiple URIs to `pulsar.zookeeper-uri`. The following is an example.
   
 ```
 pulsar.broker-service-url=http://localhost:8080,localhost:8081,localhost:8082
-
+pulsar.zookeeper-uri=localhost1,localhost2:2181
 ```
-
 
 ## Query data from existing Presto clusters
 


### PR DESCRIPTION
Fixes #5287 

### Motivation
Users do not know how to specify cluster (multi broker/zk) connection for presto.

### Modifications
Add content on how to configure multiple hosts for `pulsar.broker-service-url`.