### PR TITLE
Bump jackson libraries to 2.10.1

### DIFF
--- a/distribution/server/licenses/LICENSE-EDL-1.0.txt
+++ b/distribution/server/licenses/LICENSE-EDL-1.0.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -314,14 +314,14 @@ The Apache Software License, Version 2.0
  * Jackson
      - org.codehaus.jackson-jackson-core-asl-1.9.13.jar
      - org.codehaus.jackson-jackson-mapper-asl-1.9.13.jar
-     - com.fasterxml.jackson.core-jackson-annotations-2.9.9.jar
-     - com.fasterxml.jackson.core-jackson-core-2.9.9.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.9.9.3.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.9.9.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.9.9.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.9.9.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.9.9.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.9.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.10.1.jar
+     - com.fasterxml.jackson.core-jackson-core-2.10.1.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.10.1.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.10.1.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.10.1.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.10.1.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.10.1.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.10.1.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
  * Gson -- com.google.code.gson-gson-2.8.2.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -429,7 +429,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-common-9.4.20.v20190813.jar
     - org.eclipse.jetty.websocket-websocket-server-9.4.20.v20190813.jar
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.20.v20190813.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.23.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.24.jar
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * HttpClient
     - org.apache.httpcomponents-httpclient-4.5.5.jar
@@ -557,6 +557,10 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - org.glassfish.jersey.media-jersey-media-multipart-2.27.jar
     - org.glassfish.jersey.inject-jersey-hk2-2.27.jar
  * Mimepull -- org.jvnet.mimepull-mimepull-1.9.6.jar
+
+Eclipse Distribution License 1.0 -- licenses/LICENSE-EDL-1.0.txt
+ * Jakarta Activation -- jakarta.activation-jakarta.activation-api-1.2.1.jar
+ * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.2.jar
 
 Eclipse Public License 1.0 -- licenses/LICENSE-AspectJ.txt
  * AspectJ

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,8 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson.databind.version>2.9.9.3</jackson.databind.version>
+    <jackson.version>2.10.1</jackson.version>
+    <jackson.databind.version>2.10.1</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>


### PR DESCRIPTION
Updated jackson libraries to the latest version. There is a security vulnerability in `jackson-databind` currently used by Pulsar.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17531