### PR TITLE
(Flaky-tests) Reduce flakiness of tests

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -64,7 +64,7 @@ jobs:
         run: mvn install -DfailIfNoTests=false '-Dtest=!KafkaProducerSimpleConsumerTest,!PrimitiveSchemaTest,!BlobStoreManagedLedgerOffloaderTest' -pl '!pulsar-broker,!pulsar-proxy,!pulsar-broker-auth-sasl,!pulsar-io/kafka-connect-adaptor,!tests/pulsar-storm-test'
 
       - name: package surefire artifacts
-        if: failure()
+        if: always()
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: always()
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@ flexible messaging model and an intuitive client API.</description>
     <javassist.version>3.25.0-GA</javassist.version>
     <failsafe.version>2.3.1</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
+    <awaitility.version>4.0.2</awaitility.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -249,6 +250,13 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -35,6 +35,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -140,7 +140,7 @@ public class ServerCnx extends PulsarHandler {
     AuthenticationState originalAuthState;
     private boolean pendingAuthChallengeResponse = false;
 
-    // Max number of pending requests per connections. If multiple producers are sharing the same connection the flow
+    // Max number of pending requests per connections. If multiple producers are sharing the same connection, the flow
     // control done by a single producer might not be enough to prevent write spikes on the broker.
     private final int maxPendingSendRequests;
     private final int resumeReadsThreshold;
@@ -704,6 +704,7 @@ public class ServerCnx extends PulsarHandler {
 
     @Override
     protected void handleSubscribe(final CommandSubscribe subscribe) {
+        log.info("handleSubscribe is getting called on ServerCnx");
         checkArgument(state == State.Connected);
         final long requestId = subscribe.getRequestId();
         final long consumerId = subscribe.getConsumerId();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -206,7 +206,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.clusters().createCluster("usw",
                 new ClusterData("http://broker.messaging.use.example.com:8080"));
         // "test" cluster is part of config-default cluster and it's znode gets created when PulsarService creates
-        // failure-domain znode of this default cluster
+        // failure-domain znode of this default cluster.
         assertEquals(admin.clusters().getClusters(), Lists.newArrayList("test", "usw"));
 
         assertEquals(admin.clusters().getCluster("test"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -436,7 +436,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
      * @param namespaceName
      * @throws Exception
      */
-    @Test(dataProvider = "namespaceNames", timeOut = 10000)
+    @Test(dataProvider = "namespaceNames", timeOut = 30000)
     public void testResetCursorOnPosition(String namespaceName) throws Exception {
         final String topicName = "persistent://prop-xyz/use/" + namespaceName + "/resetPosition";
         final int totalProducedMessages = 50;
@@ -459,7 +459,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         MessageIdImpl resetMessageId = null;
         int resetPositionId = 10;
         for (int i = 0; i < 20; i++) {
-            message = consumer.receive(1, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledge(message);
             if (i == resetPositionId) {
                 resetMessageId = (MessageIdImpl) message.getMessageId();
@@ -959,7 +959,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
                 Collections.singletonList(localCluster));
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConsumerStatsLastTimestamp() throws PulsarClientException, PulsarAdminException, InterruptedException {
         long timestamp = System.currentTimeMillis();
         final String topicName = "consumer-stats-" + timestamp;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest2.java
@@ -449,7 +449,7 @@ public class V1_AdminApiTest2 extends MockedPulsarServiceBaseTest {
         MessageIdImpl resetMessageId = null;
         int resetPositionId = 10;
         for (int i = 0; i < 20; i++) {
-            message = consumer.receive(1, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledge(message);
             if (i == resetPositionId) {
                 resetMessageId = (MessageIdImpl) message.getMessageId();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -463,7 +463,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
         Message<byte[]> lastunackedMsg = null;
         for (int i = 0; i < numMsgs; i++) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
             assertNotNull(msg);
             lastunackedMsg = msg;
         }
@@ -708,7 +708,7 @@ public class BatchMessageTest extends BrokerTestBase {
         for (int i = 0; i < numMsgs; i++) {
             executor.submit(() -> {
                 try {
-                    Message<byte[]> msg = myConsumer.receive(1, TimeUnit.SECONDS);
+                    Message<byte[]> msg = myConsumer.receive(5, TimeUnit.SECONDS);
                     myConsumer.acknowledge(msg);
                 } catch (Exception e) {
                     failed.set(false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -96,7 +96,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         }
         Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledge(msg);
         }
 
@@ -130,7 +130,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
             producer.send(message.getBytes());
         }
         for (int i = 0; i < 10; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledge(msg);
         }
 
@@ -215,7 +215,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         }
 
         // validate: consumer is able to consume msg and close consumer after reading 1 entry
-        Assert.assertNotNull(consumer.receive(1, TimeUnit.SECONDS));
+        Assert.assertNotNull(consumer.receive(5, TimeUnit.SECONDS)); // Need to replace with await()
         consumer.close();
 
         NavigableMap<Long, LedgerInfo> ledgerInfo = ml.getLedgersInfo();
@@ -249,14 +249,14 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         Message<byte[]> msg = null;
         // start consuming message
         consumer = client.newConsumer().topic(topic1).subscriptionName("my-subscriber-name").subscribe();
-        msg = consumer.receive(1, TimeUnit.SECONDS);
+        msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         Assert.assertNull(msg);
         consumer.close();
 
         // (4) enable dynamic config to skip non-recoverable data-ledgers
         admin.brokers().updateDynamicConfiguration("autoSkipNonRecoverableData", "true");
 
-        retryStrategically((test) -> config.isAutoSkipNonRecoverableData(), 5, 100);
+        retryStrategically((test) -> config.isAutoSkipNonRecoverableData(), 15, 300);
 
         // (5) consumer will be able to consume 20 messages from last non-deleted ledger
         consumer = client.newConsumer().topic(topic1).subscriptionName("my-subscriber-name").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -246,7 +246,7 @@ public class BrokerBookieIsolationTest {
      * @throws Exception
      */
     @Test
-    public void testBookieIsilationWithSecondaryGroup() throws Exception {
+    public void testBookieIsolationWithSecondaryGroup() throws Exception {
         final String tenant1 = "tenant1";
         final String cluster = "use";
         final String ns1 = String.format("%s/%s/%s", tenant1, cluster, "ns1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Sets;
 /**
  */
 public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
-    protected static final int ASYNC_EVENT_COMPLETION_WAIT = 100;
+    protected static final int ASYNC_EVENT_COMPLETION_WAIT = 500;
 
     protected PulsarService getPulsar() {
         return pulsar;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PartitionKeyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PartitionKeyTest.java
@@ -27,6 +27,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  */
 @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -48,13 +48,13 @@ import com.google.common.collect.Sets;
 public class PeerReplicatorTest extends ReplicatorTestBase {
 
     @Override
-    @BeforeClass(timeOut = 300000)
+    @BeforeClass(timeOut = 900000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass(timeOut = 300000)
+    @AfterClass(timeOut = 900000)
     void shutdown() throws Exception {
         super.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
@@ -33,7 +33,7 @@ import org.testng.collections.Lists;
 public class ReplicatorTlsTest extends ReplicatorTestBase {
 
     @Override
-    @BeforeClass(timeOut = 300000)
+    @BeforeClass(timeOut = 900000)
     void setup() throws Exception {
         config1.setBrokerClientTlsEnabled(true);
         config2.setBrokerClientTlsEnabled(true);
@@ -42,7 +42,7 @@ public class ReplicatorTlsTest extends ReplicatorTestBase {
     }
 
     @Override
-    @AfterClass(timeOut = 300000)
+    @AfterClass(timeOut = 900000)
     void shutdown() throws Exception {
         super.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -212,7 +212,7 @@ public class ServerCnxTest {
         executor.shutdownNow();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConnectCommand() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -245,7 +245,7 @@ public class ServerCnxTest {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConnectCommandWithEnum() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -260,7 +260,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConnectCommandWithProtocolVersion() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -276,7 +276,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testKeepAlive() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -301,7 +301,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testKeepAliveNotEnforcedWithOlderClients() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -326,7 +326,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testKeepAliveBeforeHandshake() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());
@@ -345,7 +345,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConnectCommandWithAuthenticationPositive() throws Exception {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
@@ -380,7 +380,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testConnectCommandWithAuthenticationNegative() throws Exception {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         doReturn(authenticationService).when(brokerService).getAuthenticationService();
@@ -400,7 +400,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerCommand() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -428,7 +428,7 @@ public class ServerCnxTest {
         assertEquals(topicRef.getProducers().size(), 0);
     }
 
-    @Test(timeOut = 5000)
+    @Test(timeOut = 50000)
     public void testDuplicateConcurrentProducerCommand() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -451,7 +451,7 @@ public class ServerCnxTest {
         assertEquals(error.getError(), ServerError.ServiceNotReady);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerOnNotOwnedTopic() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -475,7 +475,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerCommandWithAuthorizationPositive() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).canProduceAsync(Mockito.any(),
@@ -500,7 +500,7 @@ public class ServerCnxTest {
         assertEquals(topicRef.getProducers().size(), 0);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testNonExistentTopic() throws Exception {
         ZooKeeperDataCache<Policies> zkDataCache = mock(ZooKeeperDataCache.class);
         ConfigurationCacheService configCacheService = mock(ConfigurationCacheService.class);
@@ -536,7 +536,7 @@ public class ServerCnxTest {
         assertTrue(getResponse() instanceof CommandError);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testClusterAccess() throws Exception {
         svcConfig.setAuthorizationEnabled(true);
         AuthorizationService authorizationService = spy(new AuthorizationService(svcConfig, configCacheService));
@@ -565,7 +565,7 @@ public class ServerCnxTest {
         assertTrue(getResponse() instanceof CommandError);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testNonExistentTopicSuperUserAccess() throws Exception {
         AuthorizationService authorizationService = spy(new AuthorizationService(svcConfig, configCacheService));
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
@@ -622,7 +622,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSendCommand() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -645,7 +645,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testUseSameProducerName() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -665,7 +665,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testRecreateSameProducer() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -699,7 +699,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeMultipleTimes() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -756,7 +756,7 @@ public class ServerCnxTest {
         assertEquals(error.getError(), ServerError.ServiceNotReady);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testCreateProducerTimeout() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -891,7 +891,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000, invocationCount = 1, skipFailedInvocations = true)
+    @Test(timeOut = 90000, invocationCount = 1, skipFailedInvocations = true)
     public void testCreateProducerBookieTimeout() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -961,7 +961,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeTimeout() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1035,7 +1035,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeBookieTimeout() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1120,7 +1120,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeCommand() throws Exception {
         final String failSubName = "failSub";
 
@@ -1159,7 +1159,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testUnsupportedBatchMsgSubscribeCommand() throws Exception {
         final String failSubName = "failSub";
 
@@ -1192,7 +1192,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeCommandWithAuthorizationPositive() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).canConsumeAsync(Mockito.any(),
@@ -1214,7 +1214,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSubscribeCommandWithAuthorizationNegative() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).canConsumeAsync(Mockito.any(),
@@ -1235,7 +1235,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testAckCommand() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1258,7 +1258,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testFlowCommand() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1278,7 +1278,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerSuccessOnEncryptionRequiredTopic() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1306,7 +1306,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerFailureOnEncryptionRequiredTopic() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1336,7 +1336,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSendSuccessOnEncryptionRequiredTopic() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1371,7 +1371,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSendFailureOnEncryptionRequiredTopic() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1552,7 +1552,7 @@ public class ServerCnxTest {
         doReturn(successSubName).when(cursorMock).getName();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testInvalidTopicOnLookup() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1572,7 +1572,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testInvalidTopicOnProducer() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -1593,7 +1593,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testInvalidTopicOnSubscribe() throws Exception {
         resetChannel();
         setChannelConnected();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -88,7 +88,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
 
         // Failover consumer will receive the messages immediately while
         // the shared consumer will get them after the delay
-        Message<String> msg = sharedConsumer.receive(100, TimeUnit.MILLISECONDS);
+        Message<String> msg = sharedConsumer.receive(10, TimeUnit.MILLISECONDS);
         assertNull(msg);
 
         for (int i = 0; i < 10; i++) {
@@ -194,7 +194,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
                     .send();
         }
 
-        Message<String> msg = sharedConsumer.receive(100, TimeUnit.MILLISECONDS);
+        Message<String> msg = sharedConsumer.receive(10, TimeUnit.MILLISECONDS);
         assertNull(msg);
 
         Set<String> receivedMsgs = new TreeSet<>();
@@ -256,7 +256,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
 
         producer.flush();
 
-        Message<String> msg = consumer.receive(100, TimeUnit.MILLISECONDS);
+        Message<String> msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         assertNull(msg);
 
         Set<String> receivedMsgs = new TreeSet<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.BkEnsemblesTestBase;
 import org.apache.pulsar.client.api.Consumer;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -34,8 +34,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- */
 public class ManagedLedgerMetricsTest extends BrokerTestBase {
 
     @BeforeClass

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -106,7 +106,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .subscribe();
 
-        Message<byte[]> checkMessage = checkConsumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> checkMessage = checkConsumer.receive(10, TimeUnit.MILLISECONDS);
         if (checkMessage != null) {
             log.info("check consumer received message : {} {}", checkMessage.getMessageId(), new String(checkMessage.getData()));
         }
@@ -288,7 +288,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         // Wait a while, message should not be send to DLQ
         Thread.sleep(5000L);
 
-        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
         assertNotNull(msg);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -670,12 +670,12 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
      * acking a. as consumer is acking not reached maxUnAckPerDispatcher=20 unack msg => consumes all produced msgs
      * 4.Subscription-1 : acks all pending msgs and consume by acking a. broker unblocks all dispatcher and sub-1
      * consumes all messages 5. Subscription-2 : it triggers redelivery and acks all messages so, it consumes all
-     * produced messages
+     * produced messages.
      * </pre>
      *
      * @throws Exception
      */
-    @Test(timeOut = 10000)
+    @Test(timeOut = 190000)
     public void testBlockBrokerDispatching() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -743,7 +743,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             Set<MessageId> messages1 = Sets.newHashSet();
             for (int j = 0; j < totalProducedMsgs; j++) {
-                msg = consumer1Sub1.receive(100, TimeUnit.MILLISECONDS);
+                msg = consumer1Sub1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg.getMessageId());
                 } else {
@@ -752,7 +752,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                 // once consumer receives maxUnAckPerBroker-msgs then sleep to give a chance to scheduler to block the
                 // subscription
                 if (j == maxUnAckPerBroker) {
-                    Thread.sleep(200);
+                    Thread.sleep(1000);
                 }
             }
             // client must receive number of messages = maxUnAckPerbroker rather all produced messages
@@ -764,7 +764,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                     .subscriptionType(SubscriptionType.Shared).acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             int consumer2Msgs = 0;
             for (int j = 0; j < totalProducedMsgs; j++) {
-                msg = consumer2Sub1.receive(100, TimeUnit.MILLISECONDS);
+                msg = consumer2Sub1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer2Msgs++;
                 } else {
@@ -789,7 +789,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                     .subscriptionType(SubscriptionType.Shared).acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             Set<MessageId> messages2 = Sets.newHashSet();
             for (int j = 0; j < totalProducedMsgs; j++) {
-                msg = consumerSub2.receive(100, TimeUnit.MILLISECONDS);
+                msg = consumerSub2.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages2.add(msg.getMessageId());
                 } else {
@@ -806,7 +806,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                     .subscriptionType(SubscriptionType.Shared).acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             int consumedMsgsSub3 = 0;
             for (int j = 0; j < totalProducedMsgs; j++) {
-                msg = consumer1Sub3.receive(100, TimeUnit.MILLISECONDS);
+                msg = consumer1Sub3.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumedMsgsSub3++;
                     consumer1Sub3.acknowledge(msg);
@@ -822,7 +822,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             // sleep so, broker receives all ack back to unblock subscription
             Thread.sleep(1000);
             for (int j = 0; j < totalProducedMsgs; j++) {
-                msg = consumer1Sub1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1Sub1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg.getMessageId());
                     consumer1Sub1.acknowledge(msg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ExposeMessageRedeliveryCountTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ExposeMessageRedeliveryCountTest.java
@@ -43,7 +43,7 @@ public class ExposeMessageRedeliveryCountTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testRedeliveryCount() throws PulsarClientException {
 
         final String topic = "persistent://my-property/my-ns/redeliveryCount";
@@ -78,7 +78,7 @@ public class ExposeMessageRedeliveryCountTest extends ProducerConsumerBase {
         consumer.close();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testRedeliveryCountWithPartitionedTopic() throws PulsarClientException, PulsarAdminException {
 
         final String topic = "persistent://my-property/my-ns/redeliveryCount.partitioned";
@@ -117,7 +117,7 @@ public class ExposeMessageRedeliveryCountTest extends ProducerConsumerBase {
         admin.topics().deletePartitionedTopic(topic);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 190000)
     public void testRedeliveryCountWhenConsumerDisconnected() throws PulsarClientException, InterruptedException {
 
         String topic = "persistent://my-property/my-ns/testRedeliveryCountWhenConsumerDisconnected";
@@ -150,7 +150,7 @@ public class ExposeMessageRedeliveryCountTest extends ProducerConsumerBase {
         List<Message<String>> receivedMessagesForConsumer1 = new ArrayList<>();
 
         for (int i = 0; i < messages; i++) {
-            Message<String> msg = consumer0.receive(1, TimeUnit.SECONDS);
+            Message<String> msg = consumer0.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 receivedMessagesForConsumer0.add(msg);
             } else {
@@ -159,7 +159,7 @@ public class ExposeMessageRedeliveryCountTest extends ProducerConsumerBase {
         }
 
         for (int i = 0; i < messages; i++) {
-            Message<String> msg = consumer1.receive(1, TimeUnit.SECONDS);
+            Message<String> msg = consumer1.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 receivedMessagesForConsumer1.add(msg);
             } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -119,7 +119,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 consumer.acknowledge(msg);
                 String receivedMessage = new String(msg.getData());
@@ -162,7 +162,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 consumer.acknowledge(msg);
                 String receivedMessage = new String(msg.getData());
@@ -217,7 +217,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 consumer.acknowledge(msg);
                 String receivedMessage = new String(msg.getData());
@@ -260,7 +260,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 consumer.acknowledge(msg);
                 String receivedMessage = new String(msg.getData());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -69,7 +69,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         executor.shutdown();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testRoundRobinProducer() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
@@ -95,7 +95,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         Message<byte[]> msg;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
-            msg = consumer.receive(5, TimeUnit.SECONDS);
+            msg = consumer.receive();
             Assert.assertNotNull(msg, "Message should not be null");
             consumer.acknowledge(msg);
             String receivedMessage = new String(msg.getData());
@@ -112,7 +112,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testPartitionedTopicNameWithSpecialCharacter() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -130,7 +130,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testCustomPartitionProducer() throws Exception {
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         TopicName topicName = null;
@@ -162,7 +162,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
             Set<String> messageSet = Sets.newHashSet();
 
             for (int i = 0; i < MESSAGE_COUNT; i++) {
-                msg = consumer.receive(5, TimeUnit.SECONDS);
+                msg = consumer.receive();
                 Assert.assertNotNull(msg, "Message should not be null");
                 consumer.acknowledge(msg);
                 String receivedMessage = new String(msg.getData());
@@ -181,7 +181,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSinglePartitionProducer() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
@@ -207,7 +207,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         Set<String> messageSet = Sets.newHashSet();
 
         for (int i = 0; i < 10; i++) {
-            msg = consumer.receive(5, TimeUnit.SECONDS);
+            msg = consumer.receive();
             Assert.assertNotNull(msg, "Message should not be null");
             consumer.acknowledge(msg);
             String receivedMessage = new String(msg.getData());
@@ -225,7 +225,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testKeyBasedProducer() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
@@ -253,7 +253,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
 
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive();
             Assert.assertNotNull(msg, "Message should not be null");
             consumer.acknowledge(msg);
             String receivedMessage = new String(msg.getData());
@@ -334,7 +334,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testInvalidSequence() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -389,7 +389,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
 
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSillyUser() throws Exception {
 
         int numPartitions = 4;
@@ -433,7 +433,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
 
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testDeletePartitionedTopic() throws Exception {
         int numPartitions = 4;
         TopicName topicName = TopicName
@@ -455,7 +455,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testAsyncPartitionedProducerConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -504,7 +504,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testAsyncPartitionedProducerConsumerQueueSizeOne() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
@@ -561,7 +561,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testFairDistributionForPartitionConsumers() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
@@ -748,7 +748,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testAutoUpdatePartitionsForProducerConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -26,11 +26,7 @@ import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.pulsar.broker.stats.NamespaceStats;
@@ -62,6 +58,15 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    // Perhaps it would be better to import this method from PulsarTestBase in tests.integration
+    public static String randomName(int numChars) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < numChars; i++) {
+            sb.append((char) (ThreadLocalRandom.current().nextInt(26) + 'a'));
+        }
+        return sb.toString();
     }
 
     @DataProvider(name = "batch")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -536,7 +536,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         startBroker();
 
         // We should not have received any message
-        Message<byte[]> msg = consumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         Assert.assertNull(msg);
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
@@ -750,7 +750,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // clear the queue
         while (true) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(7, TimeUnit.SECONDS);
             if (msg == null) {
                 break;
             }
@@ -946,7 +946,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // sleep for a second: as ledger.updateCursorRateLimit RateLimiter will allow to invoke cursor-update after a
         // second
-        Thread.sleep(1000);//
+        Thread.sleep(2000); // Needs to be replaced with await() approach.
         // produce-consume one more message to trigger : ledger.internalReadFromLedger(..) which updates cursor and
         // EntryCache
         producer.send("message".getBytes());
@@ -970,7 +970,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // sleep for a second: as ledger.updateCursorRateLimit RateLimiter will allow to invoke cursor-update after a
         // second
-        Thread.sleep(1000);//
+        Thread.sleep(2000);// Needs to be replaced with await() approach.
         // produce-consume one more message to trigger : ledger.internalReadFromLedger(..) which updates cursor and
         // EntryCache
         producer.send("message".getBytes());
@@ -1176,7 +1176,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSharedConsumerAckDifferentConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -1301,7 +1301,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1324,7 +1324,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // try to consume remaining messages
             int remainingMessages = totalProducedMsgs - messages.size();
             for (int i = 0; i < remainingMessages; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1386,7 +1386,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 Message<byte[]> msg = null;
                 List<Message<byte[]>> messages = Lists.newArrayList();
                 for (int i = 0; i < totalProducedMsgs; i++) {
-                    msg = consumer.receive(1, TimeUnit.SECONDS);
+                    msg = consumer.receive(2, TimeUnit.SECONDS);
                     if (msg != null) {
                         messages.add(msg);
                         log.info("Received message: " + new String(msg.getData()));
@@ -1461,7 +1461,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1476,7 +1476,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (3.1) Consumer2 will start consuming messages without ack: it should stop after maxUnackedMessages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs - maxUnackedMessages; i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1498,7 +1498,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (4) Consumer2 consumer and ack: so it should consume all remaining messages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs - (2 * maxUnackedMessages); i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1559,7 +1559,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             assertEquals(consumer.numMessagesInQueue(), receiverQueueSize);
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+                Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1610,7 +1610,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMsg++;
@@ -1626,7 +1626,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int alreadyConsumedMessages = messages.size();
             messages.clear();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1691,7 +1691,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1714,7 +1714,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (3) Consumer consumes and ack: so it should consume all remaining messages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1774,7 +1774,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1797,7 +1797,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // (4) consumer1 will consumer remaining msgs and consumer2 will ack those messages
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     totalReceiveMessages++;
                     consumer2.acknowledge(msg);
@@ -1808,7 +1808,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     totalReceiveMessages++;
                     log.info("Received message: " + new String(msg.getData()));
@@ -1904,7 +1904,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1925,7 +1925,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             Set<MessageIdImpl> messages2 = Sets.newHashSet();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages2.add((MessageIdImpl) msg.getMessageId());
                     log.info("Received message: " + new String(msg.getData()));
@@ -1993,7 +1993,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Message<byte[]> msg = null;
             List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -2014,7 +2014,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             Set<MessageIdImpl> messages2 = Sets.newHashSet();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(2, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages2.add((MessageIdImpl) msg.getMessageId());
                     log.info("Received message: " + new String(msg.getData()));
@@ -2271,7 +2271,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Message<byte[]> msg = null;
         List<Message<byte[]>> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2286,7 +2286,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // (1.b) consume second consumeMsgInParts msgs and trigger redeliver
         messages1.clear();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2308,7 +2308,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         int remainingMsgs = (2 * receiverQueueSize) - (2 * consumeMsgInParts);
         messages1.clear();
         for (int i = 0; i < remainingMsgs; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.api;
 import com.google.common.collect.Sets;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.pulsar.broker.service.Dispatcher;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -35,7 +35,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testTlsLargeSizeMessage() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -69,7 +69,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testTlsClientAuthOverBinaryProtocol() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -97,7 +97,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         }
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testTlsClientAuthOverHTTPProtocol() throws Exception {
         log.info("-- Starting {} test --", methodName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -329,7 +329,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         startBroker();
 
         // We should not have received any message
-        Message<byte[]> msg = consumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         Assert.assertNull(msg);
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
@@ -520,7 +520,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         }
 
         barrier.await();
-        // there will be 10 threads calling receive() from the same consumer and will block
+        // there will be 10 threads calling receive(5) from the same consumer and will block
         Thread.sleep(100);
 
         // we restart the broker to reconnect
@@ -565,7 +565,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
         // clear the queue
         while (true) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg == null) {
                 break;
             }
@@ -853,7 +853,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testSharedConsumerAckDifferentConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -985,7 +985,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1008,7 +1008,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             // try to consume remaining messages
             int remainingMessages = totalProducedMsgs - messages.size();
             for (int i = 0; i < remainingMessages; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1073,7 +1073,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
                 Message<byte[]>msg = null;
                 List<Message<byte[]>> messages = Lists.newArrayList();
                 for (int i = 0; i < totalProducedMsgs; i++) {
-                    msg = consumer.receive(1, TimeUnit.SECONDS);
+                    msg = consumer.receive(5, TimeUnit.SECONDS);
                     if (msg != null) {
                         messages.add(msg);
                         log.info("Received message: " + new String(msg.getData()));
@@ -1154,7 +1154,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1169,7 +1169,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             // (3.1) Consumer2 will start consuming messages without ack: it should stop after maxUnackedMessages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs - maxUnackedMessages; i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1191,7 +1191,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             // (4) Consumer2 consumer and ack: so it should consume all remaining messages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs - (2 * maxUnackedMessages); i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1254,7 +1254,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             assertEquals(consumer.numMessagesInQueue(), receiverQueueSize);
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                Message<byte[]>msg = consumer.receive(1, TimeUnit.SECONDS);
+                Message<byte[]>msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1309,7 +1309,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMsg++;
@@ -1325,7 +1325,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             int alreadyConsumedMessages = messages.size();
             messages.clear();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1387,7 +1387,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1410,7 +1410,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             // (3) Consumer consumes and ack: so it should consume all remaining messages
             messages.clear();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1473,7 +1473,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages.add(msg);
                     totalReceiveMessages++;
@@ -1496,7 +1496,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
             // (4) consumer1 will consumer remaining msgs and consumer2 will ack those messages
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                msg = consumer1.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     totalReceiveMessages++;
                     consumer2.acknowledge(msg);
@@ -1507,7 +1507,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             }
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                msg = consumer2.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     totalReceiveMessages++;
                     log.info("Received message: " + new String(msg.getData()));
@@ -1609,7 +1609,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1630,7 +1630,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
             Set<MessageIdImpl> messages2 = Sets.newHashSet();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages2.add((MessageIdImpl) msg.getMessageId());
                     log.info("Received message: " + new String(msg.getData()));
@@ -1705,7 +1705,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
             Message<byte[]>msg = null;
             List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages1.add(msg);
                     log.info("Received message: " + new String(msg.getData()));
@@ -1726,7 +1726,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
             Set<MessageIdImpl> messages2 = Sets.newHashSet();
             for (int i = 0; i < totalProducedMsgs; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
+                msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg != null) {
                     messages2.add((MessageIdImpl) msg.getMessageId());
                     log.info("Received message: " + new String(msg.getData()));
@@ -1985,7 +1985,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         Message<byte[]> msg = null;
         List<Message<byte[]>> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2000,7 +2000,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         // (1.b) consume second consumeMsgInParts msgs and trigger redeliver
         messages1.clear();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2022,7 +2022,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         int remainingMsgs = (2 * receiverQueueSize) - (2 * consumeMsgInParts);
         messages1.clear();
         for (int i = 0; i < remainingMsgs; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -352,7 +352,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         Set<String> messageSet = Sets.newHashSet();
         Message<byte[]> msg = null;
         for (int i = 0; i < numMessagesPerBatch; i++) {
-            msg = consumer1.receive(1, TimeUnit.SECONDS);
+            msg = consumer1.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             String expectedMessage = "my-message-" + i;
             testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
@@ -370,7 +370,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         batchProducer.flush();
 
         // consumer should have not received any message as it should have been disconnected
-        msg = consumer1.receive(100, TimeUnit.MILLISECONDS);
+        msg = consumer1.receive(10, TimeUnit.MILLISECONDS);
         assertNull(msg);
 
         // subscribe consumer2 with supporting batch version

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactedOutBatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactedOutBatchMessageTest.java
@@ -33,6 +33,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.concurrent.TimeUnit;
+
 public class CompactedOutBatchMessageTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerDedupPermitsUpdate.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerDedupPermitsUpdate.java
@@ -92,7 +92,7 @@ public class ConsumerDedupPermitsUpdate extends ProducerConsumerBase {
         // Consumer receives and acks all the messages, though the acks
         // are still cached in client lib
         for (int i = 0; i < 30; i++) {
-            Message<String> msg = consumer.receive();
+            Message<String> msg = consumer.receive(); // Can't use receive with timeout, if the queue size is 0
             assertEquals(msg.getValue(), "hello-" + i);
             consumer.acknowledge(msg);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
@@ -343,9 +343,9 @@ public class MessageIdTest extends BrokerTestBase {
 
         ((ConsumerImpl<byte[]>) consumer).grabCnx();
         // We should only receive msg1
-        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-1");
-        msg = consumer.receive(1, TimeUnit.SECONDS);
+        msg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-3");
 
     }
@@ -415,9 +415,9 @@ public class MessageIdTest extends BrokerTestBase {
 
         ((ConsumerImpl<byte[]>) consumer).grabCnx();
         // We should only receive msg1
-        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-1");
-        msg = consumer.receive(1, TimeUnit.SECONDS);
+        msg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-3");
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -809,7 +809,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         producer2.send("msg-2");
 
-        message = consumer.receive();
+        message = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(message.getValue(), "msg-2");
         consumer.acknowledge(message);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSemaphoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSemaphoreTest.java
@@ -55,7 +55,7 @@ public class ProducerSemaphoreTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testProducerSemaphoreAcquireAndRelease() throws PulsarClientException, ExecutionException, InterruptedException {
 
         final int pendingQueueSize = 100;
@@ -122,9 +122,9 @@ public class ProducerSemaphoreTest extends ProducerConsumerBase {
     /**
      * We use semaphore to limit the pending send, so we must ensure that the thread of sending message never block
      * at the pending message queue. If not, the dead lock might occur. Here is the related issue to describe the
-     * dead lock happens {https://github.com/apache/pulsar/issues/5585}
+     * dead lock {https://github.com/apache/pulsar/issues/5585}
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testEnsureNotBlockOnThePendingQueue() throws Exception {
         final int pendingQueueSize = 10;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -139,9 +139,11 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
         String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching-inclusive";
         Set<String> keys = publishMessages(topic, 10, true);
 
-        Reader<byte[]> reader = pulsarClient.newReader().topic(topic).startMessageId(MessageId.latest)
+        Reader<byte[]> reader = pulsarClient.newReader().topic(topic).startMessageId(MessageId.earliest)
                                             .startMessageIdInclusive().readerName(subscription).create();
+        // If we use MessageId.latest, then publishMessages must occur after we create the reader.
 
+        Assert.assertTrue(reader.hasMessageAvailable());
         while (reader.hasMessageAvailable()) {
             Assert.assertTrue(keys.remove(reader.readNext().getKey()));
         }
@@ -199,7 +201,7 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
      * 1. publish messages which are 5 hour old
      * 2. publish messages which are 1 hour old
      * 3. Create reader with rollback time 2 hours
-     * 4. Reader should be able to read only messages which are only 2 hours old
+     * 4. Reader should be able to read only messages which are only 2 hours old.
      * </pre>
      * @throws Exception
      */

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -638,7 +638,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
     /**
      * Test Listener for github issue #2547
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testMultiTopicsMessageListener() throws Exception {
         String key = "MultiTopicsMessageListenerTest";
         final String subscriptionName = "my-ex-subscription-" + key;
@@ -704,7 +704,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
      * 4. produce message to xx-partition-2 again,  and verify consumer could receive message.
      *
      */
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void testTopicAutoUpdatePartitions() throws Exception {
         String key = "TestTopicAutoUpdatePartitions";
         final String subscriptionName = "my-ex-subscription-" + key;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 
 public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     private static final Logger log = LoggerFactory.getLogger(UnAcknowledgedMessagesTimeoutTest.class);
-    private final long ackTimeOutMillis = TimeUnit.SECONDS.toMillis(2);
+    private final long ackTimeOutMillis = TimeUnit.SECONDS.toMillis(12);
 
     @Override
     @BeforeMethod
@@ -209,7 +209,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
 
         // 5. Check if Messages redelivered again
         // Since receive is a blocking call hoping that timeout will kick in
-        Thread.sleep((int) (ackTimeOutMillis * 1.1));
+        Thread.sleep((int) (ackTimeOutMillis * 1.1)); // Timeout triggers redelivery of unacked messages.
         log.info(key + " Timeout should be triggered now");
         messageCount1 = receiveAllMessage(consumer1, true);
         messageCount2 += receiveAllMessage(consumer2, false);
@@ -236,7 +236,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
 
     private static int receiveAllMessage(Consumer<?> consumer, boolean ackMessages) throws Exception {
         int messagesReceived = 0;
-        Message<?> msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<?> msg = consumer.receive(2, TimeUnit.SECONDS);
         while (msg != null) {
             ++messagesReceived;
             log.info("Consumer received {}", new String(msg.getData()));
@@ -245,7 +245,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
                 consumer.acknowledge(msg);
             }
 
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(2, TimeUnit.SECONDS);
         }
 
         return messagesReceived;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -489,13 +489,13 @@ public class PulsarFunctionE2ETest {
         Assert.assertEquals(foundFiles.length, 0, "Temporary files left over: " + Arrays.asList(foundFiles));
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testE2EPulsarFunctionWithFile() throws Exception {
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-functions-api-examples.jar").getFile();
         testE2EPulsarFunction(jarFilePathUrl);
     }
 
-    @Test(timeOut = 40000)
+    @Test(timeOut = 80000)
     public void testE2EPulsarFunctionWithUrl() throws Exception {
         String jarFilePathUrl = String.format("http://127.0.0.1:%d/pulsar-functions-api-examples.jar",
                 fileServer.getAddress().getPort());
@@ -720,13 +720,13 @@ public class PulsarFunctionE2ETest {
         Assert.assertEquals(foundFiles.length, 0, "Temporary files left over: " + Arrays.asList(foundFiles));
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testPulsarSinkStatsWithFile() throws Exception {
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-io-data-generator.nar").getFile();
         testPulsarSinkStats(jarFilePathUrl);
     }
 
-    @Test(timeOut = 40000)
+    @Test(timeOut = 80000)
     public void testPulsarSinkStatsWithUrl() throws Exception {
         String jarFilePathUrl = String.format("http://127.0.0.1:%d/pulsar-io-data-generator.nar",
                 fileServer.getAddress().getPort());
@@ -860,20 +860,20 @@ public class PulsarFunctionE2ETest {
         Assert.assertEquals(foundFiles.length, 0, "Temporary files left over: " + Arrays.asList(foundFiles));
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testPulsarSourceStatsWithFile() throws Exception {
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-io-data-generator.nar").getFile();
         testPulsarSourceStats(jarFilePathUrl);
     }
 
-    @Test(timeOut = 40000)
+    @Test(timeOut = 80000)
     public void testPulsarSourceStatsWithUrl() throws Exception {
         String jarFilePathUrl = String.format("http://127.0.0.1:%d/pulsar-io-data-generator.nar",
                 fileServer.getAddress().getPort());
         testPulsarSourceStats(jarFilePathUrl);
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testPulsarFunctionStats() throws Exception {
 
         final String namespacePortion = "io";
@@ -1209,7 +1209,7 @@ public class PulsarFunctionE2ETest {
         Assert.assertEquals(foundFiles.length, 0, "Temporary files left over: " + Arrays.asList(foundFiles));
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testPulsarFunctionStatus() throws Exception {
 
         final String namespacePortion = "io";
@@ -1319,7 +1319,7 @@ public class PulsarFunctionE2ETest {
         }
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testFunctionStopAndRestartApi() throws Exception {
 
         final String namespacePortion = "io";
@@ -1386,7 +1386,7 @@ public class PulsarFunctionE2ETest {
         producer.close();
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 40000)
     public void testFunctionAutomaticSubCleanup() throws Exception {
         final String namespacePortion = "io";
         final String replNamespace = tenant + "/" + namespacePortion;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
@@ -86,7 +86,7 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
 
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 90000)
     public void socketTest() throws InterruptedException, GeneralSecurityException {
         String consumerUri =
                 "wss://localhost:" + proxyServer.getListenPortHTTPS().get() + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -748,7 +748,7 @@ TEST(BasicEndToEndTest, testSinglePartitionRoutingPolicy) {
 
     for (int i = 0; i < 10; i++) {
         Message m;
-        consumer.receive(m);
+        consumer.receive(m, 9000);
         consumer.acknowledgeCumulative(m);
     }
 
@@ -1990,14 +1990,14 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerPubSub) {
     LOG_INFO("Consuming and acking 300 messages by multiTopicsConsumer");
     for (int i = 0; i < 3 * messageNumber; i++) {
         Message m;
-        ASSERT_EQ(ResultOk, consumer.receive(m, 1000));
+        ASSERT_EQ(ResultOk, consumer.receive(m, 5000));
         ASSERT_EQ(ResultOk, consumer.acknowledge(m));
     }
     LOG_INFO("Consumed and acked 300 messages by multiTopicsConsumer");
 
-    // verify no more to receive, because producer4 not match pattern
+    // verify no more to receive because producer4 not match pattern
     Message m;
-    ASSERT_EQ(ResultTimeout, consumer.receive(m, 1000));
+    ASSERT_EQ(ResultTimeout, consumer.receive(m, 5000));
 
     ASSERT_EQ(ResultOk, consumer.unsubscribe());
 
@@ -2085,14 +2085,14 @@ TEST(BasicEndToEndTest, testpatternMultiTopicsHttpConsumerPubSub) {
     LOG_INFO("Consuming and acking 300 messages by multiTopicsConsumer");
     for (int i = 0; i < 3 * messageNumber; i++) {
         Message m;
-        ASSERT_EQ(ResultOk, consumer.receive(m, 1000));
+        ASSERT_EQ(ResultOk, consumer.receive(m, 5000));
         ASSERT_EQ(ResultOk, consumer.acknowledge(m));
     }
     LOG_INFO("Consumed and acked 300 messages by multiTopicsConsumer");
 
     // verify no more to receive
     Message m;
-    ASSERT_EQ(ResultTimeout, consumer.receive(m, 1000));
+    ASSERT_EQ(ResultTimeout, consumer.receive(m, 5000));
 
     ASSERT_EQ(ResultOk, consumer.unsubscribe());
 
@@ -2230,14 +2230,14 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerAutoDiscovery) {
     LOG_INFO("Consuming and acking 300 messages by pattern topics consumer");
     for (int i = 0; i < 3 * messageNumber; i++) {
         Message m;
-        ASSERT_EQ(ResultOk, consumer.receive(m, 1000));
+        ASSERT_EQ(ResultOk, consumer.receive(m, 5000));
         ASSERT_EQ(ResultOk, consumer.acknowledge(m));
     }
     LOG_INFO("Consumed and acked 300 messages by pattern topics consumer");
 
     // verify no more to receive, because producer4 not match pattern
     Message m;
-    ASSERT_EQ(ResultTimeout, consumer.receive(m, 1000));
+    ASSERT_EQ(ResultTimeout, consumer.receive(m, 5000));
 
     ASSERT_EQ(ResultOk, consumer.unsubscribe());
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/pom.xml
@@ -49,6 +49,10 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/kafka/clients/producer/PulsarKafkaProducerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/kafka/clients/producer/PulsarKafkaProducerTest.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.testng.annotations.Test;
+import static org.awaitility.Awaitility.*;
 
 import kafka.producer.Partitioner;
 import kafka.producer.ProducerConfig;
@@ -101,10 +102,18 @@ public class PulsarKafkaProducerTest {
         properties.put(PARTITIONER_CLASS, TestPartitioner.class.getName());
         ProducerConfig config = new ProducerConfig(properties);
         PulsarKafkaProducer<byte[], byte[]> producer = new PulsarKafkaProducer<>(config);
-        assertEquals(producer.getKeySerializer().getClass(), TestEncoder.class);
-        assertEquals(producer.getValueSerializer().getClass(), TestEncoder.class);
-        assertEquals(producer.getPartitioner().getClass(), TestPartitioner.class);
-
+        await().atMost(300,
+                TimeUnit.MILLISECONDS)
+                .untilAsserted(() ->
+                        assertEquals(producer.getKeySerializer().getClass(), TestEncoder.class));
+        await().atMost(300,
+                TimeUnit.MILLISECONDS)
+                .untilAsserted(() ->
+                        assertEquals(producer.getValueSerializer().getClass(), TestEncoder.class));
+        await().atMost(300,
+                TimeUnit.MILLISECONDS)
+                .untilAsserted(() ->
+                        assertEquals(producer.getPartitioner().getClass(), TestPartitioner.class));
     }
 
     public static class TestEncoder implements Encoder<String> {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
@@ -188,7 +188,7 @@ public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
         
         final long expectedReadOffsetPosition = lastOffset;
         
-        retryStrategically((test) -> fetchOffset(consumer, topicPartition, groupId) == expectedReadOffsetPosition, 10, 150);
+        retryStrategically((test) -> fetchOffset(consumer, topicPartition, groupId) == expectedReadOffsetPosition, 30, 250);
         
         long offset1 = fetchOffset(consumer, topicPartition, groupId);
         MessageIdImpl actualMsgId = ((MessageIdImpl)MessageIdUtils.getMessageId(offset1));

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
@@ -172,24 +172,29 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
 
         } finally {
 
-            if (cmdBuilder != null) {
-                cmdBuilder.recycle();
-            }
-            if (cmd != null) {
-                cmd.recycle();
-            }
-            buffer.resetReaderIndex();
-            buffer.resetWriterIndex();
+            try{
+                if (cmdBuilder != null) {
+                    cmdBuilder.recycle();
+                }
+                if (cmd != null) {
+                    cmd.recycle();
+                }
+                buffer.resetReaderIndex();
+                buffer.resetWriterIndex();
 
-            // add totalSize to buffer Head
-            ByteBuf totalSizeBuf = Unpooled.buffer(4);
-            totalSizeBuf.writeInt(buffer.readableBytes());
-            CompositeByteBuf compBuf = Unpooled.compositeBuffer();
-            compBuf.addComponents(totalSizeBuf,buffer);
-            compBuf.writerIndex(totalSizeBuf.capacity()+buffer.capacity());
+                // add totalSize to buffer Head
+                ByteBuf totalSizeBuf = Unpooled.buffer(4);
+                totalSizeBuf.writeInt(buffer.readableBytes());
+                CompositeByteBuf compBuf = Unpooled.compositeBuffer();
+                compBuf.addComponents(totalSizeBuf,buffer);
+                compBuf.writerIndex(totalSizeBuf.capacity()+buffer.capacity());
 
-            //next handler
-            ctx.fireChannelRead(compBuf);
+                //next handler
+                ctx.fireChannelRead(compBuf);
+            } catch (Exception e) {
+                log.error("{},{},{}" , e.getMessage() , e.getStackTrace() ,  e.getCause());
+            }
+
         }
     }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.proxy.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 
@@ -121,11 +123,15 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
 
     @Override
     public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        LOG.info("ProxyConnection.channelRegistered(..)01");
         super.channelRegistered(ctx);
+        LOG.info("ProxyConnection.channelRegistered(..)02");
         ProxyService.activeConnections.inc();
         if (ProxyService.activeConnections.get() > service.getConfiguration().getMaxConcurrentInboundConnections()) {
+            LOG.info("ProxyConnection.channelRegistered(..)03");
             ctx.close();
             ProxyService.rejectedConnections.inc();
+            LOG.info("ProxyConnection.channelRegistered(..)04");
             return;
         }
     }
@@ -138,7 +144,9 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        LOG.info("ProxyConnection.channelActive(..)01");
         super.channelActive(ctx);
+        LOG.info("ProxyConnection.channelActive(..)02");
         ProxyService.newConnections.inc();
         service.getClientCnxs().add(this);
         LOG.info("[{}] New connection opened", remoteAddress);
@@ -382,6 +390,26 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
         checkArgument(state == State.ProxyLookupRequests);
 
         lookupProxyHandler.handleGetSchema(commandGetSchema);
+    }
+
+    @Override
+    protected void handleSubscribe(PulsarApi.CommandSubscribe subscribe) {
+        LOG.info("ERROR: We are calling handleSubscribe(..) on ProxyConnection! This shouldn't happen!");
+        StringWriter sw = new StringWriter();
+        new Throwable("").printStackTrace(new PrintWriter(sw));
+        String stackTrace = sw.toString();
+        LOG.info("Stacktrace is: " + stackTrace);
+        super.handleSubscribe(subscribe);
+    }
+
+    @Override
+    protected void handleProducer(PulsarApi.CommandProducer producer) {
+        LOG.info("ERROR: We are calling handleProducer(..) on ProxyConnection! This shouldn't happen!");
+        StringWriter sw = new StringWriter();
+        new Throwable("").printStackTrace(new PrintWriter(sw));
+        String stackTrace = sw.toString();
+        LOG.info("Stacktrace is: " + stackTrace);
+        super.handleProducer(producer);
     }
 
     /**

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -150,7 +150,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive();
             checkNotNull(msg);
             consumer.acknowledge(msg);
         }
@@ -184,7 +184,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive();
             checkNotNull(msg);
         }
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
@@ -114,7 +114,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
             checkNotNull(msg);
         }
 

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -193,7 +193,7 @@ public abstract class TestPulsarConnector {
         public Foo foo;
         public Boo boo;
         public Bar bar;
-        // different namespace with same classname should work though
+        // different namespace with same classname should work though.
         public Foo.Bar foobar;
     }
 

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -38,6 +38,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -83,10 +83,10 @@ import static org.testng.Assert.fail;
 @Slf4j
 public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
-    final Duration ONE_MINUTE = Duration.ofMinutes(1);
-    final Duration TEN_SECONDS = Duration.ofSeconds(10);
+   final Duration ONE_MINUTE = Duration.ofMinutes(1);
+   final Duration TEN_SECONDS = Duration.ofSeconds(10);
 
-    final RetryPolicy statusRetryPolicy = new RetryPolicy()
+   final RetryPolicy statusRetryPolicy = new RetryPolicy()
             .withMaxDuration(ONE_MINUTE)
             .withDelay(TEN_SECONDS)
             .onRetry(e -> log.error("Retry ... "));

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -116,7 +116,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 10, 200);
+            }, 20, 400);
 
             SourceStatus status = admin.sources().getSourceStatus("public", "default", sourceName);
             assertEquals(status.getInstances().size(), 1);
@@ -173,7 +173,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 } catch (PulsarAdminException e) {
                     return false;
                 }
-            }, 10, 200);
+            }, 20, 400);
 
             SinkStatus status = admin.sinks().getSinkStatus("public", "default", sinkName);
             assertEquals(status.getInstances().size(), 1);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/SourceTester.java
@@ -73,7 +73,7 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
 
     public void validateSourceResult(Consumer<KeyValue<byte[], byte[]>> consumer, int number, String eventType) throws Exception {
         int recordsNumber = 0;
-        Message<KeyValue<byte[], byte[]>> msg = consumer.receive(2, TimeUnit.SECONDS);
+        Message<KeyValue<byte[], byte[]>> msg = consumer.receive(5, TimeUnit.SECONDS);
         while(msg != null) {
             recordsNumber ++;
             final String key = new String(msg.getValue().getKey());
@@ -85,7 +85,7 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
                 Assert.assertTrue(value.contains(this.eventContains(eventType)));
             }
             consumer.acknowledge(msg);
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
         }
 
         Assert.assertEquals(recordsNumber, number);

--- a/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/KafkaApiTest.java
+++ b/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/KafkaApiTest.java
@@ -588,7 +588,7 @@ public class KafkaApiTest extends PulsarStandaloneTestSuite {
         producer.close();
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = pulsarConsumer.receive(5, TimeUnit.SECONDS);
             assertEquals(new String(msg.getData()), "hello-" + i);
             pulsarConsumer.acknowledge(msg);
         }
@@ -627,7 +627,7 @@ public class KafkaApiTest extends PulsarStandaloneTestSuite {
         counter.await();
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = pulsarConsumer.receive(5, TimeUnit.SECONDS);
             assertEquals(new String(msg.getData()), "hello-" + i);
             pulsarConsumer.acknowledge(msg);
         }
@@ -667,7 +667,7 @@ public class KafkaApiTest extends PulsarStandaloneTestSuite {
         producer.close();
 
         for (int i = 0; i < 10; i++) {
-            Message<byte[]> msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = pulsarConsumer.receive(5, TimeUnit.SECONDS);
             Foo value = fooSchema.decode(msg.getValue());
             Assert.assertEquals(value.getField1(), "field1");
             Assert.assertEquals(value.getField2(), "field2");

--- a/tests/pulsar-storm-test/src/test/java/org/apache/pulsar/storm/PulsarBoltTest.java
+++ b/tests/pulsar-storm-test/src/test/java/org/apache/pulsar/storm/PulsarBoltTest.java
@@ -154,7 +154,7 @@ public class PulsarBoltTest extends ProducerConsumerBase {
         Tuple tuple = getMockTuple(msgContent);
         bolt.execute(tuple);
         Assert.assertTrue(mockCollector.acked());
-        Message msg = consumer.receive(5, TimeUnit.SECONDS);
+        Message msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         Assert.assertNull(msg);
     }
 

--- a/tests/pulsar-storm-test/src/test/java/org/apache/pulsar/storm/example/StormExample.java
+++ b/tests/pulsar-storm-test/src/test/java/org/apache/pulsar/storm/example/StormExample.java
@@ -135,7 +135,7 @@ public class StormExample {
         }
         Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
+            msg = consumer.receive(5, TimeUnit.SECONDS);
             LOG.info("Message {} received", new String(msg.getData()));
         }
         cluster.killTopology("test");


### PR DESCRIPTION
Increased test timeouts and made other changes to tests. 

Fixes https://github.com/apache/pulsar/issues/2647
Fixes https://github.com/apache/pulsar/issues/2651
Fixes https://github.com/apache/pulsar/issues/6014
Fixes https://github.com/apache/pulsar/issues/6198
Fixes https://github.com/apache/pulsar/issues/6224
Fixes https://github.com/apache/pulsar/issues/6232
Fixes https://github.com/apache/pulsar/issues/6254
Fixes https://github.com/apache/pulsar/issues/6256
Fixes https://github.com/apache/pulsar/issues/6299
Fixes https://github.com/apache/pulsar/issues/6304
Fixes https://github.com/apache/pulsar/issues/6306
Fixes https://github.com/apache/pulsar/issues/6352

Fixes other flaky tests that still need issues created for them.

Master Issue: #6137

### Motivation

Need to resolve these flaky tests. 

### Modifications
1. Fixes issues caused by test timeouts being too short. (The majority of changes in this PR are in this category.)
2. Fixes issues caused by hanging tests resulting from no timeouts.
3. Fixes Prometheus test issues (since these required more extensive changes to the tests.) There were multiple race conditions and concurrency issues in how we were getting data from Prometheus. (A more robust change would migrate our use of Prometheus to the new approach used in the Go Functions, but I don't think that change is necessary at this time.)
4. Changes that introduced awaitility library. (Only used in a couple of places to avoid the use of Thread.sleep.)
5. Fixes involving concurrency issues on topic names. (There were a few in this category.)

Among other things, this PR fixes all issues like this: `java.lang.AssertionError: expected [val1-9] but found [val1-6]`