### PR TITLE
[docs] Add support for websocket produce/consume command

### DIFF
--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -290,7 +290,7 @@ Options
 |---|---|---|
 |`--auth-params`|Authentication parameters, whose format is determined by the implementation of method `configure` in authentication plugin class, for example "key1:val1,key2:val2" or "{\"key1\":\"val1\",\"key2\":\"val2\"}"|{"saslJaasClientSectionName":"PulsarClient", "serverType":"broker"}|
 |`--auth-plugin`|Authentication plugin class name|org.apache.pulsar.client.impl.auth.AuthenticationSasl|
-|`--url`|Broker URL to which to connect|pulsar://localhost:6650/|
+|`--url`|Broker URL to which to connect|pulsar://localhost:6650/ </br> ws://localhost:8080 |
 
 
 ### `produce`


### PR DESCRIPTION
### Motivation
Support for websocket produce/consume command is added in https://github.com/apache/pulsar/pull/3835. The info is not updated in doc content.

### Modifications
Sync doc content with code update.
