### PR TITLE
[Issue 6317][function] remove future.join() from PulsarSinkEffectivelyOnceProcessor

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -234,7 +234,6 @@ public class PulsarSink<T> implements Sink<T> {
             CompletableFuture<MessageId> future = msg.sendAsync();
 
             future.thenAccept(messageId -> record.ack()).exceptionally(getPublishErrorHandler(record, true));
-            future.join();
         }
     }
 


### PR DESCRIPTION
Fixes #6317 

### Motivation
Remove unnecessary wait to improve the throughput with EFFECTIVELY_ONCE processing guarantee.

### Modifications

- remove the `future.join` from the `PulsarSinkEffectivelyOnceProcessor`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
