### PR TITLE
fix the bug of authenticationData is't initialized.

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -327,6 +327,7 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
             }
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
+            authenticationData = authState.getAuthDataSource();
             doAuthentication(clientData);
         } catch (Exception e) {
             LOG.warn("[{}] Unable to authenticate: ", remoteAddress, e);


### PR DESCRIPTION

### Motivation

fix the bug of authenticationData is't initialized.

the method ```org.apache.pulsar.proxy.server.ProxyConnection#handleConnect``` can't init the value of authenticationData.
cause of the bug that you will get the null value  form the method ```org.apache.pulsar.broker.authorization.AuthorizationProvider#canConsumeAsync```
when implements  ```org.apache.pulsar.broker.authorization.AuthorizationProvider``` interface.

### Modifications

init the value of authenticationData from the method ```org.apache.pulsar.proxy.server.ProxyConnection#handleConnect```.

### Verifying this change

implements  ```org.apache.pulsar.broker.authorization.AuthorizationProvider``` interface， and get the value of authenticationData.
