### PR TITLE
[Issue 3289][docs 2.5.0] Append / to metrics url to fix documentation

### DIFF
--- a/site2/website/versioned_docs/version-2.5.0/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.5.0/deploy-monitoring.md
@@ -32,7 +32,7 @@ All the message rates are updated every 1min.
 The aggregated broker metrics are also exposed in the [Prometheus](https://prometheus.io) format at:
 
 ```shell
-http://$BROKER_ADDRESS:8080/metrics
+http://$BROKER_ADDRESS:8080/metrics/
 ```
 
 ### ZooKeeper stats


### PR DESCRIPTION
Fixes #3289

Not a real fix for #3289 as the bug is in jetty, but at least documentation isn't misleading now.