### PR TITLE
[Issue 5579][broker] Fix bug that backlog message that has not yet expired could be deleted due to TTL

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -67,7 +67,10 @@ class OpFindNewest implements ReadEntryCallback {
         switch (state) {
         case checkFirst:
             if (!condition.apply(entry)) {
-                callback.findEntryComplete(startPosition, OpFindNewest.this.ctx);
+                // If no entry is found that matches the condition, it is expected to pass null to the callback.
+                // Otherwise, a message before the expiration date will be deleted due to message TTL.
+                // cf. https://github.com/apache/pulsar/issues/5579
+                callback.findEntryComplete(null, OpFindNewest.this.ctx);
                 return;
             } else {
                 lastMatchedPosition = position;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1654,7 +1654,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ledger.addEntry("not-expired".getBytes(Encoding));
         ledger.addEntry("not-expired".getBytes(Encoding));
 
-        assertEquals(c1.readPosition,
+        assertNull(
                 c1.findNewestMatching(entry -> Arrays.equals(entry.getDataAndRelease(), "expired".getBytes(Encoding))));
     }
 
@@ -2117,7 +2117,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedger ledger = factory.open(ledgerAndCursorName, config);
         ManagedCursorImpl c1 = (ManagedCursorImpl) ledger.openCursor(ledgerAndCursorName);
 
-        Position firstPosition = ledger.addEntry(getEntryPublishTime("retained1"));
+        ledger.addEntry(getEntryPublishTime("retained1"));
         // space apart message publish times
         Thread.sleep(100);
         ledger.addEntry(getEntryPublishTime("retained2"));
@@ -2146,7 +2146,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(found.getEntryId(), expectedEntryId);
 
         found = (PositionImpl) findPositionFromAllEntries(c1, 0);
-        assertEquals(found, firstPosition);
+        assertNull(found);
     }
 
     @Test(timeOut = 20000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -162,7 +162,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         future = findMessage(result, c1, beginTimestamp);
         future.get();
         assertNull(result.exception);
-        assertEquals(result.position, c1.getFirstPosition());
+        assertNull(result.position);
 
         result.reset();
         future = findMessage(result, c1, endTimestamp);


### PR DESCRIPTION
Fixes #5579 

### Motivation

In Pulsar 2.4.1 and later versions, if message TTL is enabled, `PersistentMessageExpiryMonitor` always deletes one non-expired message every 5 minutes.

The cause of this bug is https://github.com/apache/pulsar/pull/4744. `PersistentMessageExpiryMonitor` expects `ManagedCursor#asyncFindNewestMatching()` to pass null as its found position to itself as a callback if no expired messages exist.
https://github.com/apache/pulsar/blob/c5ba52983fee994de61984aae7d1757e9b738caf/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java#L119-L130

However, due to the change in https://github.com/apache/pulsar/pull/4744, if no entry is found that matches the search condition, the callback will be passed `startPosition` instead of null now. For this reason, the earliest backlog message is always deleted by `PersistentMessageExpiryMonitor`.

This means that unexpected message loss can occur.

### Modifications

Revert the https://github.com/apache/pulsar/pull/4744 changes. The motivation of https://github.com/apache/pulsar/pull/4744 is to avoid NPE caused in pulse-sql, but that seems to be fixed in https://github.com/apache/pulsar/pull/4757.
https://github.com/apache/pulsar/blob/2069f761753940ed6a1faca8999af70036f20fd6/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java#L363-L382