### PR TITLE
Bump athenz libraries to 1.8.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.20.v20190813</jetty.version>
     <jersey.version>2.27</jersey.version>
-    <athenz.version>1.8.17</athenz.version>
+    <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
     <rocksdb.version>5.13.3</rocksdb.version>


### PR DESCRIPTION
Updated Athenz libraries to the latest version. The latest version of Athenz seems to include some bug fixes.
https://github.com/yahoo/athenz/releases