### PR TITLE
Remove duplicated lombok annotations in the pulsar-commmon module

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -26,20 +26,12 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * Configuration of Pulsar Function.
  */
-@Getter
-@Setter
 @Data
-@EqualsAndHashCode
-@ToString
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionState.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionState.java
@@ -22,20 +22,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * Function state.
  */
-@Getter
-@Setter
 @Data
-@EqualsAndHashCode
-@ToString
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Resources.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Resources.java
@@ -21,20 +21,12 @@ package org.apache.pulsar.common.functions;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * Class representing resources, such as CPU, RAM, and disk size.
  */
-@Getter
-@Setter
 @Data
-@EqualsAndHashCode
-@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/WindowConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/WindowConfig.java
@@ -19,19 +19,13 @@
 package org.apache.pulsar.common.functions;
 
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
  * Configuration of a windowing function.
  */
 @Data
-@Setter
-@Getter
 @Accessors(chain = true)
-@ToString
 public class WindowConfig {
 
     public static final String WINDOW_CONFIG_KEY = "__WINDOWCONFIGS__";

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -24,11 +24,7 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -37,11 +33,7 @@ import org.apache.pulsar.common.functions.Resources;
 /**
  * Configuration of Pulsar Sink.
  */
-@Getter
-@Setter
 @Data
-@EqualsAndHashCode
-@ToString
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -22,22 +22,14 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 
 /**
  * Pulsar source configuration.
  */
-@Getter
-@Setter
 @Data
-@EqualsAndHashCode
-@ToString
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaData.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
-import lombok.ToString;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
@@ -31,7 +30,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  */
 @Builder
 @Data
-@ToString
 public class SchemaData {
     private final SchemaType type;
     private final boolean isDeleted;


### PR DESCRIPTION
### Motivation

Some of the classes in the pulsar-common module had a mixture of the following lombok annotations:

```
@Data
@Setter	
@Getter	
@EqualsAndHashCode	
@ToString
```

The [@Data](https://projectlombok.org/features/Data) annotation includes all other annotations:

> All together now: A shortcut for @ToString, @EqualsAndHashCode, @Getter on all fields, @Setter on all non-final fields, and @RequiredArgsConstructor!


### Modifications

Removed `@Setter`, `@Getter`, `@EqualsAndHashCode`, and '@ToString' if the `@Data` annotation was also present