### PR TITLE
Remove duplicated lombok annotations in functions instance

### DIFF
--- a/pulsar-functions/api-java/src/test/java/org/apache/pulsar/functions/api/utils/JavaSerDeTest.java
+++ b/pulsar-functions/api-java/src/test/java/org/apache/pulsar/functions/api/utils/JavaSerDeTest.java
@@ -23,8 +23,6 @@ import static org.testng.Assert.assertEquals;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.testng.annotations.Test;
 
 /**
@@ -34,8 +32,6 @@ public class JavaSerDeTest {
 
     @Data
     @AllArgsConstructor
-    @EqualsAndHashCode
-    @ToString
     private static class TestObject implements Serializable {
 
         private int intField;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
@@ -20,19 +20,11 @@ package org.apache.pulsar.functions.instance;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * Configuration to aggregate various authentication params.
  */
 @Data
-@Getter
-@Setter
-@EqualsAndHashCode
-@ToString
 @Builder
 public class AuthenticationConfig {
     private String clientAuthenticationPlugin;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -19,10 +19,6 @@
 package org.apache.pulsar.functions.instance;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 
@@ -31,10 +27,6 @@ import org.apache.pulsar.functions.proto.Function.FunctionDetails;
  * passed to run functions.
  */
 @Data
-@Getter
-@Setter
-@EqualsAndHashCode
-@ToString
 public class InstanceConfig {
     private int instanceId;
     private String functionId;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.instance;
 
-import lombok.*;
+import lombok.Data;
 
 /**
  * This is the Java Instance. This is started by the runtimeSpawner using the JavaInstanceClient
@@ -26,10 +26,6 @@ import lombok.*;
  * based invocation.
  */
 @Data
-@Setter
-@Getter
-@EqualsAndHashCode
-@ToString
 public class JavaExecutionResult {
     private Exception userException;
     private Exception systemException;

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/pojo/Tick.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/pojo/Tick.java
@@ -19,15 +19,11 @@
 package org.apache.pulsar.functions.api.examples.pojo;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 /**
  * Pojo to represent a stock tick.
  */
 @Data
-@ToString
-@EqualsAndHashCode
 public class Tick {
 
     private long timeStamp;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
@@ -19,14 +19,12 @@
 package org.apache.pulsar.functions.runtime.kubernetes;
 
 import lombok.Data;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.common.configuration.FieldContext;
 
 import java.util.Map;
 
 @Data
-@ToString
 @Accessors(chain = true)
 public class KubernetesRuntimeFactoryConfig {
     @FieldContext(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeFactoryConfig.java
@@ -19,11 +19,9 @@
 package org.apache.pulsar.functions.runtime.process;
 
 import lombok.Data;
-import lombok.ToString;
 import org.apache.pulsar.common.configuration.FieldContext;
 
 @Data
-@ToString
 public class ProcessRuntimeFactoryConfig {
     @FieldContext(
         doc = "The path to the java instance. Change the jar location only when you put"

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntimeFactoryConfig.java
@@ -19,12 +19,10 @@
 package org.apache.pulsar.functions.runtime.thread;
 
 import lombok.Data;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.common.configuration.FieldContext;
 
 @Data
-@ToString
 @Accessors(chain = true)
 public class ThreadRuntimeFactoryConfig {
     @FieldContext(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -43,10 +43,6 @@ import org.apache.pulsar.common.configuration.PulsarConfiguration;
 import org.apache.pulsar.common.functions.Resources;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactoryConfig;
 import org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactoryConfig;
@@ -54,10 +50,6 @@ import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactoryConfig;
 
 @Data
-@Setter
-@Getter
-@EqualsAndHashCode
-@ToString
 @Accessors(chain = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkerConfig implements Serializable, PulsarConfiguration {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -22,10 +22,6 @@ import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.distributedlog.api.namespace.Namespace;
@@ -74,10 +70,6 @@ import static org.apache.pulsar.functions.utils.FunctionCommon.getSinkType;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getSourceType;
 
 @Data
-@Setter
-@Getter
-@EqualsAndHashCode
-@ToString
 @Slf4j
 public class FunctionActioner {
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeInfo.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeInfo.java
@@ -18,14 +18,12 @@
  */
 package org.apache.pulsar.functions.worker;
 
-import lombok.*;
+import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.functions.proto.Function.Instance;
 import org.apache.pulsar.functions.runtime.RuntimeSpawner;
 
 @Data
-@Setter
-@Getter
 @Accessors(chain = true)
 public class FunctionRuntimeInfo {
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/request/ServiceRequestInfo.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/request/ServiceRequestInfo.java
@@ -19,10 +19,7 @@
 package org.apache.pulsar.functions.worker.request;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.client.api.MessageId;
 
@@ -31,9 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.functions.proto.Request.ServiceRequest;
 
 @Data
-@Getter
-@EqualsAndHashCode
-@ToString
 @Accessors(chain = true)
 public class ServiceRequestInfo {
     private final ServiceRequest serviceRequest;

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/executor/MockExecutorController.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/executor/MockExecutorController.java
@@ -53,7 +53,6 @@ import org.mockito.stubbing.Answer;
 public class MockExecutorController {
 
     @Data
-    @Getter
     private class DeferredTask implements ScheduledFuture<Void> {
 
         private final Runnable runnable;


### PR DESCRIPTION
### Motivation

Some of the classes in the pulsar-functions module had a mixture of the following lombok annotations:

```
@Data
@Setter	
@Getter	
@EqualsAndHashCode	
@ToString
```

The [@Data](https://projectlombok.org/features/Data) annotation includes all other annotations:

> All together now: A shortcut for @ToString, @EqualsAndHashCode, @Getter on all fields, @Setter on all non-final fields, and @RequiredArgsConstructor!


### Modifications

Removed `@Setter`, `@Getter`, `@EqualsAndHashCode`, and '@ToString' if the `@Data` annotation was also present