### PR TITLE
[WIP][Issue 6437][broker] Prevent marker messages from accumulating in backlog of replicated subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -58,9 +59,10 @@ import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.SendCallback;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
-import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.MarkerType;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.Codec;
@@ -728,15 +730,26 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
             return;
         }
 
-        int markerType = msg.getMessageBuilder().getMarkerType();
+        String replicatedFrom = msg.getMessageBuilder().getReplicatedFrom();
 
-        if (!remoteCluster.equals(msg.getMessageBuilder().getReplicatedFrom())) {
+        if (!localCluster.equals(replicatedFrom)) {
+            topic.getSubscriptions().forEach((subName, sub) -> {
+                if (sub != null) {
+                    sub.acknowledgeMessage(Collections.singletonList(position), AckType.Individual,
+                            Collections.emptyMap());
+                }
+            });
+        }
+
+        if (!remoteCluster.equals(replicatedFrom)) {
             // Only consider markers that are coming from the same cluster that this
             // replicator instance is assigned to.
             // All the replicators will see all the markers, but we need to only process
             // it once.
             return;
         }
+
+        int markerType = msg.getMessageBuilder().getMarkerType();
 
         switch (markerType) {
         case MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST_VALUE:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -308,6 +308,7 @@ public class PersistentSubscription implements Subscription {
     @Override
     public void acknowledgeMessage(List<Position> positions, AckType ackType, Map<String,Long> properties) {
         Position previousMarkDeletePosition = cursor.getMarkDeletedPosition();
+        Dispatcher dispatcher = this.dispatcher;
 
         if (ackType == AckType.Cumulative) {
             if (this.pendingCumulativeAckTxnId != null) {
@@ -361,7 +362,9 @@ public class PersistentSubscription implements Subscription {
                 cursor.asyncDelete(positions, deleteCallback, positions);
             }
 
-            dispatcher.getRedeliveryTracker().removeBatch(positions);
+            if (dispatcher != null) {
+                dispatcher.getRedeliveryTracker().removeBatch(positions);
+            }
         }
 
         if (!cursor.getMarkDeletedPosition().equals(previousMarkDeletePosition)) {
@@ -377,7 +380,8 @@ public class PersistentSubscription implements Subscription {
             }
         }
 
-        if (topic.getManagedLedger().isTerminated() && cursor.getNumberOfEntriesInBacklog(false) == 0) {
+        if (topic.getManagedLedger().isTerminated() && cursor.getNumberOfEntriesInBacklog(false) == 0
+                && dispatcher != null) {
             // Notify all consumer that the end of topic was reached
             dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -241,6 +241,16 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         if (log.isDebugEnabled()) {
             log.debug("[{}] Published marker at {}:{}. Exception: {}", topic.getName(), ledgerId, entryId, e);
         }
+
+        if (e == null) {
+            Position position = new PositionImpl(ledgerId, entryId);
+            topic.getSubscriptions().forEach((subName, sub) -> {
+                if (sub != null) {
+                    sub.acknowledgeMessage(Collections.singletonList(position), AckType.Individual,
+                            Collections.emptyMap());
+                }
+            });
+        }
     }
 
     PersistentTopic topic() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -243,6 +243,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         }
 
         if (e == null) {
+            // Acknowledge the marker message to prevent it from accumulating in the backlog
             Position position = new PositionImpl(ledgerId, entryId);
             topic.getSubscriptions().forEach((subName, sub) -> {
                 if (sub != null) {


### PR DESCRIPTION
Fixes #6437

### Motivation

In a replicated subscription with no consumers connected, the number of marker messages in the backlog will continue to increase. If at least one consumer is connected, the marker messages will be acknowledged and deleted by the dispatcher.
https://github.com/apache/pulsar/blob/5fc4a90ba8a7d87c75d8425a0e67ac1d3e5c1651/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L80-L92
However, if no consumers are connected, the dispatcher does not exist or has stopped reading entries. As a result, the marker messages accumulate in the backlog without being acknoledged by anyone.


### Modifications

There are four types of marker messages:

- ReplicatedSubscriptionsSnapshotRequest
- ReplicatedSubscriptionsSnapshotResponse
- ReplicatedSubscriptionsSnapshot
- ReplicatedSubscriptionsUpdate

Of these, three messages, except `ReplicatedSubscriptionsSnapshot`, are not used in the local cluster. They are published to local topics for sending to remote clusters. So, modified the `ReplicatedSubscriptionsController` class to acknowledge these marker messages on all subscriptions immediately after publishing the messages to a local topic.

On the other hand, `ReplicatedSubscriptionsSnapshot` is used only in the local cluster and does not need to be sent to remote clusters. So stopped publishing `ReplicatedSubscriptionsSnapshot` to topics.

In addition, marker messages sent from remote clusters are now acknowledged by the replicator on all subscriptions.

With these changes, marker messages no longer continue to accumulate in the replicated subscription backlog.