### PR TITLE
[Issue-5958][helm]: Fixing templates for helm deployment

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
@@ -60,9 +60,9 @@ spec:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           image: "{{ .Values.pulsar_manager.image.repository }}:{{ .Values.pulsar_manager.image.tag }}"
           imagePullPolicy: {{ .Values.pulsar_manager.image.pullPolicy }}
-        {{- if .Values.grafana.resources }}
+        {{- if .Values.pulsar_manager.resources }}
           resources:
-{{ toYaml .Values.pulsar_manager.resources | indent 10 }}
+{{ toYaml .Values.pulsar_manager.resources | indent 12 }}
         {{- end }}
           ports:
           - containerPort: 9527

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -348,7 +348,7 @@ dashboard:
 
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
-    
+
     ## Required if ingress is enabled
     hostname: ""
     path: "/"
@@ -434,10 +434,10 @@ grafana:
     repository: apachepulsar/pulsar-grafana
     tag: latest
     pullPolicy: IfNotPresent
-#  resources:
-#    requests:
-#      memory: 4Gi
-#      cpu: 1
+  resources:
+    requests:
+      memory: 4Gi
+      cpu: 1
   ## Grafana service
   ## templates/grafana-service.yaml
   ##


### PR DESCRIPTION
Motivation:
Fixes #5958: 

The following error appears when trying to deploy Pulsar using helm and values-mini.yaml: 

```unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "requests" in io.k8s.api.core.v1.Container``` 

Cause:
Mistake in the `pulsar-manager-deployment.yaml` deployment file:

First line **63** should be:
`{{- if .Values.pulsar_manager.resources }}` and it is currently `{{- if .Values.grafana.resources }}`

There is also a mistake at line **65**:
`{{ toYaml .Values.grafana.resources | indent 10 }}` should be `{{ toYaml .Values.pulsar_manager.resources | indent 12 }}`

Modifications:
Changed values in `values.yaml` and `templates/pulsar-manager-deployment.yaml`

Test:
Deploy the application into a kubernetes local cluster with
`helm install pulsar-cluster --values pulsar/values-mini.yaml pulsar`

AND

`helm install pulsar-cluster --values pulsar/values.yaml pulsar`

Documentation:
Does this pull request introduce a new feature? - **No**