### PR TITLE
Upgrade ZooKeeper to 3.5.7

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -497,7 +497,7 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-core-3.4.1.jar
     - io.vertx-vertx-web-3.4.1.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-jute-3.5.6.jar
+    - org.apache.zookeeper-zookeeper-jute-3.5.7.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.19</commons-compress.version>
 
     <bookkeeper.version>4.10.0</bookkeeper.version>
-    <zookeeper.version>3.5.6</zookeeper.version>
+    <zookeeper.version>3.5.7</zookeeper.version>
     <netty.version>4.1.43.Final</netty.version>
     <netty-tc-native.version>2.0.26.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -449,8 +448,8 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
   * Apache Zookeeper
-    - zookeeper-3.5.6.jar
-    - zookeeper-jute-3.5.6.jar 
+    - zookeeper-3.5.7.jar
+    - zookeeper-jute-3.5.7.jar
   * Apache Yetus Audience Annotations
     - audience-annotations-0.5.0.jar
   * Swagger


### PR DESCRIPTION
### Motivation

Upgrade ZK to latest stable version. In particular we need to include: 
 * Split brain on log disk full https://issues.apache.org/jira/browse/ZOOKEEPER-3701
 * Data loss after upgrading standalone ZK server 3.4.14 to 3.5.6 with snapshot.trust.empty=true https://issues.apache.org/jira/browse/ZOOKEEPER-3644
