### PR TITLE
[pulsar-client-cpp] Fix for crash in Producer destructor

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -101,8 +101,6 @@ class ProducerImpl : public HandlerBase,
     virtual void flushAsync(FlushCallback callback);
 
    protected:
-    ProducerStatsBasePtr producerStatsBasePtr_;
-
     typedef BlockingQueue<OpSendMsg> MessageQueue;
 
     void setMessageMetadata(const Message& msg, const uint64_t& sequenceId, const uint32_t& uncompressedSize);
@@ -172,6 +170,11 @@ class ProducerImpl : public HandlerBase,
     DeadlineTimerPtr dataKeyGenTImer_;
     uint32_t dataKeyGenIntervalSec_;
     std::shared_ptr<Promise<Result, bool_type>> flushPromise_;
+
+   protected:
+    // the producerStatsBasePtr_ must be declared after the ExecutorService to ensure it is destroyed
+    // before the service. This is because its destructor interacts with the executor service
+    ProducerStatsBasePtr producerStatsBasePtr_;
 };
 
 struct ProducerImplCmp {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

This change fixes a crash I encountered when the destructor of the Producer is called.

### Modifications

The ProducerStatsBasePtr is now declared in the header after the ExecutorServicePtr to ensure that it is destroyed before the ExecutorService. This is because the destructor of ProducerStatsImpl will attempt to cancel its outstanding DeadlineTimer which will then dereference the now destroyed ExecutorService and cause an exception.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no