### PR TITLE
[Doc][Issue 5397] Generate a complete list of connectors on the Pulsar Download Page

### DIFF
--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -21,7 +21,7 @@ module.exports = [
         name: 'data-generator',
         longName: 'Test Data Generator source',
         type: 'Source',
-        link: ''
+        link: 'https://github.com/apache/pulsar/tree/master/pulsar-io/data-generator'
     },
     {
         name: 'debezium-mysql',
@@ -45,7 +45,7 @@ module.exports = [
         name: 'file',
         longName: 'File sink',
         type: 'Sink',
-        link: null
+        link: 'https://github.com/apache/pulsar/tree/master/pulsar-io/file'
     },
     {
         name: 'flume',
@@ -87,7 +87,7 @@ module.exports = [
         name: 'jdbc',
         longName: 'JDBC sink',
         type: 'Sink',
-        link: null
+        link: 'https://github.com/apache/pulsar/tree/master/pulsar-io/jdbc'
     },
     {
         name: 'kafka-connect-adaptor',

--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -1,116 +1,170 @@
 module.exports = [
     {
         name: 'aerospike',
-        longName: 'Aerospike',
+        longName: 'Aerospike sink',
         type: 'Sink',
         link: 'https://www.aerospike.com/'
     },
     {
         name: 'canal',
-        longName: 'Alibaba Canal CDC',
+        longName: 'Alibaba Canal CDC source',
         type: 'Source',
         link: 'https://github.com/alibaba/canal'
     },
     {
         name: 'cassandra',
-        longName: 'Apache Cassandra',
+        longName: 'Apache Cassandra sink',
         type: 'Sink',
         link: 'https://cassandra.apache.org'
     },
     {
         name: 'data-generator',
-        longName: 'Test Data Generator',
+        longName: 'Test Data Generator source',
         type: 'Source',
         link: ''
     },
     {
         name: 'debezium-mysql',
-        longName: 'Debezium MySQL CDC',
+        longName: 'Debezium MySQL CDC source',
         type: 'Source',
         link: 'https://debezium.io/'
     },
     {
         name: 'debezium-postgres',
-        longName: 'Debezium PostgreSQL CDC',
+        longName: 'Debezium PostgreSQL CDC source',
         type: 'Source',
         link: 'https://debezium.io/'
     },
     {
         name: 'elastic-search',
-        longName: 'Elastic Search',
+        longName: 'ElasticSearch sink',
         type: 'Sink',
         link: 'https://www.elastic.co/'
     },
     {
         name: 'file',
-        longName: 'Read from local file',
+        longName: 'File sink',
         type: 'Sink',
         link: null
     },
     {
+        name: 'flume',
+        longName: 'Flume source',
+        type: 'Source',
+        link: 'https://flume.apache.org/'
+    },
+    {
+        name: 'flume',
+        longName: 'Flume sink',
+        type: 'Sink',
+        link: 'https://flume.apache.org/'
+    },
+    {
+        name: 'hbase',
+        longName: 'HBase sink',
+        type: 'Sink',
+        link: 'https://hbase.apache.org/'
+    },
+    {
         name: 'hdfs2',
-        longName: 'Apache HDFS v2',
+        longName: 'HDFS2 sink',
         type: 'Sink',
         link: 'https://hadoop.apache.org/'
     },
     {
         name: 'hdfs3',
-        longName: 'Apache HDFS v3',
+        longName: 'HDFS3 sink',
         type: 'Sink',
         link: 'https://hadoop.apache.org/'
     },
     {
+        name: 'influxdb',
+        longName: 'InfluxDB sink',
+        type: 'Sink',
+        link: 'https://www.influxdata.com/'
+    },
+    {
         name: 'jdbc',
-        longName: 'JDBC',
+        longName: 'JDBC sink',
         type: 'Sink',
         link: null
     },
     {
         name: 'kafka-connect-adaptor',
-        longName: 'Apache Kafka Connect Adaptor',
-        type: 'Source, Sink',
+        longName: 'Apache Kafka Connect Adaptor source',
+        type: 'Source',
+        link: 'http://kafka.apache.org/'
+    },
+    {
+        name: 'kafka-connect-adaptor',
+        longName: 'Apache Kafka Connect Adaptor sink',
+        type: 'Sink',
         link: 'http://kafka.apache.org/'
     },
     {
         name: 'kafka',
-        longName: 'Apache Kafka',
-        type: 'Source, Sink',
+        longName: 'Kafka source',
+        type: 'Source',
+        link: 'https://kafka.apache.org/'
+    },
+    {
+        name: 'kafka',
+        longName: 'Kafka sink',
+        type: 'Sink',
         link: 'https://kafka.apache.org/'
     },
     {
         name: 'kinesis',
-        longName: 'AWS Kinesis',
+        longName: 'AWS Kinesis source',
+        type: 'Source',
+        link: 'https://aws.amazon.com/kinesis/'
+    },
+    {
+        name: 'kinesis',
+        longName: 'AWS Kinesis sink',
         type: 'Sink',
         link: 'https://aws.amazon.com/kinesis/'
     },
     {
         name: 'mongo',
-        longName: 'MongoDB',
+        longName: 'MongoDB sink',
         type: 'Sink',
         link: 'https://www.mongodb.com/'
     },
     {
         name: 'netty',
-        longName: 'TCP/UDP with Netty',
+        longName: 'TCP/UDP with Netty source',
         type: 'Source',
         link: 'https://netty.io/'
     },
     {
         name: 'rabbitmq',
-        longName: 'RabbitMQ',
+        longName: 'RabbitMQ source',
         type: 'Source',
         link: 'https://www.rabbitmq.com/'
     },
     {
-        name: 'twitter',
-        longName: 'Twitter Firehose',
-        type: 'Source',
-        link: 'https://developer.twitter.com/en/docs'
+        name: 'rabbitmq',
+        longName: 'RabbitMQ sink',
+        type: 'Sink',
+        link: 'https://www.rabbitmq.com/'
     },
     {
-        name: 'influxdb',
-        longName: 'InfluxDB',
+        name: 'redis',
+        longName: 'Redis sink',
+        type: 'Sink',
+        link: 'https://redis.io/'
+    },
+    {
+        name: 'solr',
+        longName: 'Solr sink',
+        type: 'Sink',
+        link: 'https://lucene.apache.org/solr/'
+    },
+    {
+        name: 'twitter',
+        longName: 'Twitter Firehose source',
         type: 'Source',
-        link: 'https://www.influxdata.com/products/influxdb-overview/'
+        link: 'https://developer.twitter.com/en/docs'
     }
 ]


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/5397

Currently, the `Pulsar IO connectors` are incomplete on the Pulsar Download Page.
For example, `flume source`, `flume sink`, `redis sink`, and `solr sink` are not shown.

![image](https://user-images.githubusercontent.com/50226895/70791254-b75e4380-1dd1-11ea-948d-42ba9d16b64d.png)

I've added the missing ones.