### PR TITLE
Create load balance znode of broker when znode missed.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -29,7 +29,6 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -869,7 +868,13 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             updateLocalBrokerData();
             if (needBrokerDataUpdate()) {
                 localData.setLastUpdate(System.currentTimeMillis());
-                zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
+
+                try {
+                    zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
+                } catch (KeeperException.NoNodeException e) {
+                    ZkUtils.createFullPathOptimistic(zkClient, brokerZnodePath, localData.getJsonBytes(),
+                            ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                }
 
                 // Clear deltas.
                 localData.getLastBundleGains().clear();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -635,8 +635,7 @@ public class ModularLoadManagerImplTest {
     public void testZnodeMissed() throws Exception {
         String path = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + pulsar1.getAdvertisedAddress() + ":" + pulsar1.getConfiguration().getWebServicePort().get();
         ZkUtils.deleteFullPathOptimistic(pulsar1.getZkClient(), path, -1);
-        // Wait broker write load balance data to zookeeper, default interval is 5s.
-        Thread.sleep(6000);
+        pulsar1.getLoadManager().get().writeLoadReportOnZookeeper();
         // Delete it again to check the znode is create before write load balance data
         ZkUtils.deleteFullPathOptimistic(pulsar1.getZkClient(), path, -1);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -630,4 +630,14 @@ public class ModularLoadManagerImplTest {
 
         pulsar.close();
     }
+
+    @Test
+    public void testZnodeMissed() throws Exception {
+        String path = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + pulsar1.getAdvertisedAddress() + ":" + pulsar1.getConfiguration().getWebServicePort().get();
+        ZkUtils.deleteFullPathOptimistic(pulsar1.getZkClient(), path, -1);
+        // Wait broker write load balance data to zookeeper, default interval is 5s.
+        Thread.sleep(6000);
+        // Delete it again to check the znode is create before write load balance data
+        ZkUtils.deleteFullPathOptimistic(pulsar1.getZkClient(), path, -1);
+    }
 }


### PR DESCRIPTION
Fixes #5763

### Motivation

Create load balance znode of broker when znode missed.

### Modifications

Catch the NoNodeException for write load balance data to zookeeper

### Verifying this change

Added unit test.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: ( no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
