### PR TITLE
[pulsar-broker] add support to configure max pending publish request per connection

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -114,6 +114,10 @@ brokerDeleteInactiveTopicsMode=delete_when_no_subscriptions
 # Topics that are inactive for longer than this value will be deleted
 brokerDeleteInactiveTopicsMaxInactiveDurationSeconds=
 
+# Max pending publish requests per connection to avoid keeping large number of pending 
+# requests in memory. Default: 1000
+maxPendingPublishdRequestsPerConnection=1000;
+
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -75,6 +75,10 @@ brokerDeleteInactiveTopicsEnabled=true
 # How often to check for inactive topics
 brokerDeleteInactiveTopicsFrequencySeconds=60
 
+# Max pending publish requests per connection to avoid keeping large number of pending 
+# requests in memory. Default: 1000
+maxPendingPublishdRequestsPerConnection=1000;
+
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -276,6 +276,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "Max pending publish requests per connection to avoid keeping large number of pending "
+                + "requests in memory. Default: 1000"
+    )
+    private int maxPendingPublishdRequestsPerConnection = 1000;
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired messages"
     )
     private int messageExpiryCheckIntervalInMinutes = 5;


### PR DESCRIPTION
### Motivation
Right now, broker restricts max number of pending publish messages per connection to protect broker going OOM when any producer is publishing messages with huge throughput.
However, right now maxRequests per cnx is 1K and it's not configurable as sometimes user may want to configure based on number of connections are expected.

### Modification
Make max number of pending publish messages per connection configurable.