### PR TITLE
Add configurable DNS client for ConnectionPool

### DIFF
--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>pulsar-transaction-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -387,4 +388,12 @@ public interface ClientBuilder extends Cloneable {
      * @return the client builder instance
      */
     ClientBuilder clock(Clock clock);
+
+    /**
+     * The DNS resolver builder used by the pulsar client.
+     *
+     * @param builder the DNS resolver builder used by the pulsar client to resolve inet names
+     * @return the client builder instance
+     */
+    ClientBuilder dns(DnsNameResolverBuilder builder);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.client.impl;
 
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -214,13 +214,13 @@ public class ClientBuilderImpl implements ClientBuilder {
     	conf.setInitialBackoffIntervalNanos(unit.toNanos(duration));
     	return this;
     }
-    
+
     @Override
     public ClientBuilder maxBackoffInterval(long duration, TimeUnit unit) {
     	conf.setMaxBackoffIntervalNanos(unit.toNanos(duration));
     	return this;
     }
-    
+
     public ClientConfigurationData getClientConfigurationData() {
         return conf;
     }
@@ -228,6 +228,12 @@ public class ClientBuilderImpl implements ClientBuilder {
     @Override
     public ClientBuilder clock(Clock clock) {
         conf.setClock(clock);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder dns(DnsNameResolverBuilder builder) {
+        conf.setDnsNameResolverBuilder(builder);
         return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -29,7 +28,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.Future;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -42,7 +40,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -84,7 +81,11 @@ public class ConnectionPool implements Closeable {
             throw new PulsarClientException(e);
         }
 
-        this.dnsResolver = new DnsNameResolverBuilder(eventLoopGroup.next()).traceEnabled(true)
+        DnsNameResolverBuilder builder = conf.getDnsNameResolverBuilder();
+        if (builder == null) {
+            builder = new DnsNameResolverBuilder();
+        }
+        this.dnsResolver = builder.eventLoop(eventLoopGroup.next()).traceEnabled(true)
                 .channelType(EventLoopUtil.getDatagramChannelClass(eventLoopGroup)).build();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -19,16 +19,16 @@
 package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import java.io.Serializable;
 import java.time.Clock;
+import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
-
-import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This is a simple holder of the client configuration values.
@@ -69,6 +69,8 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int requestTimeoutMs = 60000;
     private long initialBackoffIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
     private long maxBackoffIntervalNanos = TimeUnit.SECONDS.toNanos(60);
+
+    private DnsNameResolverBuilder dnsNameResolverBuilder = null;
 
     @JsonIgnore
     private Clock clock = Clock.systemDefaultZone();


### PR DESCRIPTION
Fixes #6346

### Motivation

Currently DNS client for PulsarClient cannot be configured and we are struck with default one. Specifically I needed to be able to configure the dns server list

### Modifications

- Added a new method: `ClientBuilder.dns`
- Used configured dns builder instead of creating a new default one if provided in `ConnectionPool`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is essentially a trivial rework, it just expose the ability to provider a custom DnsNameResolverBuilder and use it if provided.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - **Dependencies (does it add or upgrade a dependency): (yes / no) yes (added dependency on netty-dns-resolver to client api)**
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - **Does this pull request introduce a new feature? (yes / no) yes**
  - **If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) JavaDocs**
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
