### PR TITLE
[pulsar-client] Fix bug that beforeConsume() of interceptor is not called when receiver queue size is 0

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -60,7 +60,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
     protected Message<T> internalReceive() throws PulsarClientException {
         zeroQueueLock.lock();
         try {
-            return fetchSingleMessageFromBroker();
+            return beforeConsume(fetchSingleMessageFromBroker());
         } finally {
             zeroQueueLock.unlock();
         }
@@ -155,7 +155,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
                     log.debug("[{}][{}] Calling message listener for unqueued message {}", topic, subscription,
                             message.getMessageId());
                 }
-                listener.received(ZeroQueueConsumerImpl.this, message);
+                listener.received(ZeroQueueConsumerImpl.this, beforeConsume(message));
             } catch (Throwable t) {
                 log.error("[{}][{}] Message listener error in processing unqueued message: {}", topic, subscription,
                         message.getMessageId(), t);


### PR DESCRIPTION
### Motivation

I implemented `ConsumerInterceptor` and used it, but I noticed that the `beforeConsume()` method is not executed when the size of the receiver queue is 0.

### Modifications

If the receiver queue size is 0, an instance of `ZeroQueueConsumerImpl` class is created instead of `ConsumerImpl`, but `beforeConsume()` is not called in this class now. So I fixed `ZeroQueueConsumerImpl`.