### PR TITLE
[pulsar-client-tools] Support CLI pulsar tokens for concise description

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
@@ -304,8 +304,9 @@ public class TokensCliUtils {
                 System.exit(1);
             }
         } catch (Exception e) {
-            jcommander.usage();
             System.err.println(e);
+            String chosenCommand = jcommander.getParsedCommand();
+            jcommander.usage(chosenCommand);
             System.exit(1);
         }
 


### PR DESCRIPTION
### Motivation

Current help description of `bin/pulsar tokens` is redundancy when only specified one subcommand.

### Modifications

Print corresponding usage according to the parsed command.