### PR TITLE
Allow Symbolic Link to Bash Scripts

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -48,7 +48,7 @@ else
 fi
 
 BINDIR=`dirname "$0"`
-BK_HOME=`cd $BINDIR/..;pwd`
+BK_HOME=`cd -P $BINDIR/..;pwd`
 
 DEFAULT_CONF=$BK_HOME/conf/bookkeper.conf
 DEFAULT_LOG_CONF=$BK_HOME/conf/log4j2.yaml

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -19,7 +19,7 @@
 #
 
 BINDIR=$(dirname "$0")
-export PULSAR_HOME=`cd $BINDIR/..;pwd`
+export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 
 # functions related variables

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -19,7 +19,7 @@
 #
 
 BINDIR=$(dirname "$0")
-export PULSAR_HOME=`cd $BINDIR/..;pwd`
+export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 
 DEFAULT_BROKER_CONF=$PULSAR_HOME/conf/broker.conf
 DEFAULT_BOOKKEEPER_CONF=$PULSAR_HOME/conf/bookkeeper.conf

--- a/bin/pulsar-admin
+++ b/bin/pulsar-admin
@@ -19,7 +19,7 @@
 #
 
 BINDIR=$(dirname "$0")
-export PULSAR_HOME=`cd $BINDIR/..;pwd`
+export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 
 #Change to PULSAR_HOME to support relative paths

--- a/bin/pulsar-client
+++ b/bin/pulsar-client
@@ -19,7 +19,7 @@
 #
 
 BINDIR=$(dirname "$0")
-PULSAR_HOME=`cd $BINDIR/..;pwd`
+PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 
 DEFAULT_CLIENT_CONF=$PULSAR_HOME/conf/client.conf
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j2.yaml

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -38,7 +38,7 @@ EOF
 }
 
 BINDIR=$(dirname "$0")
-PULSAR_HOME=$(cd $BINDIR/..;pwd)
+PULSAR_HOME=$(cd -P $BINDIR/..;pwd)
 
 # Check bookkeeper env and load bkenv.sh
 if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -19,7 +19,7 @@
 #
 
 BINDIR=$(dirname "$0")
-PULSAR_HOME=`cd $BINDIR/..;pwd`
+PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 
 DEFAULT_CLIENT_CONF=${PULSAR_CLIENT_CONF:-"$PULSAR_HOME/conf/client.conf"}
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j2.yaml


### PR DESCRIPTION
### Motivation
If a symbolic link is used to access a Pulsar bash script in the bin directory the script may fail to work as the code that determines the working directory assumes the user is accessing the script from the physical path.

### Modifications
I have simply added the option "-P" to the "cd" command at the top of each bash script in the bin directory.  This instructs the change directory command to resolve the physical path so that relative paths are calculated properly.

### Verifying this change

I executed the scripts to confirm they still work if user's current working directory contains a symbolic link in it or not.  Specifically, a symbolic link in which the directory depth differs now works.   For example, if you have a symbolic link on your Desktop or a "latest" link that you can simply update to point to newest version of pulsar as it becomes available. 

This change should already by covered by existing tests assuming some tests execute the scripts.

### Does this pull request potentially affect one of the following parts:
Bash Scripts only, nothing else.

### Documentation
Not exactly a new feature and not exactly a bug fix.  Just scripts are more robust.
