### PR TITLE
[CI] Use PULSARBOT_TOKEN in pulsarbot ci job

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -35,5 +35,5 @@ jobs:
       - name: Execute pulsarbot command
         id:   pulsarbot
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master


### PR DESCRIPTION
*Motivation*

`PULSARBOT_TOKEN` is configured in apache/pulsar to trigger re-running CI checks.
