### PR TITLE
[functions] WIP Introduce `RichFunction` interface for more control

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/OutputRecord.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/OutputRecord.java
@@ -16,25 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.instance;
-
-import lombok.Data;
-import org.apache.pulsar.functions.api.OutputRecord;
+package org.apache.pulsar.functions.api;
 
 /**
- * This is the Java Instance. This is started by the runtimeSpawner using the JavaInstanceClient
- * program if invoking via a process based invocation or using JavaInstance using a thread
- * based invocation.
+ * This small extension to the interface allows us to fetch the sourceRecord
+ * from the outputRecord
+ * @param <O> the type of the record value
  */
-@Data
-public class JavaExecutionResult {
-    private Exception userException;
-    private Exception systemException;
-    private OutputRecord result;
-
-    public void reset() {
-        setUserException(null);
-        setSystemException(null);
-        setResult(null);
-    }
+public interface OutputRecord<I, O> extends Record<O> {
+    Record<I> getSourceRecord();
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/RichFunction.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/RichFunction.java
@@ -16,25 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.instance;
-
-import lombok.Data;
-import org.apache.pulsar.functions.api.OutputRecord;
+package org.apache.pulsar.functions.api;
 
 /**
- * This is the Java Instance. This is started by the runtimeSpawner using the JavaInstanceClient
- * program if invoking via a process based invocation or using JavaInstance using a thread
- * based invocation.
+ * This interface is a more advanced version of the `Function`, which allows for more complex processing
+ * and control of the outgoing message. This enables use cases like controlling the ack behavior as well
+ * as dynamically routing the message to an output topic based on the message while
+ * still allowing the Functions API to do error handling.
+ *
+ * All instances of `Function` are wrapped with a default implementation of this interface
  */
-@Data
-public class JavaExecutionResult {
-    private Exception userException;
-    private Exception systemException;
-    private OutputRecord result;
-
-    public void reset() {
-        setUserException(null);
-        setSystemException(null);
-        setResult(null);
-    }
+public interface RichFunction<I, O> {
+    /**
+     * Process the input.
+     *
+     * @return the output, wrapped in an implementation of record
+     */
+    OutputRecord<I, O> process(Record<I> srcRecord, Context context) throws Exception;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/DefaultRichFunctionWrapper.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/DefaultRichFunctionWrapper.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance;
+
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.OutputRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.RichFunction;
+
+public class DefaultRichFunctionWrapper<I, O> implements RichFunction<I, O> {
+    private static class JavaFuncWrapper<I, O> implements Function<I, O> {
+        private final java.util.function.Function<I, O> func;
+        JavaFuncWrapper(java.util.function.Function<I, O> func) {
+            this.func = func;
+        }
+
+        @Override
+        public O process(I input, Context context) throws Exception {
+            return func.apply(input);
+        }
+    }
+
+    private final Function<I, O> func;
+    DefaultRichFunctionWrapper(Function<I, O> func){
+        this.func = func;
+    }
+    DefaultRichFunctionWrapper(java.util.function.Function<I, O> function) {
+        this.func = new JavaFuncWrapper<>(function);
+    }
+
+    @Override
+    public OutputRecord<I, O> process(Record<I> srcRecord, Context context) throws Exception {
+        return new SinkRecord<>(srcRecord, func.process(srcRecord.getValue(), context));
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -264,7 +264,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
                 // process the message
                 Thread.currentThread().setContextClassLoader(functionClassLoader);
-                result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
+                result = javaInstance.handleMessage(currentRecord);
                 Thread.currentThread().setContextClassLoader(instanceClassLoader);
 
                 // register end time

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -24,16 +24,18 @@ import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import org.apache.pulsar.functions.api.OutputRecord;
 import org.apache.pulsar.functions.api.Record;
 
 @Data
 @AllArgsConstructor
-public class SinkRecord<T> implements Record<T> {
+public class SinkRecord<I, O> implements OutputRecord<I, O> {
 
-    private final Record<T> sourceRecord;
-    private final T value;
+    private final Record<I> sourceRecord;
+    private final O value;
 
-    public Record<T> getSourceRecord() {
+    @Override
+    public Record<I> getSourceRecord() {
         return sourceRecord;
     }
 
@@ -48,7 +50,7 @@ public class SinkRecord<T> implements Record<T> {
     }
 
     @Override
-    public T getValue() {
+    public O getValue() {
         return value;
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.functions.api.OutputRecord;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.FunctionResultRouter;
 import org.apache.pulsar.functions.instance.SinkRecord;
@@ -140,8 +141,8 @@ public class PulsarSink<T> implements Sink<T> {
         public Function<Throwable, Void> getPublishErrorHandler(Record<T> record, boolean failSource) {
 
             return throwable -> {
-                SinkRecord<T> sinkRecord = (SinkRecord<T>) record;
-                Record<T> srcRecord = sinkRecord.getSourceRecord();
+                OutputRecord<?, T> sinkRecord = (OutputRecord<?, T>) record;
+                Record<?> srcRecord = sinkRecord.getSourceRecord();
                 if (failSource) {
                     srcRecord.fail();
                 }
@@ -284,9 +285,9 @@ public class PulsarSink<T> implements Sink<T> {
             msg.properties(record.getProperties());
         }
 
-        SinkRecord<T> sinkRecord = (SinkRecord<T>) record;
+        SinkRecord<?, T> sinkRecord = (SinkRecord<?, T>) record;
         if (sinkRecord.getSourceRecord() instanceof PulsarRecord) {
-            PulsarRecord<T> pulsarRecord = (PulsarRecord<T>) sinkRecord.getSourceRecord();
+            PulsarRecord<?> pulsarRecord = (PulsarRecord<?>) sinkRecord.getSourceRecord();
             // forward user properties to sink-topic
             msg.property("__pfn_input_topic__", pulsarRecord.getTopicName().get())
                .property("__pfn_input_msg_id__",


### PR DESCRIPTION
Early commit! Not intended for merge, just discussion.

This commit introduces a new interface `RichFunction` (name subject to
change!) that gives you more control over `Record` object emitted by
functions, here is some reasons for it:

- in some cases where a function has outputs to multiple topics, you
currently need to use the context and manually do sends, however, for
performance reasons, you need to use `sendAsync` which then creates some
issues around error handling and any delivery gurantees are now up to
the user. Since you don't control acks, there are
cases in which you can lose messages in error handling. With this API,
it is trivial to just return a message with an overriden
destinationTopic, which the `PulsarSink` already handles
- in cases where you want to do some work asyncronously, you may want to
control ack-ing to ensure that the async work is completed before you
ack the source message. This gives you the ability to do that

