### PR TITLE
[Issue 5857][Helm Chart] - Support to existing Storage Class with StorageClassName

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/bookkeeper-statefulset.yaml
@@ -143,7 +143,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.journal.size }}
-    {{- if .Values.bookkeeper.volumes.journal.storageClass }}
+    {{- if .Values.bookkeeper.volumes.journal.storageClassName }}
+      storageClassName: "{{ .Values.bookkeeper.volumes.journal.storageClassName }}"
+    {{- else if .Values.bookkeeper.volumes.journal.storageClass }}
       storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
     {{- end }}
   - metadata:
@@ -153,7 +155,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.ledgers.size }}
-    {{- if .Values.bookkeeper.volumes.ledgers.storageClass }}
+    {{- if .Values.bookkeeper.volumes.ledgers.storageClassName }}
+      storageClassName: "{{ .Values.bookkeeper.volumes.ledgers.storageClassName }}"
+    {{- else if .Values.bookkeeper.volumes.ledgers.storageClass }}
       storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
     {{- end }}
 {{- end }}

--- a/deployment/kubernetes/helm/pulsar/templates/prometheus-pvc.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/prometheus-pvc.yaml
@@ -29,7 +29,9 @@ spec:
     requests:
       storage: {{ .Values.prometheus.volumes.data.size }}
   accessModes: [ "ReadWriteOnce" ]
-{{- if .Values.prometheus.volumes.data.storageClass }}
+{{- if .Values.prometheus.volumes.data.storageClassName }}
+  storageClassName: "{{ .Values.prometheus.volumes.data.storageClassName }}"
+{{- else if .Values.prometheus.volumes.data.storageClass }}
   storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
 {{- end }}
 {{- end }}

--- a/deployment/kubernetes/helm/pulsar/templates/zookeeper-statefulset.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/zookeeper-statefulset.yaml
@@ -136,7 +136,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.zookeeper.volumes.data.size }}
-    {{- if .Values.zookeeper.volumes.data.storageClass }}
+    {{- if .Values.zookeeper.volumes.data.storageClassName }}
+      storageClassName: "{{ .Values.zookeeper.volumes.data.storageClassName }}"
+    {{- else if .Values.zookeeper.volumes.data.storageClass }}
       storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
     {{- end }}
 {{- end }}

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -80,8 +80,12 @@ zookeeper:
     data:
       name: data
       size: 20Gi
-      ## If the storage class is left undefined when using persistence
-      ## the default storage class for the cluster will be used.
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class
+      #
+      ## Instead if you want to create a new storage class define it below
+      ## If left undefined no storage class will be defined along with PVC
       ##
       # storageClass:
         # type: pd-ssd
@@ -146,8 +150,12 @@ bookkeeper:
     journal:
       name: journal
       size: 50Gi
-      ## If the storage class is left undefined when using persistence
-      ## the default storage class for the cluster will be used.
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class
+      #
+      ## Instead if you want to create a new storage class define it below
+      ## If left undefined no storage class will be defined along with PVC
       ##
       # storageClass:
         # type: pd-ssd
@@ -156,8 +164,12 @@ bookkeeper:
     ledgers:
       name: ledgers
       size: 50Gi
-      ## If the storage class is left undefined when using persistence
-      ## the default storage class for the cluster will be used.
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class
+      #
+      ## Instead if you want to create a new storage class define it below
+      ## If left undefined no storage class will be defined along with PVC
       ##
       # storageClass:
         # type: pd-ssd
@@ -381,8 +393,12 @@ prometheus:
     data:
       name: data
       size: 50Gi
-      ## If the storage class is left undefined when using persistence
-      ## the default storage class for the cluster will be used.
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class
+      #
+      ## Instead if you want to create a new storage class define it below
+      ## If left undefined no storage class will be defined along with PVC
       ##
       # storageClass:
         # type: pd-standard


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #5857 

### Motivation

With current aproach for specifying storage class in persistent volume claim it's not possible to customize the provisioner parameters. If the property 'storageClass' is declared the chart always create a new storage class with hardcoded parameters.

### Modifications

A property 'storageClassName' was added to support an existent storage class.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes
