### PR TITLE
[Issue:5465] Fix the download path of functions jar pkg

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -38,7 +38,7 @@ zooKeeperOperationTimeoutSeconds: 30
 ################################
 
 numFunctionPackageReplicas: 1
-downloadDirectory: /tmp/pulsar_functions
+downloadDirectory: download/pulsar_functions
 # Classname of Pluggable JVM GC metrics logger that can log GC specific metrics
 # jvmGCMetricsLoggerClassName: 
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #5465

### Motivation

Generally, users rarely change the configuration of `downloadDirectory`. If we store it in the `/tmp` directory, the file will be invalid after a period of time. 

### Modifications

- Replace `/tmp/pulsar_functions` with `download/pulsar_functions`