### PR TITLE
[Issue 5326] make bookie ranges stored in path/to/bkdata/ranges

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -310,6 +310,9 @@ public class LocalBookkeeperEnsemble {
         // stream storage port
         conf.setProperty("storageserver.grpc.port", streamStoragePort);
 
+        // storage server settings
+        conf.setProperty("storage.range.store.dirs", bkDataDirName + "/ranges/data");
+
         // initialize the stream storage metadata
         ClusterInitializer initializer = new ZkClusterInitializer(zkServers);
         initializer.initializeCluster(metadataServiceUri, 2);


### PR DESCRIPTION
Master Issue: #5326  

### Motivation

After this fix, pulsar will not create data/bookkeeper/ranges in the pulsar library folder after executing `bin/pulsar standalone --bookkeeper-dir dir1 --zookeeper-dir dir2`. All the bookie ranges will be stored in bookkeeper's data directory. 

### Modifications
Pass `storage.range.store.dirs` to storage server when starting pulsar. Hardcode ranges's dir to ${path/to/bookie/datadir}/ranges/data, just under bookie. 

### Verifying this change
Follow the steps in [issue 5326](https://github.com/apache/pulsar/issues/5326) and start pulsar with `bin/pulsar standalone --bookkeeper-dir dir1 --zookeeper-dir dir2`