### PR TITLE
Support delete inactive topic when subscriptions caught up

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -106,9 +106,10 @@ brokerDeleteInactiveTopicsFrequencySeconds=60
 # and no active producers/consumers
 brokerDeleteInactiveTopicsMode=delete_when_no_subscriptions
 
-# Max duration of topic inactivity in seconds, default is 60s
+# Max duration of topic inactivity in seconds, default is not present
+# If not present, 'brokerDeleteInactiveTopicsFrequencySeconds' will be used
 # Topics that are inactive for longer than this value will be deleted
-brokerDeleteInactiveTopicsMaxInactiveDurationSeconds=60
+brokerDeleteInactiveTopicsMaxInactiveDurationSeconds=
 
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -100,6 +100,12 @@ brokerDeleteInactiveTopicsEnabled=true
 # How often to check for inactive topics
 brokerDeleteInactiveTopicsFrequencySeconds=60
 
+# Set the inactive topic delete mode. Default is delete_when_no_subscriptions
+# 'delete_when_no_subscriptions' mode only delete the topic which has no subscriptions and no active producers
+# 'delete_when_subscriptions_caught_up' mode only delete the topic that all subscriptions has no backlogs(caught up)
+# and no active producers/consumers
+brokerDeleteInactiveTopicsMode=delete_when_no_subscriptions
+
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -106,6 +106,10 @@ brokerDeleteInactiveTopicsFrequencySeconds=60
 # and no active producers/consumers
 brokerDeleteInactiveTopicsMode=delete_when_no_subscriptions
 
+# Max duration of topic inactivity in seconds, default is 60s
+# Topics that are inactive for longer than this value will be deleted
+brokerDeleteInactiveTopicsMaxInactiveDurationSeconds=60
+
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -267,6 +267,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "Max duration of topic inactivity in seconds, default is 60s\n"
+        + "Topics that are inactive for longer than this value will be deleted"
+    )
+    private int brokerDeleteInactiveTopicsMaxInactiveDurationSeconds = 60;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired messages"
     )
     private int messageExpiryCheckIntervalInMinutes = 5;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -33,6 +33,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
@@ -254,6 +255,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "How often to check for inactive topics"
     )
     private int brokerDeleteInactiveTopicsFrequencySeconds = 60;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
+        doc = "Set the inactive topic delete mode. Default is delete_when_no_subscriptions\n"
+        + "'delete_when_no_subscriptions' mode only delete the topic which has no subscriptions and no active producers\n"
+        + "'delete_when_subscriptions_caught_up' mode only delete the topic that all subscriptions has no backlogs(caught up)"
+        + "and no active producers/consumers"
+    )
+    private InactiveTopicDeleteMode brokerDeleteInactiveTopicsMode = InactiveTopicDeleteMode.delete_when_no_subscriptions;
+
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired messages"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -267,10 +267,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Max duration of topic inactivity in seconds, default is 60s\n"
+        doc = "Max duration of topic inactivity in seconds, default is not present\n"
+        + "If not present, 'brokerDeleteInactiveTopicsFrequencySeconds' will be used\n"
         + "Topics that are inactive for longer than this value will be deleted"
     )
