### PR TITLE
Change log level related to batch message timer to trace

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1385,8 +1385,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (timeout.isCancelled()) {
                 return;
             }
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Batching the messages from the batch container from timer thread", topic,
+            if (log.isTraceEnabled()) {
+                log.trace("[{}] [{}] Batching the messages from the batch container from timer thread", topic,
                         producerName);
             }
             // semaphore acquired when message was enqueued to container
@@ -1427,8 +1427,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     // must acquire semaphore before enqueuing
     private void batchMessageAndSend() {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] Batching the messages from the batch container with {} messages", topic, producerName,
+        if (log.isTraceEnabled()) {
+            log.trace("[{}] [{}] Batching the messages from the batch container with {} messages", topic, producerName,
                     batchMessageContainer.getNumMessagesInBatch());
         }
         if (!batchMessageContainer.isEmpty()) {


### PR DESCRIPTION
### Motivation

Change log level related to batch message timer to trace since it will trigger every mills default which make noise when user set log level to debug.

### Modifications

Change log level related to batch message timer to trace 

### Verifying this change

Change log level only, don't need test here

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: ( no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: ( no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
