### PR TITLE
[CI] Add GITHUB_TOKEN as the environment variable for running pulsarbot

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -34,4 +34,6 @@ jobs:
         uses: actions/checkout@v1
       - name: Execute pulsarbot command
         id:   pulsarbot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master


### PR DESCRIPTION
*Motivation*

Fix `Bad credentials` error when re-running checks

```
{
  "message": "Bad credentials",
  "documentation_url": "https://developer.github.com/v3"
}
```