### PR TITLE
Add a message on how to make log refresh immediately when starting a component

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -151,6 +151,7 @@ case $startStop in
 
     rotate_out_log $out
     echo starting $command, logging to $logfile
+    echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
     pulsar=$PULSAR_HOME/bin/pulsar
     nohup $pulsar $command "$@" > "$out" 2>&1 < /dev/null &
     echo $! > $pid

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -61,7 +61,7 @@ Configuration:
       name: RollingFile
       fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
-      immediateFlush: true
+      immediateFlush: false
       PatternLayout:
         Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
       Policies:

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -61,7 +61,7 @@ Configuration:
       name: RollingFile
       fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
-      immediateFlush: false
+      immediateFlush: true
       PatternLayout:
         Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
       Policies:


### PR DESCRIPTION
### Motivation

Some users may confuse by pulsar/bookie log without flushing immediately.

### Modifications

Add a message in `bin/pulsar-daemon` when starting a component.