### PR TITLE
[IO] updated aerospike-java-client version and fixed NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@ flexible messaging model and an intuitive client API.</description>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>
-    <aerospike-client.version>4.1.11</aerospike-client.version>
+    <aerospike-client.version>4.4.8</aerospike-client.version>
     <kafka-client.version>2.3.0</kafka-client.version>
     <rabbitmq-client.version>5.1.1</rabbitmq-client.version>
     <aws-sdk.version>1.11.297</aws-sdk.version>


### PR DESCRIPTION
### Motivation


You need to pass Eventloop to the client policy as at the time of creating the Cluster object, the constructor extracts Eventloop from the ClientPolicy. It was not being set previously which was causing NullPointerException in com.aerospike.client.async.NioCommand#NioCommand

### Modifications

Updated: 
 1) pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeAbstractSink.java
 2) Project's parent pom.xml for Aerospike Java Client version
### Documentation

  - Does this pull request introduce a new feature?: NO
