### PR TITLE
Fixes #5772: Bump Lombok version to allow building with a JDK>=12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1050,7 +1050,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.4</version>
+        <version>1.18.10</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #5772 

### Motivation

I would like to be able to build Pulsar with at least JDK12.

### Modifications

Bumping lombok dep.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):