### PR TITLE
[API Document]Fixes api document for internal topic info.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -308,7 +308,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @GET
     @Path("{property}/{cluster}/{namespace}/{topic}/internal-info")
-    @ApiOperation(hidden = true, value = "Get the internal stats for the topic.")
+    @ApiOperation(hidden = true, value = "Get the stored topic metadata.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist") })
     public void getManagedLedgerInfo(@PathParam("property") String property, @PathParam("cluster") String cluster,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -515,7 +515,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @GET
     @Path("{tenant}/{namespace}/{topic}/internal-info")
-    @ApiOperation(value = "Get the internal stats for the topic.")
+    @ApiOperation(value = "Get the stored topic metadata.")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),


### PR DESCRIPTION
### Motivation

The document for internal-info looks like a typo to me.

### Modifications

Changed the document in the annotation of `getManagedLedgerInfo`.

TBD
- Is the new description accurate?
- Should other occurrences in `swagger.json` of history version also be changed?
