### PR TITLE
[docs] Apply correct language identifiers to the code blocks in the documentation about Pulsar functions

### DIFF
--- a/site2/docs/functions-debug.md
+++ b/site2/docs/functions-debug.md
@@ -142,7 +142,7 @@ In Pulsar Functions, you can generate log information defined in functions to a 
 
 **Example** 
 
-```text
+```java
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 import org.slf4j.Logger;
@@ -168,7 +168,7 @@ As shown in the example above, you can get the logger via `context.getLogger()` 
 
 **Example** 
 
-```
+```bash
 $ bin/pulsar-admin functions create \
   --log-topic persistent://public/default/logging-function-logs \
   # Other function configs
@@ -194,7 +194,7 @@ Get information about a Pulsar Function.
 
 **Usage**
 
-```text
+```bash
 $ pulsar-admin functions get options
 ```
 
@@ -215,12 +215,12 @@ $ pulsar-admin functions get options
 
 You can specify `--fqfn` to get information about a Pulsar Function.
 
-```text
+```bash
 $ ./bin/pulsar-admin functions get public/default/ExclamationFunctio6
 ```
 Optionally, you can specify `--name`, `--namespace` and `--tenant` to get information about a Pulsar Function.
 
-```text
+```bash
 $ ./bin/pulsar-admin functions get \
     --tenant public \
     --namespace default \
@@ -229,7 +229,7 @@ $ ./bin/pulsar-admin functions get \
 
 As shown below, the `get` command shows input, output, runtime, and other information about the _ExclamationFunctio6_ function.
 
-```text
+```json
 {
   "tenant": "public",
   "namespace": "default",
@@ -256,7 +256,7 @@ Check the current status of a Pulsar Function.
 
 **Usage**
 
-```text
+```bash
 $ pulsar-admin functions status options
 ```
 
@@ -272,7 +272,7 @@ $ pulsar-admin functions status options
 
 **Example** 
 
-```text
+```bash
 $ ./bin/pulsar-admin functions status \
     --tenant public \
     --namespace default \
@@ -281,7 +281,7 @@ $ ./bin/pulsar-admin functions status \
 
 As shown below, the `status` command shows the number of instances, running instances, the instance running under the _ExclamationFunctio6_ function, received messages, successfully processed messages, system exceptions, the average latency and so on.
 
-```text
+```json
 {
   "numInstances" : 1,
   "numRunning" : 1,
@@ -311,7 +311,7 @@ Get the current stats of a Pulsar Function.
 
 **Usage**
 
-```text
+```bash
 $ pulsar-admin functions stats options
 ```
 
@@ -327,7 +327,7 @@ $ pulsar-admin functions stats options
 
 **Example**
 
-```text
+```bash
 $ ./bin/pulsar-admin functions stats \
     --tenant public \
     --namespace default \
@@ -336,7 +336,7 @@ $ ./bin/pulsar-admin functions stats \
 
 The output is shown as follows:
 
-```text
+```json
 {
   "receivedTotal" : 1,
   "processedSuccessfullyTotal" : 1,
@@ -379,7 +379,7 @@ List all Pulsar Functions running under a specific tenant and namespace.
 
 **Usage**
 
-```text
+```bash
 $ pulsar-admin functions list options
 ```
 
@@ -392,7 +392,7 @@ $ pulsar-admin functions list options
 
 **Example** 
 
-```text
+```bash
 $ ./bin/pulsar-admin functions list \
     --tenant public \
     --namespace default
@@ -411,7 +411,7 @@ Trigger a specified Pulsar Function with a supplied value. This command simulate
 
 **Usage**
 
-```text
+```bash
 $ pulsar-admin functions trigger options
 ```
 
@@ -429,7 +429,7 @@ $ pulsar-admin functions trigger options
 
 **Example** 
 
-```text
+```bash
 $ ./bin/pulsar-admin functions trigger \
     --tenant public \
     --namespace default \


### PR DESCRIPTION
### Motivation

When I read the documentation on how to debug Pulsar functions I saw that some code blocks are not highlighted, because of incorrect language identifiers.

### Modifications

Correct language identifiers were applied.