### PR TITLE
[Issue 6314][Helm] Pulsar Manager do not work if Pulsar authentication is enabled

### DIFF
--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-configmap.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-configmap.yaml
@@ -17,28 +17,17 @@
 # under the License.
 #
 
-{{- if .Values.extra.monitoring }}
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ template "pulsar.name" . }}
     chart: {{ template "pulsar.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ .Values.grafana.component }}
+    component: {{ .Values.pulsar_manager.component }}
     cluster: {{ template "pulsar.fullname" . }}
-  annotations:
-{{ toYaml .Values.grafana.service.annotations | indent 4 }}
-spec:
-  ports:
-{{ toYaml .Values.grafana.service.ports | indent 2 }}
-  selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.grafana.component }}
-  type: ClusterIP
-  sessionAffinity: None
-{{- end }}
+data:
+{{ toYaml .Values.pulsar_manager.configData | indent 2 }}

--- a/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/pulsar-manager-deployment.yaml
@@ -69,18 +69,12 @@ spec:
           volumeMounts:
           - name: pulsar-manager-data
             mountPath: /data
+          envFrom:
+          - configMapRef:
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           env:
-          # for supporting apachepulsar/pulsar-manager
           - name: PULSAR_CLUSTER
             value: {{ template "pulsar.fullname" . }}
-          - name: REDIRECT_HOST
-            value: http://127.0.0.1
-          - name: REDIRECT_PORT
-            value: "9527"
-          - name: DRIVER_CLASS_NAME
-            value: org.postgresql.Driver
-          - name: URL
-            value: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
           - name: USERNAME
             valueFrom:
               secretKeyRef:
@@ -91,8 +85,6 @@ spec:
               secretKeyRef:
                 key: PULSAR_MANAGER_ADMIN_PASSWORD
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
-          - name: LOG_LEVEL
-            value: DEBUG
       volumes:
         - name: pulsar-manager-data
           emptyDir: {}

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -497,6 +497,15 @@ pulsar_manager:
     requests:
       memory: 250Mi
       cpu: 0.1
+  configData:
+    REDIRECT_HOST: "http://127.0.0.1"
+    REDIRECT_PORT: "9527"
+    DRIVER_CLASS_NAME: org.postgresql.Driver
+    URL: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
+    LOG_LEVEL: DEBUG
+    ## If you enabled authentication support
+    #JWT_TOKEN: <token>
+    #SECRET_KEY: data:base64,<secret key>
   ## Pulsar manager service
   ## templates/pulsar-manager-service.yaml
   ##

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -493,6 +493,15 @@ pulsar_manager:
     requests:
       memory: 250Mi
       cpu: 0.1
+  configData:
+    REDIRECT_HOST: "http://127.0.0.1"
+    REDIRECT_PORT: "9527"
+    DRIVER_CLASS_NAME: org.postgresql.Driver
+    URL: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
+    LOG_LEVEL: DEBUG
+    ## If you enabled authentication support
+    #JWT_TOKEN: <token>
+    #SECRET_KEY: data:base64,<secret key>
   ## Pulsar manager service
   ## templates/pulsar-manager-service.yaml
   ##


### PR DESCRIPTION
Fixes ##6314

### Motivation

Pulsar Manager do not work if Pulsar authentication is enabled.

### Modifications

pulsar-manager-configmap.yaml was created in order to allow configuration of the enviroment properties in values.yaml

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies: no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
