### PR TITLE
[Issue 4612][proxy] Fix proxy to forward V3 API request to functions worker cluster

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -260,8 +260,13 @@ class AdminProxyHandler extends ProxyServlet {
 
         boolean isFunctionsRestRequest = false;
         String requestUri = request.getRequestURI();
-        if (requestUri.startsWith("/admin/v2/functions")
-            || requestUri.startsWith("/admin/functions")) {
+        // Functions workers handle function, sources, and sinks endpoints
+        if (requestUri.startsWith("/admin/v3/functions")
+                || requestUri.startsWith("/admin/v2/functions")
+                || requestUri.startsWith("/admin/functions")
+                || requestUri.startsWith("/admin/v3/sources")
+                || requestUri.startsWith("/admin/v3/sinks")
+        ) {
             isFunctionsRestRequest = true;
         }
 


### PR DESCRIPTION
Fixes #4612

### Motivation

When running function workers separate from the broker, the proxy is supposed to forward function REST commands to the function worker(s), not the broker(s). This does not work since the function API is v3, but the proxy only works on v2 version of the API. This PR fixes that. It also forwards v3 sink and source command since those are served by the function worker(s) when running separately from the broker.


### Modifications

Simple change to include extra V3 paths in the check for which endpoints to forward to the function worker.

### Verifying this change

I have been running with this fix in multiple Pulsar setups with independent function workers for a while now. The proxy now forwards the V3 REST calls.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)

