### PR TITLE
Add retry when using async method to perform request in AsyncHttpConnector

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -120,48 +120,25 @@ public class AsyncHttpConnector implements Connector {
     }
 
     public ClientResponse apply(ClientRequest jerseyRequest) {
+        final CompletableFuture<ClientResponse> resp = new CompletableFuture<>();
 
-        CompletableFuture<ClientResponse> future = new CompletableFuture<>();
-        long startTime = System.currentTimeMillis();
-        Throwable lastException = null;
-        Set<InetSocketAddress> triedAddresses = new HashSet<>();
-
-        while (true) {
-            InetSocketAddress address = serviceNameResolver.resolveHost();
-            if (triedAddresses.contains(address)) {
-                // We already tried all available addresses
-                throw new ProcessingException((lastException.getMessage()), lastException);
+        apply(jerseyRequest, new AsyncConnectorCallback() {
+            @Override
+            public void response(ClientResponse clientResponse) {
+                resp.complete(clientResponse);
             }
 
-            triedAddresses.add(address);
-            URI requestUri = replaceWithNew(address, jerseyRequest.getUri());
-            jerseyRequest.setUri(requestUri);
-            CompletableFuture<ClientResponse> tempFuture = new CompletableFuture<>();
-            try {
-                resolveRequest(tempFuture, jerseyRequest);
-                if (System.currentTimeMillis() - startTime > httpClient.getConfig().getRequestTimeout()) {
-                    throw new ProcessingException(
-                        "Request timeout, the last try service url is : " + jerseyRequest.getUri().toString());
-                }
-            } catch (ExecutionException ex) {
-                Throwable e = ex.getCause() == null ? ex : ex.getCause();
-                if (System.currentTimeMillis() - startTime > httpClient.getConfig().getRequestTimeout()) {
-                    throw new ProcessingException((e.getMessage()), e);
-                }
-                lastException = e;
-                continue;
-            } catch (Exception e) {
-                if (System.currentTimeMillis() - startTime > httpClient.getConfig().getRequestTimeout()) {
-                    throw new ProcessingException(e.getMessage(), e);
-                }
-                lastException = e;
-                continue;
+            @Override
+            public void failure(Throwable throwable) {
+                resp.completeExceptionally(throwable);
             }
-            future = tempFuture;
-            break;
+        });
+
+        try {
+            return resp.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new ProcessingException(e);
         }
-
-        return future.join();
     }
 
     private URI replaceWithNew(InetSocketAddress address, URI uri) {
@@ -176,39 +153,83 @@ public class AsyncHttpConnector implements Connector {
         return URI.create(newUri);
     }
 
+    @Override
+    public Future<?> apply(ClientRequest jerseyRequest, AsyncConnectorCallback callback) {
+        final CompletableFuture<ClientResponse> resp = new CompletableFuture<>();
 
 
-    private void resolveRequest(CompletableFuture<ClientResponse> future,
-                                ClientRequest jerseyRequest)
-        throws InterruptedException, ExecutionException, TimeoutException {
-        Future<?> resultFuture = apply(jerseyRequest, new AsyncConnectorCallback() {
-            @Override
-            public void response(ClientResponse response) {
-                future.complete(response);
+        CompletableFuture.runAsync(() -> {
+            long startTime = System.currentTimeMillis();
+            Set<InetSocketAddress> triedAddresses = new HashSet<>();
+
+            while (true) {
+                InetSocketAddress address = serviceNameResolver.resolveHost();
+                if (triedAddresses.contains(address)) {
+                    Exception e = new ProcessingException("All addresses are tried and failed");
+                    callback.failure(e);
+                    resp.completeExceptionally(e);
+                    return;
+                }
+                triedAddresses.add(address);
+
+                URI requestUri = replaceWithNew(address, jerseyRequest.getUri());
+                ClientRequest tmpRequest = new ClientRequest(jerseyRequest);
+                tmpRequest.setUri(requestUri);
+
+                try {
+                    ClientResponse response = doRequest(tmpRequest);
+                    callback.response(response);
+                    resp.complete(response);
+                    log.info("Using url [{}] to perform the request was succeed", address.toString());
+                    return;
+                } catch (Exception e) {
+                    Throwable err = e.getCause() == null ? e : e.getCause();
+                    if (httpClient.getConfig().getRequestTimeout() > 0 &&
+                        System.currentTimeMillis() - startTime > httpClient.getConfig().getRequestTimeout()) {
+                        Exception timeoutException = new Exception(
+                            String.format("Request timeout, the last try service url is : %s",
+                                jerseyRequest.getUri().toASCIIString()), err);
+                        callback.failure(timeoutException);
+                        resp.completeExceptionally(timeoutException);
+                        return;
+                    } else {
+                        log.warn("Using url [{}] to perform the request was failed: {}", address.toString(), e.getMessage());
+                    }
+                }
             }
-            @Override
-            public void failure(Throwable failure) {
-                future.completeExceptionally(failure);
+        }).whenComplete((ignore, throwable) -> {
+            if (throwable != null) {
+                resp.completeExceptionally(throwable);
             }
         });
 
-        Integer timeout = httpClient.getConfig().getRequestTimeout() / 3;
+        return resp;
+    }
 
-        Object result = null;
-        if (timeout != null && timeout > 0) {
-            result = resultFuture.get(timeout, TimeUnit.MILLISECONDS);
+    private ClientResponse doRequest(ClientRequest request) throws InterruptedException, ExecutionException, TimeoutException {
+        // The response result will return to the future and the callback, so we can handle one of them.
+        CompletableFuture<ClientResponse> resp = doRequestAsync(request, new AsyncConnectorCallback() {
+            @Override
+            public void response(ClientResponse clientResponse) {
+                // do nothing
+            }
+
+            @Override
+            public void failure(Throwable throwable) {
+                // do nothing
+            }
+        });
+
+        int timeout = httpClient.getConfig().getRequestTimeout() / 3;
+        if (timeout >= 0) {
+            return resp.get(timeout, TimeUnit.MILLISECONDS);
         } else {
-            result = resultFuture.get();
-        }
-
-        if (result != null && result instanceof Throwable) {
-            throw new ExecutionException((Throwable) result);
+            return resp.get();
         }
     }
 
-    @Override
-    public Future<?> apply(ClientRequest jerseyRequest, AsyncConnectorCallback callback) {
-        final CompletableFuture<Object> future = new CompletableFuture<>();
+    private CompletableFuture<ClientResponse> doRequestAsync(ClientRequest jerseyRequest, AsyncConnectorCallback callback) {
+        final CompletableFuture<ClientResponse> future = new CompletableFuture<>();
 
         BoundRequestBuilder builder = httpClient.prepare(jerseyRequest.getMethod(), jerseyRequest.getUri().toString());
 
@@ -235,7 +256,7 @@ public class AsyncHttpConnector implements Connector {
             @Override
             public Response onCompleted(Response response) throws Exception {
                 ClientResponse jerseyResponse = new ClientResponse(Status.fromStatusCode(response.getStatusCode()),
-                        jerseyRequest);
+                    jerseyRequest);
                 response.getHeaders().forEach(e -> jerseyResponse.header(e.getKey(), e.getValue()));
                 if (response.hasResponseBody()) {
                     jerseyResponse.setEntityStream(response.getResponseBodyAsStream());


### PR DESCRIPTION
---

Master Issue: #<xyz>

*Motivation*

There are two methods in AsycnHttpConnector to perform a request
for pulsar admin. One is the sync method and another is the async
method. We only add the multi-host logic in the sync method,
this PR makes the async method can handle the multi-host URL.

*Modifications*

- Make the async apply method in the `AsycnHttpConnector` can handle the multi-host
