### PR TITLE
Remove duplicated lombok annotations in the tests module

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/JdbcSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/JdbcSinkTester.java
@@ -50,8 +50,6 @@ public class JdbcSinkTester extends SinkTester<MySQLContainer> {
      *
      */
     @Data
-    @ToString
-    @EqualsAndHashCode
     public static class Foo {
         private String field1;
         private String field2;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/Schemas.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/Schemas.java
@@ -56,10 +56,6 @@ public final class Schemas {
      * A Person Struct.
      */
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     public static class Person {
 
         private String name;
@@ -71,10 +67,6 @@ public final class Schemas {
      * A Person Struct.
      */
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     public static class PersonConsumeSchema {
 
         private String name;
@@ -88,10 +80,6 @@ public final class Schemas {
      * A Student Struct.
      */
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     public static class Student {
 
         private String name;
@@ -102,12 +90,8 @@ public final class Schemas {
     }
 
     @Data
-    @Getter
-    @Setter
-    @ToString
     @NoArgsConstructor
     @AllArgsConstructor
-    @EqualsAndHashCode
     @Builder
     public static class AvroLogicalType{
         @org.apache.avro.reflect.AvroSchema("{\n" +
@@ -132,10 +116,6 @@ public final class Schemas {
     private Schemas() {}
 
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PersonOne{
@@ -143,10 +123,6 @@ public final class Schemas {
     }
 
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PersonTwo{
@@ -157,10 +133,6 @@ public final class Schemas {
     }
 
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     public static class PersonThree{
         int id;
 
@@ -168,10 +140,6 @@ public final class Schemas {
     }
 
     @Data
-    @Getter
-    @Setter
-    @ToString
-    @EqualsAndHashCode
     public static class PersonFour{
         int id;
 

--- a/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/KafkaApiTest.java
+++ b/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/KafkaApiTest.java
@@ -71,8 +71,6 @@ import org.testng.annotations.Test;
 public class KafkaApiTest extends PulsarStandaloneTestSuite {
 
     @Data
-    @ToString
-    @EqualsAndHashCode
     public static class Foo {
         @Nullable
         private String field1;
@@ -82,8 +80,6 @@ public class KafkaApiTest extends PulsarStandaloneTestSuite {
     }
 
     @Data
-    @ToString
-    @EqualsAndHashCode
     public static class Bar {
         private boolean field1;
     }


### PR DESCRIPTION
### Modifications

This is a simple cleanup to reduce the number of lombok annotations by deleting the duplicated lombok annotations in the tests module.
