### PR TITLE
[Issue 5858][helm chart] Provide better defaults for ingress tls and secretName configuration.

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
@@ -34,11 +34,13 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
   namespace: {{ .Values.namespace }}
 spec:                                                                                                                                                                                     
-{{- if .Values.dashboard.ingress.tls }}
+{{- if .Values.dashboard.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.dashboard.ingress.hostname }}
-      secretName: {{ .Values.dashboard.ingress.tls.secretName }}
+      {{- with .Values.dashboard.ingress.tls.secretName }}
+      secretName: {{ . }}
+      {{- end }}
 {{- end }}
   rules:
     - host: {{ required "Dashboard ingress hostname not provided" .Values.dashboard.ingress.hostname }}

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -331,7 +331,13 @@ dashboard:
   ingress:
     enabled: false
     annotations: {}
-    tls: {}
+    tls:
+      enabled: false
+
+      ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
+      secretName: ""
+    
+    ## Required if ingress is enabled
     hostname: ""
     path: "/"
     port: 80


### PR DESCRIPTION
Fixes #5858, provides better defaults for the Ingress object and allows TLS to be enabled with an empty secretName.

### Motivation

The current helm chart can create an Ingress with TLS, but it requires a secretName to be added. This is not an Ingress requirement and, in some cases, the ingress controller can provide a default certificate when the Ingress object does not declare one.

### Modifications

Modifications include `values.yaml` and `dashboard-ingress.yaml` to address the issue.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes - Ingress deployment on Kubernetes.

