### PR TITLE
Avoid using same OpAddEntry between different ledger handles

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1296,6 +1296,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         // Process all the pending addEntry requests
         for (OpAddEntry op : pendingAddEntries) {
+            op.close();
+            op = OpAddEntry.create(op.ml, op.data, op.callback, op.ctx);
             op.setLedger(currentLedger);
             ++currentLedgerEntries;
             currentLedgerSize += op.data.readableBytes();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1299,9 +1299,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             op = pendingAddEntries.poll();
             if (op != null) {
                 // If op is used by another ledger handle, we need to close it and create a new one
-                if (op.ledger == null) {
-                    pendingAddEntries.add(op);
-                } else {
+                if (op.ledger != null) {
                     op.close();
                     op = OpAddEntry.create(op.ml, op.data, op.callback, op.ctx);
                 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1287,6 +1287,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     public synchronized void updateLedgersIdsComplete(Stat stat) {
+        int pendingSize = pendingAddEntries.size();
         STATE_UPDATER.set(this, State.LedgerOpened);
         lastLedgerCreatedTimestamp = clock.millis();
 
@@ -1294,7 +1295,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("[{}] Resending {} pending messages", name, pendingAddEntries.size());
         }
         // Process all the pending addEntry requests
-        int pendingSize = pendingAddEntries.size();
         OpAddEntry op;
         do {
             op = pendingAddEntries.poll();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -43,12 +43,14 @@ import org.slf4j.LoggerFactory;
  *
  */
 class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
-    private ManagedLedgerImpl ml;
+    protected ManagedLedgerImpl ml;
     LedgerHandle ledger;
     private long entryId;
 
     @SuppressWarnings("unused")
-    private volatile AddEntryCallback callback;
+    private static final AtomicReferenceFieldUpdater<OpAddEntry, AddEntryCallback> callbackUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(OpAddEntry.class, AddEntryCallback.class, "callback");
+    protected volatile AddEntryCallback callback;
     Object ctx;
     volatile long addOpCount;
     private static final AtomicLongFieldUpdater<OpAddEntry> ADD_OP_COUNT_UPDATER = AtomicLongFieldUpdater
@@ -60,8 +62,16 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     ByteBuf data;
     private int dataLength;
 
-    private static final AtomicReferenceFieldUpdater<OpAddEntry, AddEntryCallback> callbackUpdater =
-        AtomicReferenceFieldUpdater.newUpdater(OpAddEntry.class, AddEntryCallback.class, "callback");
+    private static final AtomicReferenceFieldUpdater<OpAddEntry, OpAddEntry.State> STATE_UPDATER = AtomicReferenceFieldUpdater
+            .newUpdater(OpAddEntry.class, OpAddEntry.State.class, "state");
+    volatile State state;
+
+    enum State {
+        OPEN,
+        INITIATED,
+        COMPLETED,
+        CLOSED
+    }
 
     public static OpAddEntry create(ManagedLedgerImpl ml, ByteBuf data, AddEntryCallback callback, Object ctx) {
         OpAddEntry op = RECYCLER.get();
@@ -75,6 +85,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         op.closeWhenDone = false;
         op.entryId = -1;
         op.startTime = System.nanoTime();
+        op.state = State.OPEN;
         ml.mbean.addAddEntrySample(op.dataLength);
         if (log.isDebugEnabled()) {
             log.debug("Created new OpAddEntry {}", op);
@@ -91,12 +102,16 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     }
 
     public void initiate() {
-        ByteBuf duplicateBuffer = data.retainedDuplicate();
+        if (STATE_UPDATER.compareAndSet(OpAddEntry.this, State.OPEN, State.INITIATED)) {
+            ByteBuf duplicateBuffer = data.retainedDuplicate();
 
-        // internally asyncAddEntry() will take the ownership of the buffer and release it at the end
-        addOpCount = ManagedLedgerImpl.ADD_OP_COUNT_UPDATER.incrementAndGet(ml);;
-        lastInitTime = System.nanoTime();
-        ledger.asyncAddEntry(duplicateBuffer, this, addOpCount);
+            // internally asyncAddEntry() will take the ownership of the buffer and release it at the end
+            addOpCount = ManagedLedgerImpl.ADD_OP_COUNT_UPDATER.incrementAndGet(ml);
+            lastInitTime = System.nanoTime();
+            ledger.asyncAddEntry(duplicateBuffer, this, addOpCount);
+        } else {
+            log.warn("[{}] initiate with unexpected state {}, expect OPEN state.", ml.getName(), state);
+        }
     }
 
     public void failed(ManagedLedgerException e) {
@@ -110,6 +125,13 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
 
     @Override
     public void addComplete(int rc, final LedgerHandle lh, long entryId, Object ctx) {
+
+        if (!STATE_UPDATER.compareAndSet(OpAddEntry.this, State.INITIATED, State.COMPLETED)) {
+            log.warn("[{}] The add op is terminal legacy callback for entry {}-{} adding.", ml.getName(), lh.getId(), entryId);
+            OpAddEntry.this.recycle();
+            return;
+        }
+
         if (ledger.getId() != lh.getId()) {
             log.warn("[{}] ledgerId {} doesn't match with acked ledgerId {}", ml.getName(), ledger.getId(), lh.getId());
         }
@@ -216,6 +238,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
 
     void handleAddTimeoutFailure(final LedgerHandle ledger, Object ctx) {
         if (checkAndCompleteOp(ctx)) {
+            this.close();
             this.handleAddFailure(ledger);
         }
     }
@@ -236,6 +259,10 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
             // from a BK callback.
             ml.ledgerClosed(ledger);
         }));
+    }
+
+    void close() {
+        STATE_UPDATER.set(OpAddEntry.this, State.CLOSED);
     }
     
     private final Handle<OpAddEntry> recyclerHandle;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -264,6 +264,10 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     void close() {
         STATE_UPDATER.set(OpAddEntry.this, State.CLOSED);
     }
+
+    public State getState() {
+        return state;
+    }
     
     private final Handle<OpAddEntry> recyclerHandle;
 


### PR DESCRIPTION
Fixes #5588

### Motivation

Avoid using same OpAddEntry between different ledger handles.

### Modifications

Add state for OpAddEntry, if op handled by new ledger handle, the op will set to CLOSED state, after the legacy callback happens will check the op state, only INITIATED can be processed.

When ledger rollover happens, pendingAddEntries will be processed. when process pendingAddEntries, will create a new OpAddEntry by the old OpAddEntry to avoid different ledger handles use same OpAddEntry.

### Verifying this change

Added new unit test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
