### PR TITLE
minor: [checkmarx]OWASP-A17: injecting topic name without validating

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1426,6 +1426,9 @@ public abstract class ComponentImpl {
         if (uploadedInputStream == null && input == null) {
             throw new IllegalArgumentException("Trigger Data is not provided");
         }
+        if (topic == null) {
+            throw new IllegalArgumentException("Topic name is not provided");
+        }
     }
 
     private void throwStateStoreUnvailableResponse() {


### PR DESCRIPTION
### Motivation
We have several [checkmarx](https://www.checkmarx.com/) issues created and one of them is indicating validation of topic name.

![Snip20200204_10](https://user-images.githubusercontent.com/2898254/73802010-18bae700-4771-11ea-851e-dc9137736058.png)
