### PR TITLE
resume some servercnx method to public

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1758,7 +1758,7 @@ public class ServerCnx extends PulsarHandler {
         return ctx.channel().isWritable();
     }
 
-    private void startSendOperation(Producer producer, int msgSize) {
+    public void startSendOperation(Producer producer, int msgSize) {
         messagePublishBufferSize += msgSize;
         boolean isPublishRateExceeded = producer.getTopic().isPublishRateExceeded();
         if (++pendingSendRequest == maxPendingSendRequests || isPublishRateExceeded) {
@@ -1774,7 +1774,7 @@ public class ServerCnx extends PulsarHandler {
         }
     }
 
-    void completedSendOperation(boolean isNonPersistentTopic, int msgSize) {
+    public void completedSendOperation(boolean isNonPersistentTopic, int msgSize) {
         messagePublishBufferSize -= msgSize;
         if (--pendingSendRequest == resumeReadsThreshold) {
             // Resume reading from socket
@@ -1787,7 +1787,7 @@ public class ServerCnx extends PulsarHandler {
         }
     }
 
-    void enableCnxAutoRead() {
+    public void enableCnxAutoRead() {
         // we can add check (&& pendingSendRequest < MaxPendingSendRequests) here but then it requires
         // pendingSendRequest to be volatile and it can be expensive while writing. also this will be called on if
         // throttling is enable on the topic. so, avoid pendingSendRequest check will be fine.
@@ -1799,7 +1799,7 @@ public class ServerCnx extends PulsarHandler {
         }
     }
 
-    void disableCnxAutoRead() {
+    public void disableCnxAutoRead() {
         if (ctx.channel().config().isAutoRead() ) {
             ctx.channel().config().setAutoRead(false);
         }
@@ -1818,7 +1818,7 @@ public class ServerCnx extends PulsarHandler {
             autoReadDisabledPublishBufferLimiting = false;
         }
     }
-    
+
     private <T> ServerError getErrorCode(CompletableFuture<T> future) {
         ServerError error = ServerError.UnknownError;
         try {


### PR DESCRIPTION
In PR #6178, some of the method in servercnx is turn from public to private, this change tries to resume them.