### PR TITLE
Fix ArrayIndexOutOfBoundsException in PerformanceProducer.

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -87,8 +87,8 @@ public class PerformanceProducer {
     private static final LongAdder totalMessagesSent = new LongAdder();
     private static final LongAdder totalBytesSent = new LongAdder();
 
-    private static Recorder recorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
-    private static Recorder cumulativeRecorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
+    private static Recorder recorder = new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+    private static Recorder cumulativeRecorder = new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
 
     static class Arguments {
 
@@ -521,6 +521,11 @@ public class PerformanceProducer {
                             cumulativeRecorder.recordValue(latencyMicros);
                         }
                     }).exceptionally(ex -> {
+                        // Ignore the exception of recorder since a very large latencyMicros will lead
+                        // ArrayIndexOutOfBoundsException in AbstractHistogram
+                        if (ex.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                            return null;
+                        }
                         log.warn("Write error on message", ex);
                         messagesFailed.increment();
                         if (arguments.exitOnFailure) {


### PR DESCRIPTION
Fixes #5760

### Motivation

We use `org.HdrHistogram.Recorder` to record write latency and `highestTrackableValue` is `TimeUnit.SECONDS.toMicros(120000)`, but we record the value in micros, the error happens when the latency in micros is a very large number, so this PR change the `highestTrackableValue` of Recorder to `TimeUnit.SECONDS.toMicros(120000)`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
