### PR TITLE
[Integration test]Add diskUsageThreshold to prevent bookie exit.

### DIFF
--- a/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -44,6 +45,8 @@ public class SmokeTest {
 
     @Test
     public void checkMessages() throws PulsarClientException {
+
+        @Cleanup
         PulsarClient client = PulsarClient.builder()
                 .serviceUrl(pulsarContainer.getPlainTextPulsarBrokerUrl())
                 .build();

--- a/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -44,6 +45,8 @@ public class SmokeTest {
 
     @Test
     public void checkMessages() throws PulsarClientException {
+
+        @Cleanup
         PulsarClient client = PulsarClient.builder()
                 .serviceUrl(pulsarContainer.getPlainTextPulsarBrokerUrl())
                 .build();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -144,6 +144,7 @@ public class PulsarCluster {
                         .withEnv("journalSyncData", "false")
                         .withEnv("journalMaxGroupWaitMSec", "0")
                         .withEnv("clusterName", clusterName)
+                        .withEnv("diskUsageThreshold", "0.99")
                 )
         );
 


### PR DESCRIPTION
### Motivation

The current GitHub action test will show that the disk space exceeds 95%, and then the bookie will detect that bookie exits, so fix this problem.

![image](https://user-images.githubusercontent.com/1907867/71616693-8748da00-2bf2-11ea-82f2-e54eda012136.png)


### Modifications

* Configuration parameter disUsageThreshold is 0.99 to prevent bookie exit.

### Verifying this change

Integration test pass