### PR TITLE
[Pulsar IO] Allow routing key per message to RabbitMQ sink connector

### DIFF
--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
@@ -83,12 +83,6 @@ public class RabbitMQAbstractConfig implements Serializable {
     private String password = "guest";
 
     @FieldDoc(
-        required = true,
-        defaultValue = "",
-        help = "The RabbitMQ queue name from which messages should be read from or written to")
-    private String queueName;
-
-    @FieldDoc(
         required = false,
         defaultValue = "0",
         help = "Initially requested maximum channel number. 0 for unlimited")
@@ -123,7 +117,6 @@ public class RabbitMQAbstractConfig implements Serializable {
         Preconditions.checkNotNull(port, "port property not set.");
         Preconditions.checkNotNull(virtualHost, "virtualHost property not set.");
         Preconditions.checkNotNull(connectionName, "connectionName property not set.");
-        Preconditions.checkNotNull(queueName, "queueName property not set.");
     }
 
     public ConnectionFactory createConnectionFactory() {

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
@@ -51,10 +51,10 @@ public class RabbitMQSinkConfig extends RabbitMQAbstractConfig implements Serial
     private String exchangeName;
 
     @FieldDoc(
-        required = true,
-        defaultValue = "",
-        help = "The routing key used for publishing the messages")
-    private String routingKey;
+        required = false,
+        defaultValue = "topic",
+        help = "The exchange type to publish the messages on")
+    private String exchangeType = "topic";
 
     public static RabbitMQSinkConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -70,6 +70,5 @@ public class RabbitMQSinkConfig extends RabbitMQAbstractConfig implements Serial
     public void validate() {
         super.validate();
         Preconditions.checkNotNull(exchangeName, "exchangeName property not set.");
-        Preconditions.checkNotNull(routingKey, "routingKey property not set.");
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -45,6 +45,12 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
     private static final long serialVersionUID = 1L;
 
     @FieldDoc(
+        required = true,
+        defaultValue = "",
+        help = "The RabbitMQ queue name from which messages should be read from or written to")
+    private String queueName;
+
+    @FieldDoc(
         required = false,
         defaultValue = "0",
         help = "Maximum number of messages that the server will deliver, 0 for unlimited")
@@ -69,6 +75,7 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
     @Override
     public void validate() {
         super.validate();
+        Preconditions.checkNotNull(queueName, "queueName property not set.");
         Preconditions.checkArgument(prefetchCount >= 0, "prefetchCount must be non-negative.");
     }
 }

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
@@ -44,7 +44,6 @@ public class RabbitMQSinkConfigTest {
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
-        assertEquals("test-queue", config.getQueueName());
         assertEquals("test-connection", config.getConnectionName());
         assertEquals(Integer.parseInt("0"), config.getRequestedChannelMax());
         assertEquals(Integer.parseInt("0"), config.getRequestedFrameMax());
@@ -63,7 +62,6 @@ public class RabbitMQSinkConfigTest {
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
-        map.put("queueName", "test-queue");
         map.put("connectionName", "test-connection");
         map.put("requestedChannelMax", "0");
         map.put("requestedFrameMax", "0");
@@ -80,7 +78,6 @@ public class RabbitMQSinkConfigTest {
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
-        assertEquals("test-queue", config.getQueueName());
         assertEquals("test-connection", config.getConnectionName());
         assertEquals(Integer.parseInt("0"), config.getRequestedChannelMax());
         assertEquals(Integer.parseInt("0"), config.getRequestedFrameMax());
@@ -99,7 +96,6 @@ public class RabbitMQSinkConfigTest {
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
-        map.put("queueName", "test-queue");
         map.put("connectionName", "test-connection");
         map.put("requestedChannelMax", "0");
         map.put("requestedFrameMax", "0");
@@ -122,7 +118,6 @@ public class RabbitMQSinkConfigTest {
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
-        map.put("queueName", "test-queue");
         map.put("connectionName", "test-connection");
         map.put("requestedChannelMax", "0");
         map.put("requestedFrameMax", "0");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
@@ -52,7 +52,7 @@ public class RabbitMQSinkConfigTest {
         assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
         assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
         assertEquals("test-exchange", config.getExchangeName());
-        assertEquals("test-key", config.getRoutingKey());
+        assertEquals("test-exchange-type", config.getExchangeType());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class RabbitMQSinkConfigTest {
         map.put("handshakeTimeout", "10000");
         map.put("requestedHeartbeat", "60");
         map.put("exchangeName", "test-exchange");
-        map.put("routingKey", "test-key");
+        map.put("exchangeType", "test-exchange-type");
 
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
         assertNotNull(config);
@@ -88,7 +88,7 @@ public class RabbitMQSinkConfigTest {
         assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
         assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
         assertEquals("test-exchange", config.getExchangeName());
-        assertEquals("test-key", config.getRoutingKey());
+        assertEquals("test-exchange-type", config.getExchangeType());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class RabbitMQSinkConfigTest {
         map.put("handshakeTimeout", "10000");
         map.put("requestedHeartbeat", "60");
         map.put("exchangeName", "test-exchange");
-        map.put("routingKey", "test-key");
+        map.put("exchangeType", "test-exchange-type");
 
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
         config.validate();
@@ -129,7 +129,7 @@ public class RabbitMQSinkConfigTest {
         map.put("connectionTimeout", "60000");
         map.put("handshakeTimeout", "10000");
         map.put("requestedHeartbeat", "60");
-        map.put("routingKey", "test-key");
+        map.put("exchangeType", "test-exchange-type");
 
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
         config.validate();

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -61,7 +61,7 @@ public class RabbitMQSinkTest {
         configs.put("handshakeTimeout", "10000");
         configs.put("requestedHeartbeat", "60");
         configs.put("exchangeName", "test-exchange");
-        configs.put("routingKey", "test-key");
+        configs.put("exchangeType", "fanout");
 
         RabbitMQSink sink = new RabbitMQSink();
 
@@ -69,13 +69,13 @@ public class RabbitMQSinkTest {
         sink.open(configs, null);
 
         // write should success
-        Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue");
+        Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");
         sink.write(record);
 
         sink.close();
     }
 
-    private Record<byte[]> build(String topic, String key, String value) {
+    private Record<byte[]> build(String topic, String key, String value, String routingKey) {
         // prepare a SinkRecord
         SinkRecord<byte[]> record = new SinkRecord<>(new Record<byte[]>() {
             @Override
@@ -95,6 +95,15 @@ public class RabbitMQSinkTest {
                 } else {
                     return Optional.empty();
                 }
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                return new HashMap<String, String>() {
+                    {
+                        put("routingKey", routingKey);
+                    }
+                };
             }
         }, value.getBytes(StandardCharsets.UTF_8));
         return record;

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -53,7 +53,6 @@ public class RabbitMQSinkTest {
         configs.put("virtualHost", "default");
         configs.put("username", "guest");
         configs.put("password", "guest");
-        configs.put("queueName", "test-queue");
         configs.put("connectionName", "test-connection");
         configs.put("requestedChannelMax", "0");
         configs.put("requestedFrameMax", "0");

--- a/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
@@ -23,7 +23,6 @@
 "virtualHost": "/",
 "username": "guest",
 "password": "guest",
-"queueName": "test-queue",
 "connectionName": "test-connection",
 "requestedChannelMax": "0",
 "requestedFrameMax": "0",
@@ -31,5 +30,5 @@
 "handshakeTimeout": "10000",
 "requestedHeartbeat": "60",
 "exchangeName": "test-exchange",
-"exchangeType": "fanout"
+"exchangeType": "test-exchange-type"
 }

--- a/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
@@ -31,6 +31,5 @@
 "handshakeTimeout": "10000",
 "requestedHeartbeat": "60",
 "exchangeName": "test-exchange",
-"routingKey": "test-key"
-
+"exchangeType": "fanout"
 }


### PR DESCRIPTION
### Motivation

With the current RabbitMQ sink connector, all messages are forwarded to an exchange with the same routing key (specified in the configuration). It would be great to give a bit more flexibility and allow the use of different routing keys for different messages on the same topic.

### Modifications

The creation of the queue has been removed from the sink, all messages will be forwarded to the exchange and each consumer will create it's on queue + binding.

The configuration has been modified to reflect those changes: added the exchange type and queue name is just required for the source connector.
