### PR TITLE
[Issue 4070][pulsar-client-cpp] Fix for possible deadlock when closing Pulsar client

### DIFF
--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -59,11 +59,12 @@ DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
 }
 
 void ExecutorService::close() {
-    // Ensure this service has not already been closed. This is
-    // because worker_.join() is not re-entrant on Windows
-    if (work_) {
-        io_service_->stop();
-        work_.reset();
+    io_service_->stop();
+    work_.reset();
+    // If this thread is attempting to join itself, do not. The destructor's
+    // call to close will handle joining if it does not occur here. This also ensures
+    // join is not called twice since it is not re-entrant on windows
+    if (std::this_thread::get_id() != worker_.get_id() && worker_.joinable()) {
         worker_.join();
     }
 }

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -29,7 +29,14 @@ ExecutorService::ExecutorService()
       work_(new BackgroundWork(*io_service_)),
       worker_(std::bind(&ExecutorService::startWorker, this, io_service_)) {}
 
-ExecutorService::~ExecutorService() { close(); }
+ExecutorService::~ExecutorService() {
+    close();
+    // If the worker_ is still not joinable at this point just detach
+    // the thread so its destructor does not terminate the app
+    if (worker_.joinable()) {
+        worker_.detach();
+    }
+}
 
 void ExecutorService::startWorker(std::shared_ptr<boost::asio::io_service> io_service) { io_service_->run(); }
 

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -70,7 +70,7 @@ class PULSAR_PUBLIC ExecutorService : private boost::noncopyable {
      * background invoking async handlers as they are finished and result is available from
      * io_service
      */
-    boost::asio::detail::thread worker_;
+    std::thread worker_;
 };
 
 typedef std::shared_ptr<ExecutorService> ExecutorServicePtr;

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -40,9 +40,8 @@ OpSendMsg::OpSendMsg(uint64_t producerId, uint64_t sequenceId, const Message& ms
       timeout_(TimeUtils::now() + milliseconds(conf.getSendTimeout())) {}
 
 ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const ProducerConfiguration& conf)
-    : HandlerBase(
-          client, topic,
-          Backoff(milliseconds(100), seconds(60), milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
+    : HandlerBase(client, topic, Backoff(milliseconds(100), seconds(60),
+                                         milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
       conf_(conf),
       executor_(client->getIOExecutorProvider()->get()),
       pendingMessagesQueue_(conf_.getMaxPendingMessages()),

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -40,8 +40,9 @@ OpSendMsg::OpSendMsg(uint64_t producerId, uint64_t sequenceId, const Message& ms
       timeout_(TimeUtils::now() + milliseconds(conf.getSendTimeout())) {}
 
 ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const ProducerConfiguration& conf)
-    : HandlerBase(client, topic, Backoff(milliseconds(100), seconds(60),
-                                         milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
+    : HandlerBase(
+          client, topic,
+          Backoff(milliseconds(100), seconds(60), milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
       conf_(conf),
       executor_(client->getIOExecutorProvider()->get()),
       pendingMessagesQueue_(conf_.getMaxPendingMessages()),


### PR DESCRIPTION
Fixes #4070

### Motivation

This change is to fix a possible deadlock that can occur when closing the Pulsar client that is caused by the ExecutorService worker thread attempting to join itself.

### Modifications

The close() method on the ExecutorService will now not join the worker_ thread if its thread id is the same as the calling thread. The type of worker_ was changed to std::thread to allow for the check since the thread id is not exposed by boost::asio::detail::thread.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no 
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
