### PR TITLE
[Issue:5787] Fix docs for creating a K8S cluster on Minikube fail

### DIFF
--- a/deployment/kubernetes/helm/README.md
+++ b/deployment/kubernetes/helm/README.md
@@ -40,8 +40,7 @@ or `hyperkit` or `VirtualBox` on macOS.
 #### Create a K8S cluster on Minikube
 
 ```
-minikube start --memory=8192 --cpus=4 \
-    --kubernetes-version=v1.10.5
+minikube start --memory=8192 --cpus=4
 ```
 
 #### Set kubectl to use Minikube.


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #5787 

### Motivation

When we creating a K8S cluster on Minikube, due to the different versions of Minikube in the local environment, the installation fails on `--kubernetes-version=v1.10.5`.

### Modifications

- Remove the `--kubernetes-version=v1.10.5` in docs.

