### PR TITLE
Supports evenly distribute topics count when splits bundle

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -691,9 +691,15 @@ loadBalancerNamespaceMaximumBundles=128
 loadBalancerOverrideBrokerNicSpeedGbps=
 
 # Name of load manager to use
-# loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl
-# loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.BalanceTopicCountModularLoadManager
 loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
+
+# Supported algorithms name for namespace bundle split.
+# "range_equally_divide" divides the bundle into two parts with the same hash range size.
+# "topic_count_equally_divide" divides the bundle into two parts with the same topics count.
+supportedNamespaceBundleSplitAlgorithms=[range_equally_divide,topic_count_equally_divide]
+
+# Default algorithm name for namespace bundle split
+defaultNamespaceBundleSplitAlgorithm=range_equally_divide
 
 ### --- Replication --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -691,6 +691,8 @@ loadBalancerNamespaceMaximumBundles=128
 loadBalancerOverrideBrokerNicSpeedGbps=
 
 # Name of load manager to use
+# loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl
+# loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.BalanceTopicCountModularLoadManager
 loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
 
 ### --- Replication --- ###

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker;
 
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import io.netty.util.internal.PlatformDependent;
@@ -1189,7 +1190,18 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Name of load manager to use"
     )
     private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl";
-
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_LOAD_BALANCER,
+        doc = "Supported algorithms name for namespace bundle split"
+    )
+    private List<String> supportedNamespaceBundleSplitAlgorithms = Lists.newArrayList("range_equally_divide", "topic_count_equally_divide");
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_LOAD_BALANCER,
+        doc = "Default algorithm name for namespace bundle split"
+    )
+    private String defaultNamespaceBundleSplitAlgorithm = "range_equally_divide";
     @FieldContext(
         category = CATEGORY_LOAD_BALANCER,
         doc = "Option to override the auto-detected network interfaces max speed"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
@@ -150,6 +151,15 @@ public class PulsarBrokerStarter {
             int maxFrameSize = brokerConfig.getMaxMessageSize() + Commands.MESSAGE_SIZE_FRAME_PADDING;
             if (maxFrameSize >= DirectMemoryUtils.maxDirectMemory()) {
                 throw new IllegalArgumentException("Max message size need smaller than jvm directMemory");
+            }
+
+            if (!NamespaceBundleSplitAlgorithm.availableAlgorithms.containsAll(brokerConfig.getSupportedNamespaceBundleSplitAlgorithms())) {
+                throw new IllegalArgumentException("The given supported namespace bundle split algorithm has unavailable algorithm. " +
+                    "Available algorithms are " + NamespaceBundleSplitAlgorithm.availableAlgorithms);
+            }
+
+            if (!brokerConfig.getSupportedNamespaceBundleSplitAlgorithms().contains(brokerConfig.getDefaultNamespaceBundleSplitAlgorithm())) {
+                throw new IllegalArgumentException("Supported namespace bundle split algorithms must contains the default namespace bundle split algorithm");
             }
 
             // init functions worker

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -802,10 +802,15 @@ public abstract class NamespacesBase extends AdminResource {
         try {
             pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload, getNamespaceBundleSplitAlgorithmByName(splitAlgorithmName)).get();
             log.info("[{}] Successfully split namespace bundle {}", clientAppId(), nsBundle.toString());
-        } catch (IllegalArgumentException e) {
-            log.error("[{}] Failed to split namespace bundle {}/{} due to {}", clientAppId(), namespaceName,
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof IllegalArgumentException) {
+                log.error("[{}] Failed to split namespace bundle {}/{} due to {}", clientAppId(), namespaceName,
                     bundleRange, e.getMessage());
-            throw new RestException(Status.PRECONDITION_FAILED, "Split bundle failed due to invalid request");
+                throw new RestException(Status.PRECONDITION_FAILED, "Split bundle failed due to invalid request");
+            } else {
+                log.error("[{}] Failed to split namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange, e);
+                throw new RestException(e.getCause());
+            }
         } catch (Exception e) {
             log.error("[{}] Failed to split namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange, e);
             throw new RestException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -64,6 +64,7 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -774,7 +775,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     @SuppressWarnings("deprecation")
-    protected void internalSplitNamespaceBundle(String bundleRange, boolean authoritative, boolean unload, boolean balanceTopicCount) {
+    protected void internalSplitNamespaceBundle(String bundleRange, boolean authoritative, boolean unload, String splitAlgorithmName) {
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange);
 
         validateSuperUserAccess();
@@ -792,8 +793,14 @@ public abstract class NamespacesBase extends AdminResource {
         NamespaceBundle nsBundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles, bundleRange,
                 authoritative, true);
 
+        List<String> supportedNamespaceBundleSplitAlgorithms = pulsar().getConfig().getSupportedNamespaceBundleSplitAlgorithms();
+        if (StringUtils.isNotBlank(splitAlgorithmName) && !supportedNamespaceBundleSplitAlgorithms.contains(splitAlgorithmName)) {
+            throw new RestException(Status.PRECONDITION_FAILED,
+                "Unsupported namespace bundle split algorithm, supported algorithms are " + supportedNamespaceBundleSplitAlgorithms);
+        }
+
         try {
-            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload, balanceTopicCount).get();
+            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload, getNamespaceBundleSplitAlgorithmByName(splitAlgorithmName)).get();
             log.info("[{}] Successfully split namespace bundle {}", clientAppId(), nsBundle.toString());
         } catch (IllegalArgumentException e) {
             log.error("[{}] Failed to split namespace bundle {}/{} due to {}", clientAppId(), namespaceName,
@@ -803,6 +810,17 @@ public abstract class NamespacesBase extends AdminResource {
             log.error("[{}] Failed to split namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange, e);
             throw new RestException(e);
         }
+    }
+
+    private NamespaceBundleSplitAlgorithm getNamespaceBundleSplitAlgorithmByName(String algorithmName) {
+        NamespaceBundleSplitAlgorithm algorithm = NamespaceBundleSplitAlgorithm.of(algorithmName);
+        if (algorithm == null) {
+            algorithm = NamespaceBundleSplitAlgorithm.of(pulsar().getConfig().getDefaultNamespaceBundleSplitAlgorithm());
+        }
+        if (algorithm == null) {
+            algorithm = NamespaceBundleSplitAlgorithm.rangeEquallyDivide;
+        }
+        return algorithm;
     }
 
     protected void internalSetPublishRate(PublishRate maxPublishMessageRate) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -774,7 +774,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     @SuppressWarnings("deprecation")
-    protected void internalSplitNamespaceBundle(String bundleRange, boolean authoritative, boolean unload) {
+    protected void internalSplitNamespaceBundle(String bundleRange, boolean authoritative, boolean unload, boolean balanceTopicCount) {
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange);
 
         validateSuperUserAccess();
@@ -793,7 +793,7 @@ public abstract class NamespacesBase extends AdminResource {
                 authoritative, true);
 
         try {
-            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload).get();
+            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload, balanceTopicCount).get();
             log.info("[{}] Successfully split namespace bundle {}", clientAppId(), nsBundle.toString());
         } catch (IllegalArgumentException e) {
             log.error("[{}] Failed to split namespace bundle {}/{} due to {}", clientAppId(), namespaceName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.Mode;
+import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
@@ -446,7 +447,7 @@ public class Namespaces extends NamespacesBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("unload") @DefaultValue("false") boolean unload) {
         validateNamespaceName(property, cluster, namespace);
-        internalSplitNamespaceBundle(bundleRange, authoritative, unload, false);
+        internalSplitNamespaceBundle(bundleRange, authoritative, unload, NamespaceBundleSplitAlgorithm.rangeEquallyDivideName);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -446,7 +446,7 @@ public class Namespaces extends NamespacesBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("unload") @DefaultValue("false") boolean unload) {
         validateNamespaceName(property, cluster, namespace);
-        internalSplitNamespaceBundle(bundleRange, authoritative, unload);
+        internalSplitNamespaceBundle(bundleRange, authoritative, unload, false);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -351,9 +351,9 @@ public class Namespaces extends NamespacesBase {
             @PathParam("bundle") String bundleRange,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("unload") @DefaultValue("false") boolean unload,
-            @QueryParam("balanceTopicCount") @DefaultValue("false") boolean balanceTopicCount) {
+            @QueryParam("splitAlgorithmName") String splitAlgorithmName) {
         validateNamespaceName(tenant, namespace);
-        internalSplitNamespaceBundle(bundleRange, authoritative, unload, balanceTopicCount);
+        internalSplitNamespaceBundle(bundleRange, authoritative, unload, splitAlgorithmName);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -350,9 +350,10 @@ public class Namespaces extends NamespacesBase {
     public void splitNamespaceBundle(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
             @PathParam("bundle") String bundleRange,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("unload") @DefaultValue("false") boolean unload) {
+            @QueryParam("unload") @DefaultValue("false") boolean unload,
+            @QueryParam("balanceTopicCount") @DefaultValue("false") boolean balanceTopicCount) {
         validateNamespaceName(tenant, namespace);
-        internalSplitNamespaceBundle(bundleRange, authoritative, unload);
+        internalSplitNamespaceBundle(bundleRange, authoritative, unload, balanceTopicCount);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BalanceTopicCountModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BalanceTopicCountModularLoadManager.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+
+public class BalanceTopicCountModularLoadManager extends ModularLoadManagerImpl {
+
+    @Override
+    protected void internalSplitNamespaceBundle(String namespaceName, String bundleRange) throws PulsarServerException, PulsarAdminException {
+        pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
+            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), true);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -169,7 +169,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     private SimpleResourceAllocationPolicies policies;
 
     // Pulsar service used to initialize this.
-    protected PulsarService pulsar;
+    private PulsarService pulsar;
 
     // Executor service used to regularly update broker data.
     private final ScheduledExecutorService scheduler;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.PlacementStrategy;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
@@ -1477,10 +1478,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
         if (bundlesToBeSplit.size() > 0) {
             for (String bundleName : bundlesToBeSplit) {
                 try {
-                    pulsar.getAdminClient().namespaces().splitNamespaceBundle(
-                            LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
-                            LoadManagerShared.getBundleRangeFromBundleName(bundleName),
-                            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled());
+                    internalSplitNamespaceBundle(LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
+                        LoadManagerShared.getBundleRangeFromBundleName(bundleName));
                     log.info("Successfully split namespace bundle {}", bundleName);
                 } catch (Exception e) {
                     log.error("Failed to split namespace bundle {}", bundleName, e);
@@ -1488,6 +1487,11 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
             }
             this.setLoadReportForceUpdateFlag();
         }
+    }
+
+    protected void internalSplitNamespaceBundle(String namespaceName, String bundleRange) throws PulsarServerException, PulsarAdminException {
+        pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
+            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), false);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1478,8 +1478,10 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
         if (bundlesToBeSplit.size() > 0) {
             for (String bundleName : bundlesToBeSplit) {
                 try {
-                    internalSplitNamespaceBundle(LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
-                        LoadManagerShared.getBundleRangeFromBundleName(bundleName));
+                    pulsar.getAdminClient().namespaces().splitNamespaceBundle(
+                        LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
+                        LoadManagerShared.getBundleRangeFromBundleName(bundleName),
+                        pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), null);
                     log.info("Successfully split namespace bundle {}", bundleName);
                 } catch (Exception e) {
                     log.error("Failed to split namespace bundle {}", bundleName, e);
@@ -1487,11 +1489,6 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
             }
             this.setLoadReportForceUpdateFlag();
         }
-    }
-
-    protected void internalSplitNamespaceBundle(String namespaceName, String bundleRange) throws PulsarServerException, PulsarAdminException {
-        pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
-            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), false);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -653,6 +653,9 @@ public class NamespaceService {
             return CompletableFuture.completedFuture(null);
         } else {
             return getOwnedTopicListForNamespaceBundle(bundle).thenCompose(topics -> {
+                if (topics == null || topics.size() <= 1) {
+                    return CompletableFuture.completedFuture(null);
+                }
                 List<Long> topicNameHashList = new ArrayList<>(topics.size());
                 for (String topic : topics) {
                     topicNameHashList.add(bundle.getNamespaceBundleFactory().getLongHashCode(topic));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -636,128 +637,152 @@ public class NamespaceService {
      * @return
      * @throws Exception
      */
-    public CompletableFuture<Void> splitAndOwnBundle(NamespaceBundle bundle, boolean unload)
+    public CompletableFuture<Void> splitAndOwnBundle(NamespaceBundle bundle, boolean unload, boolean balanceTopicCount)
         throws Exception {
 
         final CompletableFuture<Void> unloadFuture = new CompletableFuture<>();
         final AtomicInteger counter = new AtomicInteger(BUNDLE_SPLIT_RETRY_LIMIT);
 
-        splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture);
+        splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture, balanceTopicCount);
 
         return unloadFuture;
+    }
+
+    CompletableFuture<Long> getSplitKeyForBalanceTopicCountAsync(NamespaceBundle bundle, boolean balanceTopicCount) {
+        if (!balanceTopicCount) {
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return getOwnedTopicListForNamespaceBundle(bundle).thenCompose(topics -> {
+                List<Long> topicNameHashList = new ArrayList<>(topics.size());
+                for (String topic : topics) {
+                    topicNameHashList.add(bundle.getNamespaceBundleFactory().getLongHashCode(topic));
+                }
+                Collections.sort(topicNameHashList);
+                long splitStart = topicNameHashList.get(Math.max((topicNameHashList.size() / 2) - 1, 0));
+                long splitEnd = topicNameHashList.get(topicNameHashList.size() / 2);
+                long splitMiddle = splitStart + (splitEnd - splitStart) / 2;
+                return CompletableFuture.completedFuture(splitMiddle);
+            });
+        }
     }
 
     void splitAndOwnBundleOnceAndRetry(NamespaceBundle bundle,
                                        boolean unload,
                                        AtomicInteger counter,
-                                       CompletableFuture<Void> unloadFuture) {
-        CompletableFuture<List<NamespaceBundle>> updateFuture = new CompletableFuture<>();
+                                       CompletableFuture<Void> unloadFuture,
+                                       boolean balanceTopicCount) {
+        getSplitKeyForBalanceTopicCountAsync(bundle, balanceTopicCount).whenComplete((splitKey, ex) -> {
+            CompletableFuture<List<NamespaceBundle>> updateFuture = new CompletableFuture<>();
+            if (ex == null) {
+                final Pair<NamespaceBundles, List<NamespaceBundle>> splittedBundles = bundleFactory.splitBundles(bundle,
+                    2 /* by default split into 2 */, splitKey);
 
-        final Pair<NamespaceBundles, List<NamespaceBundle>> splittedBundles = bundleFactory.splitBundles(bundle,
-            2 /* by default split into 2 */);
-
-        // Split and updateNamespaceBundles. Update may fail because of concurrent write to Zookeeper.
-        if (splittedBundles != null) {
-            checkNotNull(splittedBundles.getLeft());
-            checkNotNull(splittedBundles.getRight());
-            checkArgument(splittedBundles.getRight().size() == 2, "bundle has to be split in two bundles");
-            NamespaceName nsname = bundle.getNamespaceObject();
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("[{}] splitAndOwnBundleOnce: {}, counter: {},  2 bundles: {}, {}",
-                    nsname.toString(), bundle.getBundleRange(), counter.get(),
-                    splittedBundles != null ? splittedBundles.getRight().get(0).getBundleRange() : "null splittedBundles",
-                    splittedBundles != null ? splittedBundles.getRight().get(1).getBundleRange() : "null splittedBundles");
-            }
-            try {
-                // take ownership of newly split bundles
-                for (NamespaceBundle sBundle : splittedBundles.getRight()) {
-                    checkNotNull(ownershipCache.tryAcquiringOwnership(sBundle));
-                }
-                updateNamespaceBundles(nsname, splittedBundles.getLeft(),
-                    (rc, path, zkCtx, stat) ->  {
-                        if (rc == Code.OK.intValue()) {
-                            // invalidate cache as zookeeper has new split
-                            // namespace bundle
-                            bundleFactory.invalidateBundleCache(bundle.getNamespaceObject());
-
-                            updateFuture.complete(splittedBundles.getRight());
-                        } else if (rc == Code.BADVERSION.intValue()) {
-                            KeeperException keeperException = KeeperException.create(KeeperException.Code.get(rc));
-                            String msg = format("failed to update namespace policies [%s], NamespaceBundle: %s " +
-                                    "due to %s, counter: %d",
-                                nsname.toString(), bundle.getBundleRange(),
-                                keeperException.getMessage(), counter.get());
-                            LOG.warn(msg);
-                            updateFuture.completeExceptionally(new ServerMetadataException(keeperException));
-                        } else {
-                            String msg = format("failed to update namespace policies [%s], NamespaceBundle: %s due to %s",
-                                nsname.toString(), bundle.getBundleRange(),
-                                KeeperException.create(KeeperException.Code.get(rc)).getMessage());
-                            LOG.warn(msg);
-                            updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
+                // Split and updateNamespaceBundles. Update may fail because of concurrent write to Zookeeper.
+                if (splittedBundles != null) {
+                    checkNotNull(splittedBundles.getLeft());
+                    checkNotNull(splittedBundles.getRight());
+                    checkArgument(splittedBundles.getRight().size() == 2, "bundle has to be split in two bundles");
+                    NamespaceName nsname = bundle.getNamespaceObject();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("[{}] splitAndOwnBundleOnce: {}, counter: {},  2 bundles: {}, {}",
+                            nsname.toString(), bundle.getBundleRange(), counter.get(),
+                            splittedBundles != null ? splittedBundles.getRight().get(0).getBundleRange() : "null splittedBundles",
+                            splittedBundles != null ? splittedBundles.getRight().get(1).getBundleRange() : "null splittedBundles");
+                    }
+                    try {
+                        // take ownership of newly split bundles
+                        for (NamespaceBundle sBundle : splittedBundles.getRight()) {
+                            checkNotNull(ownershipCache.tryAcquiringOwnership(sBundle));
                         }
-                    });
-            } catch (Exception e) {
-                String msg = format("failed to acquire ownership of split bundle for namespace [%s], %s",
-                    nsname.toString(), e.getMessage());
-                LOG.warn(msg, e);
-                updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
-            }
-        } else {
-            String msg = format("bundle %s not found under namespace", bundle.toString());
-            LOG.warn(msg);
-            updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
-        }
+                        updateNamespaceBundles(nsname, splittedBundles.getLeft(),
+                            (rc, path, zkCtx, stat) ->  {
+                                if (rc == Code.OK.intValue()) {
+                                    // invalidate cache as zookeeper has new split
+                                    // namespace bundle
+                                    bundleFactory.invalidateBundleCache(bundle.getNamespaceObject());
 
-        // If success updateNamespaceBundles, then do invalidateBundleCache and unload.
-        // Else retry splitAndOwnBundleOnceAndRetry.
-        updateFuture.whenCompleteAsync((r, t)-> {
-            if (t != null) {
-                // retry several times on BadVersion
-                if ((t instanceof ServerMetadataException) && (counter.decrementAndGet() >= 0)) {
-                    pulsar.getOrderedExecutor()
-                            .execute(() -> splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture));
+                                    updateFuture.complete(splittedBundles.getRight());
+                                } else if (rc == Code.BADVERSION.intValue()) {
+                                    KeeperException keeperException = KeeperException.create(KeeperException.Code.get(rc));
+                                    String msg = format("failed to update namespace policies [%s], NamespaceBundle: %s " +
+                                            "due to %s, counter: %d",
+                                        nsname.toString(), bundle.getBundleRange(),
+                                        keeperException.getMessage(), counter.get());
+                                    LOG.warn(msg);
+                                    updateFuture.completeExceptionally(new ServerMetadataException(keeperException));
+                                } else {
+                                    String msg = format("failed to update namespace policies [%s], NamespaceBundle: %s due to %s",
+                                        nsname.toString(), bundle.getBundleRange(),
+                                        KeeperException.create(KeeperException.Code.get(rc)).getMessage());
+                                    LOG.warn(msg);
+                                    updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
+                                }
+                            });
+                    } catch (Exception e) {
+                        String msg = format("failed to acquire ownership of split bundle for namespace [%s], %s",
+                            nsname.toString(), e.getMessage());
+                        LOG.warn(msg, e);
+                        updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
+                    }
                 } else {
-                    // Retry enough, or meet other exception
-                    String msg2 = format(" %s not success update nsBundles, counter %d, reason %s",
-                        bundle.toString(), counter.get(), t.getMessage());
-                    LOG.warn(msg2);
-                    unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg2));
+                    String msg = format("bundle %s not found under namespace", bundle.toString());
+                    LOG.warn(msg);
+                    updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
+                }
+            } else {
+                updateFuture.completeExceptionally(ex);
+            }
+
+            // If success updateNamespaceBundles, then do invalidateBundleCache and unload.
+            // Else retry splitAndOwnBundleOnceAndRetry.
+            updateFuture.whenCompleteAsync((r, t)-> {
+                if (t != null) {
+                    // retry several times on BadVersion
+                    if ((t instanceof ServerMetadataException) && (counter.decrementAndGet() >= 0)) {
+                        pulsar.getOrderedExecutor()
+                            .execute(() -> splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture, balanceTopicCount));
+                    } else {
+                        // Retry enough, or meet other exception
+                        String msg2 = format(" %s not success update nsBundles, counter %d, reason %s",
+                            bundle.toString(), counter.get(), t.getMessage());
+                        LOG.warn(msg2);
+                        unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg2));
+                    }
+                    return;
+                }
+
+                // success updateNamespaceBundles
+                try {
+                    // disable old bundle in memory
+                    getOwnershipCache().updateBundleState(bundle, false);
+
+                    // update bundled_topic cache for load-report-generation
+                    pulsar.getBrokerService().refreshTopicToStatsMaps(bundle);
+                    loadManager.get().setLoadReportForceUpdateFlag();
+
+                    if (unload) {
+                        // unload new split bundles
+                        r.forEach(splitBundle -> {
+                            try {
+                                unloadNamespaceBundle(splitBundle);
+                            } catch (Exception e) {
+                                LOG.warn("Failed to unload split bundle {}", splitBundle, e);
+                                throw new RuntimeException("Failed to unload split bundle " + splitBundle, e);
+                            }
+                        });
+                    }
+
+                    unloadFuture.complete(null);
+                } catch (Exception e) {
+                    String msg1 = format(
+                        "failed to disable bundle %s under namespace [%s] with error %s",
+                        bundle.getNamespaceObject().toString(), bundle.toString(), e.getMessage());
+                    LOG.warn(msg1, e);
+                    unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg1));
                 }
                 return;
-            }
-
-            // success updateNamespaceBundles
-            try {
-                // disable old bundle in memory
-                getOwnershipCache().updateBundleState(bundle, false);
-
-                // update bundled_topic cache for load-report-generation
-                pulsar.getBrokerService().refreshTopicToStatsMaps(bundle);
-                loadManager.get().setLoadReportForceUpdateFlag();
-
-                if (unload) {
-                    // unload new split bundles
-                    r.forEach(splitBundle -> {
-                        try {
-                            unloadNamespaceBundle(splitBundle);
-                        } catch (Exception e) {
-                            LOG.warn("Failed to unload split bundle {}", splitBundle, e);
-                            throw new RuntimeException("Failed to unload split bundle " + splitBundle, e);
-                        }
-                    });
-                }
-
-                unloadFuture.complete(null);
-            } catch (Exception e) {
-                String msg1 = format(
-                    "failed to disable bundle %s under namespace [%s] with error %s",
-                    bundle.getNamespaceObject().toString(), bundle.toString(), e.getMessage());
-                LOG.warn(msg1, e);
-                unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg1));
-            }
-            return;
-        }, pulsar.getOrderedExecutor());
+            }, pulsar.getOrderedExecutor());
+        });
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
@@ -153,4 +153,8 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
     public static String getBundleRange(String namespaceBundle) {
         return namespaceBundle.substring(namespaceBundle.lastIndexOf('/') + 1);
     }
+
+    public NamespaceBundleFactory getNamespaceBundleFactory() {
+        return factory;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -221,16 +221,16 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
      *            {@link NamespaceBundle} needs to be split
      * @param numBundles
      *            split into numBundles
-     * @param splitKey
+     * @param splitBoundary
      *            split into 2 numBundles by the given split key. The given split key must between the key range of the
      *            given split bundle.
      * @return List of split {@link NamespaceBundle} and {@link NamespaceBundles} that contains final bundles including
      *         split bundles for a given namespace
      */
-    public Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles(NamespaceBundle targetBundle, int numBundles, Long splitKey) {
+    public Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles(NamespaceBundle targetBundle, int numBundles, Long splitBoundary) {
         checkArgument(canSplitBundle(targetBundle), "%s bundle can't be split further", targetBundle);
-        if (splitKey != null) {
-            checkArgument(splitKey > targetBundle.getLowerEndpoint() && splitKey < targetBundle.getUpperEndpoint(),
+        if (splitBoundary != null) {
+            checkArgument(splitBoundary > targetBundle.getLowerEndpoint() && splitBoundary < targetBundle.getUpperEndpoint(),
                 "The given fixed key must between the key range of the %s bundle", targetBundle);
             numBundles = 2;
         }
@@ -251,7 +251,7 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
                 splitPartition = i;
                 Long maxVal = sourceBundle.partitions[i + 1];
                 Long minVal = sourceBundle.partitions[i];
-                Long segSize = splitKey == null ? (maxVal - minVal) / numBundles : splitKey - minVal;
+                Long segSize = splitBoundary == null ? (maxVal - minVal) / numBundles : splitBoundary - minVal;
                 partitions[pos++] = minVal;
                 Long curPartition = minVal + segSize;
                 for (int j = 0; j < numBundles - 1; j++) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.naming;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Algorithm interface for namespace bundle split.
+ */
+public interface NamespaceBundleSplitAlgorithm {
+
+    String rangeEquallyDivideName = "range_equally_divide";
+    String topicCountEquallyDivideName = "topic_count_equally_divide";
+
+    List<String> availableAlgorithms = Lists.newArrayList(rangeEquallyDivideName, topicCountEquallyDivideName);
+
+    NamespaceBundleSplitAlgorithm rangeEquallyDivide = new RangeEquallyDivideBundleSplitAlgorithm();
+    NamespaceBundleSplitAlgorithm topicCountEquallyDivide = new TopicCountEquallyDivideBundleSplitAlgorithm();
+
+    static NamespaceBundleSplitAlgorithm of(String algorithmName) {
+        if (algorithmName == null) {
+            return null;
+        }
+        switch (algorithmName) {
+            case  rangeEquallyDivideName:
+                return rangeEquallyDivide;
+            case topicCountEquallyDivideName:
+                return topicCountEquallyDivide;
+            default:
+                return null;
+        }
+    }
+
+    CompletableFuture<Long> getSplitBoundary(NamespaceService service, NamespaceBundle bundle);
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithm.java
@@ -16,16 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.loadbalance.impl;
+package org.apache.pulsar.common.naming;
 
-import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 
-public class BalanceTopicCountModularLoadManager extends ModularLoadManagerImpl {
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This algorithm divides the bundle into two parts with the same hash range size.
+ */
+public class RangeEquallyDivideBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm {
 
     @Override
-    protected void internalSplitNamespaceBundle(String namespaceName, String bundleRange) throws PulsarServerException, PulsarAdminException {
-        pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
-            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), true);
+    public CompletableFuture<Long> getSplitBoundary(NamespaceService service, NamespaceBundle bundle) {
+        return CompletableFuture.completedFuture(bundle.getLowerEndpoint() +
+            (bundle.getUpperEndpoint() - bundle.getLowerEndpoint()) / 2);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/TopicCountEquallyDivideBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/TopicCountEquallyDivideBundleSplitAlgorithm.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.naming;
+
+import org.apache.pulsar.broker.namespace.NamespaceService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This algorithm divides the bundle into two parts with the same topics count.
+ */
+public class TopicCountEquallyDivideBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm  {
+
+    @Override
+    public CompletableFuture<Long> getSplitBoundary(NamespaceService service, NamespaceBundle bundle) {
+        return service.getOwnedTopicListForNamespaceBundle(bundle).thenCompose(topics -> {
+            if (topics == null || topics.size() <= 1) {
+                return CompletableFuture.completedFuture(null);
+            }
+            List<Long> topicNameHashList = new ArrayList<>(topics.size());
+            for (String topic : topics) {
+                topicNameHashList.add(bundle.getNamespaceBundleFactory().getLongHashCode(topic));
+            }
+            Collections.sort(topicNameHashList);
+            long splitStart = topicNameHashList.get(Math.max((topicNameHashList.size() / 2) - 1, 0));
+            long splitEnd = topicNameHashList.get(topicNameHashList.size() / 2);
+            long splitMiddle = splitStart + (splitEnd - splitStart) / 2;
+            return CompletableFuture.completedFuture(splitMiddle);
+        });
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -90,6 +91,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -995,7 +997,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, null);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1008,6 +1010,95 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         }
 
         producer.close();
+    }
+
+    @Test
+    public void testNamespaceSplitBundleWithTopicCountEquallyDivideAlgorithm() throws Exception {
+        // Force to create a topic
+        final String namespace = "prop-xyz/ns1";
+        List<String> topicNames = Lists.newArrayList(
+            (new StringBuilder("persistent://")).append(namespace).append("/topicCountEquallyDivideAlgorithum-1").toString(),
+            (new StringBuilder("persistent://")).append(namespace).append("/topicCountEquallyDivideAlgorithum-2").toString());
+
+        List<Producer<byte[]>> producers = new ArrayList<>(2);
+        for (String topicName : topicNames) {
+            Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(topicName)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+            producers.add(producer);
+            producer.send("message".getBytes());
+        }
+
+        assertTrue(admin.topics().getList(namespace).containsAll(topicNames));
+
+        try {
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true,
+                NamespaceBundleSplitAlgorithm.topicCountEquallyDivideName);
+        } catch (Exception e) {
+            fail("split bundle shouldn't have thrown exception");
+        }
+        NamespaceBundles bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        NamespaceBundle bundle1 = pulsar.getNamespaceService().getBundle(TopicName.get(topicNames.get(0)));
+        NamespaceBundle bundle2 = pulsar.getNamespaceService().getBundle(TopicName.get(topicNames.get(1)));
+        assertNotEquals(bundle1, bundle2);
+        String[] splitRange = { namespace + "/0x00000000_0x7fffffff", namespace + "/0x7fffffff_0xffffffff" };
+        for (int i = 0; i < bundles.getBundles().size(); i++) {
+            assertNotEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
+        }
+        producers.forEach(Producer::closeAsync);
+    }
+
+    @Test
+    public void testNamespaceSplitBundleWithInvalidAlgorithm() throws Exception {
+        // Force to create a topic
+        final String namespace = "prop-xyz/ns1";
+        try {
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true,
+                "invalid_test");
+            fail("unsupported namespace bundle split algorithm");
+        } catch (PulsarAdminException ignored) {
+        }
+    }
+
+    @Test
+    public void testNamespaceSplitBundleWithDefaultTopicCountEquallyDivideAlgorithm() throws Exception {
+        conf.setDefaultNamespaceBundleSplitAlgorithm(NamespaceBundleSplitAlgorithm.topicCountEquallyDivideName);
+        // Force to create a topic
+        final String namespace = "prop-xyz/ns1";
+        List<String> topicNames = Lists.newArrayList(
+            (new StringBuilder("persistent://")).append(namespace).append("/topicCountEquallyDivideAlgorithum-1").toString(),
+            (new StringBuilder("persistent://")).append(namespace).append("/topicCountEquallyDivideAlgorithum-2").toString());
+
+        List<Producer<byte[]>> producers = new ArrayList<>(2);
+        for (String topicName : topicNames) {
+            Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(topicName)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+            producers.add(producer);
+            producer.send("message".getBytes());
+        }
+
+        assertTrue(admin.topics().getList(namespace).containsAll(topicNames));
+
+        try {
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, null);
+        } catch (Exception e) {
+            fail("split bundle shouldn't have thrown exception");
+        }
+        NamespaceBundles bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        NamespaceBundle bundle1 = pulsar.getNamespaceService().getBundle(TopicName.get(topicNames.get(0)));
+        NamespaceBundle bundle2 = pulsar.getNamespaceService().getBundle(TopicName.get(topicNames.get(1)));
+        assertNotEquals(bundle1, bundle2);
+        String[] splitRange = { namespace + "/0x00000000_0x7fffffff", namespace + "/0x7fffffff_0xffffffff" };
+        for (int i = 0; i < bundles.getBundles().size(); i++) {
+            assertNotEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
+        }
+        producers.forEach(Producer::closeAsync);
+        conf.setDefaultNamespaceBundleSplitAlgorithm(NamespaceBundleSplitAlgorithm.rangeEquallyDivideName);
     }
 
     @Test
@@ -1025,7 +1116,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, null);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1042,11 +1133,11 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         try {
             executorService.invokeAll(Arrays.asList(() -> {
                 log.info("split 2 bundles at the same time. spilt: 0x00000000_0x7fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, null);
                 return null;
             }, () -> {
                 log.info("split 2 bundles at the same time. spilt: 0x7fffffff_0xffffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, null);
                 return null;
             }));
         } catch (Exception e) {
@@ -1064,19 +1155,19 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         try {
             executorService.invokeAll(Arrays.asList(() -> {
                 log.info("split 4 bundles at the same time. spilt: 0x00000000_0x3fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, null);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0x3fffffff_0x7fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, null);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0x7fffffff_0xbfffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, null);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0xbfffffff_0xffffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, null);
                 return null;
             }));
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -995,7 +995,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1025,7 +1025,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, false);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1042,11 +1042,11 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         try {
             executorService.invokeAll(Arrays.asList(() -> {
                 log.info("split 2 bundles at the same time. spilt: 0x00000000_0x7fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, false);
                 return null;
             }, () -> {
                 log.info("split 2 bundles at the same time. spilt: 0x7fffffff_0xffffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, false);
                 return null;
             }));
         } catch (Exception e) {
@@ -1064,19 +1064,19 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         try {
             executorService.invokeAll(Arrays.asList(() -> {
                 log.info("split 4 bundles at the same time. spilt: 0x00000000_0x3fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, false);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0x3fffffff_0x7fffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, false);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0x7fffffff_0xbfffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, false);
                 return null;
             }, () -> {
                 log.info("split 4 bundles at the same time. spilt: 0xbfffffff_0xffffffff ");
-                admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false);
+                admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, false);
                 return null;
             }));
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -956,7 +956,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, null);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -986,7 +986,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, null);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1007,13 +1007,13 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
                     () ->
                     {
                         log.info("split 2 bundles at the same time. spilt: 0x00000000_0x7fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, null);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 2 bundles at the same time. spilt: 0x7fffffff_0xffffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, null);
                         return null;
                     }
                 )
@@ -1039,25 +1039,25 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x00000000_0x3fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, null);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x3fffffff_0x7fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, null);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x7fffffff_0xbfffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, null);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0xbfffffff_0xffffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, null);
                         return null;
                     }
                 )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -956,7 +956,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -986,7 +986,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false);
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false, false);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }
@@ -1007,13 +1007,13 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
                     () ->
                     {
                         log.info("split 2 bundles at the same time. spilt: 0x00000000_0x7fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false, false);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 2 bundles at the same time. spilt: 0x7fffffff_0xffffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false, false);
                         return null;
                     }
                 )
@@ -1039,25 +1039,25 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x00000000_0x3fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false, false);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x3fffffff_0x7fffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false, false);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0x7fffffff_0xbfffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false, false);
                         return null;
                     },
                     () ->
                     {
                         log.info("split 4 bundles at the same time. spilt: 0xbfffffff_0xffffffff ");
-                        admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false);
+                        admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false, false);
                         return null;
                     }
                 )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -680,25 +680,25 @@ public class LoadBalancerTest {
         boolean isAutoUnooadSplitBundleEnabled = pulsarServices[0].getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled();
         // verify bundles are split
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-01", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-02", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-03", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-04", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-05", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-06", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-07", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-08", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-09", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-10", "0x00000000_0x02000000",
-                isAutoUnooadSplitBundleEnabled, false);
+                isAutoUnooadSplitBundleEnabled, null);
     }
 
     /*

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -680,25 +680,25 @@ public class LoadBalancerTest {
         boolean isAutoUnooadSplitBundleEnabled = pulsarServices[0].getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled();
         // verify bundles are split
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-01", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-02", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-03", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-04", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-05", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-06", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-07", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-08", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-09", "0x00000000_0x80000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-10", "0x00000000_0x02000000",
-                isAutoUnooadSplitBundleEnabled);
+                isAutoUnooadSplitBundleEnabled, false);
     }
 
     /*

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -110,7 +110,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
 
         try {
             result.get();
@@ -190,7 +190,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         assertNotNull(list);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
         try {
             result.get();
         } catch (Exception e) {
@@ -383,7 +383,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
 
         try {
             result.get();
@@ -448,7 +448,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
-        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false);
+        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false, false);
         try {
             result1.get();
         } catch (Exception e) {
@@ -467,7 +467,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
             }
         });
 
-        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true);
+        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true, false);
         try {
             result2.get();
         } catch (Exception e) {
@@ -483,7 +483,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         bCacheField.setAccessible(true);
         ((AsyncLoadingCache<NamespaceName, NamespaceBundles>) bCacheField.get(utilityFactory)).put(nsname,
                 CompletableFuture.completedFuture(bundles));
-        return utilityFactory.splitBundles(targetBundle, 2);
+        return utilityFactory.splitBundles(targetBundle, 2, null);
     }
 
     private static final Logger log = LoggerFactory.getLogger(NamespaceServiceTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -110,7 +111,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.rangeEquallyDivide);
 
         try {
             result.get();
@@ -190,7 +191,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         assertNotNull(list);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.rangeEquallyDivide);
         try {
             result.get();
         } catch (Exception e) {
@@ -383,7 +384,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, false);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.rangeEquallyDivide);
 
         try {
             result.get();
@@ -448,7 +449,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
-        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false, false);
+        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.rangeEquallyDivide);
         try {
             result1.get();
         } catch (Exception e) {
@@ -467,7 +468,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
             }
         });
 
-        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true, false);
+        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true, NamespaceBundleSplitAlgorithm.rangeEquallyDivide);
         try {
             result2.get();
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -103,7 +103,7 @@ public class TopicOwnerTest {
         // All brokers will invalidate bundles cache after namespace bundle split
         pulsarAdmins[0].namespaces().splitNamespaceBundle("my-tenant/my-ns",
                 pulsarServices[0].getNamespaceService().getBundle(TopicName.get(topic1)).getBundleRange(),
-                true);
+                true, false);
 
         PulsarClient client = PulsarClient.builder().
                 serviceUrl(serviceUrlForTopic1)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -103,7 +103,7 @@ public class TopicOwnerTest {
         // All brokers will invalidate bundles cache after namespace bundle split
         pulsarAdmins[0].namespaces().splitNamespaceBundle("my-tenant/my-ns",
                 pulsarServices[0].getNamespaceService().getBundle(TopicName.get(topic1)).getBundleRange(),
-                true, false);
+                true, null);
 
         PulsarClient client = PulsarClient.builder().
                 serviceUrl(serviceUrlForTopic1)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -871,7 +871,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         assertEquals(bundleInBroker2.toString(), unsplitBundle);
 
         // (5) Split the bundle for topic-1
-        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
+        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, null);
 
         // (6) Broker-2 should get the watch and update bundle cache
         final int retry = 5;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -871,7 +871,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         assertEquals(bundleInBroker2.toString(), unsplitBundle);
 
         // (5) Split the bundle for topic-1
-        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true);
+        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true, false);
 
         // (6) Broker-2 should get the watch and update bundle cache
         final int retry = 5;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
@@ -249,7 +249,7 @@ public class NamespaceBundlesTest {
     }
 
     @Test
-    public void testSplitBundleByFixKey() throws Exception {
+    public void testSplitBundleByFixBoundary() throws Exception {
         NamespaceName nsname = NamespaceName.get("pulsar/global/ns1");
         NamespaceBundles bundles = factory.getBundles(nsname);
         NamespaceBundle bundleToSplit = bundles.getBundles().get(0);
@@ -265,10 +265,10 @@ public class NamespaceBundlesTest {
             //No-op
         }
 
-        Long fixKey = bundleToSplit.getLowerEndpoint() + 10;
-        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundleToSplit, 0, fixKey);
+        Long fixBoundary = bundleToSplit.getLowerEndpoint() + 10;
+        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundleToSplit, 0, fixBoundary);
         assertEquals(splitBundles.getRight().get(0).getLowerEndpoint(), bundleToSplit.getLowerEndpoint());
-        assertEquals(splitBundles.getRight().get(1).getLowerEndpoint().longValue(), bundleToSplit.getLowerEndpoint() + fixKey);
+        assertEquals(splitBundles.getRight().get(1).getLowerEndpoint().longValue(), bundleToSplit.getLowerEndpoint() + fixBoundary);
     }
 
     private void validateSplitBundlesRange(NamespaceBundle fullBundle, List<NamespaceBundle> splitBundles) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
@@ -182,7 +182,7 @@ public class NamespaceBundlesTest {
         NamespaceBundle bundle = bundles.findBundle(topicName);
         final int numberSplitBundles = 4;
         // (1) split in 4
-        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundle, numberSplitBundles);
+        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundle, numberSplitBundles, null);
         // existing_no_bundles(1) +
         // additional_new_split_bundle(4) -
         // parent_target_bundle(1)
@@ -225,7 +225,7 @@ public class NamespaceBundlesTest {
         NamespaceBundles bundles = factory.getBundles(nsname);
         NamespaceBundle bundle = bundles.findBundle(topicName);
         // (1) split : [0x00000000,0xffffffff] => [0x00000000_0x7fffffff,0x7fffffff_0xffffffff]
-        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundle, NO_BUNDLES);
+        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundle, NO_BUNDLES, null);
         assertNotNull(splitBundles);
         assertBundleDivideInTwo(bundle, splitBundles.getRight(), NO_BUNDLES);
 
@@ -248,6 +248,29 @@ public class NamespaceBundlesTest {
 
     }
 
+    @Test
+    public void testSplitBundleByFixKey() throws Exception {
+        NamespaceName nsname = NamespaceName.get("pulsar/global/ns1");
+        NamespaceBundles bundles = factory.getBundles(nsname);
+        NamespaceBundle bundleToSplit = bundles.getBundles().get(0);
+
+        try {
+            factory.splitBundles(bundleToSplit, 0, bundleToSplit.getLowerEndpoint());
+        } catch (IllegalArgumentException e) {
+            //No-op
+        }
+        try {
+            factory.splitBundles(bundleToSplit, 0, bundleToSplit.getUpperEndpoint());
+        } catch (IllegalArgumentException e) {
+            //No-op
+        }
+
+        Long fixKey = bundleToSplit.getLowerEndpoint() + 10;
+        Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundleToSplit, 0, fixKey);
+        assertEquals(splitBundles.getRight().get(0).getLowerEndpoint(), bundleToSplit.getLowerEndpoint());
+        assertEquals(splitBundles.getRight().get(1).getLowerEndpoint().longValue(), bundleToSplit.getLowerEndpoint() + fixKey);
+    }
+
     private void validateSplitBundlesRange(NamespaceBundle fullBundle, List<NamespaceBundle> splitBundles) {
         assertNotNull(fullBundle);
         assertNotNull(splitBundles);
@@ -267,7 +290,7 @@ public class NamespaceBundlesTest {
         bCacheField.setAccessible(true);
         ((AsyncLoadingCache<NamespaceName, NamespaceBundles>) bCacheField.get(utilityFactory)).put(nsname,
                 CompletableFuture.completedFuture(bundles));
-        return utilityFactory.splitBundles(targetBundle, numBundles);
+        return utilityFactory.splitBundles(targetBundle, numBundles, null);
     }
 
     private void assertBundles(NamespaceBundleFactory utilityFactory, NamespaceName nsname, NamespaceBundle bundle,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -61,6 +61,8 @@ public class ServiceConfigurationTest {
                 && config.getBrokerServicePort().get().equals(brokerServicePort));
         assertEquals(config.getBootstrapNamespaces().get(1), "ns2");
         assertEquals(config.getBrokerDeleteInactiveTopicsMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        assertEquals(config.getDefaultNamespaceBundleSplitAlgorithm(), "topic_count_equally_divide");
+        assertEquals(config.getSupportedNamespaceBundleSplitAlgorithms().size(), 1);
     }
 
     @Test

--- a/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
+++ b/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
@@ -86,3 +86,5 @@ replicationConnectionsPerBroker=16
 replicationProducerQueueSize=1000
 replicatorPrefix=pulsar.repl
 brokerDeleteInactiveTopicsMode=delete_when_subscriptions_caught_up
+supportedNamespaceBundleSplitAlgorithms=[range_equally_divide]
+defaultNamespaceBundleSplitAlgorithm=topic_count_equally_divide

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -929,7 +929,7 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles) throws PulsarAdminException;
+    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, boolean balanceTopicCount) throws PulsarAdminException;
 
     /**
      * Set message-publish-rate (topics under this namespace can publish this many messages per second)

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -929,7 +929,7 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, boolean balanceTopicCount) throws PulsarAdminException;
+    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, String splitAlgorithmName) throws PulsarAdminException;
 
     /**
      * Set message-publish-rate (topics under this namespace can publish this many messages per second)

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -526,13 +526,13 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, boolean balanceTopicCount)
+    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, String splitAlgorithmName)
             throws PulsarAdminException {
         try {
             NamespaceName ns = NamespaceName.get(namespace);
             WebTarget path = namespacePath(ns, bundle, "split");
             request(path.queryParam("unload", Boolean.toString(unloadSplitBundles))
-                    .queryParam("balanceTopicCount", Boolean.toString(balanceTopicCount)))
+                    .queryParam("splitAlgorithmName", splitAlgorithmName))
                     .put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -526,12 +526,13 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles)
+    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles, boolean balanceTopicCount)
             throws PulsarAdminException {
         try {
             NamespaceName ns = NamespaceName.get(namespace);
             WebTarget path = namespacePath(ns, bundle, "split");
-            request(path.queryParam("unload", Boolean.toString(unloadSplitBundles)))
+            request(path.queryParam("unload", Boolean.toString(unloadSplitBundles))
+                    .queryParam("balanceTopicCount", Boolean.toString(balanceTopicCount)))
                     .put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -309,7 +309,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff");
 
         namespaces.run(split("split-bundle myprop/clust/ns1 -b 0x00000000_0xffffffff"));
-        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false);
+        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false, false);
 
         namespaces.run(split("get-backlog-quotas myprop/clust/ns1"));
         verify(mockNamespaces).getBacklogQuotaMap("myprop/clust/ns1");

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -309,7 +309,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff");
 
         namespaces.run(split("split-bundle myprop/clust/ns1 -b 0x00000000_0xffffffff"));
-        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false, false);
+        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false, null);
 
         namespaces.run(split("get-backlog-quotas myprop/clust/ns1"));
         verify(mockNamespaces).getBacklogQuotaMap("myprop/clust/ns1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -513,14 +513,15 @@ public class CmdNamespaces extends CmdBase {
                 "-u" }, description = "Unload newly split bundles after splitting old bundle", required = false)
         private boolean unload;
 
-        @Parameter(names = { "--balance-topic-count",
-                "-btc" }, description = "Balance topic count for split bundles", required = false)
-        private boolean balanceTopicCount;
+        @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split namespace bundle.\n" +
+            " Valid options are: [range_equally_divide, topic_count_equally_divide].\n" +
+            " Default is range_equally_divide.", required = false)
+        private String splitAlgorithmName;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            admin.namespaces().splitNamespaceBundle(namespace, bundle, unload, balanceTopicCount);
+            admin.namespaces().splitNamespaceBundle(namespace, bundle, unload, splitAlgorithmName);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -515,7 +515,7 @@ public class CmdNamespaces extends CmdBase {
 
         @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split namespace bundle.\n" +
             " Valid options are: [range_equally_divide, topic_count_equally_divide].\n" +
-            " Default is range_equally_divide.", required = false)
+            " Use broker side config if absent", required = false)
         private String splitAlgorithmName;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -513,10 +513,14 @@ public class CmdNamespaces extends CmdBase {
                 "-u" }, description = "Unload newly split bundles after splitting old bundle", required = false)
         private boolean unload;
 
+        @Parameter(names = { "--balance-topic-count",
+                "-btc" }, description = "Balance topic count for split bundles", required = false)
+        private boolean balanceTopicCount;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            admin.namespaces().splitNamespaceBundle(namespace, bundle, unload);
+            admin.namespaces().splitNamespaceBundle(namespace, bundle, unload, balanceTopicCount);
         }
     }
 

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -225,6 +225,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |defaultRetentionSizeInMB|  Default retention size  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
+|supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|
+|defaultNamespaceBundleSplitAlgorithm| Default algorithm name for namespace bundle split |range_equally_divide|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||
 |managedLedgerOffloadMaxThreads|  Maximum number of thread pool threads for ledger offloading |2|
 |managedLedgerUnackedRangesOpenCacheSetEnabled|  Use Open Range-Set to cache unacknowledged messages |true|


### PR DESCRIPTION
### Motivation

Currently, bundle split splits the bundle into two parts of the same size. When there are fewer topics, bundle split does not work well. The topic assigned to the broker according to the topic name hash value, hashing is not effective in a small number of topics bundle split.

So, this PR introduces an option(-balance-topic-count) for bundle split.  When setting it to true, the given bundle splits to 2 parts, each part has the same amount of topics.

And introduce a new Load Manager implementation named `org.apache.pulsar.broker.loadbalance.impl.BalanceTopicCountModularLoadManager`.  The new Load Manager implementation splits bundle with balance topics count, others are not different from ModularLoadManagerImpl.

### Verifying this change

Test is coming

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
