### PR TITLE
[Issue 5832][Pulsar IO]Fix npe of debezium delete event

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -142,7 +142,13 @@ public class KafkaConnectSource implements Source<KeyValue<byte[], byte[]>> {
                 currentBatch = recordList.iterator();
             }
             if (currentBatch.hasNext()) {
-                return processSourceRecord(currentBatch.next());
+                Record<KeyValue<byte[], byte[]>> processRecord = processSourceRecord(currentBatch.next());
+                if (processRecord.getValue().getValue() == null) {
+                    outstandingRecords.decrementAndGet();
+                    continue;
+                } else {
+                    return processRecord;
+                }
             } else {
                 // there is no records any more, then waiting for the batch to complete writing
                 // to sink and the offsets are committed as well, then do next round read.

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -2109,6 +2109,18 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         // validate the source result
         sourceTester.validateSourceResult(consumer, 9);
 
+        // prepare insert event
+        sourceTester.prepareInsertEvent();
+
+        // validate the source insert event
+        sourceTester.validateSourceResult(consumer, 1);
+
+        // prepare delete event
+        sourceTester.prepareDeleteEvent();
+
+        // validate the source delete event
+        sourceTester.validateSourceResult(consumer, 1);
+
         // delete the source
         deleteSource(tenant, namespace, sourceName);
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -2107,19 +2107,25 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 waitForProcessingSourceMessages(tenant, namespace, sourceName, numMessages));
 
         // validate the source result
-        sourceTester.validateSourceResult(consumer, 9);
+        sourceTester.validateSourceResult(consumer, 9, null);
 
         // prepare insert event
         sourceTester.prepareInsertEvent();
 
         // validate the source insert event
-        sourceTester.validateSourceResult(consumer, 1);
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.INSERT);
+
+        // prepare update event
+        sourceTester.prepareUpdateEvent();
+
+        // validate the source update event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.UPDATE);
 
         // prepare delete event
         sourceTester.prepareDeleteEvent();
 
         // validate the source delete event
-        sourceTester.validateSourceResult(consumer, 1);
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.DELETE);
 
         // delete the source
         deleteSource(tenant, namespace, sourceName);
@@ -2176,7 +2182,25 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 waitForProcessingSourceMessages(tenant, namespace, sourceName, numMessages));
 
         // validate the source result
-        sourceTester.validateSourceResult(consumer, 9);
+        sourceTester.validateSourceResult(consumer, 9, null);
+
+        // prepare insert event
+        sourceTester.prepareInsertEvent();
+
+        // validate the source insert event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.INSERT);
+
+        // prepare update event
+        sourceTester.prepareUpdateEvent();
+
+        // validate the source update event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.UPDATE);
+
+        // prepare delete event
+        sourceTester.prepareDeleteEvent();
+
+        // validate the source delete event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.DELETE);
 
         // delete the source
         deleteSource(tenant, namespace, sourceName);
@@ -2232,7 +2256,25 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 waitForProcessingSourceMessages(tenant, namespace, sourceName, numMessages));
 
         // validate the source result
-        sourceTester.validateSourceResult(consumer, 9);
+        sourceTester.validateSourceResult(consumer, 9, null);
+
+        // prepare insert event
+        sourceTester.prepareInsertEvent();
+
+        // validate the source insert event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.INSERT);
+
+        // prepare update event
+        sourceTester.prepareUpdateEvent();
+
+        // validate the source update event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.UPDATE);
+
+        // prepare delete event
+        sourceTester.prepareDeleteEvent();
+
+        // validate the source delete event
+        sourceTester.validateSourceResult(consumer, 1, SourceTester.DELETE);
 
         // delete the source
         deleteSource(tenant, namespace, sourceName);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMongoDbSourceTester.java
