### PR TITLE
[pulsar-proxy] fixing data-type of logging-level

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -153,7 +153,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
                     + " 1: Parse and log any tcp channel info and command info without message body"
                     + " 2: Parse and log channel info, command info and message body"
     )
-    private Integer proxyLogLevel = 0;
+    private Optional<Integer> proxyLogLevel = Optional.ofNullable(0);
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -384,13 +384,6 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     public Optional<Integer> getServicePort() {
         return servicePort;
-    }
-
-    public Optional<Integer> getproxyLogLevel() {
-        return Optional.ofNullable(proxyLogLevel);
-    }
-    public void setProxyLogLevel(int proxyLogLevel) {
-        this.proxyLogLevel = proxyLogLevel;
     }
 
     public Optional<Integer> getServicePortTls() {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -106,8 +106,8 @@ public class ProxyService implements Closeable {
         this.lookupRequestSemaphore = new AtomicReference<Semaphore>(
                 new Semaphore(proxyConfig.getMaxConcurrentLookupRequests(), false));
 
-        if (proxyConfig.getproxyLogLevel().isPresent()) {
-            ProxyService.proxyLogLevel = Integer.valueOf(proxyConfig.getproxyLogLevel().get());
+        if (proxyConfig.getProxyLogLevel().isPresent()) {
+            ProxyService.proxyLogLevel = Integer.valueOf(proxyConfig.getProxyLogLevel().get());
         } else {
             ProxyService.proxyLogLevel = 0;
         }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
@@ -75,14 +75,14 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
         proxyConfig.setZookeeperServers(DUMMY_VALUE);
         proxyConfig.setConfigurationStoreServers(DUMMY_VALUE);
         //enable full parsing feature
-        proxyConfig.setProxyLogLevel(2);
+        proxyConfig.setProxyLogLevel(Optional.ofNullable(2));
 
         proxyService = Mockito.spy(new ProxyService(proxyConfig, new AuthenticationService(
                                                             PulsarConfigurationLoader.convertFrom(proxyConfig))));
         doReturn(mockZooKeeperClientFactory).when(proxyService).getZooKeeperClientFactory();
 
         Optional<Integer> proxyLogLevel = Optional.of(2);
-        assertEquals( proxyLogLevel , proxyService.getConfiguration().getproxyLogLevel());
+        assertEquals( proxyLogLevel , proxyService.getConfiguration().getProxyLogLevel());
         proxyService.start();
     }
 


### PR DESCRIPTION
### Modification
`ProxyConfig` has wrapper method for `proxyLogLevel` to present `Optional` data-type. after #3543 we can define config param as optional without creating wrapper methods.