### PR TITLE
pulsar-proxy: fix correct name for proxy thread executor name

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/util/ZookeeperCacheLoader.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/util/ZookeeperCacheLoader.java
@@ -54,7 +54,7 @@ public class ZookeeperCacheLoader implements Closeable {
     private volatile List<LoadManagerReport> availableBrokers;
 
     private final OrderedScheduler orderedExecutor = OrderedScheduler.newSchedulerBuilder().numThreads(8)
-            .name("pulsar-discovery-ordered-cache").build();
+            .name("pulsar-proxy-ordered-cache").build();
 
     public static final String LOADBALANCE_BROKERS_ROOT = "/loadbalance/brokers";
 


### PR DESCRIPTION
### Motivation
fix correct name for proxy thread executor name