### PR TITLE
Add pulsar-manager to helm chart

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-admin-secret.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-admin-secret.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.extra.pulsar_manager }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsar_manager.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+type: Opaque
+data:
+  {{- if .Values.pulsar_manager.admin}}
+  PULSAR_MANAGER_ADMIN_PASSWORD: {{ .Values.pulsar_manager.admin.password | default "pulsar" | b64enc }}
+  PULSAR_MANAGER_ADMIN_USER: {{ .Values.pulsar_manager.admin.user | default "pulsar" | b64enc }}
+  {{- end }}
+{{- end }}

--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.extra.pulsar_manager }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsar_manager.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "pulsar.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.pulsar_manager.component }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "pulsar.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ .Values.pulsar_manager.component }}
+        cluster: {{ template "pulsar.fullname" . }}
+      annotations:
+{{ toYaml .Values.pulsar_manager.annotations | indent 8 }}
+    spec:
+    {{- if .Values.pulsar_manager.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pulsar_manager.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.pulsar_manager.tolerations }}
+      tolerations:
+{{ toYaml .Values.pulsar_manager.tolerations | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.pulsar_manager.gracePeriod }}
+      containers:
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+          image: "{{ .Values.pulsar_manager.image.repository }}:{{ .Values.pulsar_manager.image.tag }}"
+          imagePullPolicy: {{ .Values.pulsar_manager.image.pullPolicy }}
+        {{- if .Values.grafana.resources }}
+          resources:
+{{ toYaml .Values.pulsar_manager.resources | indent 10 }}
+        {{- end }}
+          ports:
+          - containerPort: 9527
+          volumeMounts:
+          - name: pulsar-manager-data
+            mountPath: /data
+          env:
+          # for supporting apachepulsar/pulsar-manager
+          - name: PULSAR_CLUSTER
+            value: {{ template "pulsar.fullname" . }}
+          - name: REDIRECT_HOST
+            value: http://127.0.0.1
+          - name: REDIRECT_PORT
+            value: "9527"
+          - name: DRIVER_CLASS_NAME
+            value: org.postgresql.Driver
+          - name: URL
+            value: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
+          - name: USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: PULSAR_MANAGER_ADMIN_USER
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: PULSAR_MANAGER_ADMIN_PASSWORD
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+          - name: LOG_LEVEL
+            value: DEBUG
+      volumes:
+        - name: pulsar-manager-data
+          emptyDir: {}
+
+{{- end }}

--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-service.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-service.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.extra.pulsar_manager }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsar_manager.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+  annotations:
+{{ toYaml .Values.pulsar_manager.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.pulsar_manager.service.type }}
+  ports:
+{{ toYaml .Values.pulsar_manager.service.ports | indent 2 }}
+  selector:
+    app: {{ template "pulsar.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.pulsar_manager.component }}
+{{- end }}

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -40,7 +40,11 @@ extra:
   # Bookkeeper auto-recovery
   autoRecovery: yes
   # Pulsar dashboard
-  dashboard: yes
+  # Deprecated
+  # Replace pulsar-dashboard with pulsar-manager
+  dashboard: no
+  # pulsar manager
+  pulsar_manager: yes
   # Bastion pod for administrative commands
   bastion: yes
   # Monitoring stack (prometheus and grafana)
@@ -276,6 +280,7 @@ autoRecovery:
 
 ## Pulsar Extra: Dashboard
 ## templates/dashboard-deployment.yaml
+## Deprecated
 ##
 dashboard:
   component: dashboard
@@ -390,3 +395,37 @@ zookeeper_metadata:
     requests:
       memory: 128Mi
       cpu: 0.1
+
+## Components Stack: pulsar_manager
+## templates/pulsar-manager.yaml
+##
+
+pulsar_manager:
+  component: pulsar-manager
+  replicaCount: 1
+  # nodeSelector:
+  # cloud.google.com/gke-nodepool: default-pool
+  annotations: {}
+  tolarations: []
+  gracePeriod: 0
+  image:
+    repository: apachepulsar/pulsar-manager
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 250Mi
+      cpu: 0.1
+  ## Pulsar manager service
+  ## templates/pulsar-manager-service.yaml
+  ##
+  service:
+    type: LoadBalancer
+    annotations: {}
+    ports:
+      - name: server
+        port: 9527
+  admin:
+    user: pulsar
+    password: pulsar
+

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -40,7 +40,11 @@ extra:
   # Bookkeeper auto-recovery
   autoRecovery: yes
   # Pulsar dashboard
-  dashboard: yes
+  # Deprecated
+  # Replace pulsar-dashboard with pulsar-manager
+  dashboard: no
+  # pulsar manager
+  pulsar_manager: yes
   # Bastion pod for administrative commands
   bastion: yes
   # Monitoring stack (prometheus and grafana)
@@ -298,6 +302,7 @@ autoRecovery:
 
 ## Pulsar Extra: Dashboard
 ## templates/dashboard-deployment.yaml
+## Deprecated
 ##
 dashboard:
   component: dashboard
@@ -419,3 +424,37 @@ grafana:
     ports:
     - name: server
       port: 3000
+
+## Components Stack: pulsar_manager
+## templates/pulsar-manager.yaml
+##
+
+pulsar_manager:
+  component: pulsar-manager
+  replicaCount: 1
+  # nodeSelector:
+  # cloud.google.com/gke-nodepool: default-pool
+  annotations: {}
+  tolarations: []
+  gracePeriod: 0
+  image:
+    repository: apachepulsar/pulsar-manager
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 250Mi
+      cpu: 0.1
+  ## Pulsar manager service
+  ## templates/pulsar-manager-service.yaml
+  ##
+  service:
+    type: LoadBalancer
+    annotations: {}
+    ports:
+      - name: server
+        port: 9527
+  admin:
+    user: pulsar
+    password: pulsar
+


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Modifications

- Add [pulsar-manager](https://github.com/apache/pulsar-manager) to helm chart
- Replace pulsar-dashboard with pulsar-manager
  - Currently, we can deprecate pulsar-dashboard, In later versions, we can use `pulsar-manager` replace `pulsar-dashboard`.
