### PR TITLE
add Murmur3_32Hash private constructor

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Murmur3_32Hash.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Murmur3_32Hash.java
@@ -28,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 public class Murmur3_32Hash implements Hash {
     private static final Murmur3_32Hash instance = new Murmur3_32Hash();
 
+    private Murmur3_32Hash(){ }
+
     public static Hash getInstance() {
         return instance;
     }


### PR DESCRIPTION
### Motivation
Add private constructor to Murmur3_32Hash Singleton.

### Modifications
Private constructor added.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
