### PR TITLE
[helm-chart] add missing check to dashboard-ingress

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/dashboard-ingress.yaml
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+{{- if .Values.extra.dashboard }}
 {{- if .Values.dashboard.ingress.enabled }}
 apiVersion: extensions/v1beta1                                                                                                                                                            
 kind: Ingress                                                                                                                                                                             
@@ -50,4 +51,5 @@ spec:
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
               servicePort: {{ .Values.dashboard.ingress.port }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
### Motivation

if you deploy pulsar using the helm chart and disable monitoring with

```
extras:
  dashboard: no

```

but you have the ingress of the dashboard set to true

```
dashboard:
  ingress:
    enabled: true
```
	

the helm chart will create an ingress that points to a non-existing service because the dashboard itself was not deployed.


### Modifications

I've added the same check that is already in place in dashboard-service and dashboard-deployment

### Verifying this change

I dont know of any automated tests, i tested it manually. In the end it's the same "if" that is already in place in dashboard-service and dashboard-deployment


### Does this pull request potentially affect one of the following parts:

Affects deployment via helm chart. An unwanted ingress object is suppressed.

### Documentation

 no documentation need
