### PR TITLE
ISSUE-6612 FIX: parse long field in GenricJsonRecord (#6612)

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -55,6 +55,14 @@ class GenericJsonRecord extends VersionedGenericRecord {
             return new GenericJsonRecord(schemaVersion, fields, fn);
         } else if (fn.isBoolean()) {
             return fn.asBoolean();
+        } else if (fn.isFloatingPointNumber()) {
+            return fn.asDouble();
+        } else if (fn.isBigInteger()) {
+            if (fn.canConvertToLong()) {
+                return fn.asLong();
+            } else {
+                return fn.asText();
+            }
         } else if (fn.isNumber()) {
             return fn.numberValue();
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -55,12 +55,8 @@ class GenericJsonRecord extends VersionedGenericRecord {
             return new GenericJsonRecord(schemaVersion, fields, fn);
         } else if (fn.isBoolean()) {
             return fn.asBoolean();
-        } else if (fn.isInt()) {
-            return fn.asInt();
-        } else if (fn.isFloatingPointNumber()) {
-            return fn.asDouble();
-        } else if (fn.isDouble()) {
-            return fn.asDouble();
+        } else if (fn.isNumber()) {
+            return fn.numberValue();
         } else {
             return fn.asText();
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecordTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecordTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema.generic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class GenericJsonRecordTest {
+
+    @Test
+    public void decodeLongField() throws Exception{
+        String jsonStr = "{\"timestamp\":1585204833128, \"count\":2, \"value\": 1.1, \"on\":true}";
+        byte[] jsonStrBytes = jsonStr.getBytes();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jn = objectMapper.readTree(new String(jsonStrBytes, 0, jsonStrBytes.length, UTF_8));
+        GenericJsonRecord record = new GenericJsonRecord(null, Collections.emptyList(), jn);
+
+        Object longValue = record.getField("timestamp");
+        assertTrue(longValue instanceof Long);
+        assertEquals(1585204833128L, longValue);
+
+        Object intValue = record.getField("count");
+        assertTrue(intValue instanceof Integer);
+        assertEquals(2, intValue);
+
+        Object value = record.getField("value");
+        assertTrue(value instanceof Double);
+        assertEquals(1.1, value);
+
+        Object boolValue = record.getField("on");
+        assertTrue((boolean)boolValue);
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #6612


### Motivation

If message sent in json schema, long field will be decoded as int if its value below Integer.MAX_VALUE, other wise decoded as string.
For example, the json message below: 
```json
{
    "timestamp": 1585204833128
}
```
will be decoded as 

```json
{
    "timestamp": "1585204833128"
}
```

### Modifications

Add field type check in GenericJsonRecord

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] Unit test added

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API:  no
  - The schema: don't know
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
