### PR TITLE
[C++] Fixed valgrind warnings in unit tests

### DIFF
--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -38,6 +38,7 @@
 #include <functional>
 #include <thread>
 #include <chrono>
+#include <cstring>
 
 DECLARE_LOG_OBJECT()
 
@@ -608,6 +609,7 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
 
     int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
+    memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
     ASSERT_EQ(ResultMessageTooBig, result);
@@ -1161,6 +1163,7 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
 
     int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
+    memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);
     ASSERT_EQ(ResultMessageTooBig, result);
@@ -1212,6 +1215,7 @@ TEST(BasicEndToEndTest, testBigMessageSizeBatching) {
 
     int size = Commands::DefaultMaxMessageSize + 1000 * 100;
     char *content = new char[size];
+    memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer1.send(msg);
     ASSERT_EQ(ResultMessageTooBig, result);

--- a/pulsar-client-cpp/tests/MessageTest.cc
+++ b/pulsar-client-cpp/tests/MessageTest.cc
@@ -47,8 +47,8 @@ TEST(MessageTest, testMessageContents) {
 TEST(MessageTest, testAllocatedContents) {
     MessageBuilder msgBuilder;
     std::string str = "content";
-    char* content = new char[str.size()];
-    strcpy(content, str.c_str());
+    char* content = new char[str.length() + 1];
+    strncpy(content, str.c_str(), str.length());
     msgBuilder.setAllocatedContent(content, str.length());
     Message msg = msgBuilder.build();
     ASSERT_FALSE(strncmp("content", (char*)msg.getData(), msg.getLength()));


### PR DESCRIPTION
### Motivation

There are few errors reported by valgrind during unit tests execution. These are not serious problem, just not initializing buffers in the test code itself, though they create noise while running valgrind and makes it more difficult to spot potential real issues.

