### PR TITLE
[functions] Allow custom resources for k8s

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
@@ -18,15 +18,14 @@
  */
 package org.apache.pulsar.functions.runtime.kubernetes;
 
+import com.google.gson.Gson;
+import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.models.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.proto.Function;
-import org.apache.pulsar.functions.runtime.kubernetes.KubernetesManifestCustomizer;
 
 import java.util.List;
 import java.util.Map;
@@ -42,6 +41,10 @@ import java.util.Map;
  */
 public class BasicKubernetesManifestCustomizer implements KubernetesManifestCustomizer {
 
+    String RESOURCE_CPU = "cpu";
+    String RESOURCE_MEMORY = "memory";
+    String[] RESOURCES = {RESOURCE_CPU, RESOURCE_MEMORY};
+
     @Getter
     @Setter
     @NoArgsConstructor
@@ -50,6 +53,7 @@ public class BasicKubernetesManifestCustomizer implements KubernetesManifestCust
         private Map<String, String> extraLabels;
         private Map<String, String> extraAnnotations;
         private Map<String, String> nodeSelectorLabels;
+        private V1ResourceRequirements resourceRequirements;
         private List<V1Toleration> tolerations;
     }
 
@@ -87,7 +91,25 @@ public class BasicKubernetesManifestCustomizer implements KubernetesManifestCust
         if (opts.getTolerations() != null && opts.getTolerations().size() > 0) {
             opts.getTolerations().forEach(ps::addTolerationsItem);
         }
+        ps.getContainers().forEach(container -> updateContainerResources(container, opts));
         return statefulSet;
+    }
+
+    private void updateContainerResources(V1Container container, RuntimeOpts opts) {
+        if (opts.getResourceRequirements() != null) {
+            V1ResourceRequirements resourceRequirements = opts.getResourceRequirements();
+            V1ResourceRequirements containerResources = container.getResources();
+            Map<String, Quantity> limits = resourceRequirements.getLimits();
+            Map<String, Quantity> requests = resourceRequirements.getRequests();
+            for (String resource : RESOURCES) {
+                if (limits.containsKey(resource)) {
+                    containerResources.putLimitsItem(resource, limits.get(resource));
+                }
+                if (requests.containsKey(resource)) {
+                    containerResources.putRequestsItem(resource, requests.get(resource));
+                }
+            }
+        }
     }
 
     private RuntimeOpts getOptsFromDetails(Function.FunctionDetails funcDetails) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
@@ -41,9 +41,9 @@ import java.util.Map;
  */
 public class BasicKubernetesManifestCustomizer implements KubernetesManifestCustomizer {
 
-    String RESOURCE_CPU = "cpu";
-    String RESOURCE_MEMORY = "memory";
-    String[] RESOURCES = {RESOURCE_CPU, RESOURCE_MEMORY};
+    private static final String RESOURCE_CPU = "cpu";
+    private static final String RESOURCE_MEMORY = "memory";
+    private static final String[] RESOURCES = {RESOURCE_CPU, RESOURCE_MEMORY};
 
     @Getter
     @Setter

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -167,6 +167,16 @@ for the `runtimeCustomerClassName` property. This implementation takes the follo
       "value": "value",
       "effect": "NoSchedule"
     }
-  ]
+  ],
+  "resourceRequirements": {  // values for cpu and memory should be defined as described here: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
+    "requests": {
+      "cpu": 1,
+      "memory": "4G"
+    },
+    "limits": {
+      "cpu": 2,
+      "memory": "8G"
+    }
+  }
 }
 ```


### PR DESCRIPTION
### Motivation

Currently for functions running in kubernetes both the request and limit for cpu and memory are specified by resources arguments. The problem is that sometimes it makes sense for the request and limit to be different values.

### Modifications

This commit adds the ability to the BasicKubernetesCustomizer to individualy override the request and limit values for cpu and memory.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added test to ensure that the values specified in the custom runtime options are passed to the containers*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: yes  (Adds additional configuration options for custom runtime options)
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? In the "functions-runtime" doc