### PR TITLE
[Issue 6312][docs] Fix typo: replace property `ack` with `acks` in docs for the Kafka sink

### DIFF
--- a/site2/docs/io-kafka-sink.md
+++ b/site2/docs/io-kafka-sink.md
@@ -18,7 +18,7 @@ The configuration of the Kafka sink connector has the following parameters.
 | Name | Type| Required | Default | Description 
 |------|----------|---------|-------------|-------------|
 |  `bootstrapServers` |String| true | " " (empty string) | A comma-separated list of host and port pairs for establishing the initial connection to the Kafka cluster. |
-|`ack`|String|true|" " (empty string) |The number of acknowledgments that the producer requires the leader to receive before a request completes. <br/>This controls the durability of the sent records.
+|`acks`|String|true|" " (empty string) |The number of acknowledgments that the producer requires the leader to receive before a request completes. <br/>This controls the durability of the sent records.
 |`batchsize`|long|false|16384L|The batch size that a Kafka producer attempts to batch records together before sending them to brokers.
 |`maxRequestSize`|long|false|1048576L|The maximum size of a Kafka request in bytes.
 |`topic`|String|true|" " (empty string) |The Kafka topic which receives messages from Pulsar.

--- a/site2/website/versioned_docs/version-2.5.0/io-kafka-sink.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-kafka-sink.md
@@ -19,7 +19,7 @@ The configuration of the Kafka sink connector has the following parameters.
 | Name | Type| Required | Default | Description 
 |------|----------|---------|-------------|-------------|
 |  `bootstrapServers` |String| true | " " (empty string) | A comma-separated list of host and port pairs for establishing the initial connection to the Kafka cluster. |
-|`ack`|String|true|" " (empty string) |The number of acknowledgments that the producer requires the leader to receive before a request completes. <br/>This controls the durability of the sent records.
+|`acks`|String|true|" " (empty string) |The number of acknowledgments that the producer requires the leader to receive before a request completes. <br/>This controls the durability of the sent records.
 |`batchsize`|long|false|16384L|The batch size that a Kafka producer attempts to batch records together before sending them to brokers.
 |`maxRequestSize`|long|false|1048576L|The maximum size of a Kafka request in bytes.
 |`topic`|String|true|" " (empty string) |The Kafka topic which receives messages from Pulsar.


### PR DESCRIPTION
Fixes #6312 

### Motivation
The docs for the Kafka sink have a typo in one of the property names: `ack` should be `acks`

### Modifications
- Fixed the above typo in the unversioned docs
- Fixed the above typo in the versioned docs

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (*no*)
  - The public API: (*no*, but it does change the documentation for it)
  - The schema: (*no*)
  - The default values of configurations: (*no*)
  - The wire protocol: (*no*)
  - The rest endpoints: (*no*)
  - The admin cli options: (*no*)
  - Anything that affects deployment: (*no*)

### Documentation

  - Does this pull request introduce a new feature? (*no*)
  - If yes, how is the feature documented? (*not applicable*)
  - If a feature is not applicable for documentation, explain why? (*not applicable*)
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (*not applicable*)
