### PR TITLE
Fix typo in Reader documentation.

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -284,7 +284,7 @@ Pulsar Node.js readers have the following methods available:
 | :----- | :---------- | :---------- |
 | `readNext()` | Receives the next message on the topic (analogous to the `receive` method for [consumers](#consumer-operations)). When the message is available, the Promise object run executor function and get message object. | `Promise<Object>` |
 | `readNext(Number)` | Receives a single message from the topic with specific timeout in milliseconds. | `Promise<Object>` |
-| `hasNext()` | Return whether Proker has next message in target topic. | `Boolean` |
+| `hasNext()` | Return whether Broker has next message in target topic. | `Boolean` |
 | `close()` | Closes the reader, disabling its ability to receive messages from the broker. | `Promise<null>` |
 
 ### Reader configuration

--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -284,7 +284,7 @@ Pulsar Node.js readers have the following methods available:
 | :----- | :---------- | :---------- |
 | `readNext()` | Receives the next message on the topic (analogous to the `receive` method for [consumers](#consumer-operations)). When the message is available, the Promise object run executor function and get message object. | `Promise<Object>` |
 | `readNext(Number)` | Receives a single message from the topic with specific timeout in milliseconds. | `Promise<Object>` |
-| `hasNext()` | Return whether Broker has next message in target topic. | `Boolean` |
+| `hasNext()` | Return whether the broker has next message in target topic. | `Boolean` |
 | `close()` | Closes the reader, disabling its ability to receive messages from the broker. | `Promise<null>` |
 
 ### Reader configuration


### PR DESCRIPTION
Proker -> Broker.

### Motivation

Fix typo in documentation.

### Modifications

Changed Proker to Broker.

### Verifying this change

no tests needed

### Does this pull request potentially affect one of the following parts:

no
