### PR TITLE
doc: Add on the missing right parenthesis

### DIFF
--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -54,7 +54,7 @@ You can use tokens to authenticate the following Pulsar clients.
 PulsarClient client = PulsarClient.builder()
     .serviceUrl("pulsar://broker.example.com:6650/")
     .authentication(
-        AuthenticationFactory.token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY")
+        AuthenticationFactory.token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY")）
     .build();
 ```
 

--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -67,7 +67,7 @@ PulsarClient client = PulsarClient.builder()
         AuthenticationFactory.token(() -> {
             // Read token from custom source
             return readToken();
-        })
+        }))
     .build();
 ```
 


### PR DESCRIPTION
### Motivation

Missing right parenthesis in the `token()` line from Pulsar Client Java Code.


### Modifications

Add on right parenthesis in both L57 and L70.
