### PR TITLE
[pulsar-dashboard] Switch from MAINTAINER instruction to LABEL with maintainer's info

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -19,7 +19,7 @@
 
 FROM python:3.7-stretch
 
-MAINTAINER Pulsar
+LABEL maintainer="Apache Pulsar <dev@pulsar.apache.org>"
 
 RUN apt-get update
 RUN apt-get -y install postgresql python sudo nginx supervisor


### PR DESCRIPTION
### Motivation & Modification

The MAINTAINER instruction is [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) in favor of the LABEL instruction with the maintainer's info in docker files.
