### PR TITLE
Documentation page next/previous buttons result in 404 in functions section  (Part II)

### DIFF
--- a/site2/website/versioned_sidebars/version-2.5.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.5.0-sidebars.json
@@ -31,10 +31,6 @@
       "version-2.5.0-functions-develop",
       "version-2.5.0-functions-debug",
       "version-2.5.0-functions-deploy",
-      "version-2.5.0-functions-configure",
-      "version-2.5.0-functions-monitor",
-      "version-2.5.0-functions-secure",
-      "version-2.5.0-functions-troubleshoot",
       "version-2.5.0-functions-cli"
     ],
     "Pulsar IO": [


### PR DESCRIPTION
The referenced markdown files do not exist and so the "Next" and "Previous" buttons on the bottom of pages surrounding them result in 404 Not Found errors

### Motivation

Extending pull request #6434 to apply to version 2.5.0 of the docs too.

Avoid 404 Error when navigating documentation.

### Modifications

Removes references to files which do not exist.

### Verifying this change

This change is a trivial rework

### Does this pull request potentially affect one of the following parts:

None

### Documentation

Bug fix only
