### PR TITLE
[pulsar-proxy] Add CLI support to get pulsar-proxy stats

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/ProxyStats.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/ProxyStats.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * Admin interface for proxy stats management.
+ */
+public interface ProxyStats {
+
+    /**
+     * Returns Connections metrics.
+     *
+     * @return
+     * @throws PulsarAdminException
+     */
+
+    JsonArray getConnections() throws PulsarAdminException;
+
+    /**
+     * Returns Topics metrics.
+     *
+     * @return
+     * @throws PulsarAdminException
+     */
+    JsonObject getTopics() throws PulsarAdminException;
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.admin.internal.JacksonConfigurator;
 import org.apache.pulsar.client.admin.internal.LookupImpl;
 import org.apache.pulsar.client.admin.internal.NamespacesImpl;
 import org.apache.pulsar.client.admin.internal.NonPersistentTopicsImpl;
+import org.apache.pulsar.client.admin.internal.ProxyStatsImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.admin.internal.ResourceQuotasImpl;
 import org.apache.pulsar.client.admin.internal.SchemasImpl;
@@ -75,6 +76,7 @@ public class PulsarAdmin implements Closeable {
     private final Clusters clusters;
     private final Brokers brokers;
     private final BrokerStats brokerStats;
+    private final ProxyStats proxyStats;
     private final Tenants tenants;
     private final Properties properties;
     private final Namespaces namespaces;
@@ -191,6 +193,7 @@ public class PulsarAdmin implements Closeable {
         this.clusters = new ClustersImpl(root, auth, readTimeoutMs);
         this.brokers = new BrokersImpl(root, auth, readTimeoutMs);
         this.brokerStats = new BrokerStatsImpl(root, auth, readTimeoutMs);
+        this.proxyStats = new ProxyStatsImpl(root, auth, readTimeoutMs);
         this.tenants = new TenantsImpl(root, auth, readTimeoutMs);
         this.properties = new TenantsImpl(root, auth, readTimeoutMs);
         this.namespaces = new NamespacesImpl(root, auth, readTimeoutMs);
@@ -386,6 +389,13 @@ public class PulsarAdmin implements Closeable {
      */
     public BrokerStats brokerStats() {
         return brokerStats;
+    }
+
+    /**
+     * @return the proxy statics
+     */
+    public ProxyStats proxyStats() {
+        return proxyStats;
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin.internal;
+
+import javax.ws.rs.client.WebTarget;
+
+import org.apache.pulsar.client.admin.ProxyStats;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Authentication;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * Pulsar Admin API client.
+ *
+ *
+ */
+public class ProxyStatsImpl extends BaseResource implements ProxyStats {
+
+    private final WebTarget adminProxyStats;
+
+    public ProxyStatsImpl(WebTarget target, Authentication auth, long readTimeoutMs) {
+        super(auth, readTimeoutMs);
+        adminProxyStats = target.path("/proxy-stats");
+    }
+    
+    @Override
+    public JsonArray getConnections() throws PulsarAdminException {
+        try {
+            String json = request(adminProxyStats.path("/connections")).get(String.class);
+            return new Gson().fromJson(json, JsonArray.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public JsonObject getTopics() throws PulsarAdminException {
+        try {
+            String json = request(adminProxyStats.path("/topics")).get(String.class);
+            return new Gson().fromJson(json, JsonObject.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
@@ -18,15 +18,15 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
 import javax.ws.rs.client.WebTarget;
 
 import org.apache.pulsar.client.admin.ProxyStats;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 
 /**
  * Pulsar Admin API client.
@@ -41,7 +41,7 @@ public class ProxyStatsImpl extends BaseResource implements ProxyStats {
         super(auth, readTimeoutMs);
         adminProxyStats = target.path("/proxy-stats");
     }
-    
+
     @Override
     public JsonArray getConnections() throws PulsarAdminException {
         try {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.admin.Clusters;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.NonPersistentTopics;
+import org.apache.pulsar.client.admin.ProxyStats;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.ResourceQuotas;
 import org.apache.pulsar.client.admin.Schemas;
@@ -900,6 +901,21 @@ public class PulsarAdminToolTest {
         atuh = (AuthenticationTls) conf.getAuthentication();
         assertNull(atuh.getCertFilePath());
         assertNull(atuh.getKeyFilePath());
+    }
+
+    @Test
+    void proxy() throws Exception {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        ProxyStats mockProxyStats = mock(ProxyStats.class);
+        doReturn(mockProxyStats).when(admin).proxyStats();
+
+        CmdProxyStats proxyStats = new CmdProxyStats(admin);
+
+        proxyStats.run(split("connections"));
+        verify(mockProxyStats).getConnections();
+
+        proxyStats.run(split("topics"));
+        verify(mockProxyStats).getTopics();
     }
 
     String[] split(String s) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdProxyStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdProxyStats.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import java.io.IOException;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+@Parameters(commandDescription = "Operations to collect Proxy statistics")
+public class CmdProxyStats extends CmdBase {
+
+    @Parameters(commandDescription = "dump connections metrics for Monitoring")
+    private class CmdConnectionMetrics extends CliCommand {
+        @Parameter(names = { "-i", "--indent" }, description = "Indent JSON output", required = false)
+        private boolean indent = false;
+
+        @Override
+        void run() throws Exception {
+            JsonArray stats = admin.proxyStats().getConnections();
+            printStats(stats, indent);
+        }
+    }
+
+    @Parameters(commandDescription = "dump topics metrics for Monitoring")
+    private class CmdTopicsMetrics extends CliCommand {
+        @Parameter(names = { "-i", "--indent" }, description = "Indent JSON output", required = false)
+        private boolean indent = false;
+
+        @Override
+        void run() throws Exception {
+            JsonObject stats = admin.proxyStats().getTopics();
+            printStats(stats, indent);
+        }
+    }
+
+    public void printStats(JsonElement json, boolean indent) throws IOException {
+        GsonBuilder builder = new GsonBuilder();
+        Gson gson = indent ? builder.setPrettyPrinting().create() : builder.create();
+        System.out.println(gson.toJson(json));
+    }
+
+    public CmdProxyStats(PulsarAdmin admin) {
+        super("proxy-stats", admin);
+        jcommander.addCommand("connections", new CmdConnectionMetrics());
+        jcommander.addCommand("topics", new CmdTopicsMetrics());
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -106,6 +106,9 @@ public class PulsarAdminTool {
 
 
         commandMap.put("resource-quotas", CmdResourceQuotas.class);
+        // pulsar-proxy cli
+        commandMap.put("proxy-stats", CmdProxyStats.class);
+        
         commandMap.put("functions", CmdFunctions.class);
         commandMap.put("functions-worker", CmdFunctionWorker.class);
         commandMap.put("sources", CmdSources.class);


### PR DESCRIPTION
### Motivation
Note: This PR is top on #6473 
In PR: #6473 we have added REST-API to get stats for the pulsar-proxy.
However, we also need cli tool to call such api and retrieve stats.

### Modification
Added CLI for proxy-stats.

**Note:**
I will rebase this PR once, #6473 changes are reviewed and merged.