### PR TITLE
[Issue 5983][docs] promote assign the advertisedAddress when startup …

### DIFF
--- a/site2/website/versioned_docs/version-2.4.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.4.2/getting-started-standalone.md
@@ -172,6 +172,8 @@ If you have started Pulsar successfully, you will see `INFO`-level log messages 
 
 > #### Tip
 > 
+> * Before starting the Pulsar standalone, you may need to config the advertisedAddress to avoid startup errors. Actually, you can modify the default value of advertisedAddress in "conf/standalone.conf" or use command "bin/pulsar standalone -a 127.0.0.1" to assign the advertisedAddress.
+>
 > * The service is running on your terminal, which is under your direct control. If you need to run other commands, open a new terminal window.  
 You can also run the service as a background process using the `pulsar-daemon start standalone` command. For more information, see [pulsar-daemon](https://pulsar.apache.org/docs/en/reference-cli-tools/#pulsar-daemon).
 > 


### PR DESCRIPTION
fixes #5983 
**Describe the bug**
When I started a local standalone cluster according to the documentation, I encountered a small problem that the standalone cluster start failure.
Using the following command
```shell
bin/pulsar standalone
```
The error message is as follows:
```shell
Caused by: java.net.UnknownHostException: failed to resolve 'pdeMacBook-Pro.local' after 4 queries
	at io.netty.resolver.dns.DnsResolveContext.finishResolve(DnsResolveContext.java:848) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.resolver.dns.DnsResolveContext.tryToFinishResolve(DnsResolveContext.java:809) ~[io.netty-netty-all-4.1.32.Final.jar:4.1.32.Final]
```

**To Reproduce**
Steps to reproduce the behavior:
```shell
wget https://archive.apache.org/dist/pulsar/pulsar-2.4.2/apache-pulsar-2.4.2-bin.tar.gz
tar xvfz apache-pulsar-2.4.2-bin.tar.gz
bin/pulsar standalone
```

**Desktop (please complete the following information):**
 - OS: Mac OS

**Solution**
Add some tips in site2/docs/getting-started-standalone.md.
