### PR TITLE
Fix topic owner check while namespace bundles cache invalidate.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -839,10 +839,10 @@ public class NamespaceService {
 
     private boolean isTopicOwned(TopicName topicName) throws Exception {
         Optional<NamespaceBundle> bundle = getBundleIfPresent(topicName);
-        if (!bundle.isPresent()) {
-            return false;
-        } else {
+        if (bundle.isPresent()) {
             return ownershipCache.getOwnedBundle(bundle.get()) != null;
+        } else {
+            return ownershipCache.getOwnedBundle(getBundle(topicName)) != null;
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -56,7 +56,7 @@ public class TopicOwnerTest {
 
     @BeforeMethod
     void setup() throws Exception {
-        log.info("---- Initializing SLAMonitoringTest -----");
+        log.info("---- Initializing TopicOwnerTest -----");
         // Start local bookkeeper ensemble
         bkEnsemble = new LocalBookkeeperEnsemble(3, ZOOKEEPER_PORT, () -> PortManager.nextFreePort());
         bkEnsemble.start();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -94,7 +94,7 @@ public class TopicOwnerTest {
     }
 
     @Test
-    public void testBundleSplit() throws Exception {
+    public void testConnectToInvalidateBundleCacheBroker() throws Exception {
         pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(brokerUrls[0].toString()));
         TenantInfo tenantInfo = new TenantInfo();
         tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
@@ -106,9 +106,11 @@ public class TopicOwnerTest {
         final String topic1 = "persistent://my-tenant/my-ns/topic-1";
         final String topic2 = "persistent://my-tenant/my-ns/topic-2";
 
+        // Do topic lookup here for broker to own namespace bundles
         if (pulsarAdmins[0].lookups().lookupTopic(topic1).equals(pulsarAdmins[0].lookups().lookupTopic(topic2))) {
-            testBundleSplit();
+            testConnectToInvalidateBundleCacheBroker();
         } else {
+            // All brokers will invalidate bundles cache after namespace bundle split
             pulsarAdmins[0].namespaces().splitNamespaceBundle("my-tenant/my-ns",
                     pulsarServices[0].getNamespaceService().getBundle(TopicName.get(topic1)).getBundleRange(),
                     true);
@@ -117,6 +119,7 @@ public class TopicOwnerTest {
                     serviceUrl(pulsarServices[0].getBrokerServiceUrl())
                     .build();
 
+            // Check connect to a topic which owner broker invalidate all namespace bundles cache
             Consumer<byte[]> consumer = client.newConsumer().topic(topic2).subscriptionName("test").subscribe();
             Assert.assertTrue(consumer.isConnected());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.collect.Sets;
+import org.apache.bookkeeper.test.PortManager;
+import org.apache.pulsar.PulsarTransactionCoordinatorMetadataSetup;
+import org.apache.pulsar.broker.NoOpShutdownService;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.util.Optional;
+
+public class TopicOwnerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(TopicOwnerTest.class);
+
+    LocalBookkeeperEnsemble bkEnsemble;
+    protected final int ZOOKEEPER_PORT = PortManager.nextFreePort();
+    protected int[] brokerWebServicePorts = new int[BROKER_COUNT];
+    protected int[] brokerNativeBrokerPorts = new int[BROKER_COUNT];
+    protected URL[] brokerUrls = new URL[BROKER_COUNT];
+    protected PulsarAdmin[] pulsarAdmins = new PulsarAdmin[BROKER_COUNT];
+    protected static final int BROKER_COUNT = 5;
+    protected ServiceConfiguration[] configurations = new ServiceConfiguration[BROKER_COUNT];
+    protected PulsarService[] pulsarServices = new PulsarService[BROKER_COUNT];
+
+    @BeforeMethod
+    void setup() throws Exception {
+        log.info("---- Initializing SLAMonitoringTest -----");
+        // Start local bookkeeper ensemble
+        bkEnsemble = new LocalBookkeeperEnsemble(3, ZOOKEEPER_PORT, () -> PortManager.nextFreePort());
+        bkEnsemble.start();
+
+        String[] args = new String[]{
+                "--cluster", "my-cluster",
+                "--configuration-store", "localhost:" + ZOOKEEPER_PORT};
+
+        PulsarTransactionCoordinatorMetadataSetup.main(args);
+
+        // start brokers
+        for (int i = 0; i < BROKER_COUNT; i++) {
+            brokerWebServicePorts[i] = PortManager.nextFreePort();
+            brokerNativeBrokerPorts[i] = PortManager.nextFreePort();
+
+            ServiceConfiguration config = new ServiceConfiguration();
+            config.setBrokerServicePort(Optional.ofNullable(brokerNativeBrokerPorts[i]));
+            config.setClusterName("my-cluster");
+            config.setAdvertisedAddress("localhost");
+            config.setWebServicePort(Optional.ofNullable(brokerWebServicePorts[i]));
+            config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
+            config.setBrokerServicePort(Optional.ofNullable(brokerNativeBrokerPorts[i]));
+            config.setDefaultNumberOfNamespaceBundles(1);
+            config.setLoadBalancerEnabled(false);
+            configurations[i] = config;
+
+            pulsarServices[i] = new PulsarService(config);
+            pulsarServices[i].setShutdownService(new NoOpShutdownService());
+            pulsarServices[i].start();
+
+            brokerUrls[i] = new URL("http://127.0.0.1" + ":" + brokerWebServicePorts[i]);
+            pulsarAdmins[i] = PulsarAdmin.builder().serviceHttpUrl(brokerUrls[i].toString()).build();
+        }
+        Thread.sleep(1000);
+    }
+
+    @Test
+    public void testBundleSplit() throws Exception {
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(brokerUrls[0].toString()));
+        TenantInfo tenantInfo = new TenantInfo();
+        tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
+        pulsarAdmins[0].tenants().createTenant("my-tenant", tenantInfo);
+        pulsarAdmins[0].namespaces().createNamespace("my-tenant/my-ns", 16);
+
+        Assert.assertEquals(pulsarAdmins[0].namespaces().getPolicies("my-tenant/my-ns").bundles.getNumBundles(), 16);
+
+        final String topic1 = "persistent://my-tenant/my-ns/topic-1";
+        final String topic2 = "persistent://my-tenant/my-ns/topic-2";
+
+        if (pulsarAdmins[0].lookups().lookupTopic(topic1).equals(pulsarAdmins[0].lookups().lookupTopic(topic2))) {
+            testBundleSplit();
+        } else {
+            pulsarAdmins[0].namespaces().splitNamespaceBundle("my-tenant/my-ns",
+                    pulsarServices[0].getNamespaceService().getBundle(TopicName.get(topic1)).getBundleRange(),
+                    true);
+
+            PulsarClient client = PulsarClient.builder().
+                    serviceUrl(pulsarServices[0].getBrokerServiceUrl())
+                    .build();
+
+            Consumer<byte[]> consumer = client.newConsumer().topic(topic2).subscriptionName("test").subscribe();
+            Assert.assertTrue(consumer.isConnected());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, when namespace bundles split happens, namespace bundles cache will be invalidated. If producer or consumer try to connect to a topic which belongs to an exists bundle and the broker owned the exists bundle invalidate namespace bundles cache, producer and consumer will always connect failed with error log:

```
org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://platform/im/operationLog.addSession-partition-0) not served by this instance. Please redo the lookup. Request is denied: namespace=platform/im
``` 

Following steps can reproduce the problem:

1. Start a pulsar cluster(>= 2 brokers)
2. Create a namespace with some bundles(>= 2), bundles need be owned by different broker
3. Create some topics and do lookup request

Suppose after above steps, you have 2 topic(topic-1 with bundle-1 owned by broker-1 and topic-2 with bundle-2 owned by broker-2)

Now,  split bundle-1 and then create a PulsarClient using service url of broker-1 as pulsar url, then create a consumer with topic-2, ServiceUnitNotReadyException will appear.

I have added a unit test for reproduce this issue on master branch and cover the change of this PR.

### Verifying this change

Added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
