### PR TITLE
[Issue 5901] Added support to offload all partitions of a partitioned topic

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.PartitionedMessageIdImpl;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
@@ -1091,6 +1092,32 @@ public interface Topics {
      * @param messageId ID of maximum message which should be offloaded
      */
     void triggerOffload(String topic, MessageId messageId) throws PulsarAdminException;
+
+    /**
+     * Trigger offloading messages in topic to longterm storage asynchronously.
+     *
+     * @param topic the topic to offload
+     * @param messageId ID of maximum message which should be offloaded
+     */
+    CompletableFuture<Void> triggerOffloadAsync(String topic, MessageId messageId);
+
+    /**
+     * Trigger offloading messages in a partitioned topic to longterm storage.
+     *
+     * @param topic
+     * @param partitionsMessagedId
+     * @throws PulsarAdminException
+     */
+    void triggerPartitionedOffload(String topic, PartitionedMessageIdImpl partitionsMessagedId) throws PulsarAdminException;
+
+    /**
+     * Trigger offloading messages in a partitioned topic to longterm storage asynchronously.
+     *
+     * @param topic
+     * @param partitionsMessagedId
+     * @throws PulsarAdminException
+     */
+    CompletableFuture<Void> triggerPartitionedOffloadAsync(String topic, PartitionedMessageIdImpl partitionsMessagedId);
 
     /**
      * Check the status of an ongoing offloading operation for a topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedMessageIdImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * This is used for triggering offload a partitioned topic.
+ */
+public class PartitionedMessageIdImpl {
+
+    public Map<String, MessageIdImpl> partitions;
+
+    public PartitionedMessageIdImpl() {
+        partitions = Maps.newTreeMap();
+    }
+}

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1685,6 +1685,7 @@ Subcommands
 * `compact`
 * `compaction-status`
 * `offload`
+* `offload-partitioned-topic`
 * `offload-status`
 * `create-partitioned-topic`
 * `create-missed-partitions`
@@ -1751,6 +1752,19 @@ Options
 |---|---|---|
 |`-s`, `--size-threshold`|The maximum amount of data to keep in BookKeeper for the specific topic||
 
+
+### `offload-partitioned-topic`
+Trigger offload of data from a partitioned topic to long-term storage (e.g. Amazon S3)
+
+Usage
+```bash
+$ pulsar-admin topics offload-partitioned-topic persistent://tenant/namespace/topic options
+```
+
+Options
+|Flag|Description|Default|
+|---|---|---|
+|`-s`, `--size-threshold`|The maximum amount of data to keep in BookKeeper for each partition of the specified topic||
 
 ### `offload-status`
 Check the status of data offloading from a topic to long-term storage


### PR DESCRIPTION
### Motivation

Fixes #5901

If there is a partitioned topic with too many partitions, users need to `offload` one by one.

### Modifications

Add a method `triggerPartitionedOffload` with parameter `PartitionedMessageIdImpl` for offloading on a partitioned topic.