### PR TITLE
Unacked messages are not redelivered on time on C++

### DIFF
--- a/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
+++ b/pulsar-client-cpp/lib/UnAckedMessageTrackerEnabled.cc
@@ -42,6 +42,7 @@ void UnAckedMessageTrackerEnabled::timeoutHandlerHelper() {
     std::lock_guard<std::mutex> acquire(lock_);
     LOG_DEBUG("UnAckedMessageTrackerEnabled::timeoutHandlerHelper invoked for consumerPtr_ "
               << consumerReference_.getName().c_str());
+    oldSet_.swap(currentSet_);
     if (!oldSet_.empty()) {
         LOG_INFO(consumerReference_.getName().c_str()
                  << ": " << oldSet_.size() << " Messages were not acked within " << timeoutMs_ << " time");
@@ -49,7 +50,6 @@ void UnAckedMessageTrackerEnabled::timeoutHandlerHelper() {
         currentSet_.clear();
         consumerReference_.redeliverUnacknowledgedMessages();
     }
-    oldSet_.swap(currentSet_);
 }
 
 UnAckedMessageTrackerEnabled::UnAckedMessageTrackerEnabled(long timeoutMs, const ClientImplPtr client,


### PR DESCRIPTION
### Motivation
On C++ lib, like the following log, unacked messages are redelivered after about 2 * unAckedMessagesTimeout.

```
my-message-0: Wed Jan 29 13:52:39 2020
2020-01-29 13:52:59.210 INFO  UnAckedMessageTrackerEnabled:47 | [persistent://k2la/test/topic0, sub1, 0] : 1 Messages were not acked within 10000 time
my-message-0: Wed Jan 29 13:52:59 2020
2020-01-29 13:53:19.214 INFO  UnAckedMessageTrackerEnabled:47 | [persistent://k2la/test/topic0, sub1, 0] : 1 Messages were not acked within 10000 time
my-message-0: Wed Jan 29 13:53:19 2020
```

### Modifications
- Move `swap` same as https://github.com/apache/pulsar/pull/2590 .
