### PR TITLE
[docker] Do not apply env values to pulsar_env.sh and bkenv.sh implicitly

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -32,7 +32,7 @@ if len(sys.argv) < 2:
     sys.exit(1)
 
 # Always apply env config to env scripts as well
-conf_files = ['conf/pulsar_env.sh', 'conf/bkenv.sh'] + sys.argv[1:]
+conf_files = sys.argv[1:]
 
 PF_ENV_PREFIX = 'PULSAR_PREFIX_'
 


### PR DESCRIPTION
### Motivation

The script `apply-config-from-env.py` always applies env config  to env scripts. However, with the changes from https://github.com/apache/pulsar/pull/4105 and https://github.com/apache/pulsar/pull/5892, it seems there is no need to do so anymore. On the other hand, it will interfere with the bash variable replacement mechanisms by replacing the values in scripts directly.

### Modifications

Remove `['conf/pulsar_env.sh', 'conf/bkenv.sh']` from `conf_files`.
