### PR TITLE
[Issue 6433][Pulsar-client]Fix message id compare between MessageId and BatchMessageId

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -186,7 +186,14 @@ public class MessageIdImpl implements MessageId {
 
     @Override
     public int compareTo(MessageId o) {
-        if (o instanceof MessageIdImpl) {
+        if (o instanceof BatchMessageIdImpl) {
+            BatchMessageIdImpl other = (BatchMessageIdImpl) o;
+            if (other.getBatchIndex() > -1) {
+                return 1;
+            } else {
+                return 0;
+            }
+        } else if (o instanceof MessageIdImpl) {
             MessageIdImpl other = (MessageIdImpl) o;
             return ComparisonChain.start()
                 .compare(this.ledgerId, other.ledgerId)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -188,10 +188,15 @@ public class MessageIdImpl implements MessageId {
     public int compareTo(MessageId o) {
         if (o instanceof BatchMessageIdImpl) {
             BatchMessageIdImpl other = (BatchMessageIdImpl) o;
-            if (other.getBatchIndex() > -1) {
-                return 1;
+            int res = ComparisonChain.start()
+                    .compare(this.ledgerId, other.ledgerId)
+                    .compare(this.entryId, other.entryId)
+                    .compare(this.getPartitionIndex(), other.getPartitionIndex())
+                    .result();
+            if (res == 0 && other.getBatchIndex() > -1) {
+                return -1;
             } else {
-                return 0;
+                return res;
             }
         } else if (o instanceof MessageIdImpl) {
             MessageIdImpl other = (MessageIdImpl) o;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -106,7 +106,12 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             doCumulativeAck(msgId);
         } else {
             // Individual ack
-            pendingIndividualAcks.add(msgId);
+            if (msgId instanceof BatchMessageIdImpl) {
+                pendingIndividualAcks.add(new MessageIdImpl(msgId.getLedgerId(),
+                        msgId.getEntryId(), msgId.getPartitionIndex()));
+            } else {
+                pendingIndividualAcks.add(msgId);
+            }
             if (pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
                 flush();
             }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -100,12 +100,24 @@ public class BatchMessageIdImplTest {
     }
 
     @Test
-    public void shouldBeSymmetric() {
+    public void compareToSymmetricTest() {
         MessageIdImpl simpleMessageId = new MessageIdImpl(1, 2, 3);
+        // batchIndex is -1 if message is non-batched message and has the batchIndex for a batch message
         BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(1, 2, 3, -1);
-        Assert.assertTrue(simpleMessageId.compareTo(batchMessageId1) == batchMessageId1.compareTo(simpleMessageId));
-
         BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(1, 2, 3, 1);
-        Assert.assertTrue(simpleMessageId.compareTo(batchMessageId2) == batchMessageId2.compareTo(simpleMessageId));
+        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(1, 2, 2, 1);
+        BatchMessageIdImpl batchMessageId4 = new BatchMessageIdImpl(1, 2, 2, -1);
+
+        assertEquals(simpleMessageId.compareTo(batchMessageId1), 0);
+        assertEquals(batchMessageId1.compareTo(simpleMessageId), 0);
+
+        assertEquals(batchMessageId2.compareTo(simpleMessageId), 1);
+        assertEquals(simpleMessageId.compareTo(batchMessageId2), -1);
+
+        assertEquals(simpleMessageId.compareTo(batchMessageId3), 1);
+        assertEquals(batchMessageId3.compareTo(simpleMessageId), -1);
+
+        assertEquals(simpleMessageId.compareTo(batchMessageId4), 1);
+        assertEquals(batchMessageId4.compareTo(simpleMessageId), -1);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.fail;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class BatchMessageIdImplTest {
@@ -98,4 +99,13 @@ public class BatchMessageIdImplTest {
         }
     }
 
+    @Test
+    public void shouldBeSymmetric() {
+        MessageIdImpl simpleMessageId = new MessageIdImpl(1, 2, 3);
+        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(1, 2, 3, -1);
+        Assert.assertTrue(simpleMessageId.compareTo(batchMessageId1) == batchMessageId1.compareTo(simpleMessageId));
+
+        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(1, 2, 3, 1);
+        Assert.assertTrue(simpleMessageId.compareTo(batchMessageId2) == batchMessageId2.compareTo(simpleMessageId));
+    }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.fail;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class BatchMessageIdImplTest {
@@ -99,25 +98,4 @@ public class BatchMessageIdImplTest {
         }
     }
 
-    @Test
-    public void compareToSymmetricTest() {
-        MessageIdImpl simpleMessageId = new MessageIdImpl(1, 2, 3);
-        // batchIndex is -1 if message is non-batched message and has the batchIndex for a batch message
-        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(1, 2, 3, -1);
-        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(1, 2, 3, 1);
-        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(1, 2, 2, 1);
-        BatchMessageIdImpl batchMessageId4 = new BatchMessageIdImpl(1, 2, 2, -1);
-
-        assertEquals(simpleMessageId.compareTo(batchMessageId1), 0);
-        assertEquals(batchMessageId1.compareTo(simpleMessageId), 0);
-
-        assertEquals(batchMessageId2.compareTo(simpleMessageId), 1);
-        assertEquals(simpleMessageId.compareTo(batchMessageId2), -1);
-
-        assertEquals(simpleMessageId.compareTo(batchMessageId3), 1);
-        assertEquals(batchMessageId3.compareTo(simpleMessageId), -1);
-
-        assertEquals(simpleMessageId.compareTo(batchMessageId4), 1);
-        assertEquals(batchMessageId4.compareTo(simpleMessageId), -1);
-    }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -117,11 +117,30 @@ public class MessageIdCompareToTest  {
         BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(123L, 345L, 567, 789);
         BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(messageIdImpl);
         assertTrue(messageIdImpl.compareTo(batchMessageId1) > 0, "Expected to be greater than");
-        assertEquals(messageIdImpl.compareTo(batchMessageId2), 0, "Expected to be equal");
+        assertTrue(messageIdImpl.compareTo(batchMessageId2) < 0, "Expected to be less than");
         assertEquals(messageIdImpl.compareTo(batchMessageId3), 0, "Expected to be equal");
         assertTrue(batchMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
         assertTrue(batchMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
         assertEquals(batchMessageId3.compareTo(messageIdImpl), 0, "Expected to be equal");
+    }
+
+    @Test
+    public void compareToSymmetricTest() {
+        MessageIdImpl simpleMessageId = new MessageIdImpl(123L, 345L, 567);
+        // batchIndex is -1 if message is non-batched message and has the batchIndex for a batch message
+        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(123L, 345L, 567, -1);
+        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(123L, 345L, 567, 1);
+        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(123L, 345L, 566, 1);
+        BatchMessageIdImpl batchMessageId4 = new BatchMessageIdImpl(123L, 345L, 566, -1);
+
+        assertEquals(simpleMessageId.compareTo(batchMessageId1), 0, "Expected to be equal");
+        assertEquals(batchMessageId1.compareTo(simpleMessageId), 0, "Expected to be equal");
+        assertTrue(batchMessageId2.compareTo(simpleMessageId) > 0, "Expected to be greater than");
+        assertTrue(simpleMessageId.compareTo(batchMessageId2) < 0, "Expected to be less than");
+        assertTrue(simpleMessageId.compareTo(batchMessageId3) > 0, "Expected to be greater than");
+        assertTrue(batchMessageId3.compareTo(simpleMessageId) < 0, "Expected to be less than");
+        assertTrue(simpleMessageId.compareTo(batchMessageId4) > 0, "Expected to be greater than");
+        assertTrue(batchMessageId4.compareTo(simpleMessageId) < 0, "Expected to be less than");
     }
 
     @Test
@@ -140,7 +159,7 @@ public class MessageIdCompareToTest  {
             "test-topic",
             new BatchMessageIdImpl(messageIdImpl));
         assertTrue(messageIdImpl.compareTo(topicMessageId1) > 0, "Expected to be greater than");
-        assertEquals(messageIdImpl.compareTo(topicMessageId2), 0, "Expected to be equal");
+        assertTrue(messageIdImpl.compareTo(topicMessageId2) < 0, "Expected to be less than");
         assertEquals(messageIdImpl.compareTo(topicMessageId3), 0, "Expected to be equal");
         assertTrue(topicMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
         assertTrue(topicMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
@@ -165,9 +184,9 @@ public class MessageIdCompareToTest  {
         assertTrue(messageIdImpl2.compareTo(topicMessageId2) > 0, "Expected to be greater than");
         assertEquals(messageIdImpl3.compareTo(topicMessageId2), 0, "Expected to be equal");
         assertTrue(topicMessageId1.compareTo(messageIdImpl1) < 0, "Expected to be less than");
-        assertEquals(topicMessageId2.compareTo(messageIdImpl1), 0, "Expected to be equal");
-        assertEquals(topicMessageId2.compareTo(messageIdImpl2), 0, "Expected to be equal");
-        assertEquals(topicMessageId2.compareTo(messageIdImpl2), 0, "Expected to be equal");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl1) < 0, "Expected to be less than");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
     }
 
     @Test


### PR DESCRIPTION
link PR: #1285
This PR resolve the compare from BatchMessageIdImpl to MessageIdImpl, but didn't consider the 
symmetry on the other side.

Master Issue: #6433

Motivation
Fix the bug of compare between MessageId and BatchMessageId, keep the symmetry of compareTo method.

Modifications
In the mothod of compareTo in BatchMessageId class, when compare to non-batched messageId and other properties is equal，if batchIndex >-1, then return 1, so in MessageId class, add the same logic, and if batchIndex >-1, then return -1.

Verifying this change
Unit tests added.

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)
Documentation
Does this pull request introduce a new feature? (no)