### PR TITLE
[Issue 5996][docs] Update links in 2.4.1 and 2.4.2 releases

### DIFF
--- a/site2/website/versioned_docs/version-2.4.1/functions-overview.md
+++ b/site2/website/versioned_docs/version-2.4.1/functions-overview.md
@@ -54,7 +54,7 @@ If you implement the classic word count example using Pulsar Functions, it looks
 
 ![Pulsar Functions word count example](assets/pulsar-functions-word-count.png)
 
-To write the function in Java with [Pulsar Functions SDK for Java](functions-develop#available-apis), you can write the function as follows.
+To write the function in Java with [Pulsar Functions SDK for Java](functions-develop.md#available-apis), you can write the function as follows.
 
 ```java
 package org.example.functions;

--- a/site2/website/versioned_docs/version-2.4.2/functions-overview.md
+++ b/site2/website/versioned_docs/version-2.4.2/functions-overview.md
@@ -54,7 +54,7 @@ If you implement the classic word count example using Pulsar Functions, it looks
 
 ![Pulsar Functions word count example](assets/pulsar-functions-word-count.png)
 
-To write the function in Java with [Pulsar Functions SDK for Java](functions-develop#available-apis), you can write the function as follows.
+To write the function in Java with [Pulsar Functions SDK for Java](functions-develop.md#available-apis), you can write the function as follows.
 
 ```java
 package org.example.functions;


### PR DESCRIPTION
Fixes #5996 
### Motivation
The link to "Pulsar Functions SDK for Java" does not work in 2.4.1 and 2.4.2 releases.

### Modifications
Fix the link issues.