@@ -67,17 +67,39 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
 
     @Override
     public void prepareInsertEvent() throws Exception {
-
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.insert({ " +
+                        "_id : NumberLong(\"110\")," +
+                        "name : \"test-debezium\"," +
+                        "description: \"24 inch spare tire\"," +
+                        "weight : 22.2," +
+                        "quantity : NumberInt(\"5\")})'");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
-
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
-
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
+        this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
+                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.update({" +
+                        "_id : 110}," +
+                        "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMongoDbSourceTester.java
@@ -66,6 +66,21 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
     }
 
     @Override
+    public void prepareInsertEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareDeleteEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareUpdateEvent() throws Exception {
+
+    }
+
+    @Override
     public Map<String, String> produceSourceMessages(int numMessages) throws Exception {
         log.info("debezium mongodb server already contains preconfigured data.");
         return null;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMySqlSourceTester.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.tests.integration.io;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import afu.org.checkerframework.checker.oigj.qual.O;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
@@ -79,6 +81,34 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
     public void prepareSource() throws Exception {
         log.info("debezium mysql server already contains preconfigured data.");
     }
+
+    @Override
+    public void prepareInsertEvent() throws Exception {
+        this.debeziumMySqlContainer.execCmd(
+                "bash", "-c",
+                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
+        this.debeziumMySqlContainer.execCmd( "bash", "-c",
+                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium",
+                "-e", "INSERT INTO inventory.products(name, description, weight) values('debezium', 'This is description', 2.0);");
+    }
+
+    @Override
+    public void prepareUpdateEvent() throws Exception {
+    }
+
+    @Override
+    public void prepareDeleteEvent() throws Exception {
+        this.debeziumMySqlContainer.execCmd(
+                "bash", "-c",
+                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
+        this.debeziumMySqlContainer.execCmd( "bash", "-c",
+                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium",
+                "-e", "DELETE FROM inventory.products WHERE name='debezium';");
+        this.debeziumMySqlContainer.execCmd(
+                "bash", "-c",
+                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
+    }
+
 
     @Override
     public Map<String, String> produceSourceMessages(int numMessages) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumMySqlSourceTester.java
@@ -20,19 +20,12 @@ package org.apache.pulsar.tests.integration.io;
 
 import java.io.Closeable;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import afu.org.checkerframework.checker.oigj.qual.O;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.impl.schema.ByteSchema;
-import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.tests.integration.containers.DebeziumMySQLContainer;
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
-import org.testng.Assert;
 
 /**
  * A tester for testing Debezium MySQL source.
@@ -85,28 +78,36 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
     @Override
     public void prepareInsertEvent() throws Exception {
         this.debeziumMySqlContainer.execCmd(
-                "bash", "-c",
-                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
-        this.debeziumMySqlContainer.execCmd( "bash", "-c",
-                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium",
-                "-e", "INSERT INTO inventory.products(name, description, weight) values('debezium', 'This is description', 2.0);");
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium -e 'SELECT * FROM inventory.products'");
+        this.debeziumMySqlContainer.execCmd(
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium " +
+                        "-e \"INSERT INTO inventory.products(name, description, weight) " +
+                        "values('test-debezium', 'This is description', 2.0)\"");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
+        this.debeziumMySqlContainer.execCmd(
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium " +
+                        "-e \"UPDATE inventory.products set description='update description', weight=10 " +
+                        "WHERE name='test-debezium'\"");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
         this.debeziumMySqlContainer.execCmd(
-                "bash", "-c",
-                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
-        this.debeziumMySqlContainer.execCmd( "bash", "-c",
-                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium",
-                "-e", "DELETE FROM inventory.products WHERE name='debezium';");
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium -e 'SELECT * FROM inventory.products'");
         this.debeziumMySqlContainer.execCmd(
-                "bash", "-c",
-                "mysql", "-h", "127.0.0.1", "-u", "root", "-pdebezium", "-e", "SELECT * FROM  inventory.products;");
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium " +
+                        "-e \"DELETE FROM inventory.products WHERE name='test-debezium'\"");
+        this.debeziumMySqlContainer.execCmd(
+                "/bin/bash", "-c",
+                "mysql -h 127.0.0.1 -u root -pdebezium -e 'SELECT * FROM inventory.products'");
     }
 
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgreSqlSourceTester.java
@@ -83,6 +83,21 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
     }
 
     @Override
+    public void prepareInsertEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareDeleteEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareUpdateEvent() throws Exception {
+
+    }
+
+    @Override
     public Map<String, String> produceSourceMessages(int numMessages) {
         log.info("debezium postgresql server already contains preconfigured data.");
         return null;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/DebeziumPostgreSqlSourceTester.java
@@ -20,17 +20,12 @@ package org.apache.pulsar.tests.integration.io;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.tests.integration.containers.DebeziumPostgreSqlContainer;
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
-import org.testng.Assert;
 
 import java.io.Closeable;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A tester for testing Debezium Postgresql source.
@@ -84,17 +79,31 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
 
     @Override
     public void prepareInsertEvent() throws Exception {
-
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres -c \"select * from inventory.products;\"");
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres " +
+                        "-c \"insert into inventory.products(name, description, weight) " +
+                        "values('test-debezium', 'description', 10);\"");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
-
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres -c \"select * from inventory.products;\"");
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres " +
+                        "-c \"delete from inventory.products where name='test-debezium';\"");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
-
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres -c \"select * from inventory.products;\"");
+        this.debeziumPostgresqlContainer.execCmd("/bin/bash", "-c",
+                "psql -h 127.0.0.1 -U postgres -d postgres " +
+                        "-c \"update inventory.products " +
+                        "set description='test-update-description', weight='20' where name='test-debezium';\"");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/KafkaSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/KafkaSourceTester.java
@@ -103,17 +103,17 @@ public class KafkaSourceTester extends SourceTester<KafkaContainer> {
 
     @Override
     public void prepareInsertEvent() throws Exception {
-
+        // pass
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
-
+        // pass
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
-
+        // pass
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/KafkaSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/KafkaSourceTester.java
@@ -102,6 +102,21 @@ public class KafkaSourceTester extends SourceTester<KafkaContainer> {
     }
 
     @Override
+    public void prepareInsertEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareDeleteEvent() throws Exception {
+
+    }
+
+    @Override
+    public void prepareUpdateEvent() throws Exception {
+
+    }
+
+    @Override
     public Map<String, String> produceSourceMessages(int numMessages) throws Exception{
         KafkaProducer<String, String> producer = new KafkaProducer<>(
                 ImmutableMap.of(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
@@ -37,6 +37,12 @@ import org.testng.collections.Maps;
 @Slf4j
 public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
 
+    public final static String INSERT = "INSERT";
+
+    public final static String DELETE = "DELETE";
+
+    public final static String UPDATE = "UPDATE";
+
     protected final String sourceType;
     protected final Map<String, Object> sourceConfig;
 
@@ -65,7 +71,7 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
 
     public abstract Map<String, String> produceSourceMessages(int numMessages) throws Exception;
 
-    public void validateSourceResult(Consumer<KeyValue<byte[], byte[]>> consumer, int number) throws Exception {
+    public void validateSourceResult(Consumer<KeyValue<byte[], byte[]>> consumer, int number, String eventType) throws Exception {
         int recordsNumber = 0;
         Message<KeyValue<byte[], byte[]>> msg = consumer.receive(2, TimeUnit.SECONDS);
         while(msg != null) {
@@ -75,6 +81,9 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
             log.info("Received message: key = {}, value = {}.", key, value);
             Assert.assertTrue(key.contains(this.keyContains()));
             Assert.assertTrue(value.contains(this.valueContains()));
+            if (eventType != null) {
+                Assert.assertTrue(value.contains(this.eventContains(eventType)));
+            }
             consumer.acknowledge(msg);
             msg = consumer.receive(1, TimeUnit.SECONDS);
         }
@@ -87,5 +96,15 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
     }
     public String valueContains(){
         return "dbserver1.inventory.products.Value";
+    }
+
+    public String eventContains(String eventType) {
+        if (eventType.equals(INSERT)) {
+            return "\"op\":\"c\"";
+        } else if (eventType.equals(UPDATE)) {
+            return "\"op\":\"u\"";
+        } else {
+            return "\"op\":\"d\"";
+        }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
@@ -57,6 +57,12 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
 
     public abstract void prepareSource() throws Exception;
 
+    public abstract void prepareInsertEvent() throws Exception;
+
+    public abstract void prepareDeleteEvent() throws Exception;
+
+    public abstract void prepareUpdateEvent() throws Exception;
+
     public abstract Map<String, String> produceSourceMessages(int numMessages) throws Exception;
 
     public void validateSourceResult(Consumer<KeyValue<byte[], byte[]>> consumer, int number) throws Exception {


### PR DESCRIPTION

Fixes https://github.com/apache/pulsar/issues/5832

Master Issue: https://github.com/apache/pulsar/issues/5832

### Motivation

Currently, in debezium, for delete events, in order to be compatible with Kafka's compaction, each delete event will be followed by a record with a null value. For records with a null value, the null value is not currently processed in pulsar, resulting in an exception of throwing a null pointer. Now, we considered to ignore the null value or use it in combination with pulsar's compaction feature in the future.

![image](https://user-images.githubusercontent.com/1907867/70976050-21cef680-20e6-11ea-963f-56471c915c98.png)
https://debezium.io/documentation/reference/0.10/connectors/mysql.html

### Modifications

* Ignore the record of the null value.
* Add more integrations, such as insert, delete, update.

### Verifying this change

Integrations test pass