### PR TITLE
[C++] Improve LatchTest.testTimedWait timing

### DIFF
--- a/pulsar-client-cpp/tests/LatchTest.cc
+++ b/pulsar-client-cpp/tests/LatchTest.cc
@@ -66,19 +66,19 @@ TEST(LatchTest, testLatchCount) {
 }
 
 TEST(LatchTest, testTimedWait) {
-    // Wait for 7 seconds which is more than the maximum sleep time (5 seconds)
+    // Wait for at most 3 seconds which is more than the maximum sleep time (50 millis)
     Latch latch1(3);
     Service service1("service1", std::chrono::milliseconds(50), latch1);
     Service service2("service2", std::chrono::milliseconds(30), latch1);
     Service service3("service3", std::chrono::milliseconds(50), latch1);
-    ASSERT_TRUE(latch1.wait(std::chrono::milliseconds(70)));
+    ASSERT_TRUE(latch1.wait(std::chrono::seconds(3)));
 
-    // Wait for 3 seconds which is less than the maximum sleep time (5 seconds)
+    // Wait for up to 300 millis which is less than the maximum sleep time (500 millis)
     Latch latch2(3);
-    Service service4("service4", std::chrono::milliseconds(50), latch2);
-    Service service5("service5", std::chrono::milliseconds(30), latch2);
-    Service service6("service6", std::chrono::milliseconds(50), latch2);
-    ASSERT_FALSE(latch2.wait(std::chrono::milliseconds(30)));
+    Service service4("service4", std::chrono::milliseconds(500), latch2);
+    Service service5("service5", std::chrono::milliseconds(300), latch2);
+    Service service6("service6", std::chrono::milliseconds(500), latch2);
+    ASSERT_FALSE(latch2.wait(std::chrono::milliseconds(300)));
 
     // After the assert is passed and Service is destroyed because of join, the
     // main thread would not exit until service4 thread is returned.


### PR DESCRIPTION
### Motivation

Fixes #630 

The timing on the test is way too tight, if there's a ~20millis delay, the test is failing.

```
 RUN      ] LatchTest.testTimedWait
2019-12-27 07:03:51.132 INFO  LatchTest:43 | Service service2 is up
2019-12-27 07:03:51.144 INFO  LatchTest:43 | Service service1 is up
/pulsar/pulsar-client-cpp/tests/LatchTest.cc:74: Failure
Value of: latch1.wait(std::chrono::milliseconds(70))
 Actual: false
 Expected: true
2019-12-27 07:03:51.160 INFO  LatchTest:43 | Service service3 is up
[  FAILED  ] LatchTest.testTimedWait (78 ms)
[----------] 1 test from LatchTest (78 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (78 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] LatchTest.testTimedWait
 1 FAILED TEST
```