### PR TITLE
updated link to Yahoo's open source website

### DIFF
--- a/site2/website/versioned_docs/version-2.3.1/concepts-overview.md
+++ b/site2/website/versioned_docs/version-2.3.1/concepts-overview.md
@@ -5,7 +5,7 @@ sidebar_label: Overview
 original_id: concepts-overview
 ---
 
-Pulsar is a multi-tenant, high-performance solution for server-to-server messaging. Pulsar was originally developed by [Yahoo](http://yahoo.github.io/), it is under the stewardship of the [Apache Software Foundation](https://www.apache.org/).
+Pulsar is a multi-tenant, high-performance solution for server-to-server messaging. Pulsar was originally developed by [Yahoo](http://opensource.yahoo.com/), it is under the stewardship of the [Apache Software Foundation](https://www.apache.org/).
 
 Key features of Pulsar are listed below:
 


### PR DESCRIPTION
### Motivation 

The current docs pointed to yahoo.github.io, which we decommissioned a while ago. I propose pointing this to the new webpage at opensource.yahoo.com.

### Modifications

I just changed the URL

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
No
