### PR TITLE
[issue 5847][dashboard] postgresql correct version (9.6 to 11)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update
 RUN apt-get -y install postgresql python sudo nginx supervisor
 
 # Postgres configuration
-COPY conf/postgresql.conf /etc/postgresql/9.6/main/
+COPY conf/postgresql.conf /etc/postgresql/11/main/
 
 # Configure nginx and supervisor
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/dashboard/conf/postgresql.conf
+++ b/dashboard/conf/postgresql.conf
@@ -24,15 +24,15 @@ synchronous_commit = off
 
 # Default configs
 data_directory = '/data'
-hba_file = '/etc/postgresql/9.6/main/pg_hba.conf'
-ident_file = '/etc/postgresql/9.6/main/pg_ident.conf'
-external_pid_file = '/var/run/postgresql/9.6-main.pid'
+hba_file = '/etc/postgresql/11/main/pg_hba.conf'
+ident_file = '/etc/postgresql/11/main/pg_ident.conf'
+external_pid_file = '/var/run/postgresql/11-main.pid'
 
 port = 5432
 max_connections = 100
 
 datestyle = 'iso, mdy'
 default_text_search_config = 'pg_catalog.english'
-stats_temp_directory = '/var/run/postgresql/9.6-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/11-main.pg_stat_tmp'
 timezone = 'UTC'
 log_timezone = 'UTC'

--- a/dashboard/init-postgres.sh
+++ b/dashboard/init-postgres.sh
@@ -23,7 +23,7 @@ set -x -e
 rm -rf /data/*
 chown -R postgres: /data
 chmod 700 /data
-sudo -u postgres /usr/lib/postgresql/9.6/bin/initdb /data/
+sudo -u postgres /usr/lib/postgresql/11/bin/initdb /data/
 sudo -u postgres /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE USER docker WITH PASSWORD 'docker';"
 sudo -u postgres createdb -O docker pulsar_dashboard

--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -37,13 +37,13 @@ COPY --from=dashboard /pulsar/conf/* /pulsar/conf/
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update
-RUN apt-get -y install python2.7 python-pip postgresql-9.6 sudo nginx supervisor libpq-dev
+RUN apt-get -y install python2.7 python-pip postgresql-11 sudo nginx supervisor libpq-dev
 
 # Python dependencies
 RUN pip2 install -r /pulsar/django/requirements.txt 
 
 # Postgres configuration
-COPY --from=dashboard /etc/postgresql/9.6/main/postgresql.conf /etc/postgresql/9.6/main/postgresql.conf
+COPY --from=dashboard /etc/postgresql/11/main/postgresql.conf /etc/postgresql/11/main/postgresql.conf
 
 # Configure supervisor
 COPY --from=dashboard /etc/supervisor/conf.d/supervisor-app.conf /etc/supervisor/conf.d/supervisor-app.conf


### PR DESCRIPTION
Fixes #5847 

### Motivation

Pulsar dashboard was not starting correctly anymore because the PostgreSQL version pulled by the docker image was not 9.6 anymore but 11.

### Modifications

I have changed references to 9.6 version with 11 version. Maybe I could have made something more automatic, like looking for the version without hardcoding it, but I am not very confident with this king of stuff :)

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - **Dependencies (does it add or upgrade a dependency): (yes) => Dashboard comes with PostgreSQL 11 now**
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - **Anything that affects deployment: don't know => Dashboard doesn't look like a big deal for Pulsar but a database version can affects deployment**

### Documentation

  - Does this pull request introduce a new feature? no
