### PR TITLE
[pulsar-client] Switch partition when a batch is full (in RoundRobinMessageRouter)

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
@@ -148,10 +148,9 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
 
         pulsarProducerBuilder = PulsarProducerKafkaConfig.getProducerBuilder(client, properties);
 
-        // To mimic the same batching mode as Kafka, we need to wait a very little amount of
-        // time to batch if the client is trying to send messages fast enough
-        long lingerMs = Long.parseLong(properties.getProperty(ProducerConfig.LINGER_MS_CONFIG, "1"));
-        pulsarProducerBuilder.batchingMaxPublishDelay(lingerMs, TimeUnit.MILLISECONDS);
+        // To mimic the same batching mode as Kafka, we need to wait until a batch is full
+        int batchSize = Integer.parseInt(properties.getProperty(ProducerConfig.BATCH_SIZE_CONFIG, "1"));
+        pulsarProducerBuilder.batchingMaxBytes(batchSize);
 
         String compressionType = properties.getProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG);
         if ("gzip".equals(compressionType)) {
@@ -160,7 +159,7 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
             pulsarProducerBuilder.compressionType(CompressionType.LZ4);
         }
 
-        pulsarProducerBuilder.messageRouter(new KafkaMessageRouter(lingerMs));
+        pulsarProducerBuilder.messageRouter(new KafkaMessageRouter(batchSize));
 
         int sendTimeoutMillis = Integer.parseInt(properties.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000"));
         pulsarProducerBuilder.sendTimeout(sendTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaMessageRouter.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaMessageRouter.java
@@ -29,8 +29,8 @@ public class KafkaMessageRouter extends RoundRobinPartitionMessageRouterImpl {
 
     public static final String PARTITION_ID = "pulsar.partition.id";
 
-    public KafkaMessageRouter(long maxBatchingDelayMs) {
-        super(HashingScheme.JavaStringHash, ThreadLocalRandom.current().nextInt(), true, maxBatchingDelayMs);
+    public KafkaMessageRouter(int maxBatchingBytes) {
+        super(HashingScheme.JavaStringHash, ThreadLocalRandom.current().nextInt(), true, maxBatchingBytes);
     }
 
     @Override

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_9/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_9/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
@@ -147,10 +147,9 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
 
         pulsarProducerBuilder = PulsarProducerKafkaConfig.getProducerBuilder(client, properties);
 
-        // To mimic the same batching mode as Kafka, we need to wait a very little amount of
-        // time to batch if the client is trying to send messages fast enough
-        long lingerMs = Long.parseLong(properties.getProperty(ProducerConfig.LINGER_MS_CONFIG, "1"));
-        pulsarProducerBuilder.batchingMaxPublishDelay(lingerMs, TimeUnit.MILLISECONDS);
+        // To mimic the same batching mode as Kafka, we need to wait until a batch is full
+        int batchSize = Integer.parseInt(properties.getProperty(ProducerConfig.BATCH_SIZE_CONFIG, "1"));
+        pulsarProducerBuilder.batchingMaxBytes(batchSize);
 
         String compressionType = properties.getProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG);
         if ("gzip".equals(compressionType)) {
@@ -159,7 +158,7 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
             pulsarProducerBuilder.compressionType(CompressionType.LZ4);
         }
 
-        pulsarProducerBuilder.messageRouter(new KafkaMessageRouter(lingerMs));
+        pulsarProducerBuilder.messageRouter(new KafkaMessageRouter(batchSize));
 
         int sendTimeoutMillis = Integer.parseInt(properties.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000"));
         pulsarProducerBuilder.sendTimeout(sendTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_9/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaMessageRouter.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_9/src/main/java/org/apache/pulsar/client/kafka/compat/KafkaMessageRouter.java
@@ -29,8 +29,8 @@ public class KafkaMessageRouter extends RoundRobinPartitionMessageRouterImpl {
 
     public static final String PARTITION_ID = "pulsar.partition.id";
 
-    public KafkaMessageRouter(long maxBatchingDelayMs) {
-        super(HashingScheme.JavaStringHash, ThreadLocalRandom.current().nextInt(), true, maxBatchingDelayMs);
+    public KafkaMessageRouter(int maxBatchingBytes) {
+        super(HashingScheme.JavaStringHash, ThreadLocalRandom.current().nextInt(), true, maxBatchingBytes);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -103,7 +103,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                         conf.getHashingScheme(),
                         ThreadLocalRandom.current().nextInt(topicMetadata.numPartitions()),
                         conf.isBatchingEnabled(),
-                        TimeUnit.MICROSECONDS.toMillis(conf.getBatchingMaxPublishDelayMicros()));
+                        conf.getBatchingMaxBytes());
         }
 
         return messageRouter;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
@@ -94,7 +94,7 @@ public class RoundRobinPartitionMessageRouterImplTest {
         when(msg.getKey()).thenReturn(null);
 
         RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(
-                HashingScheme.JavaStringHash, 0, true, 10);
+                HashingScheme.JavaStringHash, 45, true, 10);
         TopicMetadataImpl metadata = new TopicMetadataImpl(100);
 
         // time at `12345*` milliseconds

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
@@ -35,17 +35,16 @@ public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
     private static final FunctionResultRouter INSTANCE = new FunctionResultRouter();
 
     public FunctionResultRouter() {
-        this(Math.abs(ThreadLocalRandom.current().nextInt()), Clock.systemUTC());
+        this(Math.abs(ThreadLocalRandom.current().nextInt()));
     }
 
     @VisibleForTesting
-    public FunctionResultRouter(int startPtnIdx, Clock clock) {
+    public FunctionResultRouter(int startPtnIdx) {
         super(
             HashingScheme.Murmur3_32Hash,
             startPtnIdx,
             true,
-            1,
-            clock);
+            128 * 1024);
     }
 
     public static FunctionResultRouter of() {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
@@ -52,11 +52,8 @@ public class FunctionResultRouterTest {
         TopicMetadata topicMetadata = mock(TopicMetadata.class);
         when(topicMetadata.numPartitions()).thenReturn(5);
 
-        Clock clock = mock(Clock.class);
-
-        FunctionResultRouter router = new FunctionResultRouter(0, clock);
+        FunctionResultRouter router = new FunctionResultRouter(0);
         for (int i = 0; i < 10; i++) {
-            when(clock.millis()).thenReturn(123450L + i);
             assertEquals(i % 5, router.choosePartition(msg, topicMetadata));
         }
     }
@@ -66,9 +63,7 @@ public class FunctionResultRouterTest {
         TopicMetadata topicMetadata = mock(TopicMetadata.class);
         when(topicMetadata.numPartitions()).thenReturn(5);
 
-        Clock clock = mock(Clock.class);
-
-        FunctionResultRouter router = new FunctionResultRouter(0, clock);
+        FunctionResultRouter router = new FunctionResultRouter(0);
         for (int i = 0; i < 10; i++) {
             Message<?> msg = mock(Message.class);
             when(msg.hasKey()).thenReturn(false);
@@ -91,9 +86,7 @@ public class FunctionResultRouterTest {
         when(msg2.getKey()).thenReturn(key2);
         when(msg1.getSequenceId()).thenReturn(-1L);
 
-        Clock clock = mock(Clock.class);
-
-        FunctionResultRouter router = new FunctionResultRouter(0, clock);
+        FunctionResultRouter router = new FunctionResultRouter(0);
         TopicMetadata metadata = mock(TopicMetadata.class);
         when(metadata.numPartitions()).thenReturn(100);
 
@@ -115,9 +108,7 @@ public class FunctionResultRouterTest {
         when(msg2.getKey()).thenReturn(key2);
         when(msg1.getSequenceId()).thenReturn((long) ((key2.hashCode() % 100) + 1));
 
-        Clock clock = mock(Clock.class);
-
-        FunctionResultRouter router = new FunctionResultRouter(0, clock);
+        FunctionResultRouter router = new FunctionResultRouter(0);
         TopicMetadata metadata = mock(TopicMetadata.class);
         when(metadata.numPartitions()).thenReturn(100);
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
@@ -54,6 +54,7 @@ public class FunctionResultRouterTest {
 
         FunctionResultRouter router = new FunctionResultRouter(0);
         for (int i = 0; i < 10; i++) {
+            when(msg.getData()).thenReturn(new byte[128 * 1024]);
             assertEquals(i % 5, router.choosePartition(msg, topicMetadata));
         }
     }


### PR DESCRIPTION
### Motivation

In RoundRobinPartitionMessageRouter, when batching is enabled, the current implementation would choose one partition from a topic and switch to another on `batchingMaxPublishDelayMicros` bases, which make the change of partition often and result in a smaller batch. 

This PR aims to deal with this situation with the partition switch timing, from `publishDelay` bases to `batchSize`, i.e. all messages without key would be batched into one batch until the batch is full. Then a new partition is chosen and continues to produce. This solution is much like that in Kafka: [KIP-480: Sticky Partitioner](https://cwiki.apache.org/confluence/display/KAFKA/KIP-480%3A+Sticky+Partitioner).

### Modifications

A private field to track accumulative message size seen in `RoundRobinPartitionMessageRouterImpl`, and change partition when a batch is full.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as `RoundRobinPartitionMessageRouterImplTest.java`, `FunctionResultRouterTest`


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
