### PR TITLE
[Issue 6355][HELM] autorecovery - could not find or load main class

### DIFF
--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -317,7 +317,7 @@ autoRecovery:
   ## templates/autorecovery-configmap.yaml
   ##
   configData:
-    PULSAR_MEM: "\" -Xms64m -Xmx128m \""
+    BOOKIE_MEM: "\" -Xms64m -Xmx128m \""
 
 ## Pulsar Extra: Dashboard
 ## templates/dashboard-deployment.yaml

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -318,7 +318,7 @@ autoRecovery:
   ## templates/autorecovery-configmap.yaml
   ##
   configData:
-    PULSAR_MEM: "\" -Xms1g -Xmx1g \""
+    BOOKIE_MEM: "\" -Xms1g -Xmx1g \""
 
 ## Pulsar Extra: Dashboard
 ## templates/dashboard-deployment.yaml


### PR DESCRIPTION
This applies the recommended fix from
https://github.com/apache/pulsar/issues/6355#issuecomment-587756717

Fixes #6355

### Motivation

This PR corrects the configmap data which was causing the autorecovery pod to crashloop
with `could not find or load main class`

### Modifications

Updated the configmap var data per [this comment](https://github.com/apache/pulsar/issues/6355#issuecomment-587756717) from @sijie 

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: No
  - The schema: No
  - The default values of configurations: No
  - The wire protocol: No
  - The rest endpoints: No
  - The admin cli options: No
  - Anything that affects deployment: **Yes**
The autorecovery service pod will now start up correctly.

### Documentation

  - Does this pull request introduce a new feature? --> **No**