-    private int brokerDeleteInactiveTopicsMaxInactiveDurationSeconds = 60;
+    private Integer brokerDeleteInactiveTopicsMaxInactiveDurationSeconds = null;
 
     @FieldContext(
         category = CATEGORY_POLICIES,
@@ -1465,6 +1466,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public boolean isDefaultTopicTypePartitioned() {
         return TopicType.PARTITIONED.toString().equals(allowAutoTopicCreationType);
+    }
+
+    public int getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds() {
+        if (brokerDeleteInactiveTopicsMaxInactiveDurationSeconds == null) {
+            return brokerDeleteInactiveTopicsFrequencySeconds;
+        } else {
+            return brokerDeleteInactiveTopicsMaxInactiveDurationSeconds;
+        }
     }
 
     enum TopicType {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -134,6 +134,16 @@ public abstract class AbstractTopic implements Topic {
         return foundLocal.get();
     }
 
+    protected boolean hasLocalConsumers() {
+        AtomicBoolean foundLocal = new AtomicBoolean(false);
+        getSubscriptions().values().forEach(sub -> {
+            if (sub.getConsumers() != null && sub.getConsumers().size() > 0) {
+                foundLocal.set(true);
+            }
+        });
+        return foundLocal.get();
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).add("topic", topic).toString();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -134,16 +134,6 @@ public abstract class AbstractTopic implements Topic {
         return foundLocal.get();
     }
 
-    protected boolean hasLocalConsumers() {
-        AtomicBoolean foundLocal = new AtomicBoolean(false);
-        getSubscriptions().values().forEach(sub -> {
-            if (sub.getConsumers() != null && sub.getConsumers().size() > 0) {
-                foundLocal.set(true);
-            }
-        });
-        return foundLocal.get();
-    }
-
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).add("topic", topic).toString();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1096,7 +1096,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     public void checkGC(int gcIntervalInSeconds) {
-        forEachTopic(topic -> topic.checkGC(gcIntervalInSeconds));
+        forEachTopic(topic -> topic.checkGC(gcIntervalInSeconds, pulsar.getConfiguration().getBrokerDeleteInactiveTopicsMode()));
     }
 
     public void checkMessageExpiry() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -403,7 +403,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     protected void startInactivityMonitor() {
         if (pulsar().getConfiguration().isBrokerDeleteInactiveTopicsEnabled()) {
             int interval = pulsar().getConfiguration().getBrokerDeleteInactiveTopicsFrequencySeconds();
-            inactivityMonitor.scheduleAtFixedRate(safeRun(() -> checkGC(interval)), interval, interval,
+            int maxInactiveDurationInSec = pulsar().getConfiguration().getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds();
+            inactivityMonitor.scheduleAtFixedRate(safeRun(() -> checkGC(maxInactiveDurationInSec)), interval, interval,
                     TimeUnit.SECONDS);
         }
 
@@ -1095,8 +1096,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return lookupRequestSemaphore.get();
     }
 
-    public void checkGC(int gcIntervalInSeconds) {
-        forEachTopic(topic -> topic.checkGC(gcIntervalInSeconds, pulsar.getConfiguration().getBrokerDeleteInactiveTopicsMode()));
+    public void checkGC(int maxInactiveDurationInSec) {
+        forEachTopic(topic -> topic.checkGC(maxInactiveDurationInSec,
+            pulsar.getConfiguration().getBrokerDeleteInactiveTopicsMode()));
     }
 
     public void checkMessageExpiry() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -123,7 +124,7 @@ public interface Topic {
 
     CompletableFuture<Void> close(boolean closeWithoutWaitingClientDisconnect);
 
-    void checkGC(int gcInterval);
+    void checkGC(int gcInterval, InactiveTopicDeleteMode deleteMode);
 
     void checkInactiveSubscriptions();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -124,7 +124,7 @@ public interface Topic {
 
     CompletableFuture<Void> close(boolean closeWithoutWaitingClientDisconnect);
 
-    void checkGC(int gcInterval, InactiveTopicDeleteMode deleteMode);
+    void checkGC(int maxInactiveDurationInSec, InactiveTopicDeleteMode deleteMode);
 
     void checkInactiveSubscriptions();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -68,6 +68,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.NonPersistentPublisherStats;
 import org.apache.pulsar.common.policies.data.NonPersistentReplicatorStats;
 import org.apache.pulsar.common.policies.data.NonPersistentSubscriptionStats;
@@ -822,7 +823,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
-    public void checkGC(int gcIntervalInSeconds) {
+    public void checkGC(int gcIntervalInSeconds, InactiveTopicDeleteMode deleteMode) {
         if (isActive()) {
             lastActive = System.nanoTime();
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -823,11 +823,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
-    public void checkGC(int gcIntervalInSeconds, InactiveTopicDeleteMode deleteMode) {
+    public void checkGC(int maxInactiveDurationInSec, InactiveTopicDeleteMode deleteMode) {
         if (isActive()) {
             lastActive = System.nanoTime();
         } else {
-            if (System.nanoTime() - lastActive > TimeUnit.SECONDS.toNanos(gcIntervalInSeconds)) {
+            if (System.nanoTime() - lastActive > TimeUnit.SECONDS.toNanos(maxInactiveDurationInSec)) {
 
                 if (TopicName.get(topic).isGlobal()) {
                     // For global namespace, close repl producers first.
@@ -835,7 +835,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
                     // provided no remote producers connected to the broker.
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] Global topic inactive for {} seconds, closing repl producers.", topic,
-                                gcIntervalInSeconds);
+                            maxInactiveDurationInSec);
                     }
 
                     stopReplProducers().thenCompose(v -> delete(true, false, true))

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1600,10 +1600,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (!subscriptions.isEmpty()) {
                     return true;
                 }
+                break;
             case delete_when_subscriptions_caught_up:
-                if (hasLocalConsumers() || hasBacklogs()) {
+                if (hasBacklogs()) {
                     return true;
                 }
+                break;
         }
         if (TopicName.get(topic).isGlobal()) {
             // no local producers

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -100,6 +100,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.LedgerInfo;
@@ -764,11 +765,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     @Override
     public CompletableFuture<Void> delete() {
-        return delete(false, false);
+        return delete(false, false, false);
     }
 
-    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions, boolean deleteSchema) {
-        return delete(failIfHasSubscriptions, false, deleteSchema);
+    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions, boolean failIfHasBacklogs, boolean deleteSchema) {
+        return delete(failIfHasSubscriptions, failIfHasBacklogs, false, deleteSchema);
     }
 
     /**
@@ -780,7 +781,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     @Override
     public CompletableFuture<Void> deleteForcefully() {
-        return delete(false, true, false);
+        return delete(false, false, true, false);
     }
 
     /**
@@ -800,6 +801,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      *         IllegalStateException if topic is still active ManagedLedgerException if ledger delete operation fails
      */
     private CompletableFuture<Void> delete(boolean failIfHasSubscriptions,
+                                           boolean failIfHasBacklogs,
                                            boolean closeIfClientsConnected,
                                            boolean deleteSchema) {
         CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
@@ -839,6 +841,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         if (!subscriptions.isEmpty()) {
                             isFenced = false;
                             deleteFuture.completeExceptionally(new TopicBusyException("Topic has subscriptions"));
+                            return;
+                        }
+                    } else if (failIfHasBacklogs) {
+                        if (hasBacklogs()) {
+                            isFenced = false;
+                            deleteFuture.completeExceptionally(new TopicBusyException("Topic has subscriptions did not catch up"));
                             return;
                         }
                     } else {
@@ -1586,17 +1594,32 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return ledger.getEstimatedBacklogSize();
     }
 
-    public boolean isActive() {
-        if (TopicName.get(topic).isGlobal()) {
-            // No local consumers and no local producers
-            return !subscriptions.isEmpty() || hasLocalProducers();
+    public boolean isActive(InactiveTopicDeleteMode deleteMode) {
+        switch (deleteMode) {
+            case delete_when_no_subscriptions:
+                if (!subscriptions.isEmpty()) {
+                    return true;
+                }
+            case delete_when_subscriptions_caught_up:
+                if (hasLocalConsumers() || hasBacklogs()) {
+                    return true;
+                }
         }
-        return USAGE_COUNT_UPDATER.get(this) != 0 || !subscriptions.isEmpty();
+        if (TopicName.get(topic).isGlobal()) {
+            // no local producers
+            return hasLocalProducers();
+        } else {
+            return USAGE_COUNT_UPDATER.get(this) != 0;
+        }
+    }
+
+    private boolean hasBacklogs() {
+        return subscriptions.values().stream().anyMatch(sub -> sub.getNumberOfEntriesInBacklog() > 0);
     }
 
     @Override
-    public void checkGC(int gcIntervalInSeconds) {
-        if (isActive()) {
+    public void checkGC(int gcIntervalInSeconds, InactiveTopicDeleteMode deleteMode) {
+        if (isActive(deleteMode)) {
             lastActive = System.nanoTime();
         } else if (System.nanoTime() - lastActive < TimeUnit.SECONDS.toNanos(gcIntervalInSeconds)) {
             // Gc interval did not expire yet
@@ -1639,7 +1662,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 replCloseFuture.complete(null);
             }
 
-            replCloseFuture.thenCompose(v -> delete(true, true))
+            replCloseFuture.thenCompose(v -> delete(deleteMode == InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                deleteMode == InactiveTopicDeleteMode.delete_when_subscriptions_caught_up, true))
                     .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
                     .exceptionally(e -> {
                         if (e.getCause() instanceof TopicBusyException) {
@@ -1969,7 +1993,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     public CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema) {
         return hasSchema()
             .thenCompose((hasSchema) -> {
-                    if (hasSchema || isActive() || ledger.getTotalSize() != 0) {
+                    if (hasSchema || isActive(InactiveTopicDeleteMode.delete_when_no_subscriptions) || ledger.getTotalSize() != 0) {
                         return checkSchemaCompatibleForConsumer(schema);
                     } else {
                         return addSchema(schema).thenCompose(schemaVersion ->

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -40,7 +40,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     public void testDeleteWhenNoSubscriptions() throws Exception {
         conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
-        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(1);
         super.baseSetup();
 
         final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
@@ -73,7 +72,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     public void testDeleteWhenNoBacklogs() throws Exception {
         conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
-        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(1);
         super.baseSetup();
 
         final String topic = "persistent://prop/ns-abc/testDeleteWhenNoBacklogs";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Consumer;
+
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class InactiveTopicDeleteTest extends BrokerTestBase {
+
+    protected void setup() throws Exception {
+        // No-op
+    }
+
+    protected void cleanup() throws Exception {
+        // No-op
+    }
+
+    @Test
+    public void testDeleteWhenNoSubscriptions() throws Exception {
+        conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        super.baseSetup();
+
+        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+            .topic(topic)
+            .create();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+            .topic(topic)
+            .subscriptionName("sub")
+            .subscribe();
+
+        consumer.close();
+        producer.close();
+
+        Thread.sleep(2000);
+        Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        admin.topics().deleteSubscription(topic, "sub");
+        Thread.sleep(2000);
+        Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testDeleteWhenNoBacklogs() throws Exception {
+        conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        super.baseSetup();
+
+        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoBacklogs";
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+            .topic(topic)
+            .create();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+            .topic(topic)
+            .subscriptionName("sub")
+            .subscribe();
+
+        for (int i = 0; i < 10; i++) {
+            producer.send("Pulsar".getBytes());
+        }
+
+        consumer.close();
+        producer.close();
+
+        Thread.sleep(2000);
+        Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        admin.topics().skipAllMessages(topic, "sub");
+        Thread.sleep(2000);
+        Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        super.internalCleanup();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -103,4 +103,29 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         super.internalCleanup();
     }
+
+    @Test
+    public void testMaxInactiveDuration() throws Exception {
+        conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(5);
+        super.baseSetup();
+
+        final String topic = "persistent://prop/ns-abc/testMaxInactiveDuration";
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+            .topic(topic)
+            .create();
+
+        producer.close();
+        Thread.sleep(2000);
+        Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        Thread.sleep(4000);
+        Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+            .contains(topic));
+
+        super.internalCleanup();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -40,6 +40,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     public void testDeleteWhenNoSubscriptions() throws Exception {
         conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(1);
         super.baseSetup();
 
         final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
@@ -72,6 +73,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     public void testDeleteWhenNoBacklogs() throws Exception {
         conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(1);
         super.baseSetup();
 
         final String topic = "persistent://prop/ns-abc/testDeleteWhenNoBacklogs";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
@@ -197,7 +198,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                     // Thread.sleep(5,0);
                     log.info("{} forcing topic GC ", Thread.currentThread());
                     for (int i = 0; i < 2000; i++) {
-                        topic.checkGC(0);
+                        topic.checkGC(0, InactiveTopicDeleteMode.delete_when_no_subscriptions);
                     }
                     log.info("GC done..");
                 } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.testng.annotations.Test;
 
 /**
@@ -59,6 +60,7 @@ public class ServiceConfigurationTest {
         assertTrue(config.getBrokerServicePort().isPresent()
                 && config.getBrokerServicePort().get().equals(brokerServicePort));
         assertEquals(config.getBootstrapNamespaces().get(1), "ns2");
+        assertEquals(config.getBrokerDeleteInactiveTopicsMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
     }
 
     @Test

--- a/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
+++ b/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
@@ -85,3 +85,4 @@ replicationMetricsEnabled=true
 replicationConnectionsPerBroker=16
 replicationProducerQueueSize=1000
 replicatorPrefix=pulsar.repl
+brokerDeleteInactiveTopicsMode=delete_when_subscriptions_caught_up

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+/**
+ * Inactive topic deletion mode.
+ */
+public enum InactiveTopicDeleteMode {
+
+    /**
+     * The topic can be deleted when no subscriptions and no active producers
+     */
+    delete_when_no_subscriptions,
+
+    /**
+     * The topic can be deleted when all subscriptions catchup and no active producers/consumers
+     */
+    delete_when_subscriptions_caught_up
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
@@ -24,12 +24,12 @@ package org.apache.pulsar.common.policies.data;
 public enum InactiveTopicDeleteMode {
 
     /**
-     * The topic can be deleted when no subscriptions and no active producers
+     * The topic can be deleted when no subscriptions and no active producers.
      */
     delete_when_no_subscriptions,
 
     /**
-     * The topic can be deleted when all subscriptions catchup and no active producers/consumers
+     * The topic can be deleted when all subscriptions catchup and no active producers/consumers.
      */
     delete_when_subscriptions_caught_up
 }


### PR DESCRIPTION
### Motivation

Currently, pulsar support delete inactive topic which has no active producers and no subscriptions. This pull request is support to delete inactive topics that all subscriptions of the topic are caught up and no active producers/consumer. 

### Modifications

Expose inactive topic delete mode in broker.conf, future more we can support namespace level configuration for the inactive topic delete mode.

### Verifying this change

New unit tests added for each inactive topic delete mode.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
