### PR TITLE
[Functions] The argument and description for dead letter topic is wrong

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -185,6 +185,8 @@ public class CmdFunctionsTest {
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", DummyFunction.class.getName(),
+            "--dead-letter-topic", "test-dead-letter-topic",
+            "--custom-runtime-options", "custom-runtime-options"
         });
 
         CreateFunction creater = cmd.getCreater();
@@ -192,6 +194,8 @@ public class CmdFunctionsTest {
         assertEquals(inputTopicName, creater.getInputs());
         assertEquals(outputTopicName, creater.getOutput());
         assertEquals(new Boolean(false), creater.getAutoAck());
+        assertEquals("test-dead-letter-topic", creater.getDeadLetterTopic());
+        assertEquals("custom-runtime-options", creater.getCustomRuntimeOptions());
 
         verify(functions, times(1)).createFunction(any(FunctionConfig.class), anyString());
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -299,9 +299,9 @@ public class CmdFunctions extends CmdBase {
         protected Long timeoutMs;
         @Parameter(names = "--max-message-retries", description = "How many times should we try to process a message before giving up")
         protected Integer maxMessageRetries;
-        @Parameter(names = "--dead-letter-topic", description = "The topic where messages that are not processed successfully are sent to")
-        protected String customRuntimeOptions;
         @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        protected String customRuntimeOptions;
+        @Parameter(names = "--dead-letter-topic", description = "The topic where messages that are not processed successfully are sent to")
         protected String deadLetterTopic;
         protected FunctionConfig functionConfig;
         protected String userCodeFile;


### PR DESCRIPTION
*Motivation*

Related to #6084

 #5400 introduces `customRuntimeOptions` in function details. But the description was wrong. The mistake was probably introduced by bad merges.

*Modification*

Fix the argument and description for `deadletterTopic` and `customRuntimeOptions`.

*Tests*

Add a unit test to ensure the parameters are set correctly.

