### PR TITLE
[conf] Amend the default value of `supportedNamespaceBundleSplitAlgorithms`

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -720,7 +720,7 @@ loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManage
 # Supported algorithms name for namespace bundle split.
 # "range_equally_divide" divides the bundle into two parts with the same hash range size.
 # "topic_count_equally_divide" divides the bundle into two parts with the same topics count.
-supportedNamespaceBundleSplitAlgorithms=[range_equally_divide,topic_count_equally_divide]
+supportedNamespaceBundleSplitAlgorithms=range_equally_divide,topic_count_equally_divide
 
 # Default algorithm name for namespace bundle split
 defaultNamespaceBundleSplitAlgorithm=range_equally_divide


### PR DESCRIPTION
### Motivation

The default value of `supportedNamespaceBundleSplitAlgorithms` is `[range_equally_divide,topic_count_equally_divide]` which will lead broker fail to start as below:

```
error Uncaught exception in thread main: The given supported namespace bundle split algorithm has unavailable algorithm. Available algorithms are [range_equally_divide, topic_count_equally_divide]
```

### Modifications

Correct the default value.