### PR TITLE
[pulsar-flink]Remove improper authentication setting

### DIFF
--- a/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCount.java
+++ b/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCount.java
@@ -35,7 +35,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.connectors.pulsar.FlinkPulsarProducer;
 import org.apache.flink.streaming.connectors.pulsar.PulsarSourceBuilder;
-import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 
 /**
  * Implements a streaming wordcount program on pulsar topics.
@@ -98,7 +97,6 @@ public class PulsarConsumerSourceWordCount {
             wc.addSink(new FlinkPulsarProducer<>(
                 serviceUrl,
                 outputTopic,
-                new AuthenticationDisabled(),
                 wordWithCount -> wordWithCount.toString().getBytes(UTF_8),
                 wordWithCount -> wordWithCount.word
             )).setParallelism(parallelism);

--- a/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCountToAvroTableSink.java
+++ b/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCountToAvroTableSink.java
@@ -35,7 +35,6 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.sinks.CsvTableSink;
 import org.apache.flink.table.sinks.TableSink;
-import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 
 /**
  * Implements a streaming wordcount program on pulsar topics.
@@ -108,7 +107,7 @@ public class PulsarConsumerSourceWordCountToAvroTableSink {
         table.printSchema();
         TableSink sink = null;
         if (null != outputTopic) {
-            sink = new PulsarAvroTableSink(serviceUrl, outputTopic, new AuthenticationDisabled(), ROUTING_KEY, WordWithCount.class);
+            sink = new PulsarAvroTableSink(serviceUrl, outputTopic, ROUTING_KEY, WordWithCount.class);
         } else {
             // print the results with a csv file
             sink = new CsvTableSink("./examples/file",  "|");

--- a/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCountToJsonTableSink.java
+++ b/examples/flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/example/PulsarConsumerSourceWordCountToJsonTableSink.java
@@ -37,7 +37,6 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.sinks.CsvTableSink;
 import org.apache.flink.table.sinks.TableSink;
-import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 
 /**
  * Implements a streaming wordcount program on pulsar topics.
@@ -109,7 +108,7 @@ public class PulsarConsumerSourceWordCountToJsonTableSink {
         table.printSchema();
         TableSink sink = null;
         if (null != outputTopic) {
-            sink = new PulsarJsonTableSink(serviceUrl, outputTopic, new AuthenticationDisabled(), ROUTING_KEY);
+            sink = new PulsarJsonTableSink(serviceUrl, outputTopic, ROUTING_KEY);
         } else {
             // print the results with a csv file
             sink = new CsvTableSink("./examples/file",  "|");

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/BasePulsarOutputFormat.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -53,8 +52,7 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
     private ProducerConfigurationData producerConf;
 
 
-    protected BasePulsarOutputFormat(final String serviceUrl, final String topicName,
-        final Authentication authentication) {
+    protected BasePulsarOutputFormat(final String serviceUrl, final String topicName) {
         Preconditions.checkArgument(StringUtils.isNotBlank(serviceUrl), "serviceUrl cannot be blank.");
         Preconditions.checkArgument(StringUtils.isNotBlank(topicName),  "topicName cannot be blank.");
 
@@ -62,7 +60,6 @@ public abstract class BasePulsarOutputFormat<T> extends RichOutputFormat<T>  {
         producerConf = new ProducerConfigurationData();
 
         this.clientConf.setServiceUrl(serviceUrl);
-        this.clientConf.setAuthentication(authentication);
         this.producerConf.setTopicName(topicName);
 
         LOG.info("PulsarOutputFormat is being started to write batches to Pulsar topic: {}",

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarAvroOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarAvroOutputFormat.java
@@ -20,7 +20,6 @@ package org.apache.flink.batch.connectors.pulsar;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.flink.batch.connectors.pulsar.serialization.AvroSerializationSchema;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -31,8 +30,8 @@ public class PulsarAvroOutputFormat<T extends SpecificRecord> extends BasePulsar
 
     private static final long serialVersionUID = -6794070714728773530L;
 
-    public PulsarAvroOutputFormat(String serviceUrl, String topicName, Authentication authentication) {
-        super(serviceUrl, topicName, authentication);
+    public PulsarAvroOutputFormat(String serviceUrl, String topicName) {
+        super(serviceUrl, topicName);
         this.serializationSchema = new AvroSerializationSchema();
     }
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarCsvOutputFormat.java
@@ -20,7 +20,6 @@ package org.apache.flink.batch.connectors.pulsar;
 
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.batch.connectors.pulsar.serialization.CsvSerializationSchema;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -31,8 +30,8 @@ public class PulsarCsvOutputFormat<T extends Tuple> extends BasePulsarOutputForm
 
     private static final long serialVersionUID = -4461671510903404196L;
 
-    public PulsarCsvOutputFormat(String serviceUrl, String topicName, Authentication authentication) {
-        super(serviceUrl, topicName, authentication);
+    public PulsarCsvOutputFormat(String serviceUrl, String topicName) {
+        super(serviceUrl, topicName);
         this.serializationSchema = new CsvSerializationSchema<>();
     }
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarJsonOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarJsonOutputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.flink.batch.connectors.pulsar;
 
 import org.apache.flink.batch.connectors.pulsar.serialization.JsonSerializationSchema;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -30,8 +29,8 @@ public class PulsarJsonOutputFormat<T> extends BasePulsarOutputFormat<T> {
 
     private static final long serialVersionUID = 8499620770848461958L;
 
-    public PulsarJsonOutputFormat(String serviceUrl, String topicName, Authentication authentication) {
-        super(serviceUrl, topicName, authentication);
+    public PulsarJsonOutputFormat(String serviceUrl, String topicName) {
+        super(serviceUrl, topicName);
         this.serializationSchema = new JsonSerializationSchema();
     }
 

--- a/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/batch/connectors/pulsar/PulsarOutputFormat.java
@@ -20,7 +20,6 @@ package org.apache.flink.batch.connectors.pulsar;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.util.Preconditions;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -31,9 +30,9 @@ public class PulsarOutputFormat<T> extends BasePulsarOutputFormat<T> {
 
     private static final long serialVersionUID = 2997027580167793000L;
 
-    public PulsarOutputFormat(String serviceUrl, String topicName, Authentication authentication,
+    public PulsarOutputFormat(String serviceUrl, String topicName,
         final SerializationSchema<T> serializationSchema) {
-        super(serviceUrl, topicName, authentication);
+        super(serviceUrl, topicName);
         Preconditions.checkNotNull(serializationSchema, "serializationSchema cannot be null.");
         this.serializationSchema = serializationSchema;
     }

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarProducer.java
@@ -34,7 +34,6 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.pulsar.partitioner.PulsarKeyExtractor;
 import org.apache.flink.util.SerializableObject;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -108,18 +107,15 @@ public class FlinkPulsarProducer<T>
 
     public FlinkPulsarProducer(String serviceUrl,
                                String defaultTopicName,
-                               Authentication authentication,
                                SerializationSchema<T> serializationSchema,
                                PulsarKeyExtractor<T> keyExtractor) {
         checkArgument(StringUtils.isNotBlank(serviceUrl), "Service url cannot be blank");
         checkArgument(StringUtils.isNotBlank(defaultTopicName), "TopicName cannot be blank");
-        checkNotNull(authentication, "auth cannot be null, set disabled for no auth");
 
         clientConf = new ClientConfigurationData();
         producerConf = new ProducerConfigurationData();
 
         this.clientConf.setServiceUrl(serviceUrl);
-        this.clientConf.setAuthentication(authentication);
         this.producerConf.setTopicName(defaultTopicName);
         this.schema = checkNotNull(serializationSchema, "Serialization Schema not set");
         this.flinkPulsarKeyExtractor = getOrNullKeyExtractor(keyExtractor);

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarAvroTableSink.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarAvroTableSink.java
@@ -37,7 +37,6 @@ import org.apache.flink.streaming.connectors.pulsar.partitioner.PulsarKeyExtract
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -65,18 +64,15 @@ public class PulsarAvroTableSink implements AppendStreamTableSink<Row> {
     public PulsarAvroTableSink(
             String serviceUrl,
             String topic,
-            Authentication authentication,
             String routingKeyFieldName,
             Class<? extends SpecificRecord> recordClazz) {
         checkArgument(StringUtils.isNotBlank(serviceUrl), "Service url not set");
         checkArgument(StringUtils.isNotBlank(topic), "Topic is null");
-        checkNotNull(authentication, "authentication is null, set new AuthenticationDisabled() instead");
 
         clientConfigurationData = new ClientConfigurationData();
         producerConfigurationData = new ProducerConfigurationData();
 
         clientConfigurationData.setServiceUrl(serviceUrl);
-        clientConfigurationData.setAuthentication(authentication);
         producerConfigurationData.setTopicName(topic);
         this.routingKeyFieldName = routingKeyFieldName;
         this.recordClazz = recordClazz;

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSink.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarJsonTableSink.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.json.JsonRowSerializationSchema;
 import org.apache.flink.types.Row;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -36,15 +35,13 @@ public class PulsarJsonTableSink extends PulsarTableSink {
      *
      * @param serviceUrl          pulsar service url
      * @param topic               topic in pulsar to which table is written
-     * @param authentication      authetication info required by pulsar client
      * @param routingKeyFieldName routing key field name
      */
     public PulsarJsonTableSink(
             String serviceUrl,
             String topic,
-            Authentication authentication,
             String routingKeyFieldName) {
-        super(serviceUrl, topic, authentication, routingKeyFieldName);
+        super(serviceUrl, topic, routingKeyFieldName);
     }
 
     public PulsarJsonTableSink(

--- a/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSink.java
+++ b/pulsar-flink/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSink.java
@@ -33,7 +33,6 @@ import org.apache.flink.streaming.connectors.pulsar.partitioner.PulsarKeyExtract
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -53,12 +52,10 @@ public abstract class PulsarTableSink implements AppendStreamTableSink<Row> {
     public PulsarTableSink(
             String serviceUrl,
             String topic,
-            Authentication authentication,
             String routingKeyFieldName) {
         checkNotNull(serviceUrl, "Service url not set");
         checkNotNull(topic, "Topic is null");
         this.clientConfigurationData.setServiceUrl(serviceUrl);
-        this.clientConfigurationData.setAuthentication(authentication);
         this.producerConfigurationData.setTopicName(topic);
         this.routingKeyFieldName = routingKeyFieldName;
     }


### PR DESCRIPTION
### Motivation

When Pulsar Client is used in Flink source/sinks, the Source/Sink functions such as `FlinkPulsarProducer`, `PulsarOutputFormat` would be constructed in user code at the driver side, and then serialized and deserialized to be used in Flink source/sink tasks. 

Therefore, when setting `Authentication` field of `ClientConfigurationData`, which is a transient field, the tasks that do the actual read/write cannot get the authentication object when it is constructed in the user code. 

In order to do the authentication in read/write tasks, the only way is to use `ClientConfigurationData`'s `authPluginClassName` and `authParams` fields. They will be used to construct `Authentication` object at the time to create PulsarClient object, this happens inside flink tasks.

### Modifications

Remove improper authentication object setting/generation in user code. Leave `authPluginClassName` and `authPluginClassName` as they are until get used in actual PulsarClient construction.

### Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: (yes)

### Documentation

  - Does this pull request introduce a new feature? (no)
