### PR TITLE
[pulsar-broker] Clean up closed producer to avoid publish-time  for producer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1210,14 +1210,15 @@ public class ServerCnx extends PulsarHandler {
         if (!producerFuture.isDone() && producerFuture
                 .completeExceptionally(new IllegalStateException("Closed producer before creation was complete"))) {
             // We have received a request to close the producer before it was actually completed, we have marked the
-            // producer future as failed and we can tell the client the close operation was successful. When the actual
-            // create operation will complete, the new producer will be discarded.
+            // producer future as failed and we can tell the client the close operation was successful.
             log.info("[{}] Closed producer {} before its creation was completed", remoteAddress, producerId);
             ctx.writeAndFlush(Commands.newSuccess(requestId));
+            producers.remove(producerId, producerFuture);
             return;
         } else if (producerFuture.isCompletedExceptionally()) {
             log.info("[{}] Closed producer {} that already failed to be created", remoteAddress, producerId);
             ctx.writeAndFlush(Commands.newSuccess(requestId));
+            producers.remove(producerId, producerFuture);
             return;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -790,7 +790,7 @@ public class ServerCnxTest {
                 producerName, Collections.emptyMap());
         channel.writeInbound(createProducer2);
 
-        // Complete the topic opening
+        // Complete the topic opening: It will make 2nd producer creation successful
         openTopicFuture.get().run();
 
         // Close succeeds
@@ -798,13 +798,11 @@ public class ServerCnxTest {
         assertEquals(response.getClass(), CommandSuccess.class);
         assertEquals(((CommandSuccess) response).getRequestId(), 2);
 
-        // 2nd producer fails to create
+        // 2nd producer will be successfully created as topic is open by then
         response = getResponse();
-        assertEquals(response.getClass(), CommandError.class);
-        assertEquals(((CommandError) response).getRequestId(), 3);
+        assertEquals(response.getClass(), CommandProducerSuccess.class);
+        assertEquals(((CommandProducerSuccess) response).getRequestId(), 3);
 
-        // We should not receive response for 1st producer, since it was cancelled by the close
-        assertTrue(channel.outboundMessages().isEmpty());
         assertTrue(channel.isActive());
 
         channel.finish();
@@ -928,7 +926,7 @@ public class ServerCnxTest {
                 producerName, Collections.emptyMap());
         channel.writeInbound(createProducer2);
 
-        // Now the topic gets opened
+        // Now the topic gets opened.. It will make 2nd producer creation successful
         openFailedTopic.get().run();
 
         // Close succeeds
@@ -936,10 +934,10 @@ public class ServerCnxTest {
         assertEquals(response.getClass(), CommandSuccess.class);
         assertEquals(((CommandSuccess) response).getRequestId(), 2);
 
-        // 2nd producer fails
+        // 2nd producer success as topic is opened
         response = getResponse();
-        assertEquals(response.getClass(), CommandError.class);
-        assertEquals(((CommandError) response).getRequestId(), 3);
+        assertEquals(response.getClass(), CommandProducerSuccess.class);
+        assertEquals(((CommandProducerSuccess) response).getRequestId(), 3);
 
         // Wait till the failtopic timeout interval
         Thread.sleep(500);
@@ -947,10 +945,10 @@ public class ServerCnxTest {
                 producerName, Collections.emptyMap());
         channel.writeInbound(createProducer3);
 
-        // 3rd producer succeeds
+        // 3rd producer fails because 2nd is already connected
         response = getResponse();
-        assertEquals(response.getClass(), CommandProducerSuccess.class);
-        assertEquals(((CommandProducerSuccess) response).getRequestId(), 4);
+        assertEquals(response.getClass(), CommandError.class);
+        assertEquals(((CommandError) response).getRequestId(), 4);
 
         Thread.sleep(500);
 


### PR DESCRIPTION
### Motivation

We found many instances where broker close the producer without clearing from cache, because of that broker doesn't allow new producer with same id to be created on the same connection and fail the publish messages with error "producer is already closed"
```
# (1) new producer request came
4:31:15.317 [ForkJoinPool.commonPool-worker-23] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606][persistent://prod-tenant/global/prod-ns/dc1:dc1747e8f] Creating producer. producerId=1038
:
# (2) broker couldn't create producer in 30 secs and after 30 seconds broker receives close producer request. Broker closes it without clearing from cache
14:31:45.191 [pulsar-io-22-20] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Closed producer 549 before its creation was completed
14:31:45.191 [pulsar-io-22-20] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Closed producer 581 before its creation was completed
14:31:45.192 [pulsar-io-22-20] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Closed producer 621 before its creation was completed
14:31:45.192 [pulsar-io-22-20] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Closed producer 894 before its creation was completed
14:31:45.192 [pulsar-io-22-20] INFO  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Closed producer 1038 before its creation was completed
:
:
# (3) Broker ignores new producer request because producer already present on that connection
14:31:45.292 [ForkJoinPool.commonPool-worker-47] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606][581] Producer with id persistent://prod-tenant/global/prod-ns/257769db47033c3abbd618141106063fc0e1a743801396f1fd4f11f95d3e457b\:WEB\:1530064:258 is already present on the connection
14:31:45.293 [ForkJoinPool.commonPool-worker-47] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606][621] Producer with id persistent://prod-tenant/global/prod-ns/93b:93b78d8338c40b6a39d27df59df7f3005bcfd9972804df360ed1b176c2e9ba15\:WEB\:15283350 is already present on the connection
14:31:45.293 [ForkJoinPool.commonPool-worker-47] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606][894] Producer with id persistent://prod-tenant/global/prod-ns/5b6:5b679b830 is already present on the connection
14:31:45.293 [ForkJoinPool.commonPool-worker-23] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606][1038] Producer with id persistent://prod-tenant/global/prod-ns/dc1:dc1747e8f is already present on the connection
:
:
# (4) Publish fails because producer is already closed
14:31:47.906 [pulsar-io-22-20] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Producer had already been closed: 581
14:31:47.906 [pulsar-io-22-20] WARN  org.apache.pulsar.broker.service.ServerCnx - [/1.1.1.1:33606] Producer had already been closed: 581
``` 

So, broker should remove the closed and failed producer from the cache to allow creation of new producer and it will avoid publish failure due to "producer already closed" error.