### PR TITLE
fix  2 copies of 3bookie and stop 2 booksie after production. After t…

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -220,6 +220,9 @@ public class EntryCacheManager {
                         ml.mbean.addReadEntriesSample(entries.size(), totalSize);
 
                         callback.readEntriesComplete(entries, ctx);
+                    }).exceptionally(exception -> {
+                    	callback.readEntriesFailed(createManagedLedgerException(exception), ctx);
+                    	return null;
                     });
         }
 


### PR DESCRIPTION
After stopping the bookie and recovering, it can be produced at this time, but cannot be consumed normally. Restarting the broker can resume normal


Fixes #5962


### Motivation

problem :
*Topic(E=3,W=3,A=2), stopped 2 bookie nodes, then recover the 2 bookie,
The message can be produced normally, but the consumer cannot pull the message unless the broker is restarted.*
We hope that the bookie summary will resume normal consumption

### Modifications

*The main cause of this problem is that readHandle.readAsync does not catch the exception, 
 causing some methods to not trigger.
 therefore, added the exception capture module , and the exceptions involved in the bookeeper project are also fixed.*







