### PR TITLE
Skip tests if a pull request only changes documentation

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -35,11 +35,12 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
-      - name: Check if changes of pull request are only made in docs
+      - name: Check if this pull request only changes documentation
         id:   docs
+        # TODO: move this action to an apache repo
         uses: sijie/pulsar-github-actions/diff-only@master
         with:
-          args: site2 .github
+          args: site2 .github deployment
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,24 +31,35 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
 
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if changes of pull request are only made in docs
+        id:   docs
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build pacakge
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR package -DskipTests
 
       - name: build cpp artifacts
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           echo "Build C++ client library"
           export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF"
           pulsar-client-cpp/docker-build.sh
 
       - name: run c++ tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: pulsar-client-cpp/docker-tests.sh
 
 

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -31,28 +31,38 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
 
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           go-version: 1.12
         id: go
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
       - name: InstallTool
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.18.0
           ./bin/golangci-lint --version
 
       - name: Build
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           go build ./pf
 
       - name: CheckStyle
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           ./bin/golangci-lint run -c ./golangci.yml ./pf

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -34,16 +34,25 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           go-version: 1.12
         id: go
 
-      - name: checkout
-        uses: actions/checkout@v1
-
       - name: run tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           go test -v $(go list ./... | grep -v examples)

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,28 +31,42 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
       - name: Set up JDK 1.8
+        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
-      - name: checkout
-        uses: actions/checkout@v1
-
       - name: run install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: clean docker container
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker system prune -f
 
       - name: remove docker node image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
 
       - name: remove docker builder and microsoft image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-backwards-compatibility.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-cli.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-function-state.yaml
+++ b/.github/workflows/ci-integration-function-state.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-function-state.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-messaging.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -56,19 +56,25 @@ jobs:
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: clean docker container
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker system prune -f
 
       - name: remove docker node image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
 
       - name: remove docker builder and microsoft image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration function
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=function
 
       - name: run integration source
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=source
 
       - name: run integraion sink
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=sink

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,18 +31,28 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: run install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: clean docker container

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-schema.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,21 +31,32 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-sql.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-standalone.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,34 +31,50 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: run install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: clean docker container
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker system prune -f
 
       - name: remove docker node image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
 
       - name: remove docker builder and microsoft image
+        if: steps.docs.outputs.changed_only == 'no'
         run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration function
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=function
 
       - name: run integration source
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=source
 
       - name: run integraion sink
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=sink

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=tiered-filesystem-storage.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,16 +31,26 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: build artifacts and docker image
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B install -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdocker -DskipTests
 
       - name: run integration tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=tiered-jcloud-storage.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,22 +31,33 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
 
       # license check fails with 3.6.2 so we have to downgrade
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: build and check license
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -DskipTests license:check install
           
       - name: license check
+        if: steps.docs.outputs.changed_only == 'no'
         run: src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/.github/workflows/ci-unit-adaptors.yml
+++ b/.github/workflows/ci-unit-adaptors.yml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,24 +31,36 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run unit tests install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: run unit tests pulsar io kafka connect adaptor
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -pl pulsar-io/kafka-connect-adaptor
 
       - name: run unit tests pulsar storm tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -pl tests/pulsar-storm-test

--- a/.github/workflows/ci-unit-broker-sasl.yml
+++ b/.github/workflows/ci-unit-broker-sasl.yml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,21 +31,32 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run unit tests install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: run unit tests pulsar auth sasl
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false -pl pulsar-broker-auth-sasl

--- a/.github/workflows/ci-unit-broker.yml
+++ b/.github/workflows/ci-unit-broker.yml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,42 +31,60 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run unit tests install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: run unit tests pulsar broker reader test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=ReaderTest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker rack aware test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=RackAwareTest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker simple producer consumer test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=SimpleProducerConsumerTest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker V1 producer consumer test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=V1_ProducerConsumerTest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker persistent failover end to end test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=PersistentFailoverE2ETest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker client integration test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=BrokerClientIntegrationTest' -pl pulsar-broker
 
       - name: run unit tests pulsar broker replicatior rate limiter test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=ReplicatorRateLimiterTest' -pl pulsar-broker
 
       - name: run unit test pulsar-broker
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test '-Dtest=!PersistentTransactionBufferTest,!PulsarFunctionE2ESecurityTest,!ServerCnxTest,!AdminApiOffloadTest,!AdminApiSchemaValidationEnforced,!V1_AdminApiTest2,!ProxyPublishConsumeTlsTest,!PulsarFunctionE2ETest,!MessageIdSerialization,!AdminApiTest2,!PulsarFunctionLocalRunTest,!PartitionedProducerConsumerTest,!KafkaProducerSimpleConsumerTest,!MessagePublishThrottlingTest,!ReaderTest,!RackAwareTest,!SimpleProducerConsumerTest,!V1_ProducerConsumerTest,!PersistentFailoverE2ETest,!BrokerClientIntegrationTest,!ReplicatorRateLimiterTest' -DfailIfNoTests=false -pl pulsar-broker

--- a/.github/workflows/ci-unit-flaky.yaml
+++ b/.github/workflows/ci-unit-flaky.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,32 +31,46 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run PersistentTransactionBuffer test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -am -pl pulsar-broker -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR clean install -Dtest=PersistentTransactionBufferTest -DfailIfNoTests=false
 
       - name: run ServerCnx test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -am -pl pulsar-broker -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR clean install -Dtest=ServerCnxTest -DfailIfNoTests=false
 
       - name: run MessagePublishThrottling test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -am -pl pulsar-broker -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR clean install -Dtest=MessagePublishThrottlingTest -DfailIfNoTests=false
 
       - name: run PrimitiveSchema test
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -am -pl pulsar-client -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR clean install -Dtest=PrimitiveSchemaTest -DfailIfNoTests=false
 
       - name: run unit tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR clean install '-Dtest=PulsarFunctionE2ESecurityTest,AdminApiOffloadTest,AdminApiSchemaValidationEnforced,V1_AdminApiTest2,PulsarFunctionE2ETest,MessageIdSerialization,AdminApiTest2,PulsarFunctionLocalRunTest,PartitionedProducerConsumerTest,KafkaProducerSimpleConsumerTest,ProxyTest' -DfailIfNoTests=false
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,24 +31,36 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run unit tests install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: run unit tests pulsar proxy
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=!ProxyTest,!ProxyLookupThrottlingTest' -pl pulsar-proxy
 
       - name: run unit tests pulsar proxy
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn test -DfailIfNoTests=false '-Dtest=ProxyTest,ProxyLookupThrottlingTest' -pl pulsar-proxy

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
@@ -33,23 +31,34 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        # TODO: move this action to an apache repo
+        uses: sijie/pulsar-github-actions/diff-only@master
+        with:
+          args: site2 .github deployment
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          java-version: 1.8
+
       - name: Set up Maven
         uses: aahmed-se/setup-maven@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           maven-version: 3.6.1
 
       - name: run unit tests install by skip tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
 
       - name: run unit tests
+        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DfailIfNoTests=false '-Dtest=!KafkaProducerSimpleConsumerTest,!PrimitiveSchemaTest' -pl '!pulsar-broker,!pulsar-proxy,!pulsar-broker-auth-sasl,!pulsar-io/kafka-connect-adaptor,!tests/pulsar-storm-test'
 
       - name: package surefire artifacts


### PR DESCRIPTION
*Motivation*

Currently github actions are marked as required. But github actions are skipped if the change only changes markdown files. So it is blocking merging documentation changes.

*Modification*

Add a github action to check if this pull request is a doc-only change or not. If it is a doc-only change, we can skip the checks. 