### PR TITLE
Add option to support message key and message properties

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -97,7 +97,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
 
         String[] args = { "produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
-                "20", topicName };
+                "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName };
         Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
 
         future.get();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -125,14 +126,30 @@ public class CmdConsume {
      * @return String representation of the message
      */
     private String interpretMessage(Message<byte[]> message, boolean displayHex) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        String properties = Arrays.toString(message.getProperties().entrySet().toArray());
+
+        String data;
         byte[] msgData = message.getData();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         if (!displayHex) {
-            return new String(msgData);
+            data = new String(msgData);
         } else {
             HexDump.dump(msgData, 0, out, 0);
-            return new String(out.toByteArray());
+            data = new String(out.toByteArray());
         }
+
+        String key = null;
+        if (message.hasKey()) {
+            key = message.getKey();
+        }
+
+        sb.append("key:[").append(key).append("], ");
+        sb.append("properties:").append(properties).append(", ");
+        sb.append("content:").append(data);
+
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
### Motivation

This change allows a user of the pulsar-client to produce message with key and properties, and print these in the consume output.