### PR TITLE
[Issue 5269][Integration tests]Improve integration testing for debezium

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -2073,6 +2073,16 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
+        try {
+            // If topic already exists, we should delete it so as not to affect the following tests.
+            admin.topics().getStats(consumeTopicName);
+            admin.topics().delete(consumeTopicName);
+            admin.schemas().deleteSchema(consumeTopicName);
+        } catch (PulsarAdminException e) {
+            // Expected results, ignoring the exception
+            log.info("Topic: {} does not exist, we can continue the following tests. Exceptions message: {}",
+                    consumeTopicName, e.getMessage());
+        }
         admin.topics().createNonPartitionedTopic(consumeTopicName);
         admin.topics().createNonPartitionedTopic(outputTopicName);
 
@@ -2134,6 +2144,21 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 .build();
 
         @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
+        try {
+            // If topic already exists, we should delete it so as not to affect the following tests.
+            admin.topics().getStats(consumeTopicName);
+            admin.topics().delete(consumeTopicName);
+            admin.schemas().deleteSchema(consumeTopicName);
+        } catch (PulsarAdminException e) {
+            // Expected results, ignoring the exception
+            log.info("Topic: {} does not exist, we can continue the following tests. Exceptions message: {}",
+                    consumeTopicName, e.getMessage());
+        }
+        admin.topics().createNonPartitionedTopic(consumeTopicName);
+        admin.topics().createNonPartitionedTopic(outputTopicName);
+
+        @Cleanup
         Consumer<KeyValue<byte[], byte[]>> consumer = client.newConsumer(KeyValueSchema.kvBytes())
                 .topic(consumeTopicName)
                 .subscriptionName("debezium-source-tester")
@@ -2189,6 +2214,21 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         PulsarClient client = PulsarClient.builder()
                 .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
                 .build();
+
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
+        try {
+            // If topic already exists, we should delete it so as not to affect the following tests.
+            admin.topics().getStats(consumeTopicName);
+            admin.topics().delete(consumeTopicName);
+            admin.schemas().deleteSchema(consumeTopicName);
+        } catch (PulsarAdminException e) {
+            // Expected results, ignoring the exception
+            log.info("Topic: {} does not exist, we can continue the following tests. Exceptions message: {}",
+                    consumeTopicName, e.getMessage());
+        }
+        admin.topics().createNonPartitionedTopic(consumeTopicName);
+        admin.topics().createNonPartitionedTopic(outputTopicName);
 
         @Cleanup
         Consumer<KeyValue<byte[], byte[]>> consumer = client.newConsumer(KeyValueSchema.kvBytes())


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/5269


Master Issue: https://github.com/apache/pulsar/issues/5269

### Motivation

The current logic for debezium integration testing is that if there is an error in the test, it will retry, but the data of the old topic still exists during the retry, and then there will be a record mismatch during verification. However, the exception during the first error cannot be correctly thrown, making it difficult to find the real error during debugging. Therefore, the pull request aims to solve this problem. During the retry, the pull request will first check whether the topic exists and if so, delete it first, and then create an empty topic. Note that the purpose of this pull request is to throw out a real exception so that we can find problems in time.


### Modifications

* Add delete topic logic for debezium test

### Verifying this change

Integration tests pass
