### PR TITLE
[kinesis] Fix netty dependency conflict in Kinesis

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -81,13 +81,13 @@
     <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>2.2.3</version>
+      <version>2.2.8</version>
     </dependency>
 
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.13.1</version>
+      <version>0.14.0</version>
     </dependency>
 
     <dependency>
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.8.5</version>
+      <version>2.10.56</version>
     </dependency>
 	<!-- /kinesis dependencies -->
 


### PR DESCRIPTION


### Motivation

The KCL was depending on a version of the aws-sdk-v2 that was relying on
unstable Netty APIs (see
aws/aws-sdk-java-v2#1344). Pulsar had taken a
netty update which was conflicting with their bundled netty and was
leading to an exception in calling an invalid function.

This newer version of the KCL takes a newer version of aws-sdk-v2 which
should depend on stable APIs

### Modifications

Bump some versions

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: no
  - The schema: (no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
