### PR TITLE
Export ManagedLedgerCache metric to prometheus

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,6 @@ import java.util.Enumeration;
 import java.util.Map;
 
 import org.apache.pulsar.broker.PulsarService;
-
 import static org.apache.pulsar.common.stats.JvmMetrics.getJvmDirectMemoryUsed;
 
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerCacheMetrics;
@@ -123,8 +122,8 @@ public class PrometheusMetricsGenerator {
             labels += "} ";
 
             for (Map.Entry<String, Object> entry : metrics1.getMetrics().entrySet()) {
-                stream.write(entry.getKey().replace(".", ":"))
-                        .write(labels).write(String.valueOf(entry.getValue()))
+                stream.write(entry.getKey().replace(".", ":")).write(labels)
+                        .write(String.valueOf(entry.getValue()))
                         .write(' ').write(System.currentTimeMillis()).write("\n");
             }
         }
@@ -165,17 +164,17 @@ public class PrometheusMetricsGenerator {
 
     static String getTypeStr(Collector.Type type) {
         switch (type) {
-            case COUNTER:
-                return "counter";
-            case GAUGE:
-                return "gauge";
-            case SUMMARY:
-                return "summary";
-            case HISTOGRAM:
-                return "histogram";
-            case UNTYPED:
-            default:
-                return "untyped";
+        case COUNTER:
+            return "counter";
+        case GAUGE:
+            return "gauge";
+        case SUMMARY        :
+            return "summary";
+        case HISTOGRAM:
+            return "histogram";
+        case UNTYPED:
+        default:
+            return "untyped";
         }
     }
 


### PR DESCRIPTION
### Motivation
The managed ledger read cache monitor metric is export via `/admin/broker-stats/metrics` with json format, it is hard to parse, collect and display, what's more the read cache is a very import module for message consuming throughput and latency. So collect and display the read cache metrics is extremely urgent for pulsar in production.

### Changes 
I parse the json format metric to prometheus message type and export to prometheus monitor port, so those metrics can be displayed in grafana.
Some of the metric name contains dot, but promethues metric name rule only accept `[a-zA-Z0-9_:]`, so i replace `dot` to `:` in metric name to avoid prometheus parse error