### PR TITLE
[broker] Fix bug that tenants whose allowed clusters include global cannot be created/updated

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -530,10 +530,9 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected Set<String> clusters() {
         try {
-            Set<String> clusters = pulsar().getConfigurationCache().clustersListCache().get();
-
             // Remove "global" cluster from returned list
-            clusters.remove(Constants.GLOBAL_CLUSTER);
+            Set<String> clusters = pulsar().getConfigurationCache().clustersListCache().get().stream()
+                    .filter(cluster -> !Constants.GLOBAL_CLUSTER.equals(cluster)).collect(Collectors.toSet());
             return clusters;
         } catch (Exception e) {
             throw new RestException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -84,10 +84,9 @@ public class ClustersBase extends AdminResource {
     })
     public Set<String> getClusters() throws Exception {
         try {
-            Set<String> clusters = clustersListCache().get();
-
             // Remove "global" cluster from returned list
-            clusters.remove(Constants.GLOBAL_CLUSTER);
+            Set<String> clusters = clustersListCache().get().stream()
+                    .filter(cluster -> !Constants.GLOBAL_CLUSTER.equals(cluster)).collect(Collectors.toSet());
             return clusters;
         } catch (Exception e) {
             log.error("[{}] Failed to get clusters list", clientAppId(), e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -623,9 +623,14 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
                 new ClusterData("http://broker.messaging.east2.example.com:8080"));
         admin.clusters().createCluster("global", new ClusterData());
 
+        List<String> allClusters = admin.clusters().getClusters();
+        Collections.sort(allClusters);
+        assertEquals(allClusters,
+                Lists.newArrayList("test", "us-east1", "us-east2", "us-west1", "us-west2", "us-west3", "us-west4"));
+
         final String property = "peer-prop";
         Set<String> allowedClusters = Sets.newHashSet("us-west1", "us-west2", "us-west3", "us-west4", "us-east1",
-                "us-east2");
+                "us-east2", "global");
         TenantInfo propConfig = new TenantInfo(Sets.newHashSet("test"), allowedClusters);
         admin.tenants().createTenant(property, propConfig);
 


### PR DESCRIPTION
### Motivation

If the allowed clusters include `global`, tenant creation and update will fail with the following error:

```sh
$ pulsar-admin tenants create -r xxx.xxx.xxx -c global,dev1,dev2 sample-tenant

Clusters do not exist

Reason: Clusters do not exist
```

However, there is actually the `global` cluster in ZK.
```sh
[zk: localhost:2184(CONNECTED) 14] ls /admin/clusters

[dev1, dev2, global]
```

As a result of the investigation, I found that `global` was removed from the cluster list in the configuration store cache after getting the list of clusters by the REST API. This is due to the following:
https://github.com/apache/pulsar/blob/e1357a7d1ae6a51dfa742986a4a2afe33beb0256/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java#L87-L91
`global` is removed from the `clusters` variable, which seems to be not a deep copy but a shallow copy.

### Modifications

When getting the list of clusters from the configuration store and deleting `global` from it, create a new `Set` instance using stream API.

```java
Set<String> clusters = clustersListCache().get().stream()
        .filter(cluster -> !Constants.GLOBAL_CLUSTER.equals(cluster)).collect(Collectors.toSet());
```

In addition, allow `global` to be included in allowed clusters when creating and updating tenants, even if the `global` cluster does not exist in the list of clusters stored in ZK. Even if the `global` cluster is not registered in ZK, global topics will work fine.