### PR TITLE
Fix: topic with one partition cannot be updated

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2162,6 +2162,11 @@ public class PersistentTopicsBase extends AdminResource {
         String path = path(PARTITIONED_TOPIC_PATH_ZNODE, topicName.getPersistenceNamingEncoding());
         CompletableFuture<Void> result = new CompletableFuture<>();
         pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName).thenAccept(partitionMetadata -> {
+            if (partitionMetadata.partitions < 1) {
+                result.completeExceptionally(new RestException(Status.CONFLICT, "Topic is not partitioned topic"));
+                return;
+            }
+
             if (partitionMetadata.partitions >= numPartitions) {
                 result.completeExceptionally(new RestException(Status.CONFLICT,
                         "number of partitions must be more than existing " + partitionMetadata.partitions));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2162,11 +2162,6 @@ public class PersistentTopicsBase extends AdminResource {
         String path = path(PARTITIONED_TOPIC_PATH_ZNODE, topicName.getPersistenceNamingEncoding());
         CompletableFuture<Void> result = new CompletableFuture<>();
         pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName).thenAccept(partitionMetadata -> {
-            if (partitionMetadata.partitions <= 1) {
-                result.completeExceptionally(new RestException(Status.CONFLICT, "Topic is not partitioned topic"));
-                return;
-            }
-
             if (partitionMetadata.partitions >= numPartitions) {
                 result.completeExceptionally(new RestException(Status.CONFLICT,
                         "number of partitions must be more than existing " + partitionMetadata.partitions));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -77,11 +77,17 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
     public void testIncrementPartitionsOfTopic() throws Exception {
         final String partitionedTopicName = "persistent://prop-xyz/use/ns1/test-topic-2";
 
-        admin.topics().createPartitionedTopic(partitionedTopicName, 10);
-        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 10);
+        admin.topics().createPartitionedTopic(partitionedTopicName, 1);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 1);
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(partitionedTopicName).subscriptionName("sub-1")
-                .subscribe();
+          .subscribe();
+
+        admin.topics().updatePartitionedTopic(partitionedTopicName, 2);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 2);
+
+        admin.topics().updatePartitionedTopic(partitionedTopicName, 10);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 10);
 
         admin.topics().updatePartitionedTopic(partitionedTopicName, 20);
         assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 20);


### PR DESCRIPTION
### Motivation

Previously, we add the the following change to allow partitioned topics to be created with one partition:

https://github.com/apache/pulsar/pull/4764

However, updating a partitioned topic with one partition to more than one partition does not work and will return the following error:

: javax.ws.rs.ClientErrorException: HTTP 409 Conflict
Topic is not partitioned topic

Reason: Topic is not partitioned topic
