### PR TITLE
Introduce maxMessagePublishBufferSizeInMB configuration to avoid broker OOM

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -332,6 +332,10 @@ replicatedSubscriptionsSnapshotMaxCachedPerSubscription=10
 # Use -1 to disable the memory limitation. Default is 1/5 of direct memory.
 maxMessagePublishBufferSizeInMB=
 
+# Interval between checks to see if message publish buffer size is exceed the max message publish buffer size
+# Use 0 or negative number to disable the max publish buffer limiting.
+messagePublishBufferCheckIntervalInMills=100
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -329,12 +329,12 @@ replicatedSubscriptionsSnapshotMaxCachedPerSubscription=10
 # from the connection. The processing messages means messages are sends to broker
 # but broker have not send response to client, usually waiting to write to bookies.
 # It's shared across all the topics running in the same broker.
-# Use -1 to disable the memory limitation. Default is 1/5 of direct memory.
+# Use -1 to disable the memory limitation. Default is 1/2 of direct memory.
 maxMessagePublishBufferSizeInMB=
 
 # Interval between checks to see if message publish buffer size is exceed the max message publish buffer size
 # Use 0 or negative number to disable the max publish buffer limiting.
-messagePublishBufferCheckIntervalInMills=100
+messagePublishBufferCheckIntervalInMillis=100
 
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -324,6 +324,14 @@ replicatedSubscriptionsSnapshotTimeoutSeconds=30
 # Max number of snapshot to be cached per subscription.
 replicatedSubscriptionsSnapshotMaxCachedPerSubscription=10
 
+# Max memory size for broker handling messages sending from producers.
+# If the processing message size exceed this value, broker will stop read data
+# from the connection. The processing messages means messages are sends to broker
+# but broker have not send response to client, usually waiting to write to bookies.
+# It's shared across all the topics running in the same broker.
+# Use -1 to disable the memory limitation. Default is 1/5 of direct memory.
+maxMessagePublishBufferSizeInMB=
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -604,6 +604,17 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Max number of snapshot to be cached per subscription.")
     private int replicatedSubscriptionsSnapshotMaxCachedPerSubscription = 10;
 
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "Max memory size for broker handling messages sending from producers.\n\n"
+            + " If the processing message size exceed this value, broker will stop read data"
+            + " from the connection. The processing messages means messages are sends to broker"
+            + " but broker have not send response to client, usually waiting to write to bookies.\n\n"
+            + " It's shared across all the topics running in the same broker.\n\n"
+            + " Use -1 to disable the memory limitation. Default is 1/5 of direct memory.\n\n")
+    private int maxMessagePublishBufferSizeInMB = Math.max(64,
+        (int) (PlatformDependent.maxDirectMemory() / 5 / (1024 * 1024)));
+
     /**** --- Messaging Protocols --- ****/
 
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -611,15 +611,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " from the connection. The processing messages means messages are sends to broker"
             + " but broker have not send response to client, usually waiting to write to bookies.\n\n"
             + " It's shared across all the topics running in the same broker.\n\n"
-            + " Use -1 to disable the memory limitation. Default is 1/5 of direct memory.\n\n")
+            + " Use -1 to disable the memory limitation. Default is 1/2 of direct memory.\n\n")
     private int maxMessagePublishBufferSizeInMB = Math.max(64,
-        (int) (PlatformDependent.maxDirectMemory() / 5 / (1024 * 1024)));
+        (int) (PlatformDependent.maxDirectMemory() / 2 / (1024 * 1024)));
 
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Interval between checks to see if message publish buffer size is exceed the max message publish buffer size"
     )
