### PR TITLE
[C++] Ensure ExecutorServicePtr is not destroyed while the timer object is alive

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -80,8 +80,7 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
     unsigned int statsIntervalInSeconds = client->getClientConfig().getStatsIntervalInSeconds();
     if (statsIntervalInSeconds) {
         consumerStatsBasePtr_ = std::make_shared<ConsumerStatsImpl>(
-            consumerStr_, client->getIOExecutorProvider()->get()->createDeadlineTimer(),
-            statsIntervalInSeconds);
+            consumerStr_, client->getIOExecutorProvider()->get(), statsIntervalInSeconds);
     } else {
         consumerStatsBasePtr_ = std::make_shared<ConsumerStatsDisabled>();
     }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -67,8 +67,8 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
 
     unsigned int statsIntervalInSeconds = client->getClientConfig().getStatsIntervalInSeconds();
     if (statsIntervalInSeconds) {
-        producerStatsBasePtr_ = std::make_shared<ProducerStatsImpl>(
-            producerStr_, executor_, statsIntervalInSeconds);
+        producerStatsBasePtr_ =
+            std::make_shared<ProducerStatsImpl>(producerStr_, executor_, statsIntervalInSeconds);
     } else {
         producerStatsBasePtr_ = std::make_shared<ProducerStatsDisabled>();
     }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -68,7 +68,7 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
     unsigned int statsIntervalInSeconds = client->getClientConfig().getStatsIntervalInSeconds();
     if (statsIntervalInSeconds) {
         producerStatsBasePtr_ = std::make_shared<ProducerStatsImpl>(
-            producerStr_, executor_->createDeadlineTimer(), statsIntervalInSeconds);
+            producerStr_, executor_, statsIntervalInSeconds);
     } else {
         producerStatsBasePtr_ = std::make_shared<ProducerStatsDisabled>();
     }

--- a/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.cc
+++ b/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.cc
@@ -25,10 +25,11 @@
 namespace pulsar {
 DECLARE_LOG_OBJECT();
 
-ConsumerStatsImpl::ConsumerStatsImpl(std::string consumerStr, DeadlineTimerPtr timer,
+ConsumerStatsImpl::ConsumerStatsImpl(std::string consumerStr, ExecutorServicePtr executor,
                                      unsigned int statsIntervalInSeconds)
     : consumerStr_(consumerStr),
-      timer_(timer),
+      executor_(executor),
+      timer_(executor_->createDeadlineTimer()),
       statsIntervalInSeconds_(statsIntervalInSeconds),
       totalNumBytesRecieved_(0),
       numBytesRecieved_(0) {

--- a/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ConsumerStatsImpl.h
@@ -37,6 +37,8 @@ class ConsumerStatsImpl : public ConsumerStatsBase {
     std::map<std::pair<Result, proto::CommandAck_AckType>, unsigned long> totalAckedMsgMap_;
 
     std::string consumerStr_;
+
+    ExecutorServicePtr executor_;
     DeadlineTimerPtr timer_;
     std::mutex mutex_;
     unsigned int statsIntervalInSeconds_;
@@ -46,7 +48,7 @@ class ConsumerStatsImpl : public ConsumerStatsBase {
     friend class PulsarFriend;
 
    public:
-    ConsumerStatsImpl(std::string, DeadlineTimerPtr, unsigned int);
+    ConsumerStatsImpl(std::string, ExecutorServicePtr, unsigned int);
     ConsumerStatsImpl(const ConsumerStatsImpl& stats);
     void flushAndReset(const boost::system::error_code&);
     virtual void receivedMessage(Message&, Result);

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
@@ -41,13 +41,14 @@ std::string ProducerStatsImpl::latencyToString(const LatencyAccumulator& obj) {
     return os.str();
 }
 
-ProducerStatsImpl::ProducerStatsImpl(std::string producerStr, DeadlineTimerPtr timer,
+ProducerStatsImpl::ProducerStatsImpl(std::string producerStr, ExecutorServicePtr executor,
                                      unsigned int statsIntervalInSeconds)
     : numMsgsSent_(0),
       numBytesSent_(0),
       totalMsgsSent_(0),
       totalBytesSent_(0),
-      timer_(timer),
+      executor_(executor),
+      timer_(executor->createDeadlineTimer()),
       producerStr_(producerStr),
       statsIntervalInSeconds_(statsIntervalInSeconds),
       mutex_(),

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -61,6 +61,8 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
     LatencyAccumulator totalLatencyAccumulator_;
 
     std::string producerStr_;
+
+    ExecutorServicePtr executor_;
     DeadlineTimerPtr timer_;
     std::mutex mutex_;
     unsigned int statsIntervalInSeconds_;
@@ -72,7 +74,7 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
     static std::string latencyToString(const LatencyAccumulator&);
 
    public:
-    ProducerStatsImpl(std::string, DeadlineTimerPtr, unsigned int);
+    ProducerStatsImpl(std::string, ExecutorServicePtr, unsigned int);
 
     ProducerStatsImpl(const ProducerStatsImpl& stats);
 


### PR DESCRIPTION
### Motivation

The `ProducerStatsImpl` and `ConsumerStatsImpl` objects are keeping a `shared_ptr` to a timer object. While that keeps the timer alive, it does not keep the required event loop object. 

When the stats objects are destroyed, we cancel the timer, though that will use the already destroyed `ExecutorService`. In most cases this will not show any problem, though in others it will cause a segfault.

Valgrind output showing the issue:

```
==12549== Invalid read of size 4
==12549==    at 0x5966010: __pthread_mutex_unlock_full (pthread_mutex_unlock.c:100)
==12549==    by 0x5BFECD9: unlock (posix_mutex.hpp:58)
==12549==    by 0x5BFECD9: unlock (scoped_lock.hpp:72)
==12549==    by 0x5BFECD9: unsigned long boost::asio::detail::epoll_reactor::cancel_timer<boost::asio::time_traits<boost::posix_time::ptime> >(boost::asio::detail::timer_queue<boost::asio::time_traits<boost::posix_time::ptime> >&, boost::asio::detail::timer_queue<boost::asio::time_traits<boost::posix_time::ptime> >::per_timer_data&, unsigned long) (epoll_reactor.hpp:65)
==12549==    by 0x5D28808: cancel (deadline_timer_service.hpp:108)
==12549==    by 0x5D28808: cancel (deadline_timer_service.hpp:96)
==12549==    by 0x5D28808: cancel (basic_deadline_timer.hpp:216)
==12549==    by 0x5D28808: pulsar::ConsumerStatsImpl::~ConsumerStatsImpl() (ConsumerStatsImpl.cc:70)
==12549==    by 0x41F2F5: std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (shared_ptr_base.h:150)
==12549==    by 0x5C50211: ~__shared_count (shared_ptr_base.h:659)
==12549==    by 0x5C50211: ~__shared_ptr (shared_ptr_base.h:925)
==12549==    by 0x5C50211: ~shared_ptr (shared_ptr.h:93)
==12549==    by 0x5C50211: pulsar::ConsumerImpl::~ConsumerImpl() (ConsumerImpl.cc:95)
==12549==    by 0x41F2F5: std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (shared_ptr_base.h:150)
==12549==    by 0x4E39EC: ~__shared_count (shared_ptr_base.h:659)
==12549==    by 0x4E39EC: ~__shared_ptr (shared_ptr_base.h:925)
==12549==    by 0x4E39EC: ~shared_ptr (shared_ptr.h:93)
==12549==    by 0x4E39EC: BasicEndToEndTest_testReceiveAsyncFailedConsumer_Test::TestBody() (Consumer.h:35)
==12549==    by 0x541853: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x53C484: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x521911: testing::Test::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x5221B9: testing::TestInfo::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x5228A8: testing::TestCase::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==  Address 0x10837bb0 is 64 bytes inside a block of size 176 free'd
==12549==    at 0x4C2F24B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12549==    by 0x431509: boost::asio::detail::epoll_reactor::~epoll_reactor() (epoll_reactor.ipp:69)
==12549==    by 0x5CEF161: destroy (service_registry.ipp:101)
==12549==    by 0x5CEF161: ~service_registry (service_registry.ipp:45)
==12549==    by 0x5CEF161: ~io_service (io_service.ipp:53)
==12549==    by 0x5CEF161: pulsar::ExecutorService::~ExecutorService() (ExecutorService.cc:30)
==12549==    by 0x41F2F5: std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (shared_ptr_base.h:150)
==12549==    by 0x5C4FD2A: ~__shared_count (shared_ptr_base.h:659)
==12549==    by 0x5C4FD2A: ~__shared_ptr (shared_ptr_base.h:925)
==12549==    by 0x5C4FD2A: ~shared_ptr (shared_ptr.h:93)
==12549==    by 0x5C4FD2A: ~NegativeAcksTracker (NegativeAcksTracker.h:32)
==12549==    by 0x5C4FD2A: pulsar::ConsumerImpl::~ConsumerImpl() (ConsumerImpl.cc:95)
==12549==    by 0x41F2F5: std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (shared_ptr_base.h:150)
==12549==    by 0x4E39EC: ~__shared_count (shared_ptr_base.h:659)
==12549==    by 0x4E39EC: ~__shared_ptr (shared_ptr_base.h:925)
==12549==    by 0x4E39EC: ~shared_ptr (shared_ptr.h:93)
==12549==    by 0x4E39EC: BasicEndToEndTest_testReceiveAsyncFailedConsumer_Test::TestBody() (Consumer.h:35)
==12549==    by 0x541853: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x53C484: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x521911: testing::Test::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x5221B9: testing::TestInfo::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==    by 0x5228A8: testing::TestCase::Run() (in /pulsar/pulsar-client-cpp/tests/main)
==12549==  Block was alloc'd at
==12549==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12549==    by 0x43763A: boost::asio::io_service::service* boost::asio::detail::service_registry::create<boost::asio::detail::epoll_reactor>(boost::asio::io_service&) (service_registry.hpp:81)
==12549==    by 0x432497: boost::asio::detail::service_registry::do_use_service(boost::asio::io_service::service::key const&, boost::asio::io_service::service* (*)(boost::asio::io_service&)) (service_registry.ipp:123)
==12549==    by 0x4325B6: use_service<boost::asio::detail::epoll_reactor> (service_registry.hpp:48)
==12549==    by 0x4325B6: use_service<boost::asio::detail::epoll_reactor> (io_service.hpp:33)
==12549==    by 0x4325B6: reactive_socket_service_base (reactive_socket_service_base.ipp:33)
==12549==    by 0x4325B6: reactive_socket_service (reactive_socket_service.hpp:77)
==12549==    by 0x4325B6: stream_socket_service (stream_socket_service.hpp:95)
==12549==    by 0x4325B6: boost::asio::io_service::service* boost::asio::detail::service_registry::create<boost::asio::stream_socket_service<boost::asio::ip::tcp> >(boost::asio::io_service&) (service_registry.hpp:81)
==12549==    by 0x5CF0E5D: do_use_service (service_registry.ipp:123)
==12549==    by 0x5CF0E5D: use_service<boost::asio::stream_socket_service<boost::asio::ip::tcp> > (service_registry.hpp:48)
==12549==    by 0x5CF0E5D: use_service<boost::asio::stream_socket_service<boost::asio::ip::tcp> > (io_service.hpp:33)
==12549==    by 0x5CF0E5D: basic_io_object (basic_io_object.hpp:183)
==12549==    by 0x5CF0E5D: basic_socket (basic_socket.hpp:71)
==12549==    by 0x5CF0E5D: basic_stream_socket (basic_stream_socket.hpp:73)
==12549==    by 0x5CF0E5D: pulsar::ExecutorService::createSocket() (ExecutorService.cc:36)
==12549==    by 0x5CB1794: pulsar::ClientConnection::ClientConnection(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<pulsar::ExecutorService>, pulsar::ClientConfiguration const&, std::shared_ptr<pulsar::Authentication> const&) (ClientConnection.cc:169)
==12549==    by 0x5C1D3F0: pulsar::ConnectionPool::getConnectionAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (ConnectionPool.cc:83)
==12549==    by 0x5CA573F: pulsar::BinaryProtoLookupService::getPartitionMetadataAsync(std::shared_ptr<pulsar::TopicName> const&) (BinaryProtoLookupService.cc:72)
==12549==    by 0x5D00CA6: pulsar::ClientImpl::subscribeAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, pulsar::ConsumerConfiguration const&, std::function<void (pulsar::Result, pulsar::Consumer)>) (ClientImpl.cc:350)
==12549==    by 0x5C985EC: pulsar::Client::subscribeAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, pulsar::ConsumerConfiguration const&, std::function<void (pulsar::Result, pulsar::Consumer)>) (Client.cc:89)
==12549==    by 0x5C98803: pulsar::Client::subscribeAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void (pulsar::Result, pulsar::Consumer)>) (Client.cc:83)
==12549==    by 0x4E3852: BasicEndToEndTest_testReceiveAsyncFailedConsumer_Test::TestBody() (BasicEndToEndTest.cc:2848)
==12549==
```

### Modifications

Keep a `shared_ptr` to `ExecutorServicePtr` to ensure the executor service is only destroyed after the timer is cancelled.