### PR TITLE
Fix broker client tls settings error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -919,7 +919,7 @@ public class PulsarService implements AutoCloseable {
 
                 if (isNotBlank(this.getConfiguration().getBrokerClientAuthenticationPlugin())) {
                     builder.authentication(this.getConfiguration().getBrokerClientAuthenticationPlugin(),
-                        this.getConfiguration().getBrokerClientAuthenticationParameters());
+                            this.getConfiguration().getBrokerClientAuthenticationParameters());
                 }
                 this.client = builder.build();
             } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -907,12 +907,16 @@ public class PulsarService implements AutoCloseable {
                 ClientBuilder builder = PulsarClient.builder()
                     .serviceUrl(this.getConfiguration().isTlsEnabled()
                                 ? this.brokerServiceUrlTls : this.brokerServiceUrl)
-                    .enableTls(this.getConfiguration().isTlsEnabled())
-                    .allowTlsInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection())
-                    .tlsTrustCertsFilePath(this.getConfiguration().getTlsCertificateFilePath());
+                    .enableTls(this.getConfiguration().isTlsEnabled());
+
+                if (this.getConfiguration().isBrokerClientTlsEnabled()) {
+                    builder.allowTlsInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection());
+                    builder.tlsTrustCertsFilePath(this.getConfiguration().getBrokerClientTrustCertsFilePath());
+                }
+
                 if (isNotBlank(this.getConfiguration().getBrokerClientAuthenticationPlugin())) {
                     builder.authentication(this.getConfiguration().getBrokerClientAuthenticationPlugin(),
-                                           this.getConfiguration().getBrokerClientAuthenticationParameters());
+                        this.getConfiguration().getBrokerClientAuthenticationParameters());
                 }
                 this.client = builder.build();
             } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -907,10 +907,11 @@ public class PulsarService implements AutoCloseable {
                 ClientBuilder builder = PulsarClient.builder()
                     .serviceUrl(this.getConfiguration().isTlsEnabled()
                                 ? this.brokerServiceUrlTls : this.brokerServiceUrl)
-                    .enableTls(this.getConfiguration().isTlsEnabled());
+                    .enableTls(this.getConfiguration().isTlsEnabled())
+                    .allowTlsInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection())
+                    .tlsTrustCertsFilePath(this.getConfiguration().getTlsCertificateFilePath());
 
                 if (this.getConfiguration().isBrokerClientTlsEnabled()) {
-                    builder.allowTlsInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection());
                     builder.tlsTrustCertsFilePath(
                         isNotBlank(this.getConfiguration().getBrokerClientTrustCertsFilePath())
                             ? this.getConfiguration().getBrokerClientTrustCertsFilePath()
@@ -919,7 +920,7 @@ public class PulsarService implements AutoCloseable {
 
                 if (isNotBlank(this.getConfiguration().getBrokerClientAuthenticationPlugin())) {
                     builder.authentication(this.getConfiguration().getBrokerClientAuthenticationPlugin(),
-                            this.getConfiguration().getBrokerClientAuthenticationParameters());
+                                           this.getConfiguration().getBrokerClientAuthenticationParameters());
                 }
                 this.client = builder.build();
             } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -911,7 +911,10 @@ public class PulsarService implements AutoCloseable {
 
                 if (this.getConfiguration().isBrokerClientTlsEnabled()) {
                     builder.allowTlsInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection());
-                    builder.tlsTrustCertsFilePath(this.getConfiguration().getBrokerClientTrustCertsFilePath());
+                    builder.tlsTrustCertsFilePath(
+                        isNotBlank(this.getConfiguration().getBrokerClientTrustCertsFilePath())
+                            ? this.getConfiguration().getBrokerClientTrustCertsFilePath()
+                            : this.getConfiguration().getTlsCertificateFilePath());
                 }
 
                 if (isNotBlank(this.getConfiguration().getBrokerClientAuthenticationPlugin())) {

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -152,7 +152,7 @@ class PulsarTest(TestCase):
         producer.send(b'hello')
 
         redelivery_count = 0
-        for i in range(4):  
+        for i in range(4):
             msg = consumer.receive(TM)
             print("Received message %s" % msg.data())
             consumer.negative_acknowledge(msg)
@@ -668,13 +668,13 @@ class PulsarTest(TestCase):
         while True:
             s=doHttpGet(url).decode('utf-8')
             if 'RUNNING' in s:
-                print("Compact still running")
                 print(s)
+                print("Compact still running")
                 time.sleep(0.2)
             else:
-                self.assertTrue('SUCCESS' in s)
-                print("Compact Complete now")
                 print(s)
+                print("Compact Complete now")
+                self.assertTrue('SUCCESS' in s)
                 break
 
         # after compaction completes the compacted ledger is recorded


### PR DESCRIPTION
when broker create the inside client, it sets tlsTrustCertsFilePath as "getTlsCertificateFilePath()", but it should be "getBrokerClientTrustCertsFilePath()"