### PR TITLE
[authentication] Validate tokens for binary connections

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -87,7 +87,7 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
     public static String getToken(AuthenticationDataSource authData) throws AuthenticationException {
         if (authData.hasDataFromCommand()) {
             // Authenticate Pulsar binary connection
-            return authData.getCommandData();
+            return validateToken(authData.getCommandData());
         } else if (authData.hasDataFromHttp()) {
             // Authentication HTTP request. The format here should be compliant to RFC-6750
             // (https://tools.ietf.org/html/rfc6750#section-2.1). Eg: Authorization: Bearer xxxxxxxxxxxxx


### PR DESCRIPTION


### Motivation

Currently, binary connects aren't checked to see if they provide a
token.

This results in a NPE in the JWT validation as well as a whole bunch of
log spam. 

### Modifications

By explicitly checking for a null/empty token here, we can
avoid some exceptions and clean up log spam.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: n
  - The default values of configurations: n
  - The wire protocol: n
  - The rest endpoints: n
  - The admin cli options: n
  - Anything that affects deployment:n

### Documentation

  - Does this pull request introduce a new feature? n
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
