### PR TITLE
[CPP] Compile fixes for ARM cpus

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -27,6 +27,8 @@ if(CCACHE_PROGRAM)
     MESSAGE(STATUS "Using CCache")
 endif(CCACHE_PROGRAM)
 
+MESSAGE(STATUS "ARCHITECTURE: ${CMAKE_SYSTEM_PROCESSOR}")
+
 option(BUILD_TESTS "Build tests" ON)
 MESSAGE(STATUS "BUILD_TESTS:  " ${BUILD_TESTS})
 
@@ -49,12 +51,16 @@ set(Boost_NO_BOOST_CMAKE ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 11)
 
-if (NOT MSVC)
-    add_compile_options(-msse4.2 -mpclmul -Werror=switch -Wno-deprecated-declarations)
-else()
+if (MSVC)
+    # Visual Studio compiler flags
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOGDI -D_WIN32_WINNT=0x0501 -D_CRT_SECURE_NO_WARNINGS)
     add_compile_options(/wd4244 /wd4267 /wd4018 /wd4715 /wd4251 /wd4275)
-endif(NOT MSVC)
+else()
+    add_compile_options(-Werror=switch -Wno-deprecated-declarations)
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        add_compile_options(-msse4.2 -mpclmul)
+    endif()
+endif(MSVC)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
@@ -21,14 +21,14 @@
 #include <stdlib.h>
 
 #if BOOST_ARCH_X86_64
-#  include <nmmintrin.h>  // SSE4.2
-#  include <wmmintrin.h>  // PCLMUL
+#include <nmmintrin.h>  // SSE4.2
+#include <wmmintrin.h>  // PCLMUL
 #endif
 
 #ifdef _MSC_VER
-#  include <intrin.h>
+#include <intrin.h>
 #elif BOOST_ARCH_X86_64
-#  include <cpuid.h>
+#include <cpuid.h>
 #endif
 
 //#define CRC32C_DEBUG
@@ -240,7 +240,7 @@ uint32_t crc32c(uint32_t init, const void *buf, size_t len, const chunk_config *
     return crc;
 }
 
-#else // ! BOOST_ARCH_X86_64
+#else  // ! BOOST_ARCH_X86_64
 
 uint32_t crc32c(uint32_t init, const void *buf, size_t len, const chunk_config *config) {
     // SSE 4.2 extension for hw implementation are not present

--- a/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
@@ -15,14 +15,20 @@
  ******************************************************************************/
 #include "crc32c_sse42.h"
 
+#include <boost/predef.h>
+
 #include <assert.h>
-#include <nmmintrin.h>  // SSE4.2
-#include <wmmintrin.h>  // PCLMUL
+#include <stdlib.h>
+
+#if BOOST_ARCH_X86_64
+#  include <nmmintrin.h>  // SSE4.2
+#  include <wmmintrin.h>  // PCLMUL
+#endif
 
 #ifdef _MSC_VER
-#include <intrin.h>
-#else
-#include <cpuid.h>
+#  include <intrin.h>
+#elif BOOST_ARCH_X86_64
+#  include <cpuid.h>
 #endif
 
 //#define CRC32C_DEBUG
@@ -55,12 +61,15 @@ bool crc32c_initialize() {
         __cpuid(CPUInfo, 1);
         has_sse42 = (CPUInfo[2] & cpuid_ecx_sse42) != 0;
         has_pclmulqdq = (CPUInfo[2] & cpuid_ecx_pclmulqdq) != 0;
-#else
+#elif BOOST_ARCH_X86_64
         unsigned int eax, ebx, ecx, edx;
         if (__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
             has_sse42 = (ecx & cpuid_ecx_sse42) != 0;
             has_pclmulqdq = (ecx & cpuid_ecx_pclmulqdq) != 0;
         }
+#else
+        has_sse42 = false;
+        has_pclmulqdq = false;
 #endif
         DEBUG_PRINTF1("has_sse42 = %d\n", has_sse42);
         DEBUG_PRINTF1("has_pclmulqdq = %d\n", has_pclmulqdq);
@@ -87,6 +96,8 @@ void chunk_config::make_shift_table(size_t bytes, uint32_t table[256]) {
     pow(m, op, bytes * 8);
     for (unsigned int i = 0; i < 256; ++i) table[i] = (const bitvector<32>)mul(m, bitvector<32>(i));
 }
+
+#if BOOST_ARCH_X86_64
 
 static uint32_t crc32c_chunk(uint32_t crc, const void *buf, const chunk_config &config) {
     DEBUG_PRINTF3("  crc32c_chunk(crc = 0x%08x, buf = %p, config.words = " SIZE_T_FORMAT ")", crc, buf,
@@ -228,3 +239,12 @@ uint32_t crc32c(uint32_t init, const void *buf, size_t len, const chunk_config *
     DEBUG_PRINTF1("crc = 0x%08x\n", crc);
     return crc;
 }
+
+#else // ! BOOST_ARCH_X86_64
+
+uint32_t crc32c(uint32_t init, const void *buf, size_t len, const chunk_config *config) {
+    // SSE 4.2 extension for hw implementation are not present
+    abort();
+}
+
+#endif

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -369,7 +369,7 @@ int main(int argc, char** argv) {
 
     pulsar::Client client(pulsar::PulsarFriend::getClient(args.serviceURL, conf, false));
 
-    std::atomic<bool> exitCondition;
+    std::atomic<bool> exitCondition(false);
     startPerfProducer(args, producerConf, client, exitCondition);
 
     Clock::time_point oldTime = Clock::now();

--- a/pulsar-client-cpp/perf/RateLimiter.h
+++ b/pulsar-client-cpp/perf/RateLimiter.h
@@ -50,7 +50,7 @@ RateLimiter::RateLimiter(double rate)
         : interval_(std::chrono::microseconds((long)(1e6 / rate))),
           storedPermits_(0.0),
           maxPermits_(rate),
-          nextFree_() {
+          nextFree_(Clock::now()) {
     assert(rate < 1e6 && "Exceeded maximum rate");
 }
 


### PR DESCRIPTION
### Motivation

Fixed compilation on ARM CPUs: 
 * Disabled SSE based CRC32C 
 * Fixed some variables initialization