### PR TITLE
[docs] feature compatibility matrix

### DIFF
--- a/site2/docs/concepts-overview.md
+++ b/site2/docs/concepts-overview.md
@@ -18,6 +18,10 @@ Key features of Pulsar are listed below:
 * A serverless connector framework [Pulsar IO](io-overview.md), which is built on Pulsar Functions, makes it easier to move data in and out Apache Pulsar.
 * [Tiered Storage](concepts-tiered-storage.md) offloads data from hot/warm storage to cold/longterm storage (such as S3 and GCS) when the data is aging out.
 
+## Feature Compatibility Matrix
+
+Most Pulsar features can be freely mixed and matched, but some features cannot be used in combination with some others. Please refer to [Feature Compatibility Matrices](reference-feature-compatibility.md) for details.
+
 ## Contents
 
 - [Messaging Concepts](concepts-messaging.md)

--- a/site2/docs/reference-feature-compatibility.md
+++ b/site2/docs/reference-feature-compatibility.md
@@ -1,0 +1,43 @@
+---
+id: reference-feature-compatibility
+title: Feature Compatibility Matrices
+sidebar_label: Feature Compatibility
+---
+
+<style type="text/css">
+  table{
+    font-size: 80%;
+  }
+</style>
+
+Most Pulsar features can be freely mixed and matched, but some features cannot be used in combination with some others. The tables below shed light on the compatibility of Pulsar features.
+
+## By Topic Type
+
+|                                                                                        | persistent | [non-persistent](concepts-messaging.md#non-persistent-topics) | [partitioned](concepts-messaging.md#partitioned-topics) |
+|-------------------------------------------------------------------------------------- |---------- |------------------------------------------------------------- |------------------------------------------------------- |
+| [partitioned topic](concepts-messaging.md#partitioned-topics)                          | ✅         | ✅                                                            |                                                         |
+| cumulative [acknowledgement](concepts-messaging.md#acknowledgement)                    | ✅         |                                                               |                                                         |
+| [multi-topic/regex subscription](concepts-messaging.md#multi-topic-subscriptions)      | ✅         |                                                               |                                                         |
+| [reader](concepts-clients.md#reader-interface)                                         | ✅         | ✅                                                            | ❌\*1                                                   |
+| [deduplication](concepts-messaging.md#message-deduplication)                           | ✅         |                                                               |                                                         |
+| [delayed delivery](concepts-messaging.md#delayed-message-delivery)                     | ✅         |                                                               |                                                         |
+| [exclusive subscription](concepts-messaging.md#exclusive)                              | ✅         |                                                               |                                                         |
+| [failover subscription](concepts-messaging.md#failover)                                | ✅         |                                                               |                                                         |
+| [shared subscription](concepts-messaging.md#shared)                                    | ✅         |                                                               |                                                         |
+| [key<sub>shared</sub> subscription](concepts-messaging.md#key<sub>shared</sub>) (beta) | ✅         |                                                               |                                                         |
+
+\*1 Readers cannot be used to subscribe to a partitioned topic directly, but as partitioned topics are internally implemented as multiple topics, one reader per partition can be created to listen on the internal partition topics readers can s cannot
+
+## By Subscription Type
+
+|                                                                                   | [exclusive subscription](concepts-messaging.md#exclusive) | [failover subscription](concepts-messaging.md#failover) | [shared subscription](concepts-messaging.md#shared) | [key<sub>shared</sub> subscription](concepts-messaging.md#key<sub>shared</sub>) (beta) |
+|--------------------------------------------------------------------------------- |--------------------------------------------------------- |------------------------------------------------------- |--------------------------------------------------- |-------------------------------------------------------------------------------------- |
+| persistent                                                                        | ✅                                                        | ✅                                                      | ✅                                                  | ✅                                                                                     |
+| [non-persistent](concepts-messaging.md#non-persistent-topics)                     | ✅                                                        |                                                         |                                                     |                                                                                        |
+| [partitioned](concepts-messaging.md#partitioned-topics)                           | ✅                                                        |                                                         |                                                     |                                                                                        |
+| cumulative [acknowledgement](concepts-messaging.md#acknowledgement)               | ✅                                                        | ✅                                                      | ✅                                                  | ❌                                                                                     |
+| [multi-topic/regex subscription](concepts-messaging.md#multi-topic-subscriptions) | ✅                                                        |                                                         |                                                     |                                                                                        |
+| [reader](concepts-clients.md#reader-interface)                                    | ✅                                                        |                                                         |                                                     |                                                                                        |
+| [deduplication](concepts-messaging.md#message-deduplication)                      | ✅                                                        |                                                         |                                                     |                                                                                        |
+| [delayed delivery](concepts-messaging.md#delayed-message-delivery)                | ✅                                                        |                                                         |                                                     |                                                                                        |

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -130,7 +130,8 @@
       "reference-cli-tools",
       "pulsar-admin",
       "reference-configuration",
-      "reference-metrics"
+      "reference-metrics",
+      "reference-feature-compatibility"
     ]
   },
   "docs-other": {


### PR DESCRIPTION
### Motivation
For newcomers, it can be hard to remember which features work together and which do not. Examples: The reader api cannot be used with partitioned topics, and cumulative acknowledgement does not work for key_shared subscriptions.

I have already discussed adding such a feature matrix on slack, and it has been endorsed by sijieg:
> A feature matrix like this is great

https://apache-pulsar.slack.com/archives/C5Z4T36F7/p1580147801255400?thread_ts=1580126358.237900&cid=C5Z4T36F7

N.B. This is still WIP and would benefit from more experienced Pulsarians filling in the blanks. Also, my intention is to add more tables, but whether or not I'll do it in this PR will depend on how quickly I or other reviewers will fill in the blanks for the existing tables.

### Modifications

- add a "Feature Compatibility Matrix" page to the "Reference section"
- add a link to that new page to the "Concepts / Overview" page

### Verifying this change

I've tested this as described in pulsar/site2/README.md, i.e. launching `yarn start` and browsing to all affected pages
