### PR TITLE
[pulsar-proxy] update proxy logging dynamically

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -136,7 +136,7 @@ public class DirectProxyHandler {
             cnx.setRemoteHostName(targetBroker.getHost());
 
             // if enable full parsing feature
-            if (ProxyService.proxyLogLevel == 2) {
+            if (service.getProxyLogLevel() == 2) {
                 //Set a map between inbound and outbound,
                 //so can find inbound by outbound or find outbound by inbound
                 inboundOutboundChannelMap.put(outboundChannel.id() , inboundChannel.id());
@@ -279,7 +279,7 @@ public class DirectProxyHandler {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] [{}] Removing decoder from pipeline", inboundChannel, outboundChannel);
                 }
-                if (ProxyService.proxyLogLevel == 0) {
+                if (service.getProxyLogLevel() == 0) {
                     // direct tcp proxy
                     inboundChannel.pipeline().remove("frameDecoder");
                     outboundChannel.pipeline().remove("frameDecoder");

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
@@ -119,7 +119,7 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
                     break;
 
                 case SEND:
-                    if (ProxyService.proxyLogLevel != 2) {
+                    if (service.getProxyLogLevel() != 2) {
                         logging(ctx.channel() , cmd.getType() , "", null);
                         break;
                     }
@@ -144,7 +144,7 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
                     break;
 
                 case MESSAGE:
-                    if (ProxyService.proxyLogLevel != 2) {
+                    if (service.getProxyLogLevel() != 2) {
                         logging(ctx.channel() , cmd.getType() , "" , null);
                         break;
                     }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -30,6 +30,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -88,7 +89,9 @@ public class ProxyService implements Closeable {
 
     protected final AtomicReference<Semaphore> lookupRequestSemaphore;
 
-    protected static int proxyLogLevel;
+    @Getter
+    @Setter
+    protected int proxyLogLevel;
 
     private final ScheduledExecutorService statsExecutor;
 
@@ -128,9 +131,9 @@ public class ProxyService implements Closeable {
                 new Semaphore(proxyConfig.getMaxConcurrentLookupRequests(), false));
 
         if (proxyConfig.getProxyLogLevel().isPresent()) {
-            ProxyService.proxyLogLevel = Integer.valueOf(proxyConfig.getProxyLogLevel().get());
+            proxyLogLevel = Integer.valueOf(proxyConfig.getProxyLogLevel().get());
         } else {
-            ProxyService.proxyLogLevel = 0;
+            proxyLogLevel = 0;
         }
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(1, acceptorThreadFactory);
         this.workerGroup = EventLoopUtil.newEventLoopGroup(numThreads, workersThreadFactory);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/ProxyStats.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/ProxyStats.java
@@ -26,6 +26,8 @@ import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.POST;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
@@ -83,6 +85,24 @@ public class ProxyStats {
             throw new RestException(Status.PRECONDITION_FAILED, "Proxy doesn't have logging level 2");
         }
         return proxyService().getTopicStats();
+    }
+
+    @POST
+    @Path("/logging/{logLevel}")
+    @ApiOperation(hidden = true, value = "Change proxy logging level dynamically", notes = "It only changes log-level in memory, change it config file to persist the change")
+    @ApiResponses(value = { @ApiResponse(code = 412, message = "Proxy log level can be [0-2]"), })
+    public void updateProxyLogLevel(@PathParam("logLevel") int logLevel) {
+        if (logLevel < 0 || logLevel > 2) {
+            throw new RestException(Status.PRECONDITION_FAILED, "Proxy log level can be only [0-2]");
+        }
+        proxyService().setProxyLogLevel(logLevel);
+    }
+
+    @GET
+    @Path("/logging")
+    @ApiOperation(hidden = true, value = "Get proxy logging")
+    public int getProxyLogLevel(@PathParam("logLevel") int logLevel) {
+        return proxyService().getProxyLogLevel();
     }
 
     protected ProxyService proxyService() {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -145,6 +147,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
      */
     @Test
     public void testTopicStats() throws Exception {
+        proxyService.setProxyLogLevel(2);
         final String topicName = "persistent://sample/test/local/topic-stats";
         final String topicName2 = "persistent://sample/test/local/topic-stats-2";
 
@@ -186,6 +189,22 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
         consumer.close();
         consumer2.close();
         client.close();
+    }
+
+    /**
+     * Change proxy log level dynamically
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testChangeLogLevel() throws Exception {
+        Assert.assertEquals(proxyService.getProxyLogLevel(), 2);
+        int newLogLevel = 1;
+        Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
+        Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/proxy-stats/logging/" + newLogLevel)
+                .request().post(Entity.entity("", MediaType.APPLICATION_JSON));
+        Assert.assertEquals(r.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+        Assert.assertEquals(proxyService.getProxyLogLevel(), newLogLevel);
     }
 
 }


### PR DESCRIPTION
### Motivation
This PR is on top of #6473 
Right now, in proxy we don't have a way to change proxy-log level dynamically and because of that we have to restart proxy for any troubleshooting and we lose all stats if we restart the proxy. So, it would be great if we can have a way to change the logging level dynamically.

### Modification
Add rest api to change logging level dynamically.

**Note:**
I am creating separate PR to add CLI to access the proxy admin api.