### PR TITLE
[website]Replace client api use correct version

### DIFF
--- a/site2/website/pages/en/pulsar-admin-cli.js
+++ b/site2/website/pages/en/pulsar-admin-cli.js
@@ -1,0 +1,23 @@
+const React = require('react');
+const CompLibrary = require('../../core/CompLibrary.js');
+
+const Container = CompLibrary.Container;
+const CWD = process.cwd();
+const releases = require(`${CWD}/releases.json`);
+
+class PulsarAdminCli extends React.Component {
+    render() {
+        const latestVersion = releases[0];
+        const url = "../js/getCliByVersion.js?latestVersion=" + latestVersion;
+        return (
+            <div className="pageContainer">
+            <Container className="mainContainer documentContainer postContainer" >
+            <span id="latestVersion" style={{display:'none'}}>{latestVersion}</span>
+            <script src={url}></script>
+            </Container>
+            </div>
+    );
+    }
+}
+
+module.exports = PulsarAdminCli;

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -85,6 +85,17 @@ function debDistUrl(version, type) {
   }
 }
 
+function clientVersionUrl(version, type) {
+  var versions = version.split('.')
+  var majorVersion = parseInt(versions[0])
+  var minorVersion = parseInt(versions[1])
+  if (majorVersion === 2 && minorVersion < 5) {
+    return `/api/` + type + `/` + version;
+  } else if (majorVersion === 2 && minorVersion >= 5) {
+    return `/api/` + type + `/` + version + `-SNAPSHOT`
+  }
+}
+
 function doReplace(options) {
   replace(options)
     .then(changes => {
@@ -122,7 +133,13 @@ const from = [
   /{{pulsar:dist_rpm:client-debuginfo}}/g,
   /{{pulsar:dist_rpm:client-devel}}/g,
   /{{pulsar:dist_deb:client}}/g,
-  /{{pulsar:dist_deb:client-devel}}/g
+  /{{pulsar:dist_deb:client-devel}}/g,
+
+  /\/api\/python/g,
+  /\/api\/cpp/g,
+  /\/api\/pulsar-functions/g,
+  /\/api\/client/g,
+  /\/api\/admin/g,
 ];
 
 const options = {
@@ -151,7 +168,13 @@ const options = {
     rpmDistUrl(`${latestVersion}`, "-debuginfo"),
     rpmDistUrl(`${latestVersion}`, "-devel"),
     debDistUrl(`${latestVersion}`, ""),
-    debDistUrl(`${latestVersion}`, "-dev")
+    debDistUrl(`${latestVersion}`, "-dev"),
+
+    clientVersionUrl(`${latestVersion}`, "python"),
+    clientVersionUrl(`${latestVersion}`, "cpp"),
+    clientVersionUrl(`${latestVersion}`, "pulsar-functions"),
+    clientVersionUrl(`${latestVersion}`, "client"),
+    clientVersionUrl(`${latestVersion}`, "admin")
   ],
   dry: false
 };
@@ -190,7 +213,12 @@ for (v of versions) {
       rpmDistUrl(`${v}`, "-debuginfo"),
       rpmDistUrl(`${v}`, "-devel"),
       debDistUrl(`${v}`, ""),
-      debDistUrl(`${v}`, "-dev")
+      debDistUrl(`${v}`, "-dev"),
+      clientVersionUrl(`${v}`, "python"),
+      clientVersionUrl(`${v}`, "cpp"),
+      clientVersionUrl(`${v}`, "pulsar-functions"),
+      clientVersionUrl(`${v}`, "client"),
+      clientVersionUrl(`${v}`, "admin")
     ],
     dry: false
   };

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -128,7 +128,6 @@
     "Reference": [
       "reference-terminology",
       "reference-cli-tools",
-      "pulsar-admin",
       "reference-configuration",
       "reference-metrics"
     ]

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -28,7 +28,7 @@ const createVariableInjectionPlugin = variables => {
       } else if (keyparts[0] == 'source') {
           return renderUrl(initializedPlugin, sourceApiUrl + "#", keyparts);
       } else if (keyparts[0] == 'sink') {
-          return renderUrl(initializedPlugin, sinkApiUrl + "#", keyparts);
+        return renderUrl(initializedPlugin, sinkApiUrl + "#", keyparts);
       } else {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
@@ -105,6 +105,7 @@ const siteConfig = {
     {page: 'download', label: 'Download'},
     {doc: 'client-libraries', label: 'Clients'},
     {href: '#restapis', label: 'REST APIs'},
+    {href: '#cli', label: 'Cli'},
     {blog: true, label: 'Blog'},
     {href: '#community', label: 'Community'},
     {href: '#apache', label: 'Apache'},

--- a/site2/website/static/css/custom.css
+++ b/site2/website/static/css/custom.css
@@ -64,6 +64,7 @@
 #community-dropdown.hide,
 #apache-dropdown.hide,
 #restapis-dropdown.hide,
+#cli-dropdown.hide,
 #languages-dropdown.hide {
   display: none;
 }
@@ -72,6 +73,7 @@
 #community-dropdown.visible,
 #apache-dropdown.visible,
 #restapis-dropdown.visible,
+#cli-dropdown.visible,
 #languages-dropdown.visible {
   display: flex;
 }
@@ -79,6 +81,7 @@
 #community-dropdown,
 #apache-dropdown,
 #restapis-dropdown,
+#cli-dropdown,
 #languages-dropdown {
   pointer-events: none;
   position: absolute;
@@ -88,6 +91,7 @@
 #community-dropdown-items,
 #apache-dropdown-items,
 #restapis-dropdown-items,
+#cli-dropdown-items,
 #languages-dropdown-items {
   background-color: white;
   display: flex;

--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -100,6 +100,31 @@ window.addEventListener('load', function() {
     }
   });
 
+  // setup cli menu items in nav bar
+  const cli = document.querySelector("a[href='#cli']").parentNode;
+  const cliMenu =
+      '<li>' +
+      '<a id="cli-menu" href="#">Cli <span style="font-size: 0.75em">&nbsp;▼</span></a>' +
+      '<div id="cli-dropdown" class="hide">' +
+      '<ul id="cli-dropdown-items">' +
+      '<li><a href="/pulsar-admin-cli?version=' + version + '">Pulsar Admin</a></li>' +
+      '</ul>' +
+      '</div>' +
+      '</li>';
+
+  cli.innerHTML = cliMenu;
+
+  const cliMenuItem = document.getElementById("cli-menu");
+  const cliDropDown = document.getElementById("cli-dropdown");
+  cliMenuItem.addEventListener("click", function(event) {
+    event.preventDefault();
+
+    if (cliDropDown.className == 'hide') {
+      cliDropDown.className = 'visible';
+    } else {
+      cliDropDown.className = 'hide';
+    }
+  });
 
   function button(label, ariaLabel, icon, className) {
     const btn = document.createElement('button');

--- a/site2/website/static/js/getCliByVersion.js
+++ b/site2/website/static/js/getCliByVersion.js
@@ -1,0 +1,34 @@
+function getCliByVersion(){
+    var params = window.location.search
+    var latestVersion = document.getElementById("latestVersion").textContent
+    params = params.replace('?', '')
+    const paramsList = params.split('&')
+    var version = 'master'
+    for (var i in paramsList) {
+        var param = paramsList[i].split('=')
+        if (param[0] === 'version') {
+            version = param[1]
+        }
+    }
+
+    if (version === "master") {
+        var latestVersionSplit = latestVersion.split('.')
+        version = parseInt(latestVersionSplit[0]) + "." + (parseInt(latestVersionSplit[1]) + 1) + ".0"
+    }
+    var versions = version.split('.')
+    var majorVersion = parseInt(versions[0])
+    var minorVersion = parseInt(versions[1])
+    if ((majorVersion == 2 && minorVersion <= 5) || majorVersion === 1) {
+        if (version === latestVersion) {
+            window.location.href = "/docs/en/pulsar-admin"
+            return
+        } else {
+            window.location.href = "/docs/en/" + version + "/pulsar-admin"
+            return
+        }
+    } else {
+        window.location.href = "http://pulsar.apache.org/tools/pulsar-admin/" + version + "-SNAPSHOT"
+        return
+    }
+}
+window.onload=getCliByVersion


### PR DESCRIPTION
Fix: #5037 #6234 


### Motivation

After all versions of API documents are added https://github.com/apache/pulsar/pull/5660, we should use the correct version in the document content. The auto-generated pulsar-admin tool should also point to the correct version.


### Modifications

* Replace client API URL using the correct version
* Add header to the navigation bar to point to the correct pulsar-admin page

### Verifying this change
local test pass