### PR TITLE
[function][Ftr] Add publishFunction for go-function

### DIFF
--- a/pulsar-function-go/examples/publishFunc/publish_func.go
+++ b/pulsar-function-go/examples/publishFunc/publish_func.go
@@ -21,12 +21,13 @@ package main
 
 import (
 	"context"
+
 	"github.com/apache/pulsar/pulsar-function-go/pf"
 )
 
 func contextFunc(ctx context.Context) {
 	if fc, ok := pf.FromContext(ctx); ok {
-		fc.NewOutputMessage("your publish topic")
+		fc.NewOutputMessage("your-publish-topic")
 	}
 	return
 }

--- a/pulsar-function-go/examples/publishFunc/publish_func.go
+++ b/pulsar-function-go/examples/publishFunc/publish_func.go
@@ -1,0 +1,36 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"context"
+	"github.com/apache/pulsar/pulsar-function-go/pf"
+)
+
+func contextFunc(ctx context.Context) {
+	if fc, ok := pf.FromContext(ctx); ok {
+		fc.NewOutputMessage("your publish topic")
+	}
+	return
+}
+
+func main() {
+	pf.Start(contextFunc)
+}

--- a/pulsar-function-go/go.mod
+++ b/pulsar-function-go/go.mod
@@ -10,11 +10,3 @@ require (
 	google.golang.org/grpc v1.26.0
 	gopkg.in/yaml.v2 v2.2.8
 )
-
-replace github.com/apache/pulsar/pulsar-function-go/pf => ./pf
-
-replace github.com/apache/pulsar/pulsar-function-go/logutil => ./logutil
-
-replace github.com/apache/pulsar/pulsar-function-go/pb => ./pb
-
-replace github.com/apache/pulsar/pulsar-function-go/conf => ./conf

--- a/pulsar-function-go/go.sum
+++ b/pulsar-function-go/go.sum
@@ -1,11 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/apache/pulsar v2.5.0+incompatible h1:g7BI4EcfHFq+OwyXXPeEnTo2hL2Koq8Y/ckBkccDgmA=
-github.com/apache/pulsar-client-go v0.0.0-20200113085434-9b739cf9d098/go.mod h1:G+CQVHnh2EPfNEQXOuisIDAyPMiKnzz4Vim/kjtj4U4=
 github.com/apache/pulsar-client-go v0.0.0-20200116214305-4d788d9935ed h1:Lp7eU5ym84jPmIXoonoaJWVN6psyB90Olookp61LCeA=
 github.com/apache/pulsar-client-go v0.0.0-20200116214305-4d788d9935ed/go.mod h1:G+CQVHnh2EPfNEQXOuisIDAyPMiKnzz4Vim/kjtj4U4=
-github.com/apache/pulsar/pulsar-function-go v0.0.0-20200124033432-ec122ed9562c h1:uqA9RBsmQz3gN045GQ6we1RfRsk+5dco60yJ695Yb0E=
-github.com/apache/pulsar/pulsar-function-go v0.0.0-20200124033432-ec122ed9562c/go.mod h1:2a3PacwSg4KPcGxO3bjH29xsoKSuSkq2mG0sjKtxsP4=
 github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6/go.mod h1:6YNgTHLutezwnBvyneBbwvB8C82y3dcoOj5EQJIdGXA=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -87,7 +83,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -21,9 +21,10 @@ package pf
 
 import (
 	"context"
+	"time"
+
 	"github.com/apache/pulsar-client-go/pulsar"
 	log "github.com/apache/pulsar/pulsar-function-go/logutil"
-	"time"
 )
 
 type FunctionContext struct {

--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -37,8 +37,9 @@ type FunctionContext struct {
 
 func NewFuncContext() *FunctionContext {
 	fc := &FunctionContext{
-		instanceConf: newInstanceConf(),
-		userConfigs:  make(map[string]interface{}),
+		instanceConf:     newInstanceConf(),
+		userConfigs:      make(map[string]interface{}),
+		publishProducers: make(map[string]pulsar.Producer),
 	}
 	return fc
 }
@@ -79,7 +80,7 @@ func (c *FunctionContext) getProducer(topic string) (pulsar.Producer, error) {
 		c.instanceConf.funcDetails.Tenant,
 		c.instanceConf.funcDetails.Namespace,
 		c.instanceConf.funcDetails.Name), c.instanceConf.instanceID)
-	provider, err := c.instance.client.CreateProducer(pulsar.ProducerOptions{
+	producer, err := c.instance.client.CreateProducer(pulsar.ProducerOptions{
 		Topic:                   topic,
 		Properties:              properties,
 		CompressionType:         pulsar.LZ4,
@@ -87,8 +88,8 @@ func (c *FunctionContext) getProducer(topic string) (pulsar.Producer, error) {
 		// set send timeout to be infinity to prevent potential deadlock with consumer
 		// that might happen when consumer is blocked due to unacked messages
 	})
-	c.publishProducers[topic] = provider
-	return provider, err
+	c.publishProducers[topic] = producer
+	return producer, err
 }
 
 func (c *FunctionContext) GetFuncTenant() string {

--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -87,6 +87,7 @@ func (c *FunctionContext) getProducer(topic string) (pulsar.Producer, error) {
 		// set send timeout to be infinity to prevent potential deadlock with consumer
 		// that might happen when consumer is blocked due to unacked messages
 	})
+	c.publishProducers[topic] = provider
 	return provider, err
 }
 


### PR DESCRIPTION


### Motivation
At present, function only has the function of calculating and changing message content, and has no routing function. This PR is intended to provide such a function. After function calculation, messages can be distributed to different outtopics for different consumers to consume. I think this function is a more practical one.
Explain here the context, and why you're making that change. What is the problem you're trying to solve.

### Modifications

Describe the modifications you've done.

My change is not big. A go function maintains a producer map to replace the previous one. The user can select the producer of the outtopic he wants by setting the value of the outtopic in the context. If the producer does not exist, create one. What I want to discuss here is what we should do if the producer fails to create. as java-function do ,I put this producer map in context

