### PR TITLE
[docs]Add auto split json swagger file

### DIFF
--- a/site2/.gitignore
+++ b/site2/.gitignore
@@ -11,3 +11,6 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 website/static/swagger/master/*
+
+website/static/swagger/restApiVersions.json
+website/static/swagger/*/v*/*.json

--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -48,6 +48,7 @@ cp versioned_docs/version-2.5.0/io-overview.md translated_docs/zh-TW/version-2.5
 yarn build
 
 node ./scripts/replace.js
+node ./scripts/split-swagger-by-version.js
 
 # Generate document for command line tools.
 ${ROOT_DIR}/site2/tools/pulsar-admin-doc-gen.sh

--- a/site2/website/scripts/split-swagger-by-version.js
+++ b/site2/website/scripts/split-swagger-by-version.js
@@ -1,0 +1,40 @@
+const globby = require('globby');
+const fs = require('fs');
+const CWD = process.cwd()
+
+const patterns = [`${CWD}/static/swagger/*/*.json`];
+
+(async () => {
+    const jsonFiles = await globby(patterns);
+    let restApiVersions = {}
+    jsonFiles.map(async (filePath) => {
+        let data = fs.readFileSync(filePath)
+        let jsonData = JSON.parse(data)
+        let pulsarPath = filePath.split('/')
+        let reverseList = pulsarPath.reverse()
+        let fileName = reverseList[0]
+        let pulsarVersion = reverseList[1]
+        let restApiVersion = jsonData.info.version
+        let restApiDir = `${CWD}/static/swagger/${pulsarVersion}/${restApiVersion}`
+        if (!fs.existsSync(restApiDir)){
+            fs.mkdirSync(restApiDir);
+        }
+        if (restApiVersions.hasOwnProperty(pulsarVersion)) {
+            if (restApiVersions[pulsarVersion].indexOf(restApiVersion) < 0) {
+                restApiVersions[pulsarVersion].push(restApiVersion)
+            }
+        } else {
+            restApiVersions[pulsarVersion] = [restApiVersion]
+        }
+        fs.writeFile(restApiDir + '/' + fileName, JSON.stringify(jsonData, null, 4),  function(err) {
+            if (err) {
+                return console.error(err);
+            }
+        })
+    })
+    fs.writeFile(`${CWD}/static/swagger/restApiVersions.json`, JSON.stringify(restApiVersions, null, 4),  function(err) {
+        if (err) {
+            return console.error(err);
+        }
+    })
+})();


### PR DESCRIPTION


### Motivation

This pr https://github.com/apache/pulsar/pull/6351/files is used to show the rest API version. Before that, we should generate swagger files of different rest API versions.

### Modifications

* Add a node script for generate swagger files of different rest API versions. 

### Verifying this change

Execute command `node ./scripts/split-swagger-by-version.js` will generate the swagger file in different Pulsar version:

![image](https://user-images.githubusercontent.com/1907867/77029425-99a70880-69d6-11ea-9db7-bab5ae9e9e57.png)

