### PR TITLE
Improve cpp-client-lib: provide another `libpulsarwithdeps.a` in dep/rpm

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -73,6 +73,29 @@ endif(NOT LOG_CATEGORY_NAME)
 
 add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME} -DBUILDING_PULSAR -DBOOST_ALL_NO_LIB -DBOOST_ALLOW_DEPRECATED_HEADERS)
 
+### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
+### After find the libs, will unset related cache, and will not affact another same call to find_package.
+### B
+if (APPLE)
+    set(OPENSSL_INCLUDE_DIR /usr/local/opt/openssl/include/)
+    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl/)
+endif ()
+
+set(OPENSSL_ROOT_DIR /usr/lib64/)
+set(OPENSSL_USE_STATIC_LIBS FALSE)
+find_package(OpenSSL REQUIRED)
+set(RECORD_OPENSSL_SSL_LIBRARY ${OPENSSL_SSL_LIBRARY})
+set(RECORD_OPENSSL_CRYPTO_LIBRARY ${OPENSSL_CRYPTO_LIBRARY})
+
+unset(OPENSSL_FOUND CACHE)
+unset(OPENSSL_INCLUDE_DIR CACHE)
+unset(OPENSSL_CRYPTO_LIBRARY CACHE)
+unset(OPENSSL_CRYPTO_LIBRARIES CACHE)
+unset(OPENSSL_SSL_LIBRARY CACHE)
+unset(OPENSSL_SSL_LIBRARIES CACHE)
+unset(OPENSSL_LIBRARIES CACHE)
+unset(OPENSSL_VERSION CACHE)
+
 if (LINK_STATIC)
     find_library(ZLIB_LIBRARIES REQUIRED NAMES libz.a z zlib)
     find_library(Protobuf_LITE_LIBRARIES NAMES libprotobuf-lite.a libprotobuf-lite)

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -75,7 +75,6 @@ add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME} -DBUILDING_PULSAR -DBOO
 
 ### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
 ### After find the libs, will unset related cache, and will not affact another same call to find_package.
-### B
 if (APPLE)
     set(OPENSSL_INCLUDE_DIR /usr/local/opt/openssl/include/)
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl/)

--- a/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
+++ b/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
@@ -31,4 +31,4 @@ cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON \
         -DPYTHON_INCLUDE_DIR=/opt/python/$PYTHON_SPEC/include/python$PYTHON_VERSION \
         -DPYTHON_LIBRARY=/opt/python/$PYTHON_SPEC/lib \
 
-make pulsarShared pulsarStatic pulsarStaticWithDeps -j4
+make pulsarShared pulsarStatic -j4

--- a/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
+++ b/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
@@ -31,4 +31,4 @@ cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON \
         -DPYTHON_INCLUDE_DIR=/opt/python/$PYTHON_SPEC/include/python$PYTHON_VERSION \
         -DPYTHON_LIBRARY=/opt/python/$PYTHON_SPEC/lib \
 
-make pulsarShared pulsarStatic -j4
+make pulsarShared pulsarStatic pulsarStaticWithDeps -j4

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -72,7 +72,7 @@ if (MSVC)
 endif()
 
 # When linking statically, install a libpulsar.a that contains all the
-# required dependencies
+# required dependencies except ssl
 if (LINK_STATIC)
     if (MSVC)
         
@@ -98,8 +98,10 @@ if (LINK_STATIC)
         set_target_properties(pulsarStaticWithDeps PROPERTIES STATIC_LIBRARY_FLAGS_DEBUG ${DEBUG_STATIC_LIBS} STATIC_LIBRARY_FLAGS_RELEASE ${STATIC_LIBS} OUTPUT_NAME ${LIB_NAME}WithDeps VERSION ${LIBRARY_VERSION})
         install(TARGETS pulsarStaticWithDeps DESTINATION lib)
     else()
-        # Build a list of the requird .a libs to merge
+        # Build a list of the requird .a libs (except ssl) to merge
         SET(STATIC_LIBS "")
+        LIST(REMOVE_ITEM COMMON_LIBS ${OPENSSL_SSL_LIBRARY})
+        LIST(REMOVE_ITEM COMMON_LIBS ${OPENSSL_CRYPTO_LIBRARY})
         foreach (LIB IN LISTS COMMON_LIBS)
             if (${LIB} MATCHES ".+\\.a$")
                 set(STATIC_LIBS "${STATIC_LIBS} ${LIB}")
