### PR TITLE
[Issue 6561] [pulsar-client] Fix NPE while call getLastMessageId

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAcker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAcker.java
@@ -24,7 +24,7 @@ import java.util.BitSet;
 class BatchMessageAcker {
 
     private BatchMessageAcker() {
-        this.bitSet = null;
+        this.bitSet = new BitSet();
         this.batchSize = 0;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAckerDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAckerDisabled.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.BitSet;
+
 class BatchMessageAckerDisabled extends BatchMessageAcker {
 
     static final BatchMessageAckerDisabled INSTANCE = new BatchMessageAckerDisabled();
 
     private BatchMessageAckerDisabled() {
-        super(null, 0);
+        super(new BitSet(), 0);
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -21,7 +21,11 @@ package org.apache.pulsar.client.impl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.annotations.Test;
 
 public class BatchMessageIdImplTest {
@@ -66,6 +70,32 @@ public class BatchMessageIdImplTest {
         assertEquals(batchMsgId4, msgId);
 
         assertEquals(msgId, batchMsgId4);
+    }
+
+    @Test
+    public void deserializationTest() {
+        // initialize BitSet with null
+        BatchMessageAcker ackerDisabled = new BatchMessageAcker(null, 0);
+        BatchMessageIdImpl batchMsgId = new BatchMessageIdImpl(0, 0, 0, 0, ackerDisabled);
+
+        ObjectWriter writer = ObjectMapperFactory.create().writerWithDefaultPrettyPrinter();
+
+        try {
+            writer.writeValueAsString(batchMsgId);
+            fail("Shouldn't be deserialized");
+        } catch (JsonProcessingException e) {
+            // expected
+            assertTrue(e.getCause() instanceof NullPointerException);
+        }
+
+        // use the default BatchMessageAckerDisabled
+        BatchMessageIdImpl batchMsgIdToDeserialize = new BatchMessageIdImpl(0, 0, 0, 0);
+
+        try {
+            writer.writeValueAsString(batchMsgIdToDeserialize);
+        } catch (JsonProcessingException e) {
+            fail("Should be successful");
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

Fixes #6561

### Modifications

Initialize `BatchMessageAckerDisabled` with a `new BitSet()` Object.