### PR TITLE
[pulsar-admin] allow tenant admin to manage subscription permission

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -373,8 +373,7 @@ public abstract class NamespacesBase extends AdminResource {
 
 
     protected void internalGrantPermissionOnSubscription(String subscription, Set<String> roles) {
-        /** controlled by system-admin(super-user) to prevent metadata footprint size */
-        validateSuperUserAccess();
+        validateAdminAccessForTenant(namespaceName.getTenant());
 
         try {
             AuthorizationService authService = pulsar().getBrokerService().getAuthorizationService();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -243,7 +243,8 @@ public class Namespaces extends NamespacesBase {
 
     @POST
     @Path("/{property}/{cluster}/{namespace}/permissions/subscription/{subscription}")
-    @ApiOperation(hidden = true, value = "Grant a new permission to roles for a subscription.")
+    @ApiOperation(hidden = true, value = "Grant a new permission to roles for a subscription. "
+            + "[Tenant admin is allowed to perform this operation]")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
             @ApiResponse(code = 409, message = "Concurrent modification"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -193,7 +193,8 @@ public class Namespaces extends NamespacesBase {
 
     @POST
     @Path("/{property}/{namespace}/permissions/subscription/{subscription}")
-    @ApiOperation(hidden = true, value = "Grant a new permission to roles for a subscription.")
+    @ApiOperation(hidden = true, value = "Grant a new permission to roles for a subscription."
+            + "[Tenant admin is allowed to perform this operation]")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
             @ApiResponse(code = 409, message = "Concurrent modification"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -226,7 +226,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
         // grant subscription access to specific different role and only that role can access the subscription
         String otherPrincipal = "Principal-1-to-access-sub";
-        superAdmin.namespaces().grantPermissionOnSubscription(namespace, subscriptionName,
+        tenantAdmin.namespaces().grantPermissionOnSubscription(namespace, subscriptionName,
                 Collections.singleton(otherPrincipal));
 
         // now, subscriptionRole doesn't have subscription level access so, it will fail to access subscription


### PR DESCRIPTION
### Motivation
In #2981, we have added support to grant subscriber-permission to manage subscription based apis. However, grant-subscription-permission api requires super-user access and it creates too much dependency on system-admin when many tenants want to grant subscription permission.
So, allow each tenant to manage subscription permission in order to reduce administrative efforts for super user. 