### PR TITLE
[docs] improve statement on ordering guarantees for multi-topic subscriptions

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -239,8 +239,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -239,8 +239,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
@@ -150,8 +150,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/concepts-messaging.md
@@ -150,8 +150,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
@@ -151,8 +151,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.0/concepts-messaging.md
@@ -151,8 +151,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
@@ -151,8 +151,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.1/concepts-messaging.md
@@ -151,8 +151,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
@@ -206,8 +206,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.3.2/concepts-messaging.md
@@ -206,8 +206,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
@@ -206,8 +206,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-messaging.md
@@ -206,8 +206,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
@@ -227,8 +227,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-messaging.md
@@ -227,8 +227,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.2/concepts-messaging.md
@@ -227,8 +227,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No cross-topic ordering guarantees
-> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.4.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.4.2/concepts-messaging.md
@@ -227,8 +227,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No cross-topic ordering guarantees
+> Ordering guarantees given for single topics do not hold across multiple topics. So users need to make sure that all messages that need to be delivered in order are on the same topic.
 
 Here are some multi-topic subscription examples for Java:
 

--- a/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
@@ -227,8 +227,8 @@ When a consumer subscribes to a Pulsar topic, by default it subscribes to one sp
 
 When subscribing to multiple topics, the Pulsar client will automatically make a call to the Pulsar API to discover the topics that match the regex pattern/list and then subscribe to all of them. If any of the topics don't currently exist, the consumer will auto-subscribe to them once the topics are created.
 
-> #### No ordering guarantees
-> When a consumer subscribes to multiple topics, all ordering guarantees normally provided by Pulsar on single topics do not hold. If your use case for Pulsar involves any strict ordering requirements, we would strongly recommend against using this feature.
+> #### No ordering guarantees across multiple topics
+> When a producer sends messages to a single topic, all messages are guaranteed to be read from that topic in the same order. However, these guarantees do not hold across multiple topics. So when a producer sends message to multiple topics, the order in which messages are read from those topics is not guaranteed to be the same.
 
 Here are some multi-topic subscription examples for Java:
 


### PR DESCRIPTION
### Motivation

*The statement "ordering guarantees [..] on single topics do not hold" on https://pulsar.apache.org/docs/en/concepts-messaging/#no-ordering-guarantees can lead readers to believe that messages on the same topic are not guaranteed to be delivered in order, which I believe to be false, as discussed in this thread https://apache-pulsar.slack.com/archives/C5Z4T36F7/p1578264274257300*

### Modifications

*I've applied the same change of wording to the current `site2/docs/concepts-messaging.md` and all the various versions under `site2/website/versioned_docs/`, as this is independent of the version.*

### N.B. This used to be PR #5995

