### PR TITLE
[docs] Enable zh-TW website translation

### DIFF
--- a/site2/website/languages.js
+++ b/site2/website/languages.js
@@ -176,6 +176,9 @@ const languages = [
     name: '中文',
     tag: 'zh-CN',
   },
-  {enabled: false, name: '繁體中文', tag: 'zh-TW'},
+  {
+    enabled: true, 
+    name: '繁體中文', 
+    tag: 'zh-TW'},
 ];
 module.exports = languages;


### PR DESCRIPTION
* Motivation : To enable document translation for zh-TW (Traditional Chinese characters)
* Changes: Modify https://github.com/apache/pulsar/blob/master/site2/website/languages.js#L179 turning "zh-TW" enabled flag to "true".
