### PR TITLE
fix duplicate key to send propertys

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -73,7 +73,13 @@ public class MessageImpl<T> implements Message<T> {
         msg.topic = null;
         msg.cnx = null;
         msg.payload = Unpooled.wrappedBuffer(payload);
-        msg.properties = null;
+        if (msgMetadataBuilder.getPropertiesCount() > 0) {
+            msg.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                            (oldValue,newValue) -> newValue)));
+        } else {
+            msg.properties = Collections.emptyMap();
+        }
         msg.schema = schema;
         return msg;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -73,13 +73,7 @@ public class MessageImpl<T> implements Message<T> {
         msg.topic = null;
         msg.cnx = null;
         msg.payload = Unpooled.wrappedBuffer(payload);
-        if (msgMetadataBuilder.getPropertiesCount() > 0) {
-            msg.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
-                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
-                            (oldValue,newValue) -> newValue)));
-        } else {
-            msg.properties = Collections.emptyMap();
-        }
+        msg.properties = null;
         msg.schema = schema;
         return msg;
     }
@@ -306,6 +300,7 @@ public class MessageImpl<T> implements Message<T> {
         }
     }
 
+    @Override
     public long getSequenceId() {
         checkNotNull(msgMetadataBuilder);
         if (msgMetadataBuilder.hasSequenceId()) {
@@ -337,8 +332,10 @@ public class MessageImpl<T> implements Message<T> {
     public synchronized Map<String, String> getProperties() {
         if (this.properties == null) {
             if (msgMetadataBuilder.getPropertiesCount() > 0) {
-                this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
-                        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
+                  this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
+                           .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                                   (oldValue,newValue) -> newValue)));
+                
             } else {
                 this.properties = Collections.emptyMap();
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -105,7 +105,8 @@ public class MessageImpl<T> implements Message<T> {
 
         if (msgMetadata.getPropertiesCount() > 0) {
             this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
-                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                            (oldValue,newValue) -> newValue)));
         } else {
             properties = Collections.emptyMap();
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
@@ -58,6 +58,21 @@ public class MessageImplTest {
     }
 
     @Test
+    public void testSetDuplicatePropertiesKey() {
+        MessageMetadata.Builder builder = MessageMetadata.newBuilder();
+        builder.addProperties(org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
+                .setKey("key1").setValue("value1").build());
+        builder.addProperties(org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
+                .setKey("key1").setValue("value2").build());
+        builder.addProperties(org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
+                .setKey("key3").setValue("value3").build());
+        ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
+        MessageImpl<?> msg = MessageImpl.create(builder, payload, Schema.BYTES);
+        assertEquals("value2", msg.getProperty("key1"));
+        assertEquals("value3", msg.getProperty("key3"));
+    }
+
+    @Test
     public void testGetSequenceIdAssociated() {
         MessageMetadata.Builder builder = MessageMetadata.newBuilder()
             .setSequenceId(1234);


### PR DESCRIPTION
**Motivation**
Fix when sending a message, set duplicate key to properties, can't pull the message while concumer #6388 
```javascript
//org.apache.pulsar.client.impl.MessageImpl
if (msgMetadata.getPropertiesCount() > 0) {
            this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
        } else {
            properties = Collections.emptyMap();
        }
        this.schema = schema;
```
Collectors.toMap can not allowed duplicate key

**Changes**
Replace old value with new value
```javascript
if (msgMetadata.getPropertiesCount() > 0) {
            this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
                            (oldValue,newValue) -> newValue)));
        } else {
            properties = Collections.emptyMap();
        }
        this.schema = schema;
```