### PR TITLE
[Issue 5729]Picture and text are not match

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -173,7 +173,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram below, only **Consumer-A** is allowed to consume messages.
+In the diagram below, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
@@ -110,7 +110,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram above, only **Consumer-A** is allowed to consume messages.
+In the diagram above, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
@@ -111,7 +111,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram above, only **Consumer-A** is allowed to consume messages.
+In the diagram above, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
@@ -111,7 +111,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram above, only **Consumer-A** is allowed to consume messages.
+In the diagram above, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
@@ -153,7 +153,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram above, only **Consumer-A** is allowed to consume messages.
+In the diagram above, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
@@ -153,7 +153,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram above, only **Consumer-A** is allowed to consume messages.
+In the diagram above, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 

--- a/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
@@ -174,7 +174,7 @@ A subscription is a named configuration rule that determines how messages are de
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If more than one consumer attempts to subscribe to a topic using the same subscription, the consumer receives an error.
 
-In the diagram below, only **Consumer-A** is allowed to consume messages.
+In the diagram below, only **Consumer A-0** is allowed to consume messages.
 
 > Exclusive mode is the default subscription mode.
 


### PR DESCRIPTION
[Issue 5729]Picture and text are not match.


Fixes #5729 

### Motivation

Picture and text are not match.

### Modifications
changed the ```Consumer-A``` to ```Consumer A-0```
