### PR TITLE
[Issues 5763] Broker graceful shutdown when znode of loadbalance disappeared

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -869,6 +869,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             updateLocalBrokerData();
             if (needBrokerDataUpdate()) {
                 localData.setLastUpdate(System.currentTimeMillis());
+                createZPathIfNotExists(zkClient,brokerZnodePath);
                 zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
 
                 // Clear deltas.


### PR DESCRIPTION
[Issues 5763] Broker graceful shutdown when znode of loadbalance disappeared

 
Fixes #5763 


### Motivation

fix 5763

### Modifications

Called ``` createZPathIfNotExists ```before calling ```zkClient.setData```
