### PR TITLE
[Issue 6292] [apply-config-from-env.py] Fix the script when settings are already present

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -68,6 +68,9 @@ for conf_filename in conf_files:
         if k not in keys:
             print('[%s] Adding config %s = %s' % (conf_filename, k, v))
             lines.append('%s=%s\n' % (k, v))
+        else:
+            print('[%s] Updating config %s = %s' %(conf_filename, k, v))
+            lines[keys[k]] = '%s=%s\n' % (k, v)
 
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
Fixes #6292 

### Motivation

As is detailed in the issue, the script is not working properly when the settings are already present in the configuration file. 

### Modifications

I added an _else_ branch in an existent _if_ that changes the elements of the _lines_ array with existent settings.


### Verifying this change

- [X ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes

### Documentation

  - Does this pull request introduce a new feature? no
