### PR TITLE
[Issue 5839][website]Fix version replace for old version document

### DIFF
--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -166,12 +166,12 @@ for (v of versions) {
   }
   const vWithoutIncubating = v.replace('-incubating', '');
   const opts = {
-      files: [
-          `${docsDir}/${v}/*.html`,
-          `${docsDir}/${v}/**/*.html`,
-          `${docsDir}/en/${v}/*.html`,
-          `${docsDir}/en/${v}/**/*.html`
-      ],
+    files: [
+      `${docsDir}/${v}/*.html`,
+      `${docsDir}/${v}/**/*.html`,
+      `${docsDir}/en/${v}/*.html`,
+      `${docsDir}/en/${v}/**/*.html`
+    ],
     from: from,
     to: [
       `${vWithoutIncubating}`,

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -130,6 +130,7 @@ const options = {
     `${docsDir}/*.html`,
     `${docsDir}/**/*.html`
   ],
+  // TODO add next and assets
   ignore: versions.map(v => `${docsDir}/${v}/**/*`).concat(versions.map(v => `${docsDir}/en/${v}/**/*`)),
   from: from,
   to: [

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -130,7 +130,7 @@ const options = {
     `${docsDir}/*.html`,
     `${docsDir}/**/*.html`
   ],
-  ignore: versions.map(v => `${docsDir}/${v}/**/*`), // TODO add next and assets
+  ignore: versions.map(v => `${docsDir}/${v}/**/*`).concat(versions.map(v => `${docsDir}/en/${v}/**/*`)),
   from: from,
   to: [
     `${latestVersionWithoutIncubating}`,
@@ -165,10 +165,12 @@ for (v of versions) {
   }
   const vWithoutIncubating = v.replace('-incubating', '');
   const opts = {
-    files: [
-      `${docsDir}/${v}/*.html`,
-      `${docsDir}/${v}/**/*.html`
-    ],
+      files: [
+          `${docsDir}/${v}/*.html`,
+          `${docsDir}/${v}/**/*.html`,
+          `${docsDir}/en/${v}/*.html`,
+          `${docsDir}/en/${v}/**/*.html`
+      ],
     from: from,
     to: [
       `${vWithoutIncubating}`,
@@ -183,7 +185,7 @@ for (v of versions) {
       debReleaseUrl(`${v}`, ""),
       debReleaseUrl(`${v}`, "-dev"),
     ],
-    dry: true
+    dry: false
   };
   doReplace(opts);
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/5839


Master Issue: https://github.com/apache/pulsar/issues/5839

### Motivation

Currently, for different contents, we use the same variables in multiple versions.

### Modifications

* When replacing the latest version, the old version is ignored
* Set option `dry` to false for enable replace

### Verifying this change

yarn build
node scripts/replace.js