### PR TITLE
[hotfix] Remove problematic semicolon from conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -533,7 +533,7 @@ bookkeeperDiskWeightBasedPlacementEnabled=false
 
 # Set the interval to check the need for sending an explicit LAC
 # A value of '0' disables sending any explicit LACs. Default is 0.
-bookkeeperExplicitLacIntervalInMills=0;
+bookkeeperExplicitLacIntervalInMills=0
 
 ### --- Managed Ledger --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -336,7 +336,7 @@ bookkeeperDiskWeightBasedPlacementEnabled=false
 
 # Set the interval to check the need for sending an explicit LAC
 # A value of '0' disables sending any explicit LACs. Default is 0.
-bookkeeperExplicitLacIntervalInMills=0;
+bookkeeperExplicitLacIntervalInMills=0
 
 ### --- Managed Ledger --- ###
 


### PR DESCRIPTION

### Motivation

When trying to run pulsar standalone on my machine I encountered this error. 
```
[AppClassLoader@3b192d32] info AspectJ Weaver Version 1.9.2 built on Wednesday Oct 24, 2018 at 15:43:33 GMT
[AppClassLoader@3b192d32] info register classloader jdk.internal.loader.ClassLoaders$AppClassLoader@3b192d32
[AppClassLoader@3b192d32] info using configuration file:/Users/kailevy/toast/git-repos/pulsar/pulsar-zookeeper/target/pulsar-zookeeper.jar!/META-INF/aop.xml
[AppClassLoader@3b192d32] info using configuration file:/Users/kailevy/toast/git-repos/pulsar/pulsar-zookeeper-utils/target/pulsar-zookeeper-utils.jar!/META-INF/aop.xml
[AppClassLoader@3b192d32] info register aspect org.apache.pulsar.zookeeper.FinalRequestProcessorAspect
[AppClassLoader@3b192d32] info register aspect org.apache.pulsar.zookeeper.ZooKeeperServerAspect
[AppClassLoader@3b192d32] info register aspect org.apache.pulsar.broker.zookeeper.aspectj.ClientCnxnAspect
Warning: Nashorn engine is planned to be removed from a future JDK release
Exception in thread "main" java.lang.IllegalArgumentException: failed to initialize bookkeeperExplicitLacIntervalInMills field while setting value 0;
	at org.apache.pulsar.common.util.FieldParser.lambda$update$0(FieldParser.java:146)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.apache.pulsar.common.util.FieldParser.update(FieldParser.java:135)
	at org.apache.pulsar.common.configuration.PulsarConfigurationLoader.create(PulsarConfigurationLoader.java:97)
	at org.apache.pulsar.common.configuration.PulsarConfigurationLoader.create(PulsarConfigurationLoader.java:74)
	at org.apache.pulsar.PulsarStandaloneStarter.<init>(PulsarStandaloneStarter.java:60)
	at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:117)
Caused by: java.lang.RuntimeException: Cannot convert from java.lang.String to java.lang.Integer. Conversion failed with null
	at org.apache.pulsar.common.util.FieldParser.convert(FieldParser.java:119)
	at org.apache.pulsar.common.util.FieldParser.value(FieldParser.java:190)
	at org.apache.pulsar.common.util.FieldParser.lambda$update$0(FieldParser.java:141)
	... 7 more
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.pulsar.common.util.FieldParser.convert(FieldParser.java:115)
	... 9 more
Caused by: java.lang.NumberFormatException: For input string: "0;"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.valueOf(Integer.java:983)
	at org.apache.pulsar.common.util.FieldParser.stringToInteger(FieldParser.java:262)
	... 13 more
```

Looks to be a typo introduced in the config recently. 

### Modifications

This change simply removes the offending semicolon from the default configs.
