### PR TITLE
[Github Action] Clean up space before running backwards compatibility test

### DIFF
--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -44,5 +44,8 @@ jobs:
       - name: build artifacts and docker image
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
+      - name: clean up
+        run: docker system prune -f
+
       - name: run integration tests
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-backwards-compatibility.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
@@ -124,7 +124,6 @@ public class PulsarTestBase {
 
                 for (int i = 0; i < numMessages; i++) {
                     Message<String> m = consumer.receive();
-                    System.out.println(i);
                     assertEquals("smoke-message-" + i, m.getValue());
                 }
             }


### PR DESCRIPTION
---

*Motivation*

Backwards compatibility test always failed with
`Docker environment should have more than 2GB free disk space`.

*Modifications*

Clean up space before running test.