-    private int messagePublishBufferCheckIntervalInMills = 100;
+    private int messagePublishBufferCheckIntervalInMillis = 100;
 
     /**** --- Messaging Protocols --- ****/
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -615,6 +615,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int maxMessagePublishBufferSizeInMB = Math.max(64,
         (int) (PlatformDependent.maxDirectMemory() / 5 / (1024 * 1024)));
 
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "Interval between checks to see if message publish buffer size is exceed the max message publish buffer size"
+    )
+    private int messagePublishBufferCheckIntervalInMills = 100;
+
     /**** --- Messaging Protocols --- ****/
 
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -277,7 +277,7 @@ public abstract class AbstractTopic implements Topic {
     public void resetTopicPublishCountAndEnableReadIfRequired() {
         // broker rate not exceeded. and completed topic limiter reset.
         if (!getBrokerPublishRateLimiter().isPublishRateExceeded() && topicPublishRateLimiter.resetPublishCount()) {
-            enableProducerRead();
+            enableProducerReadForPublishRateLimiting();
         }
     }
 
@@ -285,17 +285,28 @@ public abstract class AbstractTopic implements Topic {
     public void resetBrokerPublishCountAndEnableReadIfRequired(boolean doneBrokerReset) {
         // topic rate not exceeded, and completed broker limiter reset.
         if (!topicPublishRateLimiter.isPublishRateExceeded() && doneBrokerReset) {
-            enableProducerRead();
+            enableProducerReadForPublishRateLimiting();
         }
     }
 
     /**
      * it sets cnx auto-readable if producer's cnx is disabled due to publish-throttling
      */
-    @Override
-    public void enableProducerRead() {
+    public void enableProducerReadForPublishRateLimiting() {
         if (producers != null) {
-            producers.values().forEach(producer -> producer.getCnx().enableCnxAutoRead());
+            producers.values().forEach(producer -> {
+                producer.getCnx().cancelPublishRateLimiting();
+                producer.getCnx().enableCnxAutoRead();
+            });
+        }
+    }
+
+    public void enableProducerReadForPublishBufferLimiting() {
+        if (producers != null) {
+            producers.values().forEach(producer -> {
+                producer.getCnx().cancelPublishBufferLimiting();
+                producer.getCnx().enableCnxAutoRead();
+            });
         }
     }
 
@@ -390,7 +401,7 @@ public abstract class AbstractTopic implements Topic {
         } else {
             log.info("Disabling publish throttling for {}", this.topic);
             this.topicPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
-            enableProducerRead();
+            enableProducerReadForPublishRateLimiting();
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -292,7 +292,7 @@ public abstract class AbstractTopic implements Topic {
     /**
      * it sets cnx auto-readable if producer's cnx is disabled due to publish-throttling
      */
-    public void enableProducerReadForPublishRateLimiting() {
+    protected void enableProducerReadForPublishRateLimiting() {
         if (producers != null) {
             producers.values().forEach(producer -> {
                 producer.getCnx().cancelPublishRateLimiting();
@@ -301,7 +301,7 @@ public abstract class AbstractTopic implements Topic {
         }
     }
 
-    public void enableProducerReadForPublishBufferLimiting() {
+    protected void enableProducerReadForPublishBufferLimiting() {
         if (producers != null) {
             producers.values().forEach(producer -> {
                 producer.getCnx().cancelPublishBufferLimiting();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -292,7 +292,8 @@ public abstract class AbstractTopic implements Topic {
     /**
      * it sets cnx auto-readable if producer's cnx is disabled due to publish-throttling
      */
-    protected void enableProducerRead() {
+    @Override
+    public void enableProducerRead() {
         if (producers != null) {
             producers.values().forEach(producer -> producer.getCnx().enableCnxAutoRead());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -147,7 +147,7 @@ public class Producer {
             cnx.ctx().channel().eventLoop().execute(() -> {
                 cnx.ctx().writeAndFlush(Commands.newSendError(producerId, highestSequenceId, ServerError.MetadataError,
                         "Invalid lowest or highest sequence id"));
-                cnx.completedSendOperation(isNonPersistentTopic);
+                cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
             return;
         }
@@ -160,7 +160,7 @@ public class Producer {
             cnx.ctx().channel().eventLoop().execute(() -> {
                 cnx.ctx().writeAndFlush(Commands.newSendError(producerId, sequenceId, ServerError.PersistenceError,
                         "Producer is closed"));
-                cnx.completedSendOperation(isNonPersistentTopic);
+                cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
 
             return;
@@ -170,7 +170,7 @@ public class Producer {
             cnx.ctx().channel().eventLoop().execute(() -> {
                 cnx.ctx().writeAndFlush(
                         Commands.newSendError(producerId, sequenceId, ServerError.ChecksumError, "Checksum failed on the broker"));
-                cnx.completedSendOperation(isNonPersistentTopic);
+                cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
             return;
         }
@@ -187,7 +187,7 @@ public class Producer {
                 cnx.ctx().channel().eventLoop().execute(() -> {
                     cnx.ctx().writeAndFlush(Commands.newSendError(producerId, sequenceId, ServerError.MetadataError,
                             "Messages must be encrypted"));
-                    cnx.completedSendOperation(isNonPersistentTopic);
+                    cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
                 });
                 return;
             }
@@ -353,7 +353,7 @@ public class Producer {
                         producer.cnx.ctx().writeAndFlush(Commands.newSendError(producer.producerId, callBackSequenceId,
                                 serverError, exception.getMessage()));
                     }
-                    producer.cnx.completedSendOperation(producer.isNonPersistentTopic);
+                    producer.cnx.completedSendOperation(producer.isNonPersistentTopic, msgSize);
                     producer.publishOperationCompleted();
                     recycle();
                 });
@@ -385,7 +385,7 @@ public class Producer {
             producer.cnx.ctx().writeAndFlush(
                     Commands.newSendReceipt(producer.producerId, sequenceId, highestSequenceId, ledgerId, entryId),
                     producer.cnx.ctx().voidPromise());
-            producer.cnx.completedSendOperation(producer.isNonPersistentTopic);
+            producer.cnx.completedSendOperation(producer.isNonPersistentTopic, msgSize);
             producer.publishOperationCompleted();
             recycle();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1684,7 +1684,7 @@ public class ServerCnx extends PulsarHandler {
     private void startSendOperation(Producer producer, int msgSize) {
         messagePublishBufferSize += msgSize;
         boolean isPublishRateExceeded = producer.getTopic().isPublishRateExceeded();
-        if (++pendingSendRequest == MaxPendingSendRequests | isPublishRateExceeded | getBrokerService().isMessagePublishBufferThreshold()) {
+        if (++pendingSendRequest == MaxPendingSendRequests || isPublishRateExceeded || getBrokerService().isMessagePublishBufferThreshold()) {
             // When the quota of pending send requests is reached, stop reading from socket to cause backpressure on
             // client connection, possibly shared between multiple producers
             ctx.channel().config().setAutoRead(false);
@@ -1725,8 +1725,6 @@ public class ServerCnx extends PulsarHandler {
         }
     }
 
-<<<<<<< HEAD
-=======
     @VisibleForTesting
     void cancelPublishBufferLimiting() {
         if (autoReadDisabledPublishBufferLimiting) {
@@ -1734,7 +1732,6 @@ public class ServerCnx extends PulsarHandler {
         }
     }
     
->>>>>>> Apply comments
     private <T> ServerError getErrorCode(CompletableFuture<T> future) {
         ServerError error = ServerError.UnknownError;
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1684,11 +1684,15 @@ public class ServerCnx extends PulsarHandler {
     private void startSendOperation(Producer producer, int msgSize) {
         messagePublishBufferSize += msgSize;
         boolean isPublishRateExceeded = producer.getTopic().isPublishRateExceeded();
-        if (++pendingSendRequest == MaxPendingSendRequests || isPublishRateExceeded || getBrokerService().isMessagePublishBufferThreshold()) {
+        if (++pendingSendRequest == MaxPendingSendRequests || isPublishRateExceeded) {
             // When the quota of pending send requests is reached, stop reading from socket to cause backpressure on
             // client connection, possibly shared between multiple producers
             ctx.channel().config().setAutoRead(false);
             autoReadDisabledRateLimiting = isPublishRateExceeded;
+
+        }
+        if (getBrokerService().isMessagePublishBufferThreshold()) {
+            ctx.channel().config().setAutoRead(false);
             autoReadDisabledPublishBufferLimiting = true;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1691,7 +1691,7 @@ public class ServerCnx extends PulsarHandler {
             autoReadDisabledRateLimiting = isPublishRateExceeded;
 
         }
-        if (getBrokerService().isMessagePublishBufferThreshold()) {
+        if (getBrokerService().isReachMessagePublishBufferThreshold()) {
             ctx.channel().config().setAutoRead(false);
             autoReadDisabledPublishBufferLimiting = true;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -201,4 +201,6 @@ public interface Topic {
     default Optional<DispatchRateLimiter> getDispatchRateLimiter() {
         return Optional.empty();
     }
+
+    void enableProducerRead();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -201,6 +201,4 @@ public interface Topic {
     default Optional<DispatchRateLimiter> getDispatchRateLimiter() {
         return Optional.empty();
     }
-
-    void enableProducerRead();
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -47,7 +47,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
     @Test
     public void testMessagePublishBufferThrottleDisabled() throws Exception {
         conf.setMaxMessagePublishBufferSizeInMB(-1);
-        conf.setMessagePublishBufferCheckIntervalInMills(10);
+        conf.setMessagePublishBufferCheckIntervalInMillis(10);
         super.baseSetup();
         final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleDisabled";
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -58,7 +58,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         Assert.assertNotNull(topicRef);
         ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(Long.MAX_VALUE / 2);
         Thread.sleep(20);
-        Assert.assertFalse(pulsar.getBrokerService().isMessagePublishBufferThreshold());
+        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         List<CompletableFuture<MessageId>> futures = new ArrayList<>();
         // Make sure the producer can publish succeed.
         for (int i = 0; i < 10; i++) {
@@ -76,10 +76,10 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
     @Test
     public void testMessagePublishBufferThrottleEnable() throws Exception {
         conf.setMaxMessagePublishBufferSizeInMB(1);
-        conf.setMessagePublishBufferCheckIntervalInMills(2);
+        conf.setMessagePublishBufferCheckIntervalInMillis(2);
         super.baseSetup();
         Thread.sleep(4);
-        Assert.assertFalse(pulsar.getBrokerService().isMessagePublishBufferThreshold());
+        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleEnable";
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
@@ -89,7 +89,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         Assert.assertNotNull(topicRef);
         ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(Long.MAX_VALUE / 2);
         Thread.sleep(4);
-        Assert.assertTrue(pulsar.getBrokerService().isMessagePublishBufferThreshold());
+        Assert.assertTrue(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         // The first message can publish success, but the second message should be blocked
         producer.sendAsync(new byte[1024]).get(1, TimeUnit.SECONDS);
         MessageId messageId = null;
@@ -121,10 +121,10 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
     @Test
     public void testBlockByPublishRateLimiting() throws Exception {
         conf.setMaxMessagePublishBufferSizeInMB(1);
-        conf.setMessagePublishBufferCheckIntervalInMills(2);
+        conf.setMessagePublishBufferCheckIntervalInMillis(2);
         super.baseSetup();
         Thread.sleep(4);
-        Assert.assertFalse(pulsar.getBrokerService().isMessagePublishBufferThreshold());
+        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleEnable";
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
@@ -139,7 +139,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setAutoReadDisabledRateLimiting(true);
         ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(0);
         Thread.sleep(4);
-        Assert.assertFalse(pulsar.getBrokerService().isMessagePublishBufferThreshold());
+        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         MessageId messageId = null;
         try {
             messageId = producer.sendAsync(new byte[1024]).get(1, TimeUnit.SECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -68,8 +68,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         for (CompletableFuture<MessageId> future : futures) {
             Assert.assertNotNull(future.get());
         }
-        Thread.sleep(4);
-        Assert.assertEquals(pulsar.getBrokerService().getCurrentMessagePublishBufferSize(), 0L);
+        Thread.sleep(20);
+        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         super.internalCleanup();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ */
+public class MessagePublishBufferThrottleTest extends BrokerTestBase {
+
+    @Override
+    protected void setup() throws Exception {
+        //No-op
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        //No-op
+    }
+
+    @Test
+    public void testMessagePublishBufferThrottleDisabled() throws Exception {
+        conf.setMaxMessagePublishBufferSizeInMB(-1);
+        super.baseSetup();
+        Assert.assertFalse(pulsar.getBrokerService().increasePublishBufferSizeAndCheckStopRead(1));
+        Assert.assertFalse(pulsar.getBrokerService().decreasePublishBufferSizeAndCheckResumeRead(1));
+    }
+
+    @Test
+    public void testMessagePublishBufferThrottle() throws Exception {
+        conf.setMaxMessagePublishBufferSizeInMB(1);
+        super.baseSetup();
+        Assert.assertFalse(pulsar.getBrokerService().increasePublishBufferSizeAndCheckStopRead(512 * 1024));
+        Assert.assertTrue(pulsar.getBrokerService().increasePublishBufferSizeAndCheckStopRead(512 * 1024));
+        Assert.assertTrue(pulsar.getBrokerService().increasePublishBufferSizeAndCheckStopRead( 1024));
+        Assert.assertFalse(pulsar.getBrokerService().decreasePublishBufferSizeAndCheckResumeRead(1024));
+        Assert.assertFalse(pulsar.getBrokerService().decreasePublishBufferSizeAndCheckResumeRead(512 * 1024));
+        Assert.assertTrue(pulsar.getBrokerService().decreasePublishBufferSizeAndCheckResumeRead(1024));
+        Assert.assertFalse(pulsar.getBrokerService().decreasePublishBufferSizeAndCheckResumeRead(1024));
+        Assert.assertTrue(pulsar.getBrokerService().increasePublishBufferSizeAndCheckStopRead(514 * 1024));
+    }
+
+    @Test
+    public void testCurrentPublishBufferShouldBeZeroWhenComplete() throws Exception {
+        conf.setMaxMessagePublishBufferSizeInMB(1);
+        super.baseSetup();
+
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
+        final int messages = 200;
+        final int producers = 10;
+
+        List<Producer<byte[]>> producerList = new ArrayList<>();
+        for (int i = 0; i < producers; i++) {
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://prop/ns-abc/testCurrentPublishBufferShouldBeZeroWhenComplete")
+                .enableBatching(false)
+                .create();
+            producerList.add(producer);
+        }
+
+        for (Producer<byte[]> producer : producerList) {
+            for (int j = 0; j < messages; j++) {
+                futures.add(producer.sendAsync(new byte[1024]));
+            }
+        }
+
+        FutureUtil.waitForAll(futures).get();
+        Assert.assertEquals(futures.size(), messages * producers);
+        Assert.assertEquals(pulsar.getBrokerService().getCurrentMessagePublishBufferSize().get(), 0);
+        Assert.assertTrue(pulsar.getBrokerService().messagePublishBufferThrottleTimes > 0
+            && pulsar.getBrokerService().messagePublishBufferThrottleTimes == pulsar.getBrokerService().messagePublishBufferResumeTimes);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -63,6 +63,7 @@ public class ServiceConfigurationTest {
         assertEquals(config.getBrokerDeleteInactiveTopicsMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
         assertEquals(config.getDefaultNamespaceBundleSplitAlgorithm(), "topic_count_equally_divide");
         assertEquals(config.getSupportedNamespaceBundleSplitAlgorithms().size(), 1);
+        assertEquals(config.getMaxMessagePublishBufferSizeInMB(), -1);
     }
 
     @Test

--- a/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
+++ b/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
@@ -88,3 +88,4 @@ replicatorPrefix=pulsar.repl
 brokerDeleteInactiveTopicsMode=delete_when_subscriptions_caught_up
 supportedNamespaceBundleSplitAlgorithms=[range_equally_divide]
 defaultNamespaceBundleSplitAlgorithm=topic_count_equally_divide
+maxMessagePublishBufferSizeInMB=-1


### PR DESCRIPTION
Master Issue: #5751

### Motivation

Introduce maxMessagePublishBufferSizeInMB configuration to avoid broker OOM.

### Modifications

If the processing message size exceed this value, broker will stop read data from the connection. When available size > half of the maxMessagePublishBufferSizeInMB, start auto read data from the connection.

### Verifying this change

Unit tests added

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