@@ -109,10 +111,9 @@ if (LINK_STATIC)
         add_custom_target(pulsarStaticWithDeps
                 ALL
                 BYPRODUCTS merged-library
-                COMMAND ./build-support/merge_archives.sh libpulsar.a $<TARGET_FILE:pulsarStatic> ${STATIC_LIBS}
+                COMMAND ./build-support/merge_archives.sh libpulsar.a $<TARGET_FILE:pulsarStatic> ${STATIC_LIBS} && mv merged-library/libpulsar.a lib/libpulsarwithdeps.a
                 DEPENDS pulsarStatic
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-        install(FILES ../merged-library/libpulsar.a DESTINATION lib)
     endif(MSVC)
 else()
     # Install regular libpulsar.a

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -61,6 +61,23 @@ add_library(pulsarShared SHARED ${PULSAR_SOURCES})
 set_target_properties(pulsarShared PROPERTIES OUTPUT_NAME ${LIB_NAME_SHARED} VERSION ${LIBRARY_VERSION})
 target_link_libraries(pulsarShared ${COMMON_LIBS} ${CMAKE_DL_LIBS})
 
+
+### pulsarSharedNossl not static link ssl, it could avoid rebuild libpulsar when ssl lib need update.
+### pulsarSharedNossl is build under condition LINK_STATIC=ON, we should replace static ssl libs with dynamic libs.
+SET(COMMON_LIBS_NOSSL ${COMMON_LIBS})
+if (NOT ${RECORD_OPENSSL_SSL_LIBRARY} MATCHES ".+\\.a$")
+    LIST(REMOVE_ITEM COMMON_LIBS_NOSSL ${OPENSSL_SSL_LIBRARY})
+    LIST(APPEND COMMON_LIBS_NOSSL ${RECORD_OPENSSL_SSL_LIBRARY})
+endif ()
+if (NOT ${RECORD_OPENSSL_CRYPTO_LIBRARY} MATCHES ".+\\.a$")
+    LIST(REMOVE_ITEM COMMON_LIBS_NOSSL  ${OPENSSL_CRYPTO_LIBRARY})
+    LIST(APPEND COMMON_LIBS_NOSSL ${RECORD_OPENSSL_CRYPTO_LIBRARY})
+endif ()
+
+add_library(pulsarSharedNossl SHARED ${PULSAR_SOURCES})
+set_target_properties(pulsarSharedNossl PROPERTIES OUTPUT_NAME ${LIB_NAME_SHARED}nossl VERSION ${LIBRARY_VERSION})
+target_link_libraries(pulsarSharedNossl ${COMMON_LIBS_NOSSL} ${CMAKE_DL_LIBS})
+
 add_library(pulsarStatic STATIC ${PULSAR_SOURCES})
 set_target_properties(pulsarStatic PROPERTIES OUTPUT_NAME ${LIB_NAME} VERSION ${LIBRARY_VERSION})
 target_compile_definitions(pulsarStatic PRIVATE PULSAR_STATIC)
@@ -100,10 +117,8 @@ if (LINK_STATIC)
     else()
         # Build a list of the requird .a libs (except ssl) to merge
         SET(STATIC_LIBS "")
-        LIST(REMOVE_ITEM COMMON_LIBS ${OPENSSL_SSL_LIBRARY})
-        LIST(REMOVE_ITEM COMMON_LIBS ${OPENSSL_CRYPTO_LIBRARY})
         foreach (LIB IN LISTS COMMON_LIBS)
-            if (${LIB} MATCHES ".+\\.a$")
+            if (${LIB} MATCHES ".+\\.a$" AND NOT ${LIB} MATCHES ${OPENSSL_SSL_LIBRARY} AND NOT ${LIB} MATCHES ${OPENSSL_CRYPTO_LIBRARY})
                 set(STATIC_LIBS "${STATIC_LIBS} ${LIB}")
             endif()
         endforeach()
@@ -123,4 +138,5 @@ endif(LINK_STATIC)
 
 install(TARGETS pulsarStatic DESTINATION lib)
 install(TARGETS pulsarShared RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+install(TARGETS pulsarSharedNossl RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 install(DIRECTORY "../include/pulsar" DESTINATION include)

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -64,13 +64,6 @@ RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.11.tar.gz && \
     make && make install && \
     rm -rf /v1.2.11.tar.gz /zlib-1.2.11
 
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-    tar xvfz OpenSSL_1_1_0j.tar.gz && \
-    cd openssl-OpenSSL_1_1_0j/ && \
-    ./Configure -fPIC --prefix=/usr/local/ssl/ no-shared linux-x86_64 && \
-    make && make install && \
-    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
-
 # Zstandard
 RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \
     tar xvfz zstd-1.3.7.tar.gz && \
@@ -78,6 +71,13 @@ RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.
     CFLAGS="-fPIC -O3" make -j8 && \
     make install && \
     rm -rf /zstd-1.3.7 /zstd-1.3.7.tar.gz
+
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
+    tar xvfz OpenSSL_1_1_0j.tar.gz && \
+    cd openssl-OpenSSL_1_1_0j/ && \
+    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
+    make && make install && \
+    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -38,7 +38,7 @@ tar xfz $SRC_ROOT_DIR/distribution/server/target/apache-pulsar-$POM_VERSION-src.
 pushd $CPP_DIR
 
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON
-make pulsarShared pulsarStatic -j 3
+make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3
 popd
 
 DEST_DIR=apache-pulsar-client
@@ -68,8 +68,11 @@ mkdir -p $DEVEL_DEST_DIR/usr/include
 mkdir -p $DEST_DIR/usr/share/doc/pulsar-client-$VERSION
 mkdir -p $DEVEL_DEST_DIR/usr/share/doc/pulsar-client-dev-$VERSION
 
+ls $CPP_DIR/lib/libpulsar*
+
 cp -ar $CPP_DIR/include/pulsar $DEVEL_DEST_DIR/usr/include/
 cp $CPP_DIR/lib/libpulsar.a $DEVEL_DEST_DIR/usr/lib
+cp $CPP_DIR/lib/libpulsarwithdeps.a $DEVEL_DEST_DIR/usr/lib
 cp $CPP_DIR/lib/libpulsar.so.$POM_VERSION $DEST_DIR/usr/lib
 pushd $DEST_DIR/usr/lib
 ln -s libpulsar.so.$POM_VERSION libpulsar.so

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -38,7 +38,7 @@ tar xfz $SRC_ROOT_DIR/distribution/server/target/apache-pulsar-$POM_VERSION-src.
 pushd $CPP_DIR
 
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON
-make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3
+make pulsarShared pulsarSharedNossl pulsarStatic pulsarStaticWithDeps  -j 3
 popd
 
 DEST_DIR=apache-pulsar-client
@@ -74,6 +74,8 @@ cp -ar $CPP_DIR/include/pulsar $DEVEL_DEST_DIR/usr/include/
 cp $CPP_DIR/lib/libpulsar.a $DEVEL_DEST_DIR/usr/lib
 cp $CPP_DIR/lib/libpulsarwithdeps.a $DEVEL_DEST_DIR/usr/lib
 cp $CPP_DIR/lib/libpulsar.so.$POM_VERSION $DEST_DIR/usr/lib
+cp $CPP_DIR/lib/libpulsarnossl.so.$POM_VERSION $DEST_DIR/usr/lib
+
 pushd $DEST_DIR/usr/lib
 ln -s libpulsar.so.$POM_VERSION libpulsar.so
 popd

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -78,6 +78,7 @@ cp $CPP_DIR/lib/libpulsarnossl.so.$POM_VERSION $DEST_DIR/usr/lib
 
 pushd $DEST_DIR/usr/lib
 ln -s libpulsar.so.$POM_VERSION libpulsar.so
+ln -s libpulsarnossl.so.$POM_VERSION libpulsarnossl.so
 popd
 
 cp $ROOT_DIR/NOTICE $DEST_DIR/usr/share/doc/pulsar-client-$VERSION

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -64,10 +64,18 @@ RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.11.tar.gz && \
     make && make install && \
     rm -rf /v1.2.11.tar.gz /zlib-1.2.11
 
+# Zstandard
+RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \
+    tar xvfz zstd-1.3.7.tar.gz && \
+    cd zstd-1.3.7 && \
+    CFLAGS="-fPIC -O3" make -j8 && \
+    make install && \
+    rm -rf /zstd-1.3.7 /zstd-1.3.7.tar.gz
+
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
     tar xvfz OpenSSL_1_1_0j.tar.gz && \
     cd openssl-OpenSSL_1_1_0j/ && \
-    ./Configure -fPIC --prefix=/usr/local/ssl/ no-shared linux-x86_64 && \
+    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make && make install && \
     rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
@@ -78,13 +86,5 @@ RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-
     CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
     make && make install && \
     rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
-
-# Zstandard
-RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \
-    tar xvfz zstd-1.3.7.tar.gz && \
-    cd zstd-1.3.7 && \
-    CFLAGS="-fPIC -O3" make -j8 && \
-    make install && \
-    rm -rf /zstd-1.3.7 /zstd-1.3.7.tar.gz
 
 ENV OPENSSL_ROOT_DIR /usr/local/ssl/

--- a/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
@@ -30,6 +30,7 @@ Version:        %{version}
 Release:        %{release}
 Source:         apache-pulsar-%{pom_version}-src.tar.gz
 Prefix:         /usr
+AutoReq:        no
 
 %package devel
 Summary:        Apache Pulsar client library

--- a/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
@@ -53,7 +53,7 @@ static library.
 %build
 cd pulsar-client-cpp
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON -DBUILD_PYTHON_WRAPPER=OFF
-make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3
+make pulsarShared pulsarSharedNossl pulsarStatic pulsarStaticWithDeps -j 3
 
 %install
 cd pulsar-client-cpp
@@ -67,6 +67,7 @@ cp -ar include/pulsar $INCLUDE_DIR
 cp lib/libpulsar.a $LIB_DIR
 cp lib/libpulsarwithdeps.a $LIB_DIR
 cp lib/libpulsar.so.%{pom_version} $LIB_DIR
+cp lib/libpulsarnossl.so.%{pom_version} $LIB_DIR
 
 # Copy LICENSE files
 cp ../NOTICE $DOC_DIR
@@ -76,11 +77,14 @@ cp $DOC_DIR/* $DOC_DEVEL_DIR/
 
 cd  $LIB_DIR
 ln -s libpulsar.so.%{pom_version} libpulsar.so
+ln -s libpulsarnossl.so.%{pom_version} libpulsarnossl.so
 
 %files
 %defattr(-,root,root)
 /usr/lib/libpulsar.so
 /usr/lib/libpulsar.so.%{pom_version}
+/usr/lib/libpulsarnossl.so
+/usr/lib/libpulsarnossl.so.%{pom_version}
 /usr/share/doc/pulsar-client-%{version}
 
 %files devel

--- a/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
@@ -53,7 +53,7 @@ static library.
 %build
 cd pulsar-client-cpp
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON -DBUILD_PYTHON_WRAPPER=OFF
-make pulsarShared pulsarStatic -j 3
+make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3
 
 %install
 cd pulsar-client-cpp
@@ -65,6 +65,7 @@ mkdir -p $INCLUDE_DIR $LIB_DIR $DOC_DIR $DOC_DEVEL_DIR
 
 cp -ar include/pulsar $INCLUDE_DIR
 cp lib/libpulsar.a $LIB_DIR
+cp lib/libpulsarwithdeps.a $LIB_DIR
 cp lib/libpulsar.so.%{pom_version} $LIB_DIR
 
 # Copy LICENSE files
@@ -85,5 +86,6 @@ ln -s libpulsar.so.%{pom_version} libpulsar.so
 %files devel
 %defattr(-,root,root)
 /usr/lib/libpulsar.a
+/usr/lib/libpulsarwithdeps.a
 /usr/include/pulsar
 /usr/share/doc/pulsar-client-devel-%{version}

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -64,6 +64,9 @@ by using user local system provided version is more reasonable, and more easy fo
 ```bash
 $ rpm -ivh apache-pulsar-client*.rpm
 ```
+
+After install, Pulsar libraries will be placed under `/usr/lib`.
+
 ### Install Debian
 
 1. Download a Debian package from the links in the table. 
@@ -78,6 +81,9 @@ $ rpm -ivh apache-pulsar-client*.rpm
 ```bash
 $ apt install ./apache-pulsar-client*.deb
 ```
+
+After install, Pulsar libraries will be placed under `/usr/lib`.
+
 ### Build
 
 > If you want to build RPM and Debian packages from the latest master, follow the instructions below. All the instructions are run at the root directory of your cloned Pulsar repository.

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -18,6 +18,31 @@ Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
 > Since 2.1.0 release, Pulsar ships pre-built RPM and Debian packages. You can download and install those packages directly.
 
+Three kind of libraries `libpulsar.so` / `libpulsar.a` / `libpulsarwithdeps.a` are included in your `/usr/lib` after rpm/deb download and install.
+By default, they are build under code path `${PULSAR_HOME}/pulsar-client-cpp`, using command
+ `cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON && make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3`
+
+1. `libpulsar.so` is the Shared library, it contains statically linked `boost` and `openssl`, and will also dynamically link all other needed libraries.
+The command the when use this pulsar library is like this:
+```bash
+ g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsar.so -I/usr/local/ssl/include
+```
+
+2. `libpulsar.a` is the Static library, it need to load some dependencies library when using it. 
+If you want to get detailed version of dependencies libraries, you can reference [these](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/rpm/Dockerfile) [file](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/deb/Dockerfile).
+The command the when use this pulsar library is like this:
+```bash
+ g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsar.a -lssl -lcrypto -ldl -lpthread  -I/usr/local/ssl/include -L/usr/local/ssl/lib -lboost_system -lboost_regex -lcurl -lprotobuf -lzstd -lz
+```
+
+3. `libpulsarwithdeps.a` is the Static library, base on `libpulsar.a`, and archived in the dependencies libraries of `libboost_regex`,  `libboost_system`, `libcurl`, `libprotobuf`, `libzstd` and `libz`, 
+The command the when use this pulsar library is like this:
+```bash
+ g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsarwithdeps.a -lssl -lcrypto -ldl -lpthread  -I/usr/local/ssl/include -L/usr/local/ssl/lib
+```
+`libpulsarwithdeps.a` does not include library openssl related libraries: `libssl` and `libcrypto`, because these 2 library is related to security, 
+by using user local system provided version is more reasonable, and more easy for user to handling security issue and library upgrade.
+
 ### Install RPM
 
 1. Download a RPM package from the links in the table. 
@@ -52,7 +77,7 @@ $ apt install ./apache-pulsar-client*.deb
 > If you want to build RPM and Debian packages from the latest master, follow the instructions below. All the instructions are run at the root directory of your cloned Pulsar repository.
 
 There are recipes that build RPM and Debian packages containing a
-statically linked `libpulsar.so` / `libpulsar.a` with all the required
+statically linked `libpulsar.so` / `libpulsar.a` / `libpulsarwithdeps.a` with all the required
 dependencies.
 
 To build the C++ library packages, build the Java packages first.
@@ -72,7 +97,7 @@ This builds the RPM inside a Docker container and it leaves the RPMs in `pulsar-
 | Package name | Content |
 |-----|-----|
 | pulsar-client | Shared library `libpulsar.so` |
-| pulsar-client-devel | Static library `libpulsar.a` and C++ and C headers |
+| pulsar-client-devel | Static library `libpulsar.a`, `libpulsarwithdeps.a`and C++ and C headers |
 | pulsar-client-debuginfo | Debug symbols for `libpulsar.so` |
 
 #### Debian
@@ -88,7 +113,7 @@ Debian packages are created at `pulsar-client-cpp/pkg/deb/BUILD/DEB/`.
 | Package name | Content |
 |-----|-----|
 | pulsar-client | Shared library `libpulsar.so` |
-| pulsar-client-dev | Static library `libpulsar.a` and C++ and C headers |
+| pulsar-client-dev | Static library `libpulsar.a`, `libpulsarwithdeps.a` and C++ and C headers |
 
 ## MacOS
 

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -18,9 +18,10 @@ Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
 > Since 2.1.0 release, Pulsar ships pre-built RPM and Debian packages. You can download and install those packages directly.
 
-Three kind of libraries `libpulsar.so` / `libpulsar.a` / `libpulsarwithdeps.a` are included in your `/usr/lib` after rpm/deb download and install.
+Four kind of libraries `libpulsar.so` / `libpulsarnossl.so` / `libpulsar.a` / `libpulsarwithdeps.a` are included in your `/usr/lib` after rpm/deb download and install.
 By default, they are build under code path `${PULSAR_HOME}/pulsar-client-cpp`, using command
- `cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON && make pulsarShared pulsarStatic pulsarStaticWithDeps -j 3`
+ `cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON && make pulsarShared pulsarSharedNossl pulsarStatic pulsarStaticWithDeps -j 3`
+These libraries rely on some other libraries, if you want to get detailed version of dependencies libraries, please reference [these](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/rpm/Dockerfile) [files](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/deb/Dockerfile).
 
 1. `libpulsar.so` is the Shared library, it contains statically linked `boost` and `openssl`, and will also dynamically link all other needed libraries.
 The command the when use this pulsar library is like this:
@@ -28,14 +29,19 @@ The command the when use this pulsar library is like this:
  g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsar.so -I/usr/local/ssl/include
 ```
 
-2. `libpulsar.a` is the Static library, it need to load some dependencies library when using it. 
-If you want to get detailed version of dependencies libraries, you can reference [these](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/rpm/Dockerfile) [file](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/pkg/deb/Dockerfile).
+2. `libpulsarnossl.so` is the Shared library that similar to `libpulsar.so` except that the library `openssl` and `crypto` are dynamically linked.
+The command the when use this pulsar library is like this:
+```bash
+ g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsarnossl.so -lssl -lcrypto -I/usr/local/ssl/include -L/usr/local/ssl/lib
+```
+
+3. `libpulsar.a` is the Static library, it need to load some dependencies library when using it. 
 The command the when use this pulsar library is like this:
 ```bash
  g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsar.a -lssl -lcrypto -ldl -lpthread  -I/usr/local/ssl/include -L/usr/local/ssl/lib -lboost_system -lboost_regex -lcurl -lprotobuf -lzstd -lz
 ```
 
-3. `libpulsarwithdeps.a` is the Static library, base on `libpulsar.a`, and archived in the dependencies libraries of `libboost_regex`,  `libboost_system`, `libcurl`, `libprotobuf`, `libzstd` and `libz`, 
+4. `libpulsarwithdeps.a` is the Static library, base on `libpulsar.a`, and archived in the dependencies libraries of `libboost_regex`,  `libboost_system`, `libcurl`, `libprotobuf`, `libzstd` and `libz`, 
 The command the when use this pulsar library is like this:
 ```bash
  g++ --std=c++11  PulsarTest.cpp -o test /usr/lib/libpulsarwithdeps.a -lssl -lcrypto -ldl -lpthread  -I/usr/local/ssl/include -L/usr/local/ssl/lib
@@ -77,7 +83,7 @@ $ apt install ./apache-pulsar-client*.deb
 > If you want to build RPM and Debian packages from the latest master, follow the instructions below. All the instructions are run at the root directory of your cloned Pulsar repository.
 
 There are recipes that build RPM and Debian packages containing a
-statically linked `libpulsar.so` / `libpulsar.a` / `libpulsarwithdeps.a` with all the required
+statically linked `libpulsar.so` / `libpulsarnossl.so` / `libpulsar.a` / `libpulsarwithdeps.a` with all the required
 dependencies.
 
 To build the C++ library packages, build the Java packages first.
@@ -96,7 +102,7 @@ This builds the RPM inside a Docker container and it leaves the RPMs in `pulsar-
 
 | Package name | Content |
 |-----|-----|
-| pulsar-client | Shared library `libpulsar.so` |
+| pulsar-client | Shared library `libpulsar.so` and `libpulsarnossl.so` |
 | pulsar-client-devel | Static library `libpulsar.a`, `libpulsarwithdeps.a`and C++ and C headers |
 | pulsar-client-debuginfo | Debug symbols for `libpulsar.so` |
 
@@ -112,7 +118,7 @@ Debian packages are created at `pulsar-client-cpp/pkg/deb/BUILD/DEB/`.
 
 | Package name | Content |
 |-----|-----|
-| pulsar-client | Shared library `libpulsar.so` |
+| pulsar-client | Shared library `libpulsar.so` and `libpulsarnossl.so` |
 | pulsar-client-dev | Static library `libpulsar.a`, `libpulsarwithdeps.a` and C++ and C headers |
 
 ## MacOS


### PR DESCRIPTION
Fix #6439 
We shouldn't static link libssl in libpulsar.a, as this is a security red flag. we should just use whatever the libssl the system provides. Because if there is a security problem in libssl, all the machines can just update their own libssl library without rebuilding libpulsar.a.
As suggested, this change not change the old behavior, and mainly provides 2 other additional pulsar cpp client library in deb/rpm, and add related docs of how to use 4 libs in doc.
The additional 2 libs: 
- pulsarSharedNossl (libpulsarnossl.so), similar to pulsarShared(libpulsar.so), with no ssl statically linked.
- pulsarStaticWithDeps(libpulsarwithdeps.a), similar to pulsarStatic(libpulsar.a), and archived in the dependencies libraries of `libboost_regex`,  `libboost_system`, `libcurl`, `libprotobuf`, `libzstd` and `libz` statically.

Passed 4 libs rpm/deb build, install, and compile with a pulsar-client example code.
