### PR TITLE
[Issue 3762][Schema] Fix wrong avro schema

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StructSchema.java
@@ -150,13 +150,21 @@ public abstract class StructSchema<T> extends AbstractSchema<T> {
             try {
                 // Disable validation of default values for compatibility
                 validateDefaults.set(false);
-                return schemaDefinition.getAlwaysAllowNull() ? ReflectData.AllowNull.get().getSchema(pojo)
-                        : ReflectData.get().getSchema(pojo);
+                return extractAvroSchema(schemaDefinition, pojo);
             } finally {
                 validateDefaults.set(savedValidateDefaults);
             }
         } else {
             throw new RuntimeException("Schema definition must specify pojo class or schema json definition");
+        }
+    }
+
+    protected static Schema extractAvroSchema(SchemaDefinition schemaDefinition, Class pojo) {
+        try {
+            return parseAvroSchema(pojo.getDeclaredField("SCHEMA$").get(null).toString());
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException ignored) {
+            return schemaDefinition.getAlwaysAllowNull() ? ReflectData.AllowNull.get().getSchema(pojo)
+                : ReflectData.get().getSchema(pojo);
         }
     }
 


### PR DESCRIPTION
Fixes #3762

### Motivation

Avro schemas are quite important for proper data flow and it is a pity that the #3762 issue stayed untouched for so long. There were some workarounds on how to make Pulsar use an original avro schema, but in the end, it is pretty hard to run an enterprise solution on workarounds. With this PR I would like to find a solution to the problem caused by shading avro in pulsar-client. As it was discussed in the issue, there are two possible solutions for this problem: 

- Unshade the avro library in the pulsar-client library. (IMHO it seems like a proper solution for this problem, but it also brings a risk of unknown side-effects)
- Use reflection to get original schemas from generated classes. (I went for this solution)

Could you please comment if this is a proper solution for the problem? I will add tests when my approach will be confirmed.

### Modifications

First, we try to extract an original avro schema from the "$SCHEMA" field using reflection. If it doesn't work, the process falls back generation of the schema from POJO.   

### Verifying this change

This change added tests and can be verified as follows: TBD

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: **yes**
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)
