### PR TITLE
[broker] Fix maxPendingPublishedRequestsPerConnection value in conf files

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -116,7 +116,7 @@ brokerDeleteInactiveTopicsMaxInactiveDurationSeconds=
 
 # Max pending publish requests per connection to avoid keeping large number of pending 
 # requests in memory. Default: 1000
-maxPendingPublishdRequestsPerConnection=1000;
+maxPendingPublishdRequestsPerConnection=1000
 
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -77,7 +77,7 @@ brokerDeleteInactiveTopicsFrequencySeconds=60
 
 # Max pending publish requests per connection to avoid keeping large number of pending 
 # requests in memory. Default: 1000
-maxPendingPublishdRequestsPerConnection=1000;
+maxPendingPublishdRequestsPerConnection=1000
 
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5


### PR DESCRIPTION
The value of `maxPendingPublishedRequestsPerConnection` in conf files has a semicolon at the end. This causes the standalone server to fail to start.
```
Exception in thread "main" java.lang.IllegalArgumentException: failed to initialize maxPendingPublishdRequestsPerConnection field while setting value 1000;
        at org.apache.pulsar.common.util.FieldParser.lambda$update$0(FieldParser.java:146)
        at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
        at org.apache.pulsar.common.util.FieldParser.update(FieldParser.java:135)
        at org.apache.pulsar.common.configuration.PulsarConfigurationLoader.create(PulsarConfigurationLoader.java:97)
        at org.apache.pulsar.common.configuration.PulsarConfigurationLoader.create(PulsarConfigurationLoader.java:74)
        at org.apache.pulsar.PulsarStandaloneStarter.<init>(PulsarStandaloneStarter.java:60)
        at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:117)
Caused by: java.lang.RuntimeException: Cannot convert from java.lang.String to java.lang.Integer. Conversion failed with null
        at org.apache.pulsar.common.util.FieldParser.convert(FieldParser.java:119)
        at org.apache.pulsar.common.util.FieldParser.value(FieldParser.java:190)
        at org.apache.pulsar.common.util.FieldParser.lambda$update$0(FieldParser.java:141)
        ... 7 more
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.pulsar.common.util.FieldParser.convert(FieldParser.java:115)
        ... 9 more
Caused by: java.lang.NumberFormatException: For input string: "1000;"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:580)
        at java.lang.Integer.valueOf(Integer.java:766)
        at org.apache.pulsar.common.util.FieldParser.stringToInteger(FieldParser.java:262)
        ... 14 more
```