### PR TITLE
Added `zookeeper.snapshot.trust.empty=true` for ZK 3.5 upgrade

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -294,7 +294,7 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 
 
-ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=*"
+ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true"
 
 #Change to PULSAR_HOME to support relative paths
 cd "$PULSAR_HOME"


### PR DESCRIPTION
### Motivation

According to https://issues.apache.org/jira/browse/ZOOKEEPER-3056 we need to pass a flag to ZK to make sure we can start it without a snapshot file, as part of the upgrade from zk-3.4.x. 

From Pulsar 2.6 on, we'll then be able to remove this flag.