### PR TITLE
[Issue 6283][Offloaders] Offload policies per ns with deletionLag & threshold

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -56,8 +56,6 @@ public class ManagedLedgerConfig {
     private long retentionTimeMs = 0;
     private long retentionSizeInMB = 0;
     private boolean autoSkipNonRecoverableData;
-    private long offloadLedgerDeletionLagMs = TimeUnit.HOURS.toMillis(4);
-    private long offloadAutoTriggerSizeThresholdBytes = -1;
     private long metadataOperationsTimeoutSeconds = 60;
     private long readEntryTimeoutSeconds = 120;
     private long addEntryTimeoutSeconds = 120;
@@ -417,7 +415,7 @@ public class ManagedLedgerConfig {
      * @param unit timeunit for lagTime
      */
     public ManagedLedgerConfig setOffloadLedgerDeletionLag(long lagTime, TimeUnit unit) {
-        this.offloadLedgerDeletionLagMs = unit.toMillis(lagTime);
+        this.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(unit.toMillis(lagTime));
         return this;
     }
 
@@ -427,7 +425,7 @@ public class ManagedLedgerConfig {
      * @return the offload ledger deletion lag time in milliseconds
      */
     public long getOffloadLedgerDeletionLagMillis() {
-        return offloadLedgerDeletionLagMs;
+        return this.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadDeletionLagMs();
     }
 
     /**
@@ -439,7 +437,7 @@ public class ManagedLedgerConfig {
      * @param threshold Threshold in bytes at which offload is automatically triggered
      */
     public ManagedLedgerConfig setOffloadAutoTriggerSizeThresholdBytes(long threshold) {
-        this.offloadAutoTriggerSizeThresholdBytes = threshold;
+        this.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadTreshold(threshold);
         return this;
     }
 
@@ -448,7 +446,7 @@ public class ManagedLedgerConfig {
      * @return the trigger threshold, in bytes
      */
     public long getOffloadAutoTriggerSizeThresholdBytes() {
-        return this.offloadAutoTriggerSizeThresholdBytes;
+        return this.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold();
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -407,49 +407,6 @@ public class ManagedLedgerConfig {
     }
 
     /**
-     * When a ledger is offloaded from bookkeeper storage to longterm storage, the bookkeeper ledger
-     * is not deleted immediately. Instead we wait for a grace period before deleting from bookkeeper.
-     * The offloadLedgerDeleteLag sets this grace period.
-     *
-     * @param lagTime period to wait before deleting offloaded ledgers from bookkeeper
-     * @param unit timeunit for lagTime
-     */
-    public ManagedLedgerConfig setOffloadLedgerDeletionLag(long lagTime, TimeUnit unit) {
-        this.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(unit.toMillis(lagTime));
-        return this;
-    }
-
-    /**
-     * Number of milliseconds before an offloaded ledger will be deleted from bookkeeper.
-     *
-     * @return the offload ledger deletion lag time in milliseconds
-     */
-    public long getOffloadLedgerDeletionLagMillis() {
-        return this.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadDeletionLagMs();
-    }
-
-    /**
-     * Size, in bytes, at which the managed ledger will start to automatically offload ledgers to longterm storage.
-     * A negative value disables autotriggering. A threshold of 0 offloads data as soon as possible.
-     * Offloading will not occur if no offloader has been set {@link #setLedgerOffloader(LedgerOffloader)}.
-     * Automatical offloading occurs when the ledger is rolled, and the ledgers up to that point exceed the threshold.
-     *
-     * @param threshold Threshold in bytes at which offload is automatically triggered
-     */
-    public ManagedLedgerConfig setOffloadAutoTriggerSizeThresholdBytes(long threshold) {
-        this.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadTreshold(threshold);
-        return this;
-    }
-
-    /**
-     * Size, in bytes, at which offloading will automatically be triggered for this managed ledger.
-     * @return the trigger threshold, in bytes
-     */
-    public long getOffloadAutoTriggerSizeThresholdBytes() {
-        return this.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold();
-    }
-
-    /**
      * Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
      * corrupted at bookkeeper and managed-cursor is stuck at that ledger.
      */

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1373,7 +1373,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         trimConsumedLedgersInBackground();
 
-        maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+        if (config.getLedgerOffloader() != null && config.getLedgerOffloader() != NullLedgerOffloader.INSTANCE) {
+            maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+        }
 
         if (!pendingAddEntries.isEmpty()) {
             // Need to create a new ledger to write pending entries

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1848,7 +1848,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private void maybeOffloadInBackground(CompletableFuture<PositionImpl> promise) {
-        if (config.getOffloadAutoTriggerSizeThresholdBytes() >= 0) {
+        if (config.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold() >= 0) {
             executor.executeOrdered(name, safeRun(() -> maybeOffload(promise)));
         }
     }
@@ -1868,7 +1868,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     }
                 });
 
-            long threshold = config.getOffloadAutoTriggerSizeThresholdBytes();
+            long threshold = config.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold();
             long sizeSummed = 0;
             long alreadyOffloadedSize = 0;
             long toOffloadSize = 0;
@@ -1923,7 +1923,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private boolean isOffloadedNeedsDelete(OffloadContext offload) {
         long elapsedMs = clock.millis() - offload.getTimestamp();
         return offload.getComplete() && !offload.getBookkeeperDeleted()
-                && elapsedMs > config.getOffloadLedgerDeletionLagMillis();
+                && elapsedMs > config.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadDeletionLagMs();
     }
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -41,6 +41,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
     @Test
     public void testLaggedDelete() throws Exception {
         OffloadPrefixTest.MockLedgerOffloader offloader = new OffloadPrefixTest.MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(TimeUnit.MINUTES.toMillis(5));
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         MockClock clock = new MockClock();
@@ -49,7 +50,6 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setClock(clock);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
@@ -103,6 +103,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
     @Test
     public void testLaggedDeleteRetentionSetLower() throws Exception {
         OffloadPrefixTest.MockLedgerOffloader offloader = new OffloadPrefixTest.MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(TimeUnit.MINUTES.toMillis(10));
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         MockClock clock = new MockClock();
@@ -110,7 +111,6 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(5, TimeUnit.MINUTES);
         config.setLedgerOffloader(offloader);
-        config.setOffloadLedgerDeletionLag(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
         config.setClock(clock);
 
@@ -151,6 +151,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
     @Test
     public void testLaggedDeleteSlowConsumer() throws Exception {
         OffloadPrefixTest.MockLedgerOffloader offloader = new OffloadPrefixTest.MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(TimeUnit.MINUTES.toMillis(5));
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         MockClock clock = new MockClock();
@@ -158,7 +159,6 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setLedgerOffloader(offloader);
-        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setClock(clock);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -48,8 +48,8 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setLedgerOffloader(offloader);
+        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setClock(clock);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
@@ -109,9 +109,9 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setMaxEntriesPerLedger(10);
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(5, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
         config.setOffloadLedgerDeletionLag(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
         config.setClock(clock);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
@@ -157,8 +157,8 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         config.setMaxEntriesPerLedger(10);
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(10, TimeUnit.MINUTES);
-        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setLedgerOffloader(offloader);
+        config.setOffloadLedgerDeletionLag(5, TimeUnit.MINUTES);
         config.setClock(clock);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
@@ -115,6 +115,12 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
     static class MockLedgerOffloader implements LedgerOffloader {
         ConcurrentHashMap<UUID, ReadHandle> offloads = new ConcurrentHashMap<UUID, ReadHandle>();
 
+        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", null, null, null,
+                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
+
         @Override
         public String getOffloadDriverName() {
             return "mock";
@@ -149,7 +155,7 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
 
         @Override
         public OffloadPolicies getOffloadPolicies() {
-            return null;
+            return offloadPolicies;
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -694,10 +694,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         MockLedgerOffloader offloader = new MockLedgerOffloader();
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
         int i = 0;
@@ -746,10 +746,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         MockLedgerOffloader offloader = new MockLedgerOffloader();
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
@@ -782,10 +782,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
@@ -843,10 +843,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
@@ -894,10 +894,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
@@ -930,10 +930,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         MockLedgerOffloader offloader = new MockLedgerOffloader();
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
+        config.setLedgerOffloader(offloader);
         config.setOffloadAutoTriggerSizeThresholdBytes(0);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
-        config.setLedgerOffloader(offloader);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
 
@@ -988,6 +988,12 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
             return deletes.keySet();
         }
 
+        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", null, null, null,
+                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
+
         @Override
         public String getOffloadDriverName() {
             return "mock";
@@ -1029,7 +1035,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         @Override
         public OffloadPolicies getOffloadPolicies() {
-            return null;
+            return offloadPolicies;
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -604,6 +604,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         Set<Pair<Long, UUID>> failedOffloads = ConcurrentHashMap.newKeySet();
 
         MockLedgerOffloader offloader = new MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(100);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(new Long(100));
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
@@ -611,6 +613,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         config.setLedgerOffloader(offloader);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
         ManagedCursor cursor = ledger.openCursor("foobar");
+
         for (int i = 0; i < 15; i++) {
             String content = "entry-" + i;
             ledger.addEntry(content.getBytes());
@@ -744,10 +747,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
     @Test
     public void testAutoTriggerOffload() throws Exception {
         MockLedgerOffloader offloader = new MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(100);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
 
@@ -779,11 +782,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
                     return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
                 }
             };
-
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(100);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
 
@@ -840,11 +842,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
                     return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
                 }
             };
-
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(100);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
 
@@ -891,11 +892,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
                     return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
                 }
             };
-
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(100);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadAutoTriggerSizeThresholdBytes(100);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
 
@@ -928,10 +928,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
     public void offloadAsSoonAsClosed() throws Exception {
 
         MockLedgerOffloader offloader = new MockLedgerOffloader();
+        offloader.getOffloadPolicies().setManagedLedgerOffloadTreshold(0);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
         config.setLedgerOffloader(offloader);
-        config.setOffloadAutoTriggerSizeThresholdBytes(0);
         config.setRetentionTime(10, TimeUnit.MINUTES);
         config.setRetentionSizeInMB(10);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.LocalPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -393,6 +394,12 @@ public abstract class AdminResource extends PulsarWebResource {
                     .getBundles(namespaceName);
             BundlesData bundleData = NamespaceBundleFactory.getBundlesData(bundles);
             policies.bundles = bundleData != null ? bundleData : policies.bundles;
+
+            if (policies.offload_policies == null) {
+                policies.offload_policies = OffloadPolicies.create(
+                        config().getManagedLedgerOffloadAutoTriggerSizeThresholdBytes(),
+                        config().getManagedLedgerOffloadDeletionLagMs());
+            }
 
             // hydrate the namespace polices
             mergeNamespaceWithDefaults(policies, namespace, policyPath);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2122,7 +2122,7 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected long internalGetOffloadThreshold() {
         validateAdminAccessForTenant(namespaceName.getTenant());
-        return getNamespacePolicies(namespaceName).offload_threshold;
+        return getNamespacePolicies(namespaceName).offload_policies.getManagedLedgerOffloadTreshold();
     }
 
     protected void internalSetOffloadThreshold(long newThreshold) {
@@ -2134,11 +2134,11 @@ public abstract class NamespacesBase extends AdminResource {
             final String path = path(POLICIES, namespaceName.toString());
             byte[] content = globalZk().getData(path, null, nodeStat);
             Policies policies = jsonMapper().readValue(content, Policies.class);
-            policies.offload_threshold = newThreshold;
+            policies.offload_policies.setManagedLedgerOffloadTreshold(newThreshold);
             globalZk().setData(path, jsonMapper().writeValueAsBytes(policies), nodeStat.getVersion());
             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
             log.info("[{}] Successfully updated offloadThreshold configuration: namespace={}, value={}",
-                     clientAppId(), namespaceName, policies.offload_threshold);
+                     clientAppId(), namespaceName, policies.offload_policies.getManagedLedgerOffloadTreshold());
 
         } catch (KeeperException.NoNodeException e) {
             log.warn("[{}] Failed to update offloadThreshold configuration for namespace {}: does not exist",
@@ -2159,7 +2159,7 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected Long internalGetOffloadDeletionLag() {
         validateAdminAccessForTenant(namespaceName.getTenant());
-        return getNamespacePolicies(namespaceName).offload_deletion_lag_ms;
+        return getNamespacePolicies(namespaceName).offload_policies.getManagedLedgerOffloadDeletionLagMs();
     }
 
     protected void internalSetOffloadDeletionLag(Long newDeletionLagMs) {
@@ -2171,11 +2171,11 @@ public abstract class NamespacesBase extends AdminResource {
             final String path = path(POLICIES, namespaceName.toString());
             byte[] content = globalZk().getData(path, null, nodeStat);
             Policies policies = jsonMapper().readValue(content, Policies.class);
-            policies.offload_deletion_lag_ms = newDeletionLagMs;
+            policies.offload_policies.setManagedLedgerOffloadDeletionLagMs(newDeletionLagMs);
             globalZk().setData(path, jsonMapper().writeValueAsBytes(policies), nodeStat.getVersion());
             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
             log.info("[{}] Successfully updated offloadDeletionLagMs configuration: namespace={}, value={}",
-                     clientAppId(), namespaceName, policies.offload_deletion_lag_ms);
+                     clientAppId(), namespaceName, policies.offload_policies.getManagedLedgerOffloadDeletionLagMs());
 
         } catch (KeeperException.NoNodeException e) {
             log.warn("[{}] Failed to update offloadDeletionLagMs configuration for namespace {}: does not exist",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -922,6 +922,12 @@ public class Namespaces extends NamespacesBase {
             policies.bundles = getBundles(defaultNumberOfBundles);
         }
 
+        if (policies.offload_policies == null) {
+            policies.offload_policies = OffloadPolicies.create(
+                    config().getManagedLedgerOffloadAutoTriggerSizeThresholdBytes(),
+                    config().getManagedLedgerCacheEvictionTimeThresholdMillis());
+        }
+
         return policies;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1006,19 +1006,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
             OffloadPolicies offloadPolicies = policies.map(p -> p.offload_policies).orElse(null);
             managedLedgerConfig.setLedgerOffloader(pulsar.getManagedLedgerOffloader(namespace, offloadPolicies));
-            policies.ifPresent(p -> {
-                    long lag = serviceConfig.getManagedLedgerOffloadDeletionLagMs();
-                    if (p.offload_deletion_lag_ms != null) {
-                        lag = p.offload_deletion_lag_ms;
-                    }
-                    long bytes = serviceConfig.getManagedLedgerOffloadAutoTriggerSizeThresholdBytes();
-                    if (p.offload_threshold != -1L) {
-                        bytes = p.offload_threshold;
-                    }
-                    managedLedgerConfig.setOffloadLedgerDeletionLag(lag, TimeUnit.MILLISECONDS);
-                    managedLedgerConfig.setOffloadAutoTriggerSizeThresholdBytes(bytes);
-                });
-
             future.complete(managedLedgerConfig);
         }, (exception) -> future.completeExceptionally(exception)));
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -962,6 +962,12 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                             serviceConfig.getDefaultRetentionSizeInMB())
             );
 
+            OffloadPolicies offloadPolicies = policies.map(p -> p.offload_policies).orElseGet(
+                    () -> OffloadPolicies.create(
+                            serviceConfig.getManagedLedgerOffloadAutoTriggerSizeThresholdBytes(),
+                            serviceConfig.getManagedLedgerOffloadDeletionLagMs())
+            );
+
             ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
             managedLedgerConfig.setEnsembleSize(persistencePolicies.getBookkeeperEnsemble());
             managedLedgerConfig.setWriteQuorumSize(persistencePolicies.getBookkeeperWriteQuorum());
@@ -1003,21 +1009,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             managedLedgerConfig.setLedgerRolloverTimeout(serviceConfig.getManagedLedgerCursorRolloverTimeInSeconds());
             managedLedgerConfig.setRetentionTime(retentionPolicies.getRetentionTimeInMinutes(), TimeUnit.MINUTES);
             managedLedgerConfig.setRetentionSizeInMB(retentionPolicies.getRetentionSizeInMB());
-
-            policies.ifPresent(p -> {
-                long lag = serviceConfig.getManagedLedgerOffloadDeletionLagMs();
-                if (p.offload_policies.getManagedLedgerOffloadDeletionLagMs() != null) {
-                    lag = p.offload_policies.getManagedLedgerOffloadDeletionLagMs();
-                }
-                long bytes = serviceConfig.getManagedLedgerOffloadAutoTriggerSizeThresholdBytes();
-                if (p.offload_policies.getManagedLedgerOffloadTreshold() != -1L) {
-                    bytes = p.offload_policies.getManagedLedgerOffloadTreshold();
-                }
-                managedLedgerConfig.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(lag);
-                managedLedgerConfig.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadTreshold(bytes);
-            });
-
-            OffloadPolicies offloadPolicies = policies.map(p -> p.offload_policies).orElse(null);
             managedLedgerConfig.setLedgerOffloader(pulsar.getManagedLedgerOffloader(namespace, offloadPolicies));
             future.complete(managedLedgerConfig);
         }, (exception) -> future.completeExceptionally(exception)));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1004,6 +1004,19 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             managedLedgerConfig.setRetentionTime(retentionPolicies.getRetentionTimeInMinutes(), TimeUnit.MINUTES);
             managedLedgerConfig.setRetentionSizeInMB(retentionPolicies.getRetentionSizeInMB());
 
+            policies.ifPresent(p -> {
+                long lag = serviceConfig.getManagedLedgerOffloadDeletionLagMs();
+                if (p.offload_policies.getManagedLedgerOffloadDeletionLagMs() != null) {
+                    lag = p.offload_policies.getManagedLedgerOffloadDeletionLagMs();
+                }
+                long bytes = serviceConfig.getManagedLedgerOffloadAutoTriggerSizeThresholdBytes();
+                if (p.offload_policies.getManagedLedgerOffloadTreshold() != -1L) {
+                    bytes = p.offload_policies.getManagedLedgerOffloadTreshold();
+                }
+                managedLedgerConfig.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadDeletionLagMs(lag);
+                managedLedgerConfig.getLedgerOffloader().getOffloadPolicies().setManagedLedgerOffloadTreshold(bytes);
+            });
+
             OffloadPolicies offloadPolicies = policies.map(p -> p.offload_policies).orElse(null);
             managedLedgerConfig.setLedgerOffloader(pulsar.getManagedLedgerOffloader(namespace, offloadPolicies));
             future.complete(managedLedgerConfig);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -149,7 +149,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         String endpoint = "test-endpoint";
 
         OffloadPolicies offload1 = OffloadPolicies.create(
-                driver, region, bucket, endpoint, 100, 100);
+                driver, region, bucket, endpoint, 100, 100, -1, null);
         admin.namespaces().setOffloadPolicies(namespaceName, offload1);
         OffloadPolicies offload2 = admin.namespaces().getOffloadPolicies(namespaceName);
         Assert.assertEquals(offload1, offload2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -75,6 +75,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
@@ -1121,7 +1122,12 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         // create the namespace
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
-        admin.namespaces().setOffloadThreshold(namespace, 1);
+        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", "", "test", "https://test.test",
+                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
+        admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
         admin.topics().createNonPartitionedTopic(topicName.toString());
 
         // assert we get the default which indicates it will fall back to default
@@ -1161,7 +1167,12 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         // create the namespace
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
-        admin.namespaces().getOffloadPolicies(namespace).setManagedLedgerOffloadTreshold(1);
+        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", "", "test", "https://test.test",
+                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
+                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
+        admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
         admin.topics().createNonPartitionedTopic(topicName.toString());
 
         // assert we get the default which indicates it will fall back to default

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -1088,25 +1088,105 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
         // the ledger config should have the expected value
         ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getOffloadAutoTriggerSizeThresholdBytes(), 1);
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
 
         // set an override for the namespace
         admin.namespaces().setOffloadThreshold(namespace, 100);
         assertEquals(100, admin.namespaces().getOffloadThreshold(namespace));
         ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getOffloadAutoTriggerSizeThresholdBytes(), 100);
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 100);
 
         // set another negative value to disable
         admin.namespaces().setOffloadThreshold(namespace, -2);
         assertEquals(-2, admin.namespaces().getOffloadThreshold(namespace));
         ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getOffloadAutoTriggerSizeThresholdBytes(), -2);
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), -2);
 
         // set back to -1 and fall back to default
         admin.namespaces().setOffloadThreshold(namespace, -1);
         assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
         ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getOffloadAutoTriggerSizeThresholdBytes(), 1);
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
+
+        // cleanup
+        admin.topics().delete(topicName.toString(), true);
+        admin.namespaces().deleteNamespace(namespace);
+    }
+
+    @Test
+    public void testSetOffloadThresholdOnNamespacesUsingNamespaceImpl() throws Exception {
+        TopicName topicName = TopicName.get("persistent", this.testTenant, "offload", "offload-topic");
+        String namespace =  topicName.getNamespaceObject().toString();
+        System.out.println(namespace);
+
+        // create the namespace
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
+        admin.namespaces().setOffloadThreshold(namespace, 1);
+        admin.topics().createNonPartitionedTopic(topicName.toString());
+
+        // assert we get the default which indicates it will fall back to default
+        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
+        // the ledger config should have the expected value
+        ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
+
+        // set an override for the namespace
+        admin.namespaces().setOffloadThreshold(namespace, 100);
+        assertEquals(100, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 100);
+
+        // set another negative value to disable
+        admin.namespaces().setOffloadThreshold(namespace, -2);
+        assertEquals(-2, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), -2);
+
+        // set back to -1 and fall back to default
+        admin.namespaces().setOffloadThreshold(namespace, -1);
+        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
+
+        // cleanup
+        admin.topics().delete(topicName.toString(), true);
+        admin.namespaces().deleteNamespace(namespace);
+    }
+
+    @Test
+    public void testSetOffloadThresholdOnNamespacesUsingOffloadPolicies() throws Exception {
+        TopicName topicName = TopicName.get("persistent", this.testTenant, "offload", "offload-topic");
+        String namespace =  topicName.getNamespaceObject().toString();
+        System.out.println(namespace);
+
+        // create the namespace
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
+        admin.namespaces().getOffloadPolicies(namespace).setManagedLedgerOffloadTreshold(1);
+        admin.topics().createNonPartitionedTopic(topicName.toString());
+
+        // assert we get the default which indicates it will fall back to default
+        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
+        // the ledger config should have the expected value
+        ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
+
+        // set an override for the namespace
+        admin.namespaces().setOffloadThreshold(namespace, 100);
+        assertEquals(100, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 100);
+
+        // set another negative value to disable
+        admin.namespaces().setOffloadThreshold(namespace, -2);
+        assertEquals(-2, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), -2);
+
+        // set back to -1 and fall back to default
+        admin.namespaces().setOffloadThreshold(namespace, -1);
+        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
+        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
 
         // cleanup
         admin.topics().delete(topicName.toString(), true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -1079,8 +1079,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         TopicName topicName = TopicName.get("persistent", this.testTenant, "offload", "offload-topic");
         String namespace =  topicName.getNamespaceObject().toString();
         System.out.println(namespace);
-        // set a default
-        pulsar.getConfiguration().setManagedLedgerOffloadAutoTriggerSizeThresholdBytes(1);
+
         // create the namespace
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
         admin.topics().createNonPartitionedTopic(topicName.toString());
@@ -1089,97 +1088,6 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
         // the ledger config should have the expected value
         ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
-
-        // set an override for the namespace
-        admin.namespaces().setOffloadThreshold(namespace, 100);
-        assertEquals(100, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 100);
-
-        // set another negative value to disable
-        admin.namespaces().setOffloadThreshold(namespace, -2);
-        assertEquals(-2, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), -2);
-
-        // set back to -1 and fall back to default
-        admin.namespaces().setOffloadThreshold(namespace, -1);
-        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
-
-        // cleanup
-        admin.topics().delete(topicName.toString(), true);
-        admin.namespaces().deleteNamespace(namespace);
-    }
-
-    @Test
-    public void testSetOffloadThresholdOnNamespacesUsingNamespaceImpl() throws Exception {
-        TopicName topicName = TopicName.get("persistent", this.testTenant, "offload", "offload-topic");
-        String namespace =  topicName.getNamespaceObject().toString();
-        System.out.println(namespace);
-
-        // create the namespace
-        admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
-        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", "", "test", "https://test.test",
-                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
-                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
-                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
-                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
-        admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
-        admin.topics().createNonPartitionedTopic(topicName.toString());
-
-        // assert we get the default which indicates it will fall back to default
-        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
-        // the ledger config should have the expected value
-        ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
-
-        // set an override for the namespace
-        admin.namespaces().setOffloadThreshold(namespace, 100);
-        assertEquals(100, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 100);
-
-        // set another negative value to disable
-        admin.namespaces().setOffloadThreshold(namespace, -2);
-        assertEquals(-2, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), -2);
-
-        // set back to -1 and fall back to default
-        admin.namespaces().setOffloadThreshold(namespace, -1);
-        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
-        ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
-
-        // cleanup
-        admin.topics().delete(topicName.toString(), true);
-        admin.namespaces().deleteNamespace(namespace);
-    }
-
-    @Test
-    public void testSetOffloadThresholdOnNamespacesUsingOffloadPolicies() throws Exception {
-        TopicName topicName = TopicName.get("persistent", this.testTenant, "offload", "offload-topic");
-        String namespace =  topicName.getNamespaceObject().toString();
-        System.out.println(namespace);
-
-        // create the namespace
-        admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
-        OffloadPolicies offloadPolicies = OffloadPolicies.create("S3", "", "test", "https://test.test",
-                OffloadPolicies.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES,
-                OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES,
-                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD,
-                OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS);
-        admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
-        admin.topics().createNonPartitionedTopic(topicName.toString());
-
-        // assert we get the default which indicates it will fall back to default
-        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
-        // the ledger config should have the expected value
-        ManagedLedgerConfig ledgerConf = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        assertEquals(ledgerConf.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadTreshold(), 1);
 
         // set an override for the namespace
         admin.namespaces().setOffloadThreshold(namespace, 100);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -504,7 +504,8 @@ public class PulsarAdminToolTest {
         namespaces.run(split("set-offload-policies myprop/clust/ns1 -r test-region -d aws-s3 -b test-bucket -e http://test.endpoint -mbs 32M -rbs 5M"));
         verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns1",
                 OffloadPolicies.create("aws-s3", "test-region", "test-bucket",
-                        "http://test.endpoint", 32 * 1024 * 1024, 5 * 1024 * 1024));
+                        "http://test.endpoint", 32 * 1024 * 1024, 5 * 1024 * 1024,
+                        -1, null));
 
         namespaces.run(split("get-offload-policies myprop/clust/ns1"));
         verify(mockNamespaces).getOffloadPolicies("myprop/clust/ns1");

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -501,11 +501,11 @@ public class PulsarAdminToolTest {
         namespaces.run(split("clear-offload-deletion-lag myprop/clust/ns1"));
         verify(mockNamespaces).clearOffloadDeleteLag("myprop/clust/ns1");
 
-        namespaces.run(split("set-offload-policies myprop/clust/ns1 -r test-region -d aws-s3 -b test-bucket -e http://test.endpoint -mbs 32M -rbs 5M"));
+        namespaces.run(split("set-offload-policies myprop/clust/ns1 -r test-region -d aws-s3 -b test-bucket -e http://test.endpoint -mbs 32M -rbs 5M -oat 10M -oae 10s"));
         verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns1",
                 OffloadPolicies.create("aws-s3", "test-region", "test-bucket",
                         "http://test.endpoint", 32 * 1024 * 1024, 5 * 1024 * 1024,
-                        -1, null));
+                        10 * 1024 * 1024, new Long(10000)));
 
         namespaces.run(split("get-offload-policies myprop/clust/ns1"));
         verify(mockNamespaces).getOffloadPolicies("myprop/clust/ns1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1392,6 +1392,18 @@ public class CmdNamespaces extends CmdBase {
                 required = false)
         private String readBufferSizeStr;
 
+        @Parameter(
+                names = {"--offloadAfterElapsed", "-oae"},
+                description = "Offload after elapsed in minutes (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w).",
+                required = false)
+        private String offloadAfterElapsedStr;
+
+        @Parameter(
+                names = {"--offloadAfterThreshold", "-oat"},
+                description = "Offload after threshold size (eg: 1M, 5M)",
+                required = false)
+        private String offloadAfterThresholdStr;
+
         private final String[] DRIVER_NAMES = {"S3", "aws-s3", "google-cloud-storage"};
 
         public boolean driverSupported(String driver) {
@@ -1453,8 +1465,26 @@ public class CmdNamespaces extends CmdBase {
                 }
             }
 
+            Long offloadAfterElapsedInMillis = OffloadPolicies.DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS;
+            if (StringUtils.isNotEmpty(offloadAfterElapsedStr) ) {
+                Long offloadAfterElapsed = TimeUnit.SECONDS.toMillis(RelativeTimeUtil.parseRelativeTimeInSeconds(offloadAfterElapsedStr));
+                if (positiveCheck("OffloadAfterElapsed", offloadAfterElapsed)
+                        && maxValueCheck("OffloadAfterElapsed", offloadAfterElapsed, Long.MAX_VALUE)) {
+                    offloadAfterElapsedInMillis = new Long(offloadAfterElapsed);
+                }
+            }
+
+            long offloadAfterThresholdInBytes = OffloadPolicies.DEFAULT_READ_BUFFER_SIZE_IN_BYTES;
+            if (StringUtils.isNotEmpty(offloadAfterThresholdStr) ) {
+                long offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
+                if (positiveCheck("OffloadAfterThreshold", offloadAfterThreshold)
+                        && maxValueCheck("OffloadAfterThreshold", offloadAfterThreshold, Long.MAX_VALUE)) {
+                    offloadAfterThresholdInBytes = new Long(offloadAfterThreshold);
+                }
+            }
+
             OffloadPolicies offloadPolicies = OffloadPolicies.create(driver, region, bucket, endpoint,
-                    maxBlockSizeInBytes, readBufferSizeInBytes);
+                    maxBlockSizeInBytes, readBufferSizeInBytes, offloadAfterThresholdInBytes, offloadAfterElapsedInMillis);
             admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
         }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
@@ -39,13 +39,15 @@ public class OffloadPolicies {
     public final static int DEFAULT_OFFLOAD_MAX_THREADS = 2;
     public final static String[] DRIVER_NAMES = {"S3", "aws-s3", "google-cloud-storage", "filesystem"};
     public final static String DEFAULT_OFFLOADER_DIRECTORY = "./offloaders";
+    public final static long DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD = -1;
+    public final static Long DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS = null;
 
     // common config
     private String offloadersDirectory = DEFAULT_OFFLOADER_DIRECTORY;
     private String managedLedgerOffloadDriver = null;
     private int managedLedgerOffloadMaxThreads = DEFAULT_OFFLOAD_MAX_THREADS;
-    private long managedLedgerOffloadTreshold = -1;
-    private Long managedLedgerOffloadDeletionLagMs = null;
+    private long managedLedgerOffloadTreshold = DEFAULT_OFFLOAD_OFFLOAD_THRESHOLD;
+    private Long managedLedgerOffloadDeletionLagMs = DEFAULT_OFFLOAD_OFFLOAD_DELETION_LAG_MS;
 
     // s3 config, set by service configuration or cli
     private String s3ManagedLedgerOffloadRegion = null;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
@@ -44,6 +44,8 @@ public class OffloadPolicies {
     private String offloadersDirectory = DEFAULT_OFFLOADER_DIRECTORY;
     private String managedLedgerOffloadDriver = null;
     private int managedLedgerOffloadMaxThreads = DEFAULT_OFFLOAD_MAX_THREADS;
+    private long managedLedgerOffloadTreshold = -1;
+    private Long managedLedgerOffloadDeletionLagMs = null;
 
     // s3 config, set by service configuration or cli
     private String s3ManagedLedgerOffloadRegion = null;
@@ -68,9 +70,12 @@ public class OffloadPolicies {
     private String fileSystemURI = null;
 
     public static OffloadPolicies create(String driver, String region, String bucket, String endpoint,
-                                         int maxBlockSizeInBytes, int readBufferSizeInBytes) {
+                                         int maxBlockSizeInBytes, int readBufferSizeInBytes, long offloadTreshold,
+                                         Long offloadDeletionLagMs) {
         OffloadPolicies offloadPolicies = new OffloadPolicies();
         offloadPolicies.setManagedLedgerOffloadDriver(driver);
+        offloadPolicies.setManagedLedgerOffloadTreshold(offloadTreshold);
+        offloadPolicies.setManagedLedgerOffloadDeletionLagMs(offloadDeletionLagMs);
         if (driver.equalsIgnoreCase(DRIVER_NAMES[0]) || driver.equalsIgnoreCase(DRIVER_NAMES[1])) {
             offloadPolicies.setS3ManagedLedgerOffloadRegion(region);
             offloadPolicies.setS3ManagedLedgerOffloadBucket(bucket);
@@ -153,6 +158,8 @@ public class OffloadPolicies {
         return Objects.hash(
                 managedLedgerOffloadDriver,
                 managedLedgerOffloadMaxThreads,
+                managedLedgerOffloadTreshold,
+                managedLedgerOffloadDeletionLagMs,
                 s3ManagedLedgerOffloadRegion,
                 s3ManagedLedgerOffloadBucket,
                 s3ManagedLedgerOffloadServiceEndpoint,
@@ -180,6 +187,8 @@ public class OffloadPolicies {
         OffloadPolicies other = (OffloadPolicies) obj;
         return Objects.equals(managedLedgerOffloadDriver, other.getManagedLedgerOffloadDriver())
                 && Objects.equals(managedLedgerOffloadMaxThreads, other.getManagedLedgerOffloadMaxThreads())
+                && Objects.equals(managedLedgerOffloadTreshold, other.getManagedLedgerOffloadTreshold())
+                && Objects.equals(managedLedgerOffloadDeletionLagMs, other.getManagedLedgerOffloadDeletionLagMs())
                 && Objects.equals(s3ManagedLedgerOffloadRegion, other.getS3ManagedLedgerOffloadRegion())
                 && Objects.equals(s3ManagedLedgerOffloadBucket, other.getS3ManagedLedgerOffloadBucket())
                 && Objects.equals(s3ManagedLedgerOffloadServiceEndpoint,
@@ -208,6 +217,8 @@ public class OffloadPolicies {
         return MoreObjects.toStringHelper(this)
                 .add("managedLedgerOffloadDriver", managedLedgerOffloadDriver)
                 .add("managedLedgerOffloadMaxThreads", managedLedgerOffloadMaxThreads)
+                .add("managedLedgerOffloadTreshold", managedLedgerOffloadTreshold)
+                .add("managedLedgerOffloadDeletionLagMs", managedLedgerOffloadDeletionLagMs)
                 .add("s3ManagedLedgerOffloadRegion", s3ManagedLedgerOffloadRegion)
                 .add("s3ManagedLedgerOffloadBucket", s3ManagedLedgerOffloadBucket)
                 .add("s3ManagedLedgerOffloadServiceEndpoint", s3ManagedLedgerOffloadServiceEndpoint)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
@@ -93,6 +93,13 @@ public class OffloadPolicies {
         return offloadPolicies;
     }
 
+    public static OffloadPolicies create(long offloadTreshold, Long offloadDeletionLagMs) {
+        OffloadPolicies offloadPolicies = new OffloadPolicies();
+        offloadPolicies.setManagedLedgerOffloadTreshold(offloadTreshold);
+        offloadPolicies.setManagedLedgerOffloadDeletionLagMs(offloadDeletionLagMs);
+        return offloadPolicies;
+    }
+
     public static OffloadPolicies create(Properties properties) {
         OffloadPolicies data = new OffloadPolicies();
         Field[] fields = OffloadPolicies.class.getDeclaredFields();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -83,10 +83,6 @@ public class Policies {
 
     @SuppressWarnings("checkstyle:MemberName")
     public long compaction_threshold = 0;
-    @SuppressWarnings("checkstyle:MemberName")
-    public long offload_threshold = -1;
-    @SuppressWarnings("checkstyle:MemberName")
-    public Long offload_deletion_lag_ms = null;
 
     @SuppressWarnings("checkstyle:MemberName")
     @Deprecated
@@ -118,8 +114,7 @@ public class Policies {
                 antiAffinityGroup, max_producers_per_topic,
                 max_consumers_per_topic, max_consumers_per_subscription,
                 max_unacked_messages_per_consumer, max_unacked_messages_per_subscription,
-                compaction_threshold, offload_threshold,
-                offload_deletion_lag_ms,
+                compaction_threshold,
                 schema_auto_update_compatibility_strategy,
                 schema_validation_enforced,
                 schema_compatibility_strategy,
@@ -143,8 +138,7 @@ public class Policies {
                     && Objects.equals(deduplicationEnabled, other.deduplicationEnabled)
                     && Objects.equals(persistence, other.persistence) && Objects.equals(bundles, other.bundles)
                     && Objects.equals(latency_stats_sample_rate, other.latency_stats_sample_rate)
-                    && Objects.equals(message_ttl_in_seconds,
-                            other.message_ttl_in_seconds)
+                    && Objects.equals(message_ttl_in_seconds, other.message_ttl_in_seconds)
                     && Objects.equals(retention_policies, other.retention_policies)
                     && Objects.equals(encryption_required, other.encryption_required)
                     && Objects.equals(delayed_delivery_policies, other.delayed_delivery_policies)
@@ -156,8 +150,6 @@ public class Policies {
                     && max_unacked_messages_per_consumer == other.max_unacked_messages_per_consumer
                     && max_unacked_messages_per_subscription == other.max_unacked_messages_per_subscription
                     && compaction_threshold == other.compaction_threshold
-                    && offload_threshold == other.offload_threshold
-                    && Objects.equals(offload_deletion_lag_ms, other.offload_deletion_lag_ms)
                     && schema_auto_update_compatibility_strategy == other.schema_auto_update_compatibility_strategy
                     && schema_validation_enforced == other.schema_validation_enforced
                     && schema_compatibility_strategy == other.schema_compatibility_strategy
@@ -209,8 +201,6 @@ public class Policies {
                 .add("max_unacked_messages_per_consumer", max_unacked_messages_per_consumer)
                 .add("max_unacked_messages_per_subscription", max_unacked_messages_per_subscription)
                 .add("compaction_threshold", compaction_threshold)
-                .add("offload_threshold", offload_threshold)
-                .add("offload_deletion_lag_ms", offload_deletion_lag_ms)
                 .add("schema_auto_update_compatibility_strategy", schema_auto_update_compatibility_strategy)
                 .add("schema_validation_enforced", schema_validation_enforced)
                 .add("schema_compatibility_Strategy", schema_compatibility_strategy)


### PR DESCRIPTION
Fixes #6283 

### Modifications

Define and use custom deletionLag and threshold for offloadpolicies per ns

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as .

### Does this pull request potentially affect one of the following parts:

  - The public API: yes, new fields to add to offloadpolicies
  - The admin cli options: yes, new fields to add to offloadpolicies

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
