### PR TITLE
Xue/skywalking changes，Pulsar create/update function supports skywalking

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.functions.SkywalkingConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.functions.Utils;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -303,6 +303,12 @@ public class CmdFunctions extends CmdBase {
         protected String customRuntimeOptions;
         @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
         protected String deadLetterTopic;
+        @Parameter(names = "--skywalking-agent-jar-path", description = "The path of skywalking-agent.jar")
+        protected String skywalkingAgentJarPath;
+        @Parameter(names = "--skywalking-agent-conf-path", description = "The path of skywalking config file, if it is not specified, --skywalking-backend-service must be specified")
+        protected String skywalkingAgentConfPath;
+        @Parameter(names = "--skywalking-backend-service", description = "The skywalking-backend-service, if it is not specified, --skywalking-agent-conf-path must be specified")
+        protected String skywalkingBackendService;
         protected FunctionConfig functionConfig;
         protected String userCodeFile;
 
@@ -503,6 +509,32 @@ public class CmdFunctions extends CmdBase {
                 userCodeFile = functionConfig.getGo();
             }
 
+            SkywalkingConfig skywalkingConfig = functionConfig.getSkywalkingConfig();
+            if (skywalkingAgentJarPath != null) {
+                if (skywalkingConfig == null) {
+                    skywalkingConfig = new SkywalkingConfig();
+                }
+                skywalkingConfig.setSkywalkingAgentJarPath(skywalkingAgentJarPath);
+            }
+
+            if (skywalkingAgentConfPath != null) {
+                if (skywalkingConfig == null) {
+                    skywalkingConfig = new SkywalkingConfig();
+                }
+                skywalkingConfig.setSkywalkingAgentConfPath(skywalkingAgentConfPath);
+            }
+
+            if (skywalkingBackendService != null) {
+                if (skywalkingConfig == null) {
+                    skywalkingConfig = new SkywalkingConfig();
+                }
+                skywalkingConfig.setSkywalkingBackendService(skywalkingBackendService);
+            }
+
+            if (skywalkingConfig != null) {
+                functionConfig.setSkywalkingConfig(skywalkingConfig);
+            }
+            
             // check if configs are valid
             validateFunctionConfigs(functionConfig);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -112,4 +112,6 @@ public class FunctionConfig {
     // to change behavior at runtime. Currently, this primarily used by the KubernetesManifestCustomizer
     // interface
     private String customRuntimeOptions;
+    // function with skywalking
+    private SkywalkingConfig skywalkingConfig;
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/SkywalkingConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/SkywalkingConfig.java
@@ -1,0 +1,21 @@
+package org.apache.pulsar.common.functions;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Data
+@EqualsAndHashCode
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder=true)
+public class SkywalkingConfig {
+
+    private String skywalkingAgentJarPath;
+
+    private String skywalkingAgentConfPath;
+
+    private String skywalkingBackendService;
+
+}

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -45,6 +45,12 @@ message Resources {
     int64 disk = 3;
 }
 
+message SkywalkingConfig {
+    string skywalkingAgentJarPath = 1;
+    string skywalkingAgentConfPath = 2;
+    string skywalkingBackendService = 3;
+}
+
 message RetryDetails {
     int32 maxMessageRetries = 1;
     string deadLetterTopic = 2;
@@ -81,6 +87,7 @@ message FunctionDetails {
     string runtimeFlags = 17;
     ComponentType componentType = 18;
     string customRuntimeOptions = 19;
+    SkywalkingConfig skywalkingConfig = 20;
 }
 
 message ConsumerSpec {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -292,6 +292,35 @@ public class RuntimeUtils {
                     args.add("-Xmx" + String.valueOf(resources.getRam()));
                 }
             }
+            
+            // function with skywalking
+            Function.SkywalkingConfig skywalkingConfig = instanceConfig.getFunctionDetails().getSkywalkingConfig();
+            if (null != skywalkingConfig) {
+                String skywalkingAgentJarPath = skywalkingConfig.getSkywalkingAgentJarPath();
+                String skywalkingAgentConfPath = skywalkingConfig.getSkywalkingAgentConfPath();
+                String skywalkingBackService = skywalkingConfig.getSkywalkingBackendService();
+
+                if (!StringUtils.isEmpty(skywalkingAgentJarPath)
+                        && (!StringUtils.isEmpty(skywalkingAgentConfPath)
+                        || !StringUtils.isEmpty(skywalkingBackService))) {
+
+                    args.add("-javaagent:" + skywalkingAgentJarPath);
+
+                    if (!StringUtils.isEmpty(skywalkingAgentConfPath)) {
+                        args.add("-Dskywalking_config=" + skywalkingAgentConfPath);
+                    }
+
+                    if (!StringUtils.isEmpty(skywalkingBackService)) {
+                        args.add("-Dservice.url=" + skywalkingBackService);
+                    }
+
+                    args.add("-Dskywalking.agent.service_name=" + instanceConfig.getFunctionDetails().getName());
+                } else {
+                    log.error("skywalking options is invalid, instanceConfig: {}", instanceConfig.toString());
+                }
+            }
+            // function with skywalking
+            
             args.add("org.apache.pulsar.functions.instance.JavaInstanceMain");
 
             args.add("--jar");

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.WindowConfig;
+import org.apache.pulsar.common.functions.SkywalkingConfig;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
@@ -238,6 +239,24 @@ public class FunctionConfigUtils {
             functionDetailsBuilder.setCustomRuntimeOptions(functionConfig.getCustomRuntimeOptions());
         }
 
+        SkywalkingConfig skywalkingConfig = functionConfig.getSkywalkingConfig();
+        if (skywalkingConfig != null) {
+            Function.SkywalkingConfig.Builder swbldr = Function.SkywalkingConfig.newBuilder();
+            if (skywalkingConfig.getSkywalkingAgentJarPath() != null) {
+                swbldr.setSkywalkingAgentJarPath(skywalkingConfig.getSkywalkingAgentJarPath());
+            }
+
+            if (skywalkingConfig.getSkywalkingAgentConfPath() != null) {
+                swbldr.setSkywalkingAgentConfPath(skywalkingConfig.getSkywalkingAgentConfPath());
+            }
+
+            if (skywalkingConfig.getSkywalkingBackendService() != null) {
+                swbldr.setSkywalkingBackendService(skywalkingConfig.getSkywalkingBackendService());
+            }
+
+            functionDetailsBuilder.setSkywalkingConfig(swbldr);
+        }
+        
         return functionDetailsBuilder.build();
     }
 
@@ -342,6 +361,13 @@ public class FunctionConfigUtils {
             functionConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
         }
 
+        if (functionDetails.hasSkywalkingConfig()) {
+            SkywalkingConfig skywalkingConfig = new SkywalkingConfig();
+            skywalkingConfig.setSkywalkingAgentJarPath(functionDetails.getSkywalkingConfig().getSkywalkingAgentJarPath());
+            skywalkingConfig.setSkywalkingAgentConfPath(functionDetails.getSkywalkingConfig().getSkywalkingAgentConfPath());
+            skywalkingConfig.setSkywalkingBackendService(functionDetails.getSkywalkingConfig().getSkywalkingBackendService());
+            functionConfig.setSkywalkingConfig(skywalkingConfig);
+        }
         return functionConfig;
     }
 
