### PR TITLE
[Issue 6330] Bump netty version to 4.1.45.Final

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -346,22 +346,22 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.19.jar
     - org.apache.commons-commons-lang3-3.4.jar
  * Netty
-    - io.netty-netty-buffer-4.1.43.Final.jar
-    - io.netty-netty-codec-4.1.43.Final.jar
-    - io.netty-netty-codec-dns-4.1.43.Final.jar
-    - io.netty-netty-codec-http-4.1.43.Final.jar
-    - io.netty-netty-codec-http2-4.1.43.Final.jar
-    - io.netty-netty-codec-socks-4.1.43.Final.jar
-    - io.netty-netty-common-4.1.43.Final.jar
-    - io.netty-netty-handler-4.1.43.Final.jar
-    - io.netty-netty-handler-proxy-4.1.43.Final.jar
-    - io.netty-netty-resolver-4.1.43.Final.jar
-    - io.netty-netty-resolver-dns-4.1.43.Final.jar
-    - io.netty-netty-transport-4.1.43.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.43.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.43.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.43.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.43.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.45.Final.jar
+    - io.netty-netty-codec-4.1.45.Final.jar
+    - io.netty-netty-codec-dns-4.1.45.Final.jar
+    - io.netty-netty-codec-http-4.1.45.Final.jar
+    - io.netty-netty-codec-http2-4.1.45.Final.jar
+    - io.netty-netty-codec-socks-4.1.45.Final.jar
+    - io.netty-netty-common-4.1.45.Final.jar
+    - io.netty-netty-handler-4.1.45.Final.jar
+    - io.netty-netty-handler-proxy-4.1.45.Final.jar
+    - io.netty-netty-resolver-4.1.45.Final.jar
+    - io.netty-netty-resolver-dns-4.1.45.Final.jar
+    - io.netty-netty-transport-4.1.45.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.45.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.45.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.45.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.45.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.26.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.10.0</bookkeeper.version>
     <zookeeper.version>3.5.7</zookeeper.version>
-    <netty.version>4.1.43.Final</netty.version>
+    <netty.version>4.1.45.Final</netty.version>
     <netty-tc-native.version>2.0.26.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.20.v20190813</jetty.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,23 +231,23 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.4.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.43.Final.jar
-    - netty-codec-4.1.43.Final.jar
-    - netty-codec-dns-4.1.43.Final.jar
-    - netty-codec-http-4.1.43.Final.jar
-    - netty-codec-socks-4.1.43.Final.jar
-    - netty-common-4.1.43.Final.jar
-    - netty-handler-4.1.43.Final.jar
-    - netty-handler-proxy-4.1.43.Final.jar
+    - netty-buffer-4.1.45.Final.jar
+    - netty-codec-4.1.45.Final.jar
+    - netty-codec-dns-4.1.45.Final.jar
+    - netty-codec-http-4.1.45.Final.jar
+    - netty-codec-socks-4.1.45.Final.jar
+    - netty-common-4.1.45.Final.jar
+    - netty-handler-4.1.45.Final.jar
+    - netty-handler-proxy-4.1.45.Final.jar
     - netty-reactive-streams-2.0.0.jar
-    - netty-resolver-4.1.43.Final.jar
-    - netty-resolver-dns-4.1.43.Final.jar
+    - netty-resolver-4.1.45.Final.jar
+    - netty-resolver-dns-4.1.45.Final.jar
     - netty-tcnative-boringssl-static-2.0.26.Final.jar
-    - netty-transport-4.1.43.Final.jar
-    - netty-transport-native-epoll-4.1.43.Final.jar
-    - netty-transport-native-epoll-4.1.43.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.43.Final.jar
-    - netty-transport-native-unix-common-4.1.43.Final-linux-x86_64.jar
+    - netty-transport-4.1.45.Final.jar
+    - netty-transport-native-epoll-4.1.45.Final.jar
+    - netty-transport-native-epoll-4.1.45.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.45.Final.jar
+    - netty-transport-native-unix-common-4.1.45.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.9.9.jar
     - joda-time-2.10.1.jar


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #6330 

### Motivation

netty 4.1.43 has a bug preventing it from using Linux native Epoll transport

This results in pulsar brokers failing over to NioEventLoopGroup even when running on Linux.

The bug is fixed in netty releases `4.1.45.Final`

### Modifications

Bumped netty version to `4.1.45.Final`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.


*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
