### PR TITLE
[Github Action]Clean disk for integration tests

### DIFF
--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-function-state.yaml
+++ b/.github/workflows/ci-integration-function-state.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration function
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -49,13 +49,14 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: remove docker node image
+      - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
 
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
@@ -64,10 +65,6 @@ jobs:
       - name: build artifacts and docker pulsar latest test image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration function
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: run install by skip tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests
@@ -56,18 +65,6 @@ jobs:
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
-
-      - name: clean docker container
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker system prune -f
-
-      - name: remove docker node image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f node:10 && docker rmi -f node:12 && docker rmi -f buildpack-deps:stretch
-
-      - name: remove docker builder and microsoft image
-        if: steps.docs.outputs.changed_only == 'no'
-        run: docker rmi -f jekyll/builder:latest && docker rmi -f mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'


### PR DESCRIPTION
Currently, integration tests are failing continuously because of limited spaces:

```
2020-03-26T23:49:36.9600294Z 23:49:36.390 [LedgerDirsMonitorThread] ERROR org.apache.bookkeeper.util.DiskChecker - Space left on device data/bookkeeper/ledgers/current : 543158272, Used space fraction: 0.99391836 > threshold 0.99.
```

This PR cleans the images for spaces, the same way as https://github.com/apache/pulsar/pull/6548