### PR TITLE
[proxy] Proxy doesn't use the right ca certicate to connect to brokers

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -214,7 +214,7 @@ class AdminProxyHandler extends ProxyServlet {
             if (config.isTlsEnabledWithBroker()) {
                 try {
                     X509Certificate trustCertificates[] = SecurityUtility
-                        .loadCertificatesFromPemFile(config.getTlsTrustCertsFilePath());
+                        .loadCertificatesFromPemFile(config.getBrokerClientTrustCertsFilePath());
 
                     SSLContext sslCtx;
                     AuthenticationDataProvider authData = auth.getAuthData();


### PR DESCRIPTION
*Motivation*

Currently proxy uses the proxy ca certicate to connect to brokers.
It is fine if proxy and broker are using th same CA. However if the broker
is using a different CA than proxy, "HTTP 502 Bad Gateway" is returned from proxy
when tlsEnabledWithBroker is set to true.

*Modifications*

Change to use the right CA

*Verify this change*

Confirmed it is working in a production environment with this fix.

The unit tests can be tricky. As all our current testing infra is using same CA.

