### PR TITLE
[C++] Fixed handling of canceled timer events on NegativeAcksTracker

### DIFF
--- a/pulsar-client-cpp/lib/NegativeAcksTracker.cc
+++ b/pulsar-client-cpp/lib/NegativeAcksTracker.cc
@@ -48,13 +48,13 @@ void NegativeAcksTracker::scheduleTimer() {
 }
 
 void NegativeAcksTracker::handleTimer(const boost::system::error_code &ec) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    timer_ = nullptr;
-
     if (ec) {
         // Ignore cancelled events
         return;
     }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    timer_ = nullptr;
 
     if (nackedMessages_.empty()) {
         return;


### PR DESCRIPTION
### Motivation

When handling a "timer cancelled" event, we cannot lock the mutex since the object itself might already be destroyed.

This causes potentially a memory corruption/segfault.