### PR TITLE
[Issue 5969] prevent redelivery of acked batch message at the client api

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchAckedTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchAckedTracker.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.pulsar.client.api.MessageId;
+
+/**
+ * Tracks any partial acked batches and its acked messages
+ * This will prevent acked message redelivery to the client only at the client API level.
+ * This class does not track batch with all acked message. We trust broker won't deliver again.
+ */
+class BatchAckedTracker {
+
+    // a map of partial acked batch and its messages already acked
+    @VisibleForTesting
+    Map<String, Set<BatchMessageIdImpl>> ackedBatches = new HashMap<String, Set<BatchMessageIdImpl>>();
+
+    public BatchAckedTracker() {
+    }
+
+    // we start to track 
+    public void negativeAcked(BatchMessageIdImpl messageId) {
+        
+    }
+
+    // If this message should be delivered and tracks this message if it is a batch message
+    public boolean deliver(MessageId messageId) {
+        if (messageId instanceof BatchMessageIdImpl) {
+            BatchMessageIdImpl id = (BatchMessageIdImpl) messageId;
+            String batchId = getBatchId(id);
+            if (ackedBatches.containsKey(batchId)){
+                Set<BatchMessageIdImpl> batch = ackedBatches.get(batchId);
+                if (batch.contains(id)) {
+                    return false;
+                }
+            }
+        }
+        // deliver non batch message and any other cases
+        return true;
+    }
+
+    /**
+     * 
+     * @param messageId batchMessageIdImpl
+     * @return boolean isAllMsgAcked for the batch
+     */
+    public boolean ack (BatchMessageIdImpl messageId) {
+        String batchId = getBatchId(messageId);
+        Set<BatchMessageIdImpl> batches = ackedBatches.getOrDefault(batchId, new HashSet<BatchMessageIdImpl>());
+        if (messageId.getBatchSize() == (batches.size() + 1)) {
+            //we ack complete batch now so delete it from the tracker
+            ackedBatches.remove(batchId);
+            return true;
+        } else {
+            batches.add(messageId);
+            ackedBatches.put(batchId, batches);
+        }
+        return false;
+    }
+
+    private static String getBatchId(BatchMessageIdImpl id) {
+        return id.ledgerId + "-" + id.entryId + "-" + id.partitionIndex;
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchAckedTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchAckedTracker.java
@@ -18,14 +18,17 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 
 /**
  * Tracks any partial acked batches and its acked messages
@@ -35,15 +38,11 @@ import org.apache.pulsar.client.api.MessageId;
 class BatchAckedTracker {
 
     // a map of partial acked batch and its messages already acked
+    // Key is the string Id for batch, the value is a synchronized set of message Id in string
     @VisibleForTesting
-    Map<String, Set<BatchMessageIdImpl>> ackedBatches = new HashMap<String, Set<BatchMessageIdImpl>>();
+    Map<String, Set<String>> ackedBatches = new ConcurrentHashMap<String, Set<String>>();
 
     public BatchAckedTracker() {
-    }
-
-    // we start to track 
-    public void negativeAcked(BatchMessageIdImpl messageId) {
-        
     }
 
     // If this message should be delivered and tracks this message if it is a batch message
@@ -52,8 +51,8 @@ class BatchAckedTracker {
             BatchMessageIdImpl id = (BatchMessageIdImpl) messageId;
             String batchId = getBatchId(id);
             if (ackedBatches.containsKey(batchId)){
-                Set<BatchMessageIdImpl> batch = ackedBatches.get(batchId);
-                if (batch.contains(id)) {
+                Set<String> batch = ackedBatches.get(batchId);
+                if (batch.contains(getBatchMessageId(batchId, id.getBatchIndex()))) {
                     return false;
                 }
             }
@@ -67,21 +66,33 @@ class BatchAckedTracker {
      * @param messageId batchMessageIdImpl
      * @return boolean isAllMsgAcked for the batch
      */
-    public boolean ack (BatchMessageIdImpl messageId) {
+    public boolean ack (BatchMessageIdImpl messageId, AckType ackType) {
         String batchId = getBatchId(messageId);
-        Set<BatchMessageIdImpl> batches = ackedBatches.getOrDefault(batchId, new HashSet<BatchMessageIdImpl>());
-        if (messageId.getBatchSize() == (batches.size() + 1)) {
+        Set<String> batch = ackedBatches.getOrDefault(batchId,
+                                                      Collections.synchronizedSet(new HashSet<String>()));
+        if (ackType == AckType.Individual) {
+            batch.add(getBatchMessageId(batchId, messageId.getBatchIndex()));
+        } else {
+            for (int i=0; i<=messageId.getBatchIndex(); i++) {
+                batch.add(getBatchMessageId(batchId, i));
+            }
+        }
+
+        if (messageId.getBatchSize() == batch.size()) {
             //we ack complete batch now so delete it from the tracker
             ackedBatches.remove(batchId);
             return true;
         } else {
-            batches.add(messageId);
-            ackedBatches.put(batchId, batches);
+            ackedBatches.put(batchId, batch);
+            return false;
         }
-        return false;
     }
 
     private static String getBatchId(BatchMessageIdImpl id) {
         return id.ledgerId + "-" + id.entryId + "-" + id.partitionIndex;
+    }
+
+    private static String getBatchMessageId(String batchId, int batchIndex) {
+        return batchId + "-" + batchIndex;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -437,7 +437,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             outstandingAcks = batchMessageId.getOutstandingAcksInSameBatch();
         }
 
-        if (batchAckedTracker.ack(batchMessageId)) {
+        if (batchAckedTracker.ack(batchMessageId, ackType)) {
             // the batch all delievered including previous acked
             outstandingAcks = 0;
             isAllMsgsAcked = true;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchAckedTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchAckedTrackerTest.java
@@ -131,7 +131,8 @@ public class BatchAckedTrackerTest  {
         assertFalse(tracker.ack(batchMessageId, AckType.Cumulative));
         assertEquals(tracker.ackedBatches.size(), 1);
         String batchId = batchMessageId.ledgerId + "-" + batchMessageId.entryId + "-" + batchMessageId.partitionIndex;
-        assertEquals(tracker.ackedBatches.get(batchId).size(), batchMessageId.getBatchIndex() + 1);
+        // assertEquals(tracker.ackedBatches.get(batchId).size(), batchMessageId.getBatchIndex() + 1);
+        assertEquals(tracker.ackedBatches.get(batchId).nextSetBit(8), 9);
 
         // ack the batch with the last message
         assertTrue(tracker.ack(new BatchMessageIdImpl(1, 1, -1, 9, acker), AckType.Cumulative));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchAckedTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchAckedTrackerTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.testng.annotations.Test;
+
+public class BatchAckedTrackerTest  {
+
+    @Test
+    public void testDeliveredAndAcked() throws Exception {
+        BatchAckedTracker tracker = new BatchAckedTracker();
+
+        MessageId nonBatchMessageId = new MessageIdImpl(1, 1, 1);
+
+        assertTrue(tracker.deliver(nonBatchMessageId));
+        assertEquals(tracker.ackedBatches.size(), 0);
+
+        int batchSize = 3;
+        BatchMessageAcker acker = BatchMessageAcker.newAcker(batchSize);
+        BatchMessageIdImpl batchMessageId = new BatchMessageIdImpl(1, 1, -1, 2, acker);
+        assertEquals(batchMessageId.getBatchIndex(), 2);
+        assertEquals(batchMessageId.getBatchSize(), batchSize);
+
+        // ensure message can be delivered to clients
+        assertTrue(tracker.deliver(batchMessageId));
+        assertEquals(tracker.ackedBatches.size(), 0);
+
+        // ensure the first message ack will be tracked
+        assertFalse(tracker.ack(batchMessageId));
+        assertEquals(tracker.ackedBatches.size(), 1);
+
+        // redeliver an acked message will return false
+        assertFalse(tracker.deliver(batchMessageId));
+
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 1, -1, 1, acker)));
+        assertEquals(tracker.ackedBatches.size(), 1);
+
+        // all message are acked in a batch of three messages
+        assertTrue(tracker.ack(new BatchMessageIdImpl(1, 1, -1, 0, acker)));
+        assertEquals(tracker.ackedBatches.size(), 0);
+
+    }
+
+    @Test
+    public void testMultipleBatchDeliveredAndAcked() throws Exception {
+        BatchAckedTracker tracker = new BatchAckedTracker();
+
+        int batch1Size = 3;
+        int batch2Size = 5;
+        int batch3Size = 8;
+
+        BatchMessageAcker acker1 = BatchMessageAcker.newAcker(batch1Size);
+        BatchMessageAcker acker2 = BatchMessageAcker.newAcker(batch2Size);
+        BatchMessageAcker acker3 = BatchMessageAcker.newAcker(batch3Size);
+
+        BatchMessageIdImpl batch1MessageId1 = new BatchMessageIdImpl(1, 1, -1, 0, acker1);
+        BatchMessageIdImpl batch1MessageId2 = new BatchMessageIdImpl(1, 1, -1, 1, acker1);
+
+        // partial first batch acked
+        assertTrue(tracker.deliver(batch1MessageId1));
+        assertFalse(tracker.ack(batch1MessageId1));
+        assertTrue(tracker.deliver(batch1MessageId2));
+        assertFalse(tracker.ack(batch1MessageId2));
+        assertEquals(tracker.ackedBatches.size(), 1);
+
+        // ensure the first message ack will be tracked
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 2, -1, 0, acker2)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 2, -1, 1, acker2)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 2, -1, 2, acker2)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 2, -1, 3, acker2)));
+        assertEquals(tracker.ackedBatches.size(), 2);
+        assertTrue(tracker.deliver(new BatchMessageIdImpl(1, 2, -1, 4, acker2)));
+
+        // redeliver an acked message will return false
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 0, acker3)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 1, acker3)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 2, acker3)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 3, acker3)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 4, acker3)));
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 5, acker3)));
+        assertEquals(tracker.ackedBatches.size(), 3);
+        assertTrue(tracker.deliver(new BatchMessageIdImpl(1, 3, -1, 7, acker3)));
+
+        // all message are acked in a batch of three messages
+        assertTrue(tracker.ack(new BatchMessageIdImpl(1, 1, -1, 2, acker1)));
+        assertEquals(tracker.ackedBatches.size(), 2);
+
+        assertTrue(tracker.ack(new BatchMessageIdImpl(1, 2, -1, 4, acker2)));
+        assertEquals(tracker.ackedBatches.size(), 1);
+
+        assertFalse(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 6, acker3)));
+        assertTrue(tracker.ack(new BatchMessageIdImpl(1, 3, -1, 7, acker3)));
+        assertEquals(tracker.ackedBatches.size(), 0);
+    }
+
+}


### PR DESCRIPTION
### Motivation
To address redelivered of acked batch message described by https://github.com/apache/pulsar/issues/5969

This is only a client side change. It covers cases of not-to-deliver-acked batch message on the client side only. Since it tracks acked messages of partial acked batch in memory, restart of client will lose the state tracking.

### Modifications
A new BatchAckedTracker is added to track all acked message in any partially acked batches. Redelivery of unacked batch will be evaluated against this tracker so that it sends only unacked messages to the client in ConsumerImpl. When all messages are acked by the client in redelivery, ConsumerImpl sends the batch ack to the broker.

This only addresses the issue in Java client. C++, and standalone Go clients updates will be tracked in separated PR.


### Verifying this change

Three new unit tests are introduced.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
