### PR TITLE
Documentation page next/previous buttons result in 404 in functions section

### DIFF
--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -30,10 +30,6 @@
       "functions-develop",
       "functions-debug",
       "functions-deploy",
-      "functions-configure",
-      "functions-monitor",
-      "functions-secure",
-      "functions-troubleshoot",
       "functions-cli"
     ],
     "Pulsar IO": [


### PR DESCRIPTION
The referenced markdown files do not exist and so the "Next" and "Previous" buttons on the bottom of pages surrounding them result in 404 Not Found errors

### Motivation

Avoid 404 Error when navigating documentation.

### Modifications

Removes references to files which do not exist.

### Verifying this change

This change is a trivial rework

### Does this pull request potentially affect one of the following parts:

None

### Documentation

Bug fix only