@@ -556,6 +582,10 @@ public class FunctionConfigUtils {
             ResourceConfigUtils.validate(functionConfig.getResources());
         }
 
+        if (functionConfig.getSkywalkingConfig() != null) {
+            SkywalkingConfigUtils.validate(functionConfig.getSkywalkingConfig());
+        }
+        
         if (functionConfig.getTimeoutMs() != null && functionConfig.getTimeoutMs() <= 0) {
             throw new IllegalArgumentException("Function timeout must be a positive number");
         }
@@ -785,6 +815,9 @@ public class FunctionConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
             mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
+        }
+        if (newConfig.getSkywalkingConfig() != null) {
+            mergedConfig.setSkywalkingConfig(newConfig.getSkywalkingConfig());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SkywalkingConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SkywalkingConfigUtils.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.utils;
+
+import org.apache.pulsar.common.functions.SkywalkingConfig;
+
+public class SkywalkingConfigUtils {
+
+    public static void validate(SkywalkingConfig skywalkingConfig) {
+        if (skywalkingConfig.getSkywalkingAgentJarPath() == null) {
+            throw new IllegalArgumentException("SkywalkingAgent Jar is not specified");
+        }
+
+        if (skywalkingConfig.getSkywalkingAgentConfPath() == null
+            && skywalkingConfig.getSkywalkingBackendService() == null) {
+            throw new IllegalArgumentException("SkywalkingAgent Config Path is not specified or SkywalkingAgent Backend Service is not specified");
+        }
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist  
  Pulsar create/update function supports skywalking
-->



### Modifications

*Describe the modifications you've done.*

### Verifying this change

update:
Function.proto
RuntimeUtils.java
FunctionConfig.java
CmdFunctions.java
FunctionConfigUtils.java

add:
SkywalkingConfig.java
SkywalkingConfigUtils.java

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (yes)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  Pulsar function supports skywalking
  
  Usage:
  bin/pulsar-admin functions create \
  --jar examples/filter.jar \
  --classname com.newland.filter.FilterFunction \
  --tenant public \
  --namespace default \
  --name filtertest3 \
  --inputs persistent://public/default/filter-input \
  --output persistent://public/default/rr-input \
  --skywalking-agent-conf-path /opt/app/pulsar-2.4.1/skywalking/agent/config/agent.config \
  --skywalking-agent-jar-path /opt/app/pulsar-2.4.1/skywalking/agent/skywalking-agent.jar \
  --skywalking-backend-service 127.0.0.1:41800
  
  skywalking-agent-conf-path、skywalking-backend-service，It can exist at the same time or fill in only one。

