### PR TITLE
[deployment][helm] Add Grafana ingress template

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/grafana-ingress.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/grafana-ingress.yaml
@@ -17,9 +17,10 @@
 # under the License.
 #
 
-  {{- if .Values.extra.monitoring }}
-apiVersion: v1
-kind: Service
+  {{- if .Values.extra.monitoring}}
+  {{- if .Values.grafana.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
   namespace: {{ .Values.namespace }}
@@ -28,17 +29,22 @@ metadata:
     chart: {{ template "pulsar.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ .Values.grafana.component }}
-    cluster: {{ template "pulsar.fullname" . }}
+{{- with .Values.grafana.ingress.annotations }}
   annotations:
-  {{ toYaml .Values.grafana.service.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
-  ports:
-  {{ toYaml .Values.grafana.service.ports | indent 2 }}
-  selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.grafana.component }}
-  type: ClusterIP
-  sessionAffinity: None
+{{- if .Values.grafana.ingress.tls }}
+  tls:
+{{ toYaml .Values.grafana.ingress.tls | indent 4 }}
+{{- end }}
+  rules:
+    - host: {{ required "Grafana ingress hostname not provided" .Values.grafana.ingress.hostname }}
+      http:
+        paths:
+        - path: {{ .Values.grafana.ingress.path }}
+          backend:
+            serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
+            servicePort: {{ .Values.grafana.ingress.port }}
+  {{- end }}
   {{- end }}

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -445,6 +445,31 @@ grafana:
     ports:
     - name: server
       port: 3000
+  plugins: []
+  ## Grafana ingress
+  ## templates/grafana-ingress.yaml
+  ##
+  ingress:
+    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # ingress.kubernetes.io/force-ssl-redirect: "true"
+      ingress.kubernetes.io/rewrite-target: /
+    labels: {}
+
+    tls: []
+
+    ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
+    #- secretName: ""
+
+    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    ## Required if ingress is enabled
+    hostname: ""
+    protocol: http
+    path: /grafana
+    port: 80
 
 zookeeper_metadata:
   resources:

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -446,6 +446,31 @@ grafana:
     ports:
     - name: server
       port: 3000
+  plugins: []
+  ## Grafana ingress
+  ## templates/grafana-ingress.yaml
+  ##
+  ingress:
+    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # ingress.kubernetes.io/force-ssl-redirect: "true"
+      ingress.kubernetes.io/rewrite-target: /
+    labels: {}
+
+    tls: []
+
+    ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
+    #- secretName: ""
+
+    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    ## Required if ingress is enabled
+    hostname: ""
+    protocol: http
+    path: /grafana
+    port: 80
 
 ## Components Stack: pulsar_manager
 ## templates/pulsar-manager.yaml


### PR DESCRIPTION
### Motivation
Exposing Grafana via soft ingress controller so that it can be exposed through a Load Balancer. 

#### Proposed solution:
Create ingress template for Grafana so that it can be automatically picked up if ingress controller instance is running in the cluster. The other solutions are to expose Grafana as NodePort or setting it as a LoadBalancer.

### Modifications
Added `grafana-ingress.yaml` template in the templates and an `ingress` section for Grafana in the values file.

### Verifying this change
1) Set ingress to `true` for Grafana in values file and provide hostname. Currently tested with NGINX, but can use another ingress controller, but will need to change the ingress controller class to another one in the template.

2) Add NGINX Helm repository :

```bash
helm repo add nginx-stable https://helm.nginx.com/stable
helm repo update
```
3) Install with Helm 3:

```bash
helm install nginix-ingress-crl nginx-stable/nginx-ingress
```

4) Follow the instructions on how deploying helm and run:
`helm install pulsar --values pulsar/values-mini.yaml ./pulsar/`. 

5) Wait until all the services are up and running.

6) Verify that Grafana is accessible via url.


**Path settings**

Currently, by default the path setting is set to `/grafana`. For that to work, the NGINX configuration file `nginx.conf` should have `grafana` sub path enabled:
```    
See https://grafana.com/docs/grafana/latest/installation/behind_proxy/

To avoid having to mess with NGINX configurations files `path` can be changed to `/`, but this path might conflict with other services that are being proxied in the cluster.

#### Modules affected:
The changes in the PR are affecting the deployment using the helm charts. Now the if the flag `functionsAsPods` is set to `yes` inside the `values.yaml. file, the functions would run as pods.

### Documentation
This PR will be adding ingress capability for Grafana and this should be documented.