### PR TITLE
[Issue 6137] (WIP) Fix flaky tests

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -107,6 +107,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2390,9 +2390,9 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             }
         }, ctxStr);
         ledger.asyncCreateLedger(bk, config, null, (rc, lh, ctx) -> {}, Collections.emptyMap());
-        retryStrategically(() -> responseException1.get() != null, 5, 1000);
-        assertNotNull(responseException1.get());
-        assertEquals(responseException1.get().getMessage(), BKException.getMessage(BKException.Code.TimeoutException));
+        retryStrategically(() -> responseException1.get() != null
+                && responseException1.get().getMessage()
+                .equals(BKException.getMessage(BKException.Code.TimeoutException)), 5, 1000);
 
         // (2) test read-timeout for: ManagedLedger.asyncReadEntry(..)
         AtomicReference<ManagedLedgerException> responseException2 = new AtomicReference<>();

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@ flexible messaging model and an intuitive client API.</description>
     <guava.version>25.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.12.0</prometheus-jmx.version>
+    <awaitility.version>4.0.2</awaitility.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -256,6 +257,13 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -326,6 +326,12 @@
 
     <!-- transaction related dependencies (end) -->
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -481,13 +481,13 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.brokers().updateDynamicConfiguration("superUserRoles", configValue);
         String storedValue = admin.brokers().getAllDynamicConfigurations().get("superUserRoles");
         assertEquals(configValue, storedValue);
-        retryStrategically((test) -> pulsar.getConfiguration().getSuperUserRoles().size() == 2, 5, 200);
+        retryStrategically(() -> pulsar.getConfiguration().getSuperUserRoles().size() == 2, 5, 200);
         assertTrue(pulsar.getConfiguration().getSuperUserRoles().contains(user1));
         assertTrue(pulsar.getConfiguration().getSuperUserRoles().contains(user2));
 
 
         admin.brokers().updateDynamicConfiguration("loadManagerClassName", SimpleLoadManagerImpl.class.getName());
