### PR TITLE
upgrade scala-maven-plugin to 4.1.0

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -133,7 +133,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### Motivation
The Pulsar examples includes some third-party libraries with security vulnerabilities.
- log4j-core-2.8.1
https://www.cvedetails.com/cve/CVE-2017-5645

### Modifications

- Upgraded the version of scala-maven-plugin from 4.0.1 to 4.1.0. log4j-core-2.8.1 were installed because scala-maven-plugin depends on it.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
