### PR TITLE
Fixed casting in ZooKeeperCache.getDataIfPresent()

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
@@ -458,7 +459,12 @@ public abstract class ZooKeeperCache implements Watcher {
 
     @SuppressWarnings("unchecked")
     public <T> T getDataIfPresent(String path) {
-        return (T) dataCache.getIfPresent(path);
+        CompletableFuture<Map.Entry<Object, Stat>> f = dataCache.getIfPresent(path);
+        if (f.isDone() && !f.isCompletedExceptionally()) {
+            return (T) f.join().getKey();
+        } else {
+            return null;
+        }
     }
 
     public Set<String> getChildrenIfPresent(String path) {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -460,7 +460,7 @@ public abstract class ZooKeeperCache implements Watcher {
     @SuppressWarnings("unchecked")
     public <T> T getDataIfPresent(String path) {
         CompletableFuture<Map.Entry<Object, Stat>> f = dataCache.getIfPresent(path);
-        if (f.isDone() && !f.isCompletedExceptionally()) {
+        if (f != null && f.isDone() && !f.isCompletedExceptionally()) {
             return (T) f.join().getKey();
         } else {
             return null;

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -109,6 +109,7 @@ public class ZookeeperCacheTest {
         zkClient.create("/my_test", value.getBytes(), null, null);
 
         assertEquals(zkCache.get("/my_test").get(), value);
+        assertEquals(zkCache.getDataIfPresent("/my_test"), value);
 
         String newValue = "test2";
 
@@ -501,11 +502,11 @@ public class ZookeeperCacheTest {
         assertEquals(zkCache.getAsync(key1).get().get(), value);
         zkExecutor.shutdown();
     }
-    
+
     /**
      * This tests verifies that {{@link ZooKeeperDataCache} invalidates the cache if the get-operation time-out on that
      * path.
-     * 
+     *
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
### Motivation

There was a casting error in `ZooKeeperCache.getDataIfPresent()` which is being called when checking the policies for the publish rate limiter. 

This result in the rate limiter to not get applied. The error printed is:

`10:07:50.378 [bookkeeper-ml-workers-OrderedExecutor-1-0] WARN org.apache.pulsar.broker.service.AbstractTopic - [persistent://public/default/testDelayedMessages-1581070070308] Error getting policies java.util.concurrent.CompletableFuture cannot be cast to org.apache.pulsar.common.policies.data.Policies and publish throttling will be disabled
`