### PR TITLE
Fix maven broken link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1687,7 +1687,7 @@ flexible messaging model and an intuitive client API.</description>
       <url>https://yahoo.bintray.com/maven</url>
     </repository>
     <repository>
-      <id>spring-libs-snapshot</id>
+      <id>spring-plugins-release</id>
       <url>https://repo.spring.io/plugins-release/</url>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1686,5 +1686,9 @@ flexible messaging model and an intuitive client API.</description>
       <name>bintray</name>
       <url>https://yahoo.bintray.com/maven</url>
     </repository>
+    <repository>
+      <id>spring-libs-snapshot</id>
+      <url>https://repo.spring.io/plugins-release/</url>
+    </repository>
   </repositories>
 </project>

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
@@ -57,7 +57,7 @@ public class FunctionCommonTest {
     @Test
     public void testValidateHttpFileUrl() throws Exception {
 
-        String jarHttpUrl = "http://central.maven.org/maven2/org/apache/pulsar/pulsar-common/1.22.0-incubating/pulsar-common-1.22.0-incubating.jar";
+        String jarHttpUrl = "https://repo1.maven.org/maven2/org/apache/pulsar/pulsar-common/2.4.2/pulsar-common-2.4.2.jar";
         FunctionCommon.extractClassLoader(jarHttpUrl);
 
         jarHttpUrl = "http://_invalidurl_.com";
@@ -72,7 +72,7 @@ public class FunctionCommonTest {
 
     @Test
     public void testDownloadFile() throws Exception {
-        String jarHttpUrl = "http://central.maven.org/maven2/org/apache/pulsar/pulsar-common/1.22.0-incubating/pulsar-common-1.22.0-incubating.jar";
+        String jarHttpUrl = "https://repo1.maven.org/maven2/org/apache/pulsar/pulsar-common/2.4.2/pulsar-common-2.4.2.jar";
         String testDir = FunctionCommonTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         File pkgFile = new File(testDir, UUID.randomUUID().toString());
         FunctionCommon.downloadFromHttpUrl(jarHttpUrl, pkgFile);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -1432,7 +1432,7 @@ public class FunctionApiV2ResourceTest {
 
     @Test
     public void testDownloadFunctionHttpUrl() throws Exception {
-        String jarHttpUrl = "http://central.maven.org/maven2/org/apache/pulsar/pulsar-common/1.22.0-incubating/pulsar-common-1.22.0-incubating.jar";
+        String jarHttpUrl = "https://repo1.maven.org/maven2/org/apache/pulsar/pulsar-common/2.4.2/pulsar-common-2.4.2.jar";
         String testDir = FunctionApiV2ResourceTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         FunctionsImplV2 function = new FunctionsImplV2(() -> mockedWorkerService);
         StreamingOutput streamOutput = (StreamingOutput) function.downloadFunction(jarHttpUrl, null).getEntity();

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -1468,7 +1468,7 @@ public class FunctionApiV3ResourceTest {
 
     @Test
     public void testDownloadFunctionHttpUrl() throws Exception {
-        String jarHttpUrl = "http://central.maven.org/maven2/org/apache/pulsar/pulsar-common/1.22.0-incubating/pulsar-common-1.22.0-incubating.jar";
+        String jarHttpUrl = "https://repo1.maven.org/maven2/org/apache/pulsar/pulsar-common/2.4.2/pulsar-common-2.4.2.jar";
         String testDir = FunctionApiV3ResourceTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         WorkerService worker = mock(WorkerService.class);
         doReturn(true).when(worker).isInitialized();

--- a/site2/docs/io-kafka-source.md
+++ b/site2/docs/io-kafka-source.md
@@ -64,7 +64,7 @@ Here is an example of using the Kafka source connecter with the configuration fi
 1. Download a Kafka client and a Kafka connector.
 
     ```bash
-    $ wget http://central.maven.org/maven2/org/apache/kafka/kafka-clients/0.10.2.1/kafka-clients-0.10.2.1.jar
+    $ wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/0.10.2.1/kafka-clients-0.10.2.1.jar
 
     $ wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-kafka-2.4.0.nar
     ```


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

1. maven broken link:

Currently, maven requires all links that start with https to download the required lib.

Same issue reference to: https://support.sonatype.com/hc/en-us/articles/360041287334

2. lookup `pulsar-io-solr` package error as follows:

```
2020-01-16T11:39:08.1688765Z [ERROR] Failed to execute goal on project pulsar-io-solr: Could not resolve dependencies for project org.apache.pulsar:pulsar-io-solr:jar:2.5.0: Failed to collect dependencies at org.apache.solr:solr-core:jar:7.5.0 -> org.restlet.jee:org.restlet:jar:2.3.0: Failed to read artifact descriptor for org.restlet.jee:org.restlet:jar:2.3.0: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.3.0 from/to maven-restlet (http://maven.restlet.org): Authorization failed for http://maven.restlet.org/org/restlet/jee/org.restlet/2.3.0/org.restlet-2.3.0.pom 403 Forbidden -> [Help 1]
```

### Modifications

- Replace 
`http://central.maven.org/maven2/org/apache/pulsar/pulsar-common/1.22.0-incubating/pulsar-common-1.22.0-incubating.jar` 
with 
`https://repo1.maven.org/maven2/org/apache/pulsar/pulsar-common/2.4.2/pulsar-common-2.4.2.jar` in `FunctionCommonTest.java`

- add a new address for `pulsar-io-solr`

