### PR TITLE
Use BOOKIE_MEM and BOOKIE_GC env vars if set.

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -33,10 +33,10 @@ BOOKIE_CONF=${BOOKIE_CONF:-"$BK_HOME/conf/bookkeeper.conf"}
 # BOOKIE_LOG_DIR=
 
 # Memory size options
-BOOKIE_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"
+BOOKIE_MEM=${BOOKIE_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"}
 
 # Garbage collection options
-BOOKIE_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
+BOOKIE_GC=${BOOKIE_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"}
 
 # Extra options to be passed to the jvm
 BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} ${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"


### PR DESCRIPTION
Use BOOKIE_MEM and BOOKIE_GC if they have already been set. This removes the need to overwrite the bkenv.sh config file and this is useful when running in a container environment.