### PR TITLE
[website] Mitigate "Invalid code tab markdown" issue on translated docs

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -23,12 +23,12 @@ VERSION=`${ROOT_DIR}/src/get-project-version.py`
 
 set -x -e
 
-# ${ROOT_DIR}/site2/tools/generate-api-docs.sh
+${ROOT_DIR}/site2/tools/generate-api-docs.sh
 cd ${ROOT_DIR}/site2/website
 yarn
-# yarn write-translations
-# yarn run crowdin-upload
-# yarn run crowdin-download
+yarn write-translations
+yarn run crowdin-upload
+yarn run crowdin-download
 
 # TODO: remove this after figuring out why crowdin removed code tab when generating translated files
 # https://github.com/apache/pulsar/issues/5816

--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -23,12 +23,19 @@ VERSION=`${ROOT_DIR}/src/get-project-version.py`
 
 set -x -e
 
-${ROOT_DIR}/site2/tools/generate-api-docs.sh
+# ${ROOT_DIR}/site2/tools/generate-api-docs.sh
 cd ${ROOT_DIR}/site2/website
 yarn
-yarn write-translations
-yarn run crowdin-upload
-yarn run crowdin-download
+# yarn write-translations
+# yarn run crowdin-upload
+# yarn run crowdin-download
+
+# TODO: remove this after figuring out why crowdin removed code tab when generating translated files
+# https://github.com/apache/pulsar/issues/5816
+cp versioned_docs/version-2.4.2/functions-develop.md translated_docs/zh-CN/version-2.4.2/functions-develop.md
+cp versioned_docs/version-2.4.2/functions-develop.md translated_docs/ja/version-2.4.2/functions-develop.md
+cp versioned_docs/version-2.4.2/functions-develop.md translated_docs/fr/version-2.4.2/functions-develop.md
+
 yarn build
 
 node ./scripts/replace.js


### PR DESCRIPTION
*Motivation*

Docusaurus code tabs are removed when crowdin generated the translated docs.
It causes website failed to build.

See details: #5816

*Modifications*

Use the original file for the translated files when building the website.

Note: this is a work around. it doesn't address the root cause of #5816.

