### PR TITLE
Use fully qualified hostname as default to advertise brokers

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -39,7 +39,8 @@ public class ServiceConfigurationUtils {
 
     public static String unsafeLocalhostResolve() {
         try {
-            return InetAddress.getLocalHost().getHostName();
+            // Get the fully qualified hostname
+            return InetAddress.getLocalHost().getCanonicalHostName();
         } catch (UnknownHostException ex) {
             LOG.error(ex.getMessage(), ex);
             throw new IllegalStateException("Failed to resolve localhost name.", ex);


### PR DESCRIPTION
### Motivation

There is a difference in getting hostnames between Java 8 and Java 11. 

In Java 8 `InetAddress.getLocalHost().getHostName()` was returning the fully qualified hostname while in 11 is returning the simple hostname. We should rather use the `getCanonicalHostName()` which is return the fully qualified hostname. 
This is the same method to get the advertised address for bookies as well.

Example: 

```java
import java.net.InetAddress;
public class test{
  public static void main(String[] args) throws Exception {
    System.out.println("Hostname: " + InetAddress.getLocalHost().getHostName());
    System.out.println("Canonical Hostname: " + InetAddress.getLocalHost().getCanonicalHostName());
  }
}
```

```shell
# Java 8
$ java test
Hostname: broker-0.broker.pulsar.svc.cluster.local
Canonical Hostname: broker-0.broker.pulsar.svc.cluster.local
```

```shell
# Java 11
$ java test
Hostname: broker-0
Canonical Hostname: broker-0.broker.pulsar.svc.cluster.local
```