### PR TITLE
Fix a typo in functions-worker.md

### DIFF
--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -26,7 +26,7 @@ functionsWorkerEnabled=true
 
 When you set `functionsWorkerEnabled` to `true`, it means that you start functions-worker as part of a broker. You need to configure the `conf/functions_worker.yml` file to customize your functions_worker.
 
-Before you run Functions-work with broker, you have to configure Functions-worker, and then start it with brokers.
+Before you run Functions-worker with broker, you have to configure Functions-worker, and then start it with brokers.
 
 ### Configure Functions-Worker to run with brokers
 In this mode, since `functions-worker` is running as part of broker, most of the settings already inherit from your broker configuration (for example, configurationStore settings, authentication settings, and so on).


### PR DESCRIPTION
from `Functions-work` to `Functions-worker`.