### PR TITLE
[Issue 5638][docs] Add explanation about the v1 REST API

### DIFF
--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -30,6 +30,14 @@ In this document, examples from each of the three available interfaces will be s
 
 Each of Pulsar's three admin interfaces---the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have [authentication](security-overview.md#authentication-providers) enabled in your Pulsar [instance](reference-terminology.md#instance).
 
+> If you are using an old version of a namespace, you need to use `v1` to replace `v2` in the request URL
+if you are requesting the HTTP service directly. If you are using the pulsar-admin to request the v1
+service, you will encounter an exception with HTTP code 405 that shows you are requesting a not supported
+method in the v1 version. About the supported method in the v1, please refer to the
+[v1 Admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
+About the old version of a namespace, please refer to the
+[namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
+
 ### pulsar-admin
 
 If you have [authentication](security-overview.md#authentication-providers) enabled, you will need to provide an auth configuration to use the [`pulsar-admin`](reference-pulsar-admin.md) tool. By default, the configuration for the `pulsar-admin` tool is found in the [`conf/client.conf`](reference-configuration.md#client) file. Here are the available parameters:

--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -30,15 +30,12 @@ In this document, examples from each of the three available interfaces will be s
 
 Each of Pulsar's three admin interfaces---the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have [authentication](security-overview.md#authentication-providers) enabled in your Pulsar [instance](reference-terminology.md#instance).
 
-> If you are using an old version of a namespace, you need to use `v1` to replace `v2` in the request URL
-if you are requesting the HTTP service directly. If you are using the pulsar-admin to request the v1
-service, you will encounter an exception with HTTP code 405 that shows you are requesting a not supported
-method in the v1 version. About the supported method in the v1, please refer to the
-[v1 Admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
-About the old version of a namespace, please refer to the
-[namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
-
 ### pulsar-admin
+
+> Tip: If you are using the pulsar-admin to request `v1` service, you will encounter an exception
+with HTTP code 405 showing that the method you are requesting is not supported in `v1`. For more
+information about the **supported method in `v1`**, see 
+[v1 admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
 
 If you have [authentication](security-overview.md#authentication-providers) enabled, you will need to provide an auth configuration to use the [`pulsar-admin`](reference-pulsar-admin.md) tool. By default, the configuration for the `pulsar-admin` tool is found in the [`conf/client.conf`](reference-configuration.md#client) file. Here are the available parameters:
 
@@ -55,6 +52,10 @@ If you have [authentication](security-overview.md#authentication-providers) enab
 ### REST API
 
 You can find documentation for the REST API exposed by Pulsar [brokers](reference-terminology.md#broker) in this reference {@inject: rest:document:/}.
+
+> Note: If you are using an old version of a namespace and requesting the HTTP service directly, 
+you need to use `v1` to replace `v2` in the request URL. More information about the old version
+of a namespace, see [namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
 
 ### Java admin client
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-overview.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-overview.md
@@ -31,6 +31,14 @@ In this document, examples from each of the three available interfaces will be s
 
 Each of Pulsar's three admin interfaces---the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have [authentication](security-overview.md#authentication-providers) enabled in your Pulsar [instance](reference-terminology.md#instance).
 
+> If you are using an old version of a namespace, you need to use `v1` to replace `v2` in the request URL
+if you are requesting the HTTP service directly. If you are using the pulsar-admin to request the v1
+service, you will encounter an exception with HTTP code 405 that shows you are requesting a not supported
+method in the v1 version. About the supported method in the v1, please refer to the
+[v1 Admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
+About the old version of a namespace, please refer to the
+[namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
+
 ### pulsar-admin
 
 If you have [authentication](security-overview.md#authentication-providers) enabled, you will need to provide an auth configuration to use the [`pulsar-admin`](reference-pulsar-admin.md) tool. By default, the configuration for the `pulsar-admin` tool is found in the [`conf/client.conf`](reference-configuration.md#client) file. Here are the available parameters:

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-overview.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-overview.md
@@ -31,15 +31,12 @@ In this document, examples from each of the three available interfaces will be s
 
 Each of Pulsar's three admin interfaces---the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have [authentication](security-overview.md#authentication-providers) enabled in your Pulsar [instance](reference-terminology.md#instance).
 
-> If you are using an old version of a namespace, you need to use `v1` to replace `v2` in the request URL
-if you are requesting the HTTP service directly. If you are using the pulsar-admin to request the v1
-service, you will encounter an exception with HTTP code 405 that shows you are requesting a not supported
-method in the v1 version. About the supported method in the v1, please refer to the
-[v1 Admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
-About the old version of a namespace, please refer to the
-[namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
-
 ### pulsar-admin
+
+> Tip: If you are using the pulsar-admin to request `v1` service, you will encounter an exception
+with HTTP code 405 showing that the method you are requesting is not supported in `v1`. For more
+information about the **supported method in `v1`**, see 
+[v1 admin API](https://github.com/apache/pulsar/tree/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1).
 
 If you have [authentication](security-overview.md#authentication-providers) enabled, you will need to provide an auth configuration to use the [`pulsar-admin`](reference-pulsar-admin.md) tool. By default, the configuration for the `pulsar-admin` tool is found in the [`conf/client.conf`](reference-configuration.md#client) file. Here are the available parameters:
 
@@ -56,6 +53,10 @@ If you have [authentication](security-overview.md#authentication-providers) enab
 ### REST API
 
 You can find documentation for the REST API exposed by Pulsar [brokers](reference-terminology.md#broker) in this reference {@inject: rest:document:/}.
+
+> Note: If you are using an old version of a namespace and requesting the HTTP service directly, 
+you need to use `v1` to replace `v2` in the request URL. More information about the old version
+of a namespace, see [namespace name changes](https://github.com/apache/pulsar/wiki/PIP-10:-Remove-cluster-for-namespace-and-topic-names).
 
 ### Java admin client
 


### PR DESCRIPTION
---

Fixes #5683

*Motivation*

There is a sample tenant that will auto-create when
a user starts a standalone service. Sometimes a user
wants to do something in the sample tenant and but
they will meet some errors when they using the pulsar
admin to operate the sample tenant. We need to explain
how to use the REST API with the old version of the
namespace.

*Modifications*

- Add explanation in the 2.4.1 doc and master doc