-        retryStrategically((test) -> pulsar.getConfiguration().getLoadManagerClassName()
+        retryStrategically(() -> pulsar.getConfiguration().getLoadManagerClassName()
                 .equals(SimpleLoadManagerImpl.class.getName()), 150, 5);
         assertEquals(pulsar.getConfiguration().getLoadManagerClassName(), SimpleLoadManagerImpl.class.getName());
         admin.brokers().deleteDynamicConfiguration("loadManagerClassName");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -358,7 +358,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         final int newEnsembleSize = 5;
         admin.namespaces().setPersistence(namespace, new PersistencePolicies(newEnsembleSize, 3, 3, newThrottleRate));
 
-        retryStrategically((test) -> managedLedger.getConfig().getEnsembleSize() == newEnsembleSize
+        retryStrategically(() -> managedLedger.getConfig().getEnsembleSize() == newEnsembleSize
                 && cursor.getThrottleMarkDelete() != newThrottleRate, 5, 200);
 
         // (1) verify cursor.markDelete has been updated
@@ -763,7 +763,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
             .producerName(producerName)
             .create();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             TopicStats stats;
             try {
                 stats = admin.topics().getStats(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest2.java
@@ -350,7 +350,7 @@ public class V1_AdminApiTest2 extends MockedPulsarServiceBaseTest {
         final int newEnsembleSize = 5;
         admin.namespaces().setPersistence(namespace, new PersistencePolicies(newEnsembleSize, 3, 3, newThrottleRate));
 
-        retryStrategically((test) -> managedLedger.getConfig().getEnsembleSize() == newEnsembleSize
+        retryStrategically(() -> managedLedger.getConfig().getEnsembleSize() == newEnsembleSize
                 && cursor.getThrottleMarkDelete() != newThrottleRate, 5, 200);
 
         // (1) verify cursor.markDelete has been updated
@@ -764,7 +764,7 @@ public class V1_AdminApiTest2 extends MockedPulsarServiceBaseTest {
             .messageRoutingMode(MessageRoutingMode.SinglePartition)
             .create();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             TopicStats stats;
             try {
                 stats = admin.topics().getStats(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.auth;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.awaitility.Awaitility.*;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -31,10 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -296,15 +294,9 @@ public abstract class MockedPulsarServiceBaseTest {
         }
     };
 
-    public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
+    public static void retryStrategically(Callable<Boolean> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
-        for (int i = 0; i < retryCount; i++) {
-            if (predicate.test(null) || i == (retryCount - 1)) {
-                return true;
-            }
-            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
-        }
-        return false;
+        await().atMost(retryCount * intSleepTimeInMillis, TimeUnit.MILLISECONDS).until(predicate);
     }
 
     public static void setFieldValue(Class<?> clazz, Object classObj, String fieldName, Object fieldValue) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -662,7 +662,7 @@ public class BatchMessageTest extends BrokerTestBase {
             consumer.acknowledgeCumulative(lastunackedMsg);
         }
 
-        retryStrategically(t -> topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog() == 0, 100, 100);
+        retryStrategically(() -> topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog() == 0, 100, 100);
 
         consumer.close();
         producer.close();
@@ -721,7 +721,7 @@ public class BatchMessageTest extends BrokerTestBase {
         PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers) topic
                 .getSubscription(subscriptionName).getDispatcher();
         // check strategically to let ack-message receive by broker
-        retryStrategically((test) -> dispatcher.getConsumers().get(0).getUnackedMessages() == 0, 5, 150);
+        retryStrategically(() -> dispatcher.getConsumers().get(0).getUnackedMessages() == 0, 5, 150);
         assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 0);
 
         executor.shutdown();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
-import static org.awaitility.Awaitility.*;
 import static org.testng.Assert.assertEquals;
 
 import java.lang.reflect.Field;
@@ -257,7 +256,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         // (4) enable dynamic config to skip non-recoverable data-ledgers
         admin.brokers().updateDynamicConfiguration("autoSkipNonRecoverableData", "true");
 
-        with().pollInSameThread().await().atMost(150 * 100, TimeUnit.MILLISECONDS).until(() -> config.isAutoSkipNonRecoverableData());
+        retryStrategically(() -> config.isAutoSkipNonRecoverableData(), 5, 100);
 
         // (5) consumer will be able to consume 20 messages from last non-deleted ledger
         consumer = client.newConsumer().topic(topic1).subscriptionName("my-subscriber-name").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
@@ -222,7 +222,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
         admin.topics().unload(topicName);
 
         // wait strategically for all consumers to reconnect
-        retryStrategically((test) -> areAllConsumersConnected(consumers), 5, 500);
+        retryStrategically(() -> areAllConsumersConnected(consumers), 5, 500);
 
         int totalConnectedConsumers = 0;
         for (int i = 0; i < consumers.size(); i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -171,7 +171,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         assertNull(admin1.clusters().getPeerClusterNames(mainClusterName));
         LinkedHashSet<String> peerClusters = Sets.newLinkedHashSet(Lists.newArrayList("r2", "r3"));
         admin1.clusters().updatePeerClusterNames(mainClusterName, peerClusters);
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin1.clusters().getPeerClusterNames(mainClusterName).size() == 1;
             } catch (PulsarAdminException e) {
@@ -230,7 +230,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         NamespaceBundles bundles = pulsar1.getNamespaceService().getNamespaceBundleFactory()
                 .getBundles(NamespaceName.get(namespace1));
         NamespaceBundle bundle = bundles.getBundles().get(0);
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return !pulsar1.getNamespaceService().isNamespaceBundleOwned(bundle).get();
             } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -243,7 +243,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
             monitor.expireMessages(1);
             Position previousPos = previousMarkDelete;
             retryStrategically(
-                    (test) -> c1.getMarkDeletedPosition() != null && !c1.getMarkDeletedPosition().equals(previousPos),
+                    () -> c1.getMarkDeletedPosition() != null && !c1.getMarkDeletedPosition().equals(previousPos),
                     5, 100);
             previousMarkDelete = c1.getMarkDeletedPosition();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -87,7 +87,7 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
         admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r2", "r3"));
 
         MockedPulsarServiceBaseTest
-                .retryStrategically((test) -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 5, 150);
+                .retryStrategically(() -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 5, 150);
 
         Assert.assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topicName));
         Assert.assertFalse(producer1.isConnected());
@@ -118,7 +118,7 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
         admin1.topics().delete(topicName, true);
 
         MockedPulsarServiceBaseTest
-                .retryStrategically((test) -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 5, 150);
+                .retryStrategically(() -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 5, 150);
 
         Assert.assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topicName));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -969,7 +969,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
             // (4) Broker-1 will own topic-1
             final String unsplitBundle = namespace + "/0x00000000_0xffffffff";
-            retryStrategically((test) -> pulsar.getNamespaceService().getOwnedServiceUnits().stream()
+            retryStrategically(() -> pulsar.getNamespaceService().getOwnedServiceUnits().stream()
                     .map(nb -> nb.toString()).collect(Collectors.toSet()).contains(unsplitBundle), 5, 100);
             Set<String> serviceUnits1 = pulsar.getNamespaceService().getOwnedServiceUnits().stream()
                     .map(nb -> nb.toString()).collect(Collectors.toSet());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
@@ -206,7 +206,7 @@ public class ClientDeduplicationFailureTest {
         ProducerThread producerThread = new ProducerThread(producer);
         producerThread.start();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sourceTopic);
                 return topicStats.publishers.size() == 1 && topicStats.publishers.get(0).getProducerName().equals("test-producer-1") && topicStats.storageSize > 0;
@@ -300,7 +300,7 @@ public class ClientDeduplicationFailureTest {
         });
         thread.start();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sourceTopic);
                 boolean c1 =  topicStats!= null
@@ -397,7 +397,7 @@ public class ClientDeduplicationFailureTest {
         }
 
         // check all messages
-        retryStrategically((test) -> msgRecvd.size() >= 20, 5, 200);
+        retryStrategically(() -> msgRecvd.size() >= 20, 5, 200);
 
         assertEquals(msgRecvd.size(), 20);
         for (int i=0; i<10; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -978,7 +978,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         subscriber2.close();
 
         // retry strategically until broker clean up closed subscribers and invalidate all cache entries
-        retryStrategically((test) -> entryCache.getSize() == 0, 5, 100);
+        retryStrategically(() -> entryCache.getSize() == 0, 5, 100);
 
         // Verify: EntryCache should be cleared
         assertEquals(entryCache.getSize(), 0);
@@ -3104,7 +3104,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Consumer<byte[]> consumer5 = consumerBuilder.consumerName("bbb4").priorityLevel(1).subscribe();
 
         Integer evenDistributionCount = noOfPartitions / 3;
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 Map<String, Integer> subsCount = Maps.newHashMap();
                 admin.topics().getPartitionedStats(topicName, true).partitions.forEach((p, stats) -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -723,7 +723,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         subscriber2.close();
 
         // retry strategically until broker clean up closed subscribers and invalidate all cache entries
-        retryStrategically((test) -> entryCache.getSize() == 0, 5, 100);
+        retryStrategically(() -> entryCache.getSize() == 0, 5, 100);
 
         // Verify: EntryCache should be cleared
         assertEquals(entryCache.getSize(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -277,7 +277,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         OwnershipCache ownershipCache = pulsar.getNamespaceService().getOwnershipCache();
         assertTrue(ownershipCache.getOwnedBundles().keySet().isEmpty());
         // Strategical retry
-        retryStrategically((test) -> (producer1.getClientCnx() == null && consumer1.getClientCnx() == null
+        retryStrategically(() -> (producer1.getClientCnx() == null && consumer1.getClientCnx() == null
                 && producer2.getClientCnx() == null), 5, 100);
         // [2] All clients must be disconnected and in connecting state
         // producer1 must not be able to connect again

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -87,7 +87,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -108,7 +108,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         publishMsgRate.publishThrottlingRateInMsg = -1;
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -151,7 +151,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
 
         // enable throttling
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -172,7 +172,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         publishMsgRate.publishThrottlingRateInByte = -1;
         admin.namespaces().setPublishRate(namespace, publishMsgRate);
-        retryStrategically((test) -> topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
+        retryStrategically(() -> topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER), 5,
                 200);
         Assert.assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
@@ -220,7 +220,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
                 Integer.toString(messageRate));
 
         retryStrategically(
-            (test) ->
+            () ->
                 (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -248,7 +248,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         admin.brokers()
             .updateDynamicConfiguration("brokerPublisherThrottlingMaxMessageRate", Integer.toString(0));
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -297,7 +297,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
             .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(byteRate));
 
         retryStrategically(
-            (test) ->
+            () ->
                 (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -327,7 +327,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable throttling
         admin.brokers()
             .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(0));
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -388,12 +388,12 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         admin.brokers().updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate",
             Long.toString(brokerByteRate));
         admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 !topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
         retryStrategically(
-            (test) ->
+            () ->
                 (topic.getBrokerPublishRateLimiter() != PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -444,7 +444,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
             Assert.assertNotEquals(iTopic.getBrokerPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
 
             admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
-            retryStrategically((test) ->
+            retryStrategically(() ->
                     !iTopic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
                 5,
                 200);
@@ -484,7 +484,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable topic throttling, it will use broker throttling, expected rateIn bigger than before.
         topicPublishMsgRate.publishThrottlingRateInByte = -1;
         admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getTopicPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);
@@ -505,7 +505,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         // disable broker throttling, expected no throttling.
         admin.brokers()
             .updateDynamicConfiguration("brokerPublisherThrottlingMaxByteRate", Long.toString(0));
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicPublishThrottlingInitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicPublishThrottlingInitTest.java
@@ -100,7 +100,7 @@ public class TopicPublishThrottlingInitTest extends ProducerConsumerBase {
         // disable throttling
         admin.brokers()
             .updateDynamicConfiguration("brokerPublisherThrottlingMaxMessageRate", Integer.toString(0));
-        retryStrategically((test) ->
+        retryStrategically(() ->
                 topic.getBrokerPublishRateLimiter().equals(PublishRateLimiter.DISABLED_RATE_LIMITER),
             5,
             200);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -794,7 +794,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         topic.get().checkMessageExpiry();
 
-        retryStrategically((test) -> subscription.getNumberOfEntriesInBacklog() == 0, 5, 200);
+        retryStrategically(() -> subscription.getNumberOfEntriesInBacklog() == 0, 5, 200);
 
         assertEquals(subscription.getNumberOfEntriesInBacklog(), 0);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -325,14 +325,14 @@ public class PulsarFunctionE2ESecurityTest {
 
             }
 
-            assertTrue(retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 1
                             && admin1.topics().getStats(sourceTopic).subscriptions.size() == 1;
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 5, 150));
+            }, 5, 150);
             // validate pulsar sink consumer has started on the topic
             assertEquals(admin1.topics().getStats(sourceTopic).subscriptions.size(), 1);
 
@@ -345,7 +345,7 @@ public class PulsarFunctionE2ESecurityTest {
                     String data = "my-message-" + i;
                     producer.newMessage().property(propertyKey, propertyValue).value(data).send();
                 }
-                retryStrategically((test) -> {
+                retryStrategically(() -> {
                     try {
                         SubscriptionStats subStats = admin1.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                         return subStats.unackedMessages == 0;
@@ -378,13 +378,13 @@ public class PulsarFunctionE2ESecurityTest {
 
                 admin1.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-                assertTrue(retryStrategically((test) -> {
+                retryStrategically(() -> {
                     try {
                         return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 2;
                     } catch (PulsarAdminException e) {
                         return false;
                     }
-                }, 5, 150));
+                }, 5, 150);
 
                 // test getFunctionInfo
                 try {
@@ -513,7 +513,7 @@ public class PulsarFunctionE2ESecurityTest {
 
                 admin1.functions().deleteFunction(TENANT, NAMESPACE, functionName);
 
-                assertTrue(retryStrategically((test) -> {
+                retryStrategically(() -> {
                     try {
                         TopicStats stats = admin1.topics().getStats(sourceTopic);
                         boolean done = stats.subscriptions.size() == 0;
@@ -524,7 +524,7 @@ public class PulsarFunctionE2ESecurityTest {
                     } catch (PulsarAdminException e) {
                         return false;
                     }
-                }, 100, 150));
+                }, 100, 150);
             }
         }
     }
@@ -596,14 +596,14 @@ public class PulsarFunctionE2ESecurityTest {
 
             }
 
-            assertTrue(retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 1
                             && admin1.topics().getStats(sourceTopic).subscriptions.size() == 1;
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 5, 150));
+            }, 5, 150);
             // validate pulsar sink consumer has started on the topic
             assertEquals(admin1.topics().getStats(sourceTopic).subscriptions.size(), 1);
 
@@ -616,7 +616,7 @@ public class PulsarFunctionE2ESecurityTest {
                     String data = "my-message-" + i;
                     producer.newMessage().property(propertyKey, propertyValue).value(data).send();
                 }
-                retryStrategically((test) -> {
+                retryStrategically(() -> {
                     try {
                         SubscriptionStats subStats = admin1.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                         return subStats.unackedMessages == 0;
@@ -649,13 +649,13 @@ public class PulsarFunctionE2ESecurityTest {
 
             admin1.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-            assertTrue(retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     return admin1.functions().getFunctionStatus(TENANT, NAMESPACE, functionName).getNumRunning() == 2;
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 5, 150));
+            }, 5, 150);
 
             // test getFunctionInfo
             try {
@@ -785,7 +785,7 @@ public class PulsarFunctionE2ESecurityTest {
 
             admin1.functions().deleteFunction(TENANT, NAMESPACE, functionName);
 
-            assertTrue(retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     TopicStats stats = admin1.topics().getStats(sourceTopic);
                     boolean done = stats.subscriptions.size() == 0;
@@ -796,7 +796,7 @@ public class PulsarFunctionE2ESecurityTest {
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 5, 150));
+            }, 5, 150);
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -404,7 +404,7 @@ public class PulsarFunctionLocalRunTest {
                 .brokerServiceUrl(pulsar.getBrokerServiceUrlTls()).build();
         localRunner.start(false);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats stats = admin.topics().getStats(sourceTopic);
                 return stats.subscriptions.get(subscriptionName) != null
@@ -423,7 +423,7 @@ public class PulsarFunctionLocalRunTest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0;
@@ -447,7 +447,7 @@ public class PulsarFunctionLocalRunTest {
         // stop functions
         localRunner.stop();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sourceTopic);
                 return topicStats.subscriptions.get(subscriptionName) != null
@@ -461,7 +461,7 @@ public class PulsarFunctionLocalRunTest {
         assertTrue(topicStats.subscriptions.get(subscriptionName) != null
                 && topicStats.subscriptions.get(subscriptionName).consumers.isEmpty());
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic).publishers.size() == 0);
             } catch (PulsarAdminException e) {
@@ -525,7 +525,7 @@ public class PulsarFunctionLocalRunTest {
 
         localRunner.start(false);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic).publishers.size() == 1);
             } catch (PulsarAdminException e) {
@@ -533,7 +533,7 @@ public class PulsarFunctionLocalRunTest {
             }
         }, 10, 150);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats sourceStats = admin.topics().getStats(sinkTopic);
                 return sourceStats.publishers.size() == 1
@@ -551,7 +551,7 @@ public class PulsarFunctionLocalRunTest {
         assertTrue(sourceStats.publishers.get(0).metadata.containsKey("id"));
         assertEquals(sourceStats.publishers.get(0).metadata.get("id"), String.format("%s/%s/%s", tenant, namespacePortion, sourceName));
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic).publishers.size() == 1)
                         && (admin.topics().getInternalStats(sinkTopic).numberOfEntries > 4);
@@ -563,7 +563,7 @@ public class PulsarFunctionLocalRunTest {
 
         localRunner.stop();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic).publishers.size() == 0);
             } catch (PulsarAdminException e) {
@@ -634,7 +634,7 @@ public class PulsarFunctionLocalRunTest {
 
         localRunner.start(false);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sourceTopic);
 
@@ -658,7 +658,7 @@ public class PulsarFunctionLocalRunTest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0 && subStats.msgThroughputOut == totalMsgs;
@@ -670,7 +670,7 @@ public class PulsarFunctionLocalRunTest {
         // stop sink
         localRunner.stop();
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats stats = admin.topics().getStats(sourceTopic);
                 return stats.subscriptions.get(subscriptionName) != null

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
@@ -298,7 +298,7 @@ public class PulsarFunctionPublishTest {
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-functions-api-examples.jar").getFile();
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -313,7 +313,7 @@ public class PulsarFunctionPublishTest {
             String data = "foo";
             producer.newMessage().property(propertyKey, propertyValue).key(String.valueOf(i)).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0;
@@ -322,7 +322,7 @@ public class PulsarFunctionPublishTest {
             }
         }, 5, 150);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 FunctionStats functionStat = admin.functions().getFunctionStats(tenant, namespacePortion, functionName);
                 return functionStat.getProcessedSuccessfullyTotal() == 5;
@@ -347,7 +347,7 @@ public class PulsarFunctionPublishTest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -185,7 +185,7 @@ public class PulsarWorkerAssignmentTest {
 
         // (1) Create function with 2 instance
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sinkTopic).subscriptions.size() == 1
                         && admin.topics().getStats(sinkTopic).subscriptions.values().iterator().next().consumers
@@ -202,7 +202,7 @@ public class PulsarWorkerAssignmentTest {
         functionConfig.setParallelism(1);
         // try to update function to test: update-function functionality
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sinkTopic).subscriptions.size() == 1
                         && admin.topics().getStats(sinkTopic).subscriptions.values().iterator().next().consumers
@@ -243,7 +243,7 @@ public class PulsarWorkerAssignmentTest {
             // don't set any log topic
             admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 Map<String, Assignment> assgn = runtimeManager.getCurrentAssignments().values().iterator().next();
                 return assgn.size() == (totalFunctions * parallelism);
@@ -272,7 +272,7 @@ public class PulsarWorkerAssignmentTest {
             String functionName = baseFunctionName + i;
             admin.functions().deleteFunction(tenant, namespacePortion, functionName);
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 Map<String, Assignment> assgn = runtimeManager.getCurrentAssignments().values().iterator().next();
                 return assgn.size() == ((totalFunctions - totalDeletedFunction) * parallelism);
@@ -291,7 +291,7 @@ public class PulsarWorkerAssignmentTest {
         functionsWorkerService = new WorkerService(workerConfig);
         functionsWorkerService.start(dlUri, new AuthenticationService(PulsarConfigurationLoader.convertFrom(workerConfig)), null);
         final FunctionRuntimeManager runtimeManager2 = functionsWorkerService.getFunctionRuntimeManager();
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 Map<String, Assignment> assgn = runtimeManager2.getCurrentAssignments().values().iterator().next();
                 return assgn.size() == ((totalFunctions - totalDeletedFunction) * parallelism);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -417,7 +417,7 @@ public class PulsarFunctionE2ETest {
         functionConfig.setOutput(sinkTopic2);
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sinkTopic2);
                 return topicStats.publishers.size() == 2
@@ -435,7 +435,7 @@ public class PulsarFunctionE2ETest {
         assertTrue(topicStats.publishers.get(0).metadata.containsKey("id"));
         assertEquals(topicStats.publishers.get(0).metadata.get("id"), String.format("%s/%s/%s", tenant, namespacePortion, functionName));
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -450,7 +450,7 @@ public class PulsarFunctionE2ETest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0;
@@ -471,7 +471,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {
@@ -527,7 +527,7 @@ public class PulsarFunctionE2ETest {
 
         admin.sink().updateSinkWithUrl(sinkConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats topicStats = admin.topics().getStats(sourceTopic);
 
@@ -620,7 +620,7 @@ public class PulsarFunctionE2ETest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0 && subStats.msgThroughputOut == totalMsgs;
@@ -702,7 +702,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.sink().deleteSink(tenant, namespacePortion, sinkName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {
@@ -746,7 +746,7 @@ public class PulsarFunctionE2ETest {
 
         admin.source().createSourceWithUrl(sourceConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic).publishers.size() == 1);
             } catch (PulsarAdminException e) {
@@ -758,7 +758,7 @@ public class PulsarFunctionE2ETest {
         sourceConfig.setTopicName(sinkTopic2);
         admin.source().updateSourceWithUrl(sourceConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 TopicStats sourceStats = admin.topics().getStats(sinkTopic2);
                 return sourceStats.publishers.size() == 1
@@ -776,7 +776,7 @@ public class PulsarFunctionE2ETest {
         assertTrue(sourceStats.publishers.get(0).metadata.containsKey("id"));
         assertEquals(sourceStats.publishers.get(0).metadata.get("id"), String.format("%s/%s/%s", tenant, namespacePortion, sourceName));
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return (admin.topics().getStats(sinkTopic2).publishers.size() == 1) && (admin.topics().getInternalStats(sinkTopic2).numberOfEntries > 4);
             } catch (PulsarAdminException e) {
@@ -899,7 +899,7 @@ public class PulsarFunctionE2ETest {
         // try to update function to test: update-function functionality
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -1047,7 +1047,7 @@ public class PulsarFunctionE2ETest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0 && subStats.msgThroughputOut == totalMsgs;
@@ -1191,7 +1191,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {
@@ -1235,7 +1235,7 @@ public class PulsarFunctionE2ETest {
         // try to update function to test: update-function functionality
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -1250,7 +1250,7 @@ public class PulsarFunctionE2ETest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats.unackedMessages == 0 && subStats.msgThroughputOut == totalMsgs;
@@ -1278,7 +1278,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {
@@ -1341,7 +1341,7 @@ public class PulsarFunctionE2ETest {
                 sourceTopicName, sinkTopic, subscriptionName);
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStats != null && subStats.consumers.size() == 1;
@@ -1356,7 +1356,7 @@ public class PulsarFunctionE2ETest {
         // it should stop consumer : so, check none of the consumer connected on subscription
         admin.functions().stopFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStat = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStat != null && subStat.consumers.size() == 0;
@@ -1371,7 +1371,7 @@ public class PulsarFunctionE2ETest {
         // it should restart consumer : so, check if consumer came up again after restarting function
         admin.functions().restartFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStat = admin.topics().getStats(sourceTopic).subscriptions.get(subscriptionName);
                 return subStat != null && subStat.consumers.size() == 1;
@@ -1415,7 +1415,7 @@ public class PulsarFunctionE2ETest {
         functionConfig.setRuntime(FunctionConfig.Runtime.JAVA);
 
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.functions().getFunction(tenant, namespacePortion, functionName).getCleanupSubscription();
             } catch (PulsarAdminException e) {
@@ -1424,7 +1424,7 @@ public class PulsarFunctionE2ETest {
         }, 5, 150);
         assertFalse(admin.functions().getFunction(tenant, namespacePortion, functionName).getCleanupSubscription());
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -1438,7 +1438,7 @@ public class PulsarFunctionE2ETest {
         functionConfig.setCleanupSubscription(true);
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.functions().getFunction(tenant, namespacePortion, functionName).getCleanupSubscription();
             } catch (PulsarAdminException e) {
@@ -1452,7 +1452,7 @@ public class PulsarFunctionE2ETest {
             String data = "my-message-" + i;
             producer.newMessage().property(propertyKey, propertyValue).value(data).send();
         }
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 SubscriptionStats subStats = admin.topics().getStats(sourceTopic).subscriptions.get(
                         InstanceUtils.getDefaultSubscriptionName(tenant, namespacePortion, functionName));
@@ -1481,7 +1481,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 0;
             } catch (PulsarAdminException e) {
@@ -1497,7 +1497,7 @@ public class PulsarFunctionE2ETest {
         functionConfig.setCleanupSubscription(false);
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {
@@ -1507,7 +1507,7 @@ public class PulsarFunctionE2ETest {
         // validate pulsar source consumer has started on the topic
         assertEquals(admin.topics().getStats(sourceTopic).subscriptions.size(), 1);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 FunctionConfig result = admin.functions().getFunction(tenant, namespacePortion, functionName);
                 return result.getParallelism() == 2 && result.getCleanupSubscription() == false;
@@ -1521,7 +1521,7 @@ public class PulsarFunctionE2ETest {
         functionConfig.setParallelism(2);
         admin.functions().updateFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 FunctionConfig result = admin.functions().getFunction(tenant, namespacePortion, functionName);
                 return result.getParallelism() == 2 && result.getCleanupSubscription() == false;
@@ -1534,7 +1534,7 @@ public class PulsarFunctionE2ETest {
         // delete functions
         admin.functions().deleteFunction(tenant, namespacePortion, functionName);
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             try {
                 return admin.topics().getStats(sourceTopic).subscriptions.size() == 1;
             } catch (PulsarAdminException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -533,18 +533,14 @@ public class PulsarFunctionE2ETest {
 
                 return topicStats.subscriptions.containsKey(subscriptionName)
                         && topicStats.subscriptions.get(subscriptionName).consumers.size() == 1
-                        && topicStats.subscriptions.get(subscriptionName).consumers.get(0).availablePermits == 523;
+                        && topicStats.subscriptions.get(subscriptionName).consumers.get(0).availablePermits == 523
+                        && topicStats.subscriptions.size() == 1
+                        && topicStats.subscriptions.containsKey(subscriptionName) == true;
 
             } catch (PulsarAdminException e) {
                 return false;
             }
         }, 50, 150);
-
-        TopicStats topicStats = admin.topics().getStats(sourceTopic);
-        assertEquals(topicStats.subscriptions.size(), 1);
-        assertTrue(topicStats.subscriptions.containsKey(subscriptionName));
-        assertEquals(topicStats.subscriptions.get(subscriptionName).consumers.size(), 1);
-        assertEquals(topicStats.subscriptions.get(subscriptionName).consumers.get(0).availablePermits, 523);
 
         // validate prometheus metrics empty
         String prometheusMetrics = getPrometheusMetrics(pulsar.getListenPortHTTP().get());

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
@@ -188,7 +188,7 @@ public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
         
         final long expectedReadOffsetPosition = lastOffset;
         
-        retryStrategically((test) -> fetchOffset(consumer, topicPartition, groupId) == expectedReadOffsetPosition, 10, 150);
+        retryStrategically(() -> fetchOffset(consumer, topicPartition, groupId) == expectedReadOffsetPosition, 10, 150);
         
         long offset1 = fetchOffset(consumer, topicPartition, groupId);
         MessageIdImpl actualMsgId = ((MessageIdImpl)MessageIdUtils.getMessageId(offset1));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -419,7 +419,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                 Assert.fail("This test case should not fail");
             }
         }
-        org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically((test) -> {
+        org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically(() -> {
             try {
                 return admin.namespaces().getPermissions(namespaceName).containsKey("Proxy")
                         && admin.namespaces().getPermissions(namespaceName).containsKey("Client");

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -121,6 +121,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
+import static org.awaitility.Awaitility.*;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -40,11 +41,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
@@ -537,7 +534,7 @@ public class ZookeeperCacheTest {
             // Ok
         }
 
-        retryStrategically((test) -> {
+        retryStrategically(() -> {
             return zkCacheService.dataCache.getIfPresent(path) == null;
         }, 5, 1000);
 
@@ -548,13 +545,10 @@ public class ZookeeperCacheTest {
         scheduledExecutor.shutdown();
     }
 
-    private static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
+
+    @Test(enabled = false) // Added because TestNG giving: Cannot inject @Test annotated Method [retryStrategically]
+    public static void retryStrategically(Callable<Boolean> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
-        for (int i = 0; i < retryCount; i++) {
-            if (predicate.test(null) || i == (retryCount - 1)) {
-                break;
-            }
-            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
-        }
+        await().atMost(retryCount * intSleepTimeInMillis, TimeUnit.MILLISECONDS).until(predicate);
     }
 }

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -865,7 +865,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
             admin.topics().createNonPartitionedTopic(inputTopicName);
             admin.topics().createNonPartitionedTopic(outputTopicName);
-            retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     return admin.topics().getStats(inputTopicName).subscriptions.size() == 1;
                 } catch (PulsarAdminException e) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -109,7 +109,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
 
         try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(container.getHttpServiceUrl()).build()) {
 
-            retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     SourceStatus status = admin.sources().getSourceStatus("public", "default", sourceName);
                     return status.getInstances().size() > 0 && status.getInstances().get(0).getStatus().numWritten > 0;
@@ -166,7 +166,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 producer.send("foo");
             }
 
-            retryStrategically((test) -> {
+            retryStrategically(() -> {
                 try {
                     SinkStatus status = admin.sinks().getSinkStatus("public", "default", sinkName);
                     return status.getInstances().size() > 0 && status.getInstances().get(0).getStatus().numWrittenToSink > 0;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
@@ -22,7 +22,10 @@ import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
 import org.testng.ITest;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
+import static org.awaitility.Awaitility.*;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 public class PulsarTestSuite extends PulsarClusterTestBase implements ITest {
@@ -44,29 +47,8 @@ public class PulsarTestSuite extends PulsarClusterTestBase implements ITest {
         return "pulsar-test-suite";
     }
 
-    public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis) throws Exception {
-        retryStrategically(predicate, retryCount, intSleepTimeInMillis, false);
-    }
-
-
-    public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis, boolean throwException)
+    public static void retryStrategically(Callable<Boolean> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
-
-        for (int i = 0; i < retryCount; i++) {
-            if (throwException) {
-                if (i == (retryCount - 1)) {
-                    throw new RuntimeException("Action was not successful after " + retryCount + " retries");
-                }
-                if (predicate.test(null)) {
-                    break;
-                }
-            } else {
-                if (predicate.test(null) || i == (retryCount - 1)) {
-                    break;
-                }
-            }
-
-           Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
-        }
+        await().atMost(retryCount * intSleepTimeInMillis, TimeUnit.MILLISECONDS).until(predicate);
     }
 }


### PR DESCRIPTION
Fixes #6137 

### Motivation

There are many unstable tests that pass locally but fail when run by Github Actions CI or Jenkins. 
This drastically slows down development and prevents working code from being merged into master. 
It appears that many of the unstable tests are associated with Thread.sleep or other timing issues. 
Use of Thread.sleep is an antipattern in tests due to the associated stability issues. 
This PR attempts to replace the usage of Thread.sleep with an asynchronous approach that will reduce some of the associated issues.

### Modifications

Added Awaitility library and started refactoring shared test methods that use Thread.sleep.

### Verifying this change

All existing tests should pass (unless this unearths other issues that will need to be addressed). 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes, Awaitility)
  - Anything that affects deployment: (yes, affects tests)

