### PR TITLE
[Issue 6538][Integration test]Add clean disk in yaml

### DIFF
--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -50,6 +50,7 @@ jobs:
           java-version: 1.8
 
       - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -49,6 +49,14 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi -f $(docker image ls -aq)
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +64,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -54,7 +54,7 @@ jobs:
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean
-          docker rmi -f $(docker image ls -aq)
+          docker rmi $(docker images -q) -f
           df -h
 
       - name: run install by skip tests


### PR DESCRIPTION
Fixed: https://github.com/apache/pulsar/issues/6538
### Motivation

Currently, some images take up a large amount of disk space, causing the test to fail, so clean up these images.

### Modifications

* Add command for clean docker image in YAML file.

### Verifying this change

This test is passed https://github.com/AmateurEvents/pulsar/pull/20/checks?check_run_id=513034384