### PR TITLE
[pulsar-broker] Implement AutoSubscriptionCreation by namespace override

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -69,6 +69,7 @@ import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -574,7 +575,7 @@ public abstract class NamespacesBase extends AdminResource {
                                     jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
                             asyncResponse.resume(Response.noContent().build());
-                            log.info("[{}] Successfully {} on namespace {}", clientAppId(),
+                            log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(),
                                     autoTopicCreationOverride.allowAutoTopicCreation ? "enabled" : "disabled", namespaceName);
                             return null;
                         } catch (KeeperException.NoNodeException e) {
@@ -622,7 +623,7 @@ public abstract class NamespacesBase extends AdminResource {
                                     jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
                             asyncResponse.resume(Response.noContent().build());
-                            log.info("[{}] Successfully removed override on namespace {}", clientAppId(), namespaceName);
+                            log.info("[{}] Successfully removed autoTopicCreation override on namespace {}", clientAppId(), namespaceName);
                             return null;
                         } catch (KeeperException.NoNodeException e) {
                             log.error("[{}] Failed to modify autoTopicCreation status for namespace {}: does not exist", clientAppId(),
@@ -648,6 +649,101 @@ public abstract class NamespacesBase extends AdminResource {
                 }
         ).exceptionally(e -> {
             log.error("[{}] Failed to modify autoTopicCreation status on namespace {}", clientAppId(), namespaceName, e);
+            asyncResponse.resume(new RestException(e));
+            return null;
+        });
+    }
+
+    protected void internalSetAutoSubscriptionCreation(AsyncResponse asyncResponse, AutoSubscriptionCreationOverride autoSubscriptionCreationOverride) {
+        validateAdminAccessForTenant(namespaceName.getTenant());
+        validatePoliciesReadOnlyAccess();
+
+        // Force to read the data s.t. the watch to the cache content is setup.
+        policiesCache().getWithStatAsync(path(POLICIES, namespaceName.toString())).thenApply(
+                policies -> {
+                    if (policies.isPresent()) {
+                        Entry<Policies, Stat> policiesNode = policies.get();
+                        policiesNode.getKey().autoSubscriptionCreationOverride = autoSubscriptionCreationOverride;
+                        try {
+                            // Write back the new policies into zookeeper
+                            globalZk().setData(path(POLICIES, namespaceName.toString()),
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
+                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                            asyncResponse.resume(Response.noContent().build());
+                            String autoOverride = autoSubscriptionCreationOverride.allowAutoSubscriptionCreation ? "enabled" : "disabled";
+                            log.info("[{}] Successfully {} autoSubscriptionCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
+                            return null;
+                        } catch (KeeperException.NoNodeException e) {
+                            log.error("[{}] Failed to modify autoSubscriptionCreation status for namespace {}: does not exist", clientAppId(),
+                                    namespaceName);
+                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                            return null;
+                        } catch (KeeperException.BadVersionException e) {
+                            log.error(
+                                    "[{}] Failed to modify autoSubscriptionCreation status on namespace {} expected policy node version={} : concurrent modification",
+                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
+
+                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                            return null;
+                        } catch (Exception e) {
+                            log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
+                            asyncResponse.resume(new RestException(e));
+                            return null;
+                        }
+                    } else {
+                        asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace " + namespaceName + " does not exist"));
+                        return null;
+                    }
+                }
+        ).exceptionally(e -> {
+            log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
+            asyncResponse.resume(new RestException(e));
+            return null;
+        });
+    }
+
+    protected void internalRemoveAutoSubscriptionCreation(AsyncResponse asyncResponse) {
+        validateAdminAccessForTenant(namespaceName.getTenant());
+        validatePoliciesReadOnlyAccess();
+
+        // Force to read the data s.t. the watch to the cache content is setup.
+        policiesCache().getWithStatAsync(path(POLICIES, namespaceName.toString())).thenApply(
+                policies -> {
+                    if (policies.isPresent()) {
+                        Entry<Policies, Stat> policiesNode = policies.get();
+                        policiesNode.getKey().autoSubscriptionCreationOverride = null;
+                        try {
+                            // Write back the new policies into zookeeper
+                            globalZk().setData(path(POLICIES, namespaceName.toString()),
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
+                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                            asyncResponse.resume(Response.noContent().build());
+                            log.info("[{}] Successfully removed autoSubscriptionCreation override on namespace {}", clientAppId(), namespaceName);
+                            return null;
+                        } catch (KeeperException.NoNodeException e) {
+                            log.error("[{}] Failed to modify autoSubscriptionCreation status for namespace {}: does not exist", clientAppId(),
+                                    namespaceName);
+                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                            return null;
+                        } catch (KeeperException.BadVersionException e) {
+                            log.error(
+                                    "[{}] Failed to modify autoSubscriptionCreation status on namespace {} expected policy node version={} : concurrent modification",
+                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
+
+                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                            return null;
+                        } catch (Exception e) {
+                            log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
+                            asyncResponse.resume(new RestException(e));
+                            return null;
+                        }
+                    } else {
+                        asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace " + namespaceName + " does not exist"));
+                        return null;
+                    }
+                }
+        ).exceptionally(e -> {
+            log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
             asyncResponse.resume(new RestException(e));
             return null;
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -576,6 +576,9 @@ public abstract class NamespacesBase extends AdminResource {
                                     (rc, path1, ctx, stat) -> {
                                         if (rc == KeeperException.Code.OK.intValue()) {
                                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                            String autoOverride = autoTopicCreationOverride.allowAutoTopicCreation ? "enabled" : "disabled";
+                                            log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
+                                            asyncResponse.resume(Response.noContent().build());
                                         } else {
                                             String errorMsg = String.format(
                                                     "[%s] Failed to modify autoTopicCreation status for namespace %s",
@@ -591,9 +594,6 @@ public abstract class NamespacesBase extends AdminResource {
                                             }
                                         }
                                     }, null);
-                            String autoOverride = autoTopicCreationOverride.allowAutoTopicCreation ? "enabled" : "disabled";
-                            log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
-                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoTopicCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -629,6 +629,8 @@ public abstract class NamespacesBase extends AdminResource {
                                     (rc, path1, ctx, stat) -> {
                                         if (rc == KeeperException.Code.OK.intValue()) {
                                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                            log.info("[{}] Successfully removed autoTopicCreation override on namespace {}", clientAppId(), namespaceName);
+                                            asyncResponse.resume(Response.noContent().build());
                                         } else {
                                             String errorMsg = String.format(
                                                     "[%s] Failed to modify autoTopicCreation status for namespace %s",
@@ -644,8 +646,6 @@ public abstract class NamespacesBase extends AdminResource {
                                             }
                                         }
                                     }, null);
-                            log.info("[{}] Successfully removed autoTopicCreation override on namespace {}", clientAppId(), namespaceName);
-                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoTopicCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -681,6 +681,9 @@ public abstract class NamespacesBase extends AdminResource {
                                     (rc, path1, ctx, stat) -> {
                                         if (rc == KeeperException.Code.OK.intValue()) {
                                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                            String autoOverride = autoSubscriptionCreationOverride.allowAutoSubscriptionCreation ? "enabled" : "disabled";
+                                            log.info("[{}] Successfully {} autoSubscriptionCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
+                                            asyncResponse.resume(Response.noContent().build());
                                         } else {
                                             String errorMsg = String.format(
                                                     "[%s] Failed to modify autoSubscriptionCreation status for namespace %s",
@@ -696,9 +699,6 @@ public abstract class NamespacesBase extends AdminResource {
                                             }
                                         }
                                     }, null);
-                            String autoOverride = autoSubscriptionCreationOverride.allowAutoSubscriptionCreation ? "enabled" : "disabled";
-                            log.info("[{}] Successfully {} autoSubscriptionCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
-                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -734,6 +734,8 @@ public abstract class NamespacesBase extends AdminResource {
                                     (rc, path1, ctx, stat) -> {
                                         if (rc == KeeperException.Code.OK.intValue()) {
                                             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                            log.info("[{}] Successfully removed autoSubscriptionCreation override on namespace {}", clientAppId(), namespaceName);
+                                            asyncResponse.resume(Response.noContent().build());
                                         } else {
                                             String errorMsg = String.format(
                                                     "[%s] Failed to modify autoSubscriptionCreation status for namespace %s",
@@ -749,8 +751,6 @@ public abstract class NamespacesBase extends AdminResource {
                                             }
                                         }
                                     }, null);
-                            log.info("[{}] Successfully removed autoSubscriptionCreation override on namespace {}", clientAppId(), namespaceName);
-                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -572,23 +572,28 @@ public abstract class NamespacesBase extends AdminResource {
                         try {
                             // Write back the new policies into zookeeper
                             globalZk().setData(path(POLICIES, namespaceName.toString()),
-                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
-                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion(),
+                                    (rc, path1, ctx, stat) -> {
+                                        if (rc == KeeperException.Code.OK.intValue()) {
+                                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                        } else {
+                                            String errorMsg = String.format(
+                                                    "[%s] Failed to modify autoTopicCreation status for namespace %s",
+                                                    clientAppId(), namespaceName);
+                                            if (rc == KeeperException.Code.NONODE.intValue()) {
+                                                log.warn("{} : does not exist", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                                            } else if (rc == KeeperException.Code.BADVERSION.intValue()) {
+                                                log.warn("{} : concurrent modification", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                                            } else {
+                                                asyncResponse.resume(KeeperException.create(KeeperException.Code.get(rc), errorMsg));
+                                            }
+                                        }
+                                    }, null);
+                            String autoOverride = autoTopicCreationOverride.allowAutoTopicCreation ? "enabled" : "disabled";
+                            log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
                             asyncResponse.resume(Response.noContent().build());
-                            log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(),
-                                    autoTopicCreationOverride.allowAutoTopicCreation ? "enabled" : "disabled", namespaceName);
-                            return null;
-                        } catch (KeeperException.NoNodeException e) {
-                            log.error("[{}] Failed to modify autoTopicCreation status for namespace {}: does not exist", clientAppId(),
-                                    namespaceName);
-                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
-                            return null;
-                        } catch (KeeperException.BadVersionException e) {
-                            log.error(
-                                    "[{}] Failed to modify autoTopicCreation status on namespace {} expected policy node version={} : concurrent modification",
-                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
-
-                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoTopicCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -620,22 +625,27 @@ public abstract class NamespacesBase extends AdminResource {
                         try {
                             // Write back the new policies into zookeeper
                             globalZk().setData(path(POLICIES, namespaceName.toString()),
-                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
-                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
-                            asyncResponse.resume(Response.noContent().build());
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion(),
+                                    (rc, path1, ctx, stat) -> {
+                                        if (rc == KeeperException.Code.OK.intValue()) {
+                                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                        } else {
+                                            String errorMsg = String.format(
+                                                    "[%s] Failed to modify autoTopicCreation status for namespace %s",
+                                                    clientAppId(), namespaceName);
+                                            if (rc == KeeperException.Code.NONODE.intValue()) {
+                                                log.warn("{} : does not exist", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                                            } else if (rc == KeeperException.Code.BADVERSION.intValue()) {
+                                                log.warn("{} : concurrent modification", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                                            } else {
+                                                asyncResponse.resume(KeeperException.create(KeeperException.Code.get(rc), errorMsg));
+                                            }
+                                        }
+                                    }, null);
                             log.info("[{}] Successfully removed autoTopicCreation override on namespace {}", clientAppId(), namespaceName);
-                            return null;
-                        } catch (KeeperException.NoNodeException e) {
-                            log.error("[{}] Failed to modify autoTopicCreation status for namespace {}: does not exist", clientAppId(),
-                                    namespaceName);
-                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
-                            return null;
-                        } catch (KeeperException.BadVersionException e) {
-                            log.error(
-                                    "[{}] Failed to modify autoTopicCreation status on namespace {} expected policy node version={} : concurrent modification",
-                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
-
-                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoTopicCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -667,23 +677,28 @@ public abstract class NamespacesBase extends AdminResource {
                         try {
                             // Write back the new policies into zookeeper
                             globalZk().setData(path(POLICIES, namespaceName.toString()),
-                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
-                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
-                            asyncResponse.resume(Response.noContent().build());
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion(),
+                                    (rc, path1, ctx, stat) -> {
+                                        if (rc == KeeperException.Code.OK.intValue()) {
+                                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                        } else {
+                                            String errorMsg = String.format(
+                                                    "[%s] Failed to modify autoSubscriptionCreation status for namespace %s",
+                                                    clientAppId(), namespaceName);
+                                            if (rc == KeeperException.Code.NONODE.intValue()) {
+                                                log.warn("{} : does not exist", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                                            } else if (rc == KeeperException.Code.BADVERSION.intValue()) {
+                                                log.warn("{} : concurrent modification", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                                            } else {
+                                                asyncResponse.resume(KeeperException.create(KeeperException.Code.get(rc), errorMsg));
+                                            }
+                                        }
+                                    }, null);
                             String autoOverride = autoSubscriptionCreationOverride.allowAutoSubscriptionCreation ? "enabled" : "disabled";
                             log.info("[{}] Successfully {} autoSubscriptionCreation on namespace {}", clientAppId(), autoOverride, namespaceName);
-                            return null;
-                        } catch (KeeperException.NoNodeException e) {
-                            log.error("[{}] Failed to modify autoSubscriptionCreation status for namespace {}: does not exist", clientAppId(),
-                                    namespaceName);
-                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
-                            return null;
-                        } catch (KeeperException.BadVersionException e) {
-                            log.error(
-                                    "[{}] Failed to modify autoSubscriptionCreation status on namespace {} expected policy node version={} : concurrent modification",
-                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
-
-                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);
@@ -715,22 +730,27 @@ public abstract class NamespacesBase extends AdminResource {
                         try {
                             // Write back the new policies into zookeeper
                             globalZk().setData(path(POLICIES, namespaceName.toString()),
-                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
-                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
-                            asyncResponse.resume(Response.noContent().build());
+                                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion(),
+                                    (rc, path1, ctx, stat) -> {
+                                        if (rc == KeeperException.Code.OK.intValue()) {
+                                            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
+                                        } else {
+                                            String errorMsg = String.format(
+                                                    "[%s] Failed to modify autoSubscriptionCreation status for namespace %s",
+                                                    clientAppId(), namespaceName);
+                                            if (rc == KeeperException.Code.NONODE.intValue()) {
+                                                log.warn("{} : does not exist", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+                                            } else if (rc == KeeperException.Code.BADVERSION.intValue()) {
+                                                log.warn("{} : concurrent modification", errorMsg);
+                                                asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                                            } else {
+                                                asyncResponse.resume(KeeperException.create(KeeperException.Code.get(rc), errorMsg));
+                                            }
+                                        }
+                                    }, null);
                             log.info("[{}] Successfully removed autoSubscriptionCreation override on namespace {}", clientAppId(), namespaceName);
-                            return null;
-                        } catch (KeeperException.NoNodeException e) {
-                            log.error("[{}] Failed to modify autoSubscriptionCreation status for namespace {}: does not exist", clientAppId(),
-                                    namespaceName);
-                            asyncResponse.resume(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
-                            return null;
-                        } catch (KeeperException.BadVersionException e) {
-                            log.error(
-                                    "[{}] Failed to modify autoSubscriptionCreation status on namespace {} expected policy node version={} : concurrent modification",
-                                    clientAppId(), namespaceName, policiesNode.getValue().getVersion());
-
-                            asyncResponse.resume(new RestException(Status.CONFLICT, "Concurrent modification"));
+                            asyncResponse.resume(Response.noContent().build());
                             return null;
                         } catch (Exception e) {
                             log.error("[{}] Failed to modify autoSubscriptionCreation status on namespace {}", clientAppId(), namespaceName, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -28,6 +28,8 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
@@ -391,6 +393,80 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace, boolean enableDeduplication) {
         validateNamespaceName(property, cluster, namespace);
         internalModifyDeduplication(enableDeduplication);
+    }
+
+    @POST
+    @Path("/{property}/{cluster}/{namespace}/autoTopicCreation")
+    @ApiOperation(value = "Override broker's allowAutoTopicCreation setting for a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 400, message = "Invalid autoTopicCreation override") })
+    public void setAutoTopicCreation(@Suspended final AsyncResponse asyncResponse,
+                                     @PathParam("property") String property, @PathParam("cluster") String cluster,
+                                     @PathParam("namespace") String namespace, AutoTopicCreationOverride autoTopicCreationOverride) {
+        try {
+            validateNamespaceName(property, cluster, namespace);
+            internalSetAutoTopicCreation(asyncResponse, autoTopicCreationOverride);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e ) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @DELETE
+    @Path("/{property}/{cluster}/{namespace}/autoTopicCreation")
+    @ApiOperation(value = "Remove override of broker's allowAutoTopicCreation in a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist") })
+    public void removeAutoTopicCreation(@Suspended final AsyncResponse asyncResponse,
+                                        @PathParam("property") String property, @PathParam("cluster") String cluster,
+                                        @PathParam("namespace") String namespace) {
+        try {
+            validateNamespaceName(property, cluster, namespace);
+            internalRemoveAutoTopicCreation(asyncResponse);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @POST
+    @Path("/{property}/{cluster}/{namespace}/autoSubscriptionCreation")
+    @ApiOperation(value = "Override broker's allowAutoSubscriptionCreation setting for a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 400, message = "Invalid autoSubscriptionCreation override") })
+    public void setAutoSubscriptionCreation(@Suspended final AsyncResponse asyncResponse,
+                                     @PathParam("property") String property, @PathParam("cluster") String cluster,
+                                     @PathParam("namespace") String namespace, AutoSubscriptionCreationOverride autoSubscriptionCreationOverride) {
+        try {
+            validateNamespaceName(property, cluster, namespace);
+            internalSetAutoSubscriptionCreation(asyncResponse, autoSubscriptionCreationOverride);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e ) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @DELETE
+    @Path("/{property}/{cluster}/{namespace}/autoSubscriptionCreation")
+    @ApiOperation(value = "Remove override of broker's allowAutoSubscriptionCreation in a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist") })
+    public void removeAutoSubscriptionCreation(@Suspended final AsyncResponse asyncResponse,
+                                        @PathParam("property") String property, @PathParam("cluster") String cluster,
+                                        @PathParam("namespace") String namespace) {
+        try {
+            validateNamespaceName(property, cluster, namespace);
+            internalRemoveAutoSubscriptionCreation(asyncResponse);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetTopicsOfNamespace.Mode;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -330,6 +331,43 @@ public class Namespaces extends NamespacesBase {
         try {
             validateNamespaceName(tenant, namespace);
             internalRemoveAutoTopicCreation(asyncResponse);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @POST
+    @Path("/{tenant}/{namespace}/autoSubscriptionCreation")
+    @ApiOperation(value = "Override broker's allowAutoSubscriptionCreation setting for a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 400, message = "Invalid autoSubscriptionCreation override") })
+    public void setAutoSubscriptionCreation(
+            @Suspended final AsyncResponse asyncResponse,
+            @PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
+            AutoSubscriptionCreationOverride autoSubscriptionCreationOverride) {
+        try {
+            validateNamespaceName(tenant, namespace);
+            internalSetAutoSubscriptionCreation(asyncResponse, autoSubscriptionCreationOverride);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e ) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/autoSubscriptionCreation")
+    @ApiOperation(value = "Remove override of broker's allowAutoSubscriptionCreation in a namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist") })
+    public void removeAutoSubscriptionCreation(@Suspended final AsyncResponse asyncResponse,
+                                        @PathParam("tenant") String tenant, @PathParam("namespace") String namespace) {
+        try {
+            validateNamespaceName(tenant, namespace);
+            internalRemoveAutoSubscriptionCreation(asyncResponse);
         } catch (RestException e) {
             asyncResponse.resume(e);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -820,7 +820,7 @@ public class ServerCnx extends PulsarHandler {
                                     Topic topic = optTopic.get();
 
                                     boolean rejectSubscriptionIfDoesNotExist = isDurable
-                                        && !service.pulsar().getConfig().isAllowAutoSubscriptionCreation()
+                                        && !service.isAllowAutoSubscriptionCreation(topicName.toString())
                                         && !topic.getSubscriptions().containsKey(subscriptionName);
 
                                     if (rejectSubscriptionIfDoesNotExist) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoSubscriptionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoSubscriptionCreationTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @AfterMethod
+    protected void cleanupTest() throws Exception {
+        pulsar.getAdminClient().namespaces().removeAutoSubscriptionCreation("prop/ns-abc");
+    }
+
+    @Test
+    public void testAutoSubscriptionCreationDisable() throws Exception {
+        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
+
+        final String topicName = "persistent://prop/ns-abc/test-subtopic";
+        final String subscriptionName = "test-subtopic-sub";
+
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        try {
+            pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe();
+            fail("Subscribe operation should have failed");
+        } catch (Exception e) {
+            assertTrue(e instanceof PulsarClientException);
+        }
+        assertFalse(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
+    }
+
+    @Test
+    public void testSubscriptionCreationWithAutoCreationDisable() throws Exception {
+        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
+
+        final String topicName = "persistent://prop/ns-abc/test-subtopic";
+        final String subscriptionName = "test-subtopic-sub-1";
+
+        admin.topics().createNonPartitionedTopic(topicName);
+        assertFalse(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
+
+        // Create the subscription by PulsarAdmin
+        admin.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
+        assertTrue(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
+
+        // Subscribe operation should be successful
+        pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe();
+    }
+
+    @Test
+    public void testAutoSubscriptionCreationNamespaceAllowOverridesBroker() throws Exception {
+        final String topic = "persistent://prop/ns-abc/test-subtopic";
+        final String subscriptionName = "test-subtopic-sub-2";
+        final TopicName topicName = TopicName.get(topic);
+
+        admin.topics().createNonPartitionedTopic(topicName.toString());
+
+        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
+        pulsar.getAdminClient().namespaces().setAutoSubscriptionCreation(topicName.getNamespace(),
+                new AutoSubscriptionCreationOverride(true));
+
+        // Subscribe operation should be successful
+        pulsarClient.newConsumer().topic(topicName.toString()).subscriptionName(subscriptionName).subscribe();
+        assertTrue(admin.topics().getSubscriptions(topicName.toString()).contains(subscriptionName));
+    }
+
+    @Test
+    public void testAutoSubscriptionCreationNamespaceDisallowOverridesBroker() throws Exception {
+        final String topic = "persistent://prop/ns-abc/test-subtopic";
+        final String subscriptionName = "test-subtopic-sub-3";
+        final TopicName topicName = TopicName.get(topic);
+
+        admin.topics().createNonPartitionedTopic(topicName.toString());
+
+        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(true);
+        pulsar.getAdminClient().namespaces().setAutoSubscriptionCreation(topicName.getNamespace(),
+                new AutoSubscriptionCreationOverride(false));
+
+        try {
+            pulsarClient.newConsumer().topic(topicName.toString()).subscriptionName(subscriptionName).subscribe();
+            fail("Subscribe operation should have failed");
+        } catch (Exception e) {
+            assertTrue(e instanceof PulsarClientException);
+        }
+        assertFalse(admin.topics().getSubscriptions(topicName.toString()).contains(subscriptionName));
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -141,48 +141,6 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
     }
 
-    @Test
-    public void testAutoSubscriptionCreationDisable() throws Exception{
-        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
-
-        final String topicName = "persistent://prop/ns-abc/test-subtopic";
-        final String subscriptionName = "test-subtopic-sub";
-
-        admin.topics().createNonPartitionedTopic(topicName);
-
-        try {
-            pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe();
-            fail("Subscribe operation should have failed");
-        } catch (Exception e) {
-            assertTrue(e instanceof PulsarClientException);
-        }
-        assertFalse(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
-
-        // Reset to default
-        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(true);
-    }
-
-    @Test
-    public void testSubscriptionCreationWithAutoCreationDisable() throws Exception{
-        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
-
-        final String topicName = "persistent://prop/ns-abc/test-subtopic";
-        final String subscriptionName = "test-subtopic-sub";
-
-        admin.topics().createNonPartitionedTopic(topicName);
-        assertFalse(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
-
-        // Create the subscription by PulsarAdmin
-        admin.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
-        assertTrue(admin.topics().getSubscriptions(topicName).contains(subscriptionName));
-
-        // Subscribe operation should be successful
-        pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe();
-
-        // Reset to default
-        pulsar.getConfiguration().setAllowAutoSubscriptionCreation(true);
-    }
-
     /**
      * CheckAllowAutoCreation's default value is false.
      * So using getPartitionedTopicMetadata() directly will not produce partitioned topic

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedExceptio
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
@@ -1024,6 +1025,91 @@ public interface Namespaces {
      *            Namespace name
      */
     CompletableFuture<Void> removeAutoTopicCreationAsync(String namespace);
+
+    /**
+     * Sets the autoSubscriptionCreation policy for a given namespace, overriding broker settings.
+     * <p/>
+     * When autoSubscriptionCreationOverride is enabled, new subscriptions will be created upon connection,
+     * regardless of the broker level configuration.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>
+     *  {
+     *      "allowAutoSubscriptionCreation" : true
+     *  }
+     * </code>
+     * </pre>
+     *
+     * @param namespace
+     *            Namespace name
+     * @param autoSubscriptionCreationOverride
+     *            Override policies for auto subscription creation
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setAutoSubscriptionCreation(
+            String namespace, AutoSubscriptionCreationOverride autoSubscriptionCreationOverride)
+            throws PulsarAdminException;
+
+    /**
+     * Sets the autoSubscriptionCreation policy for a given namespace, overriding broker settings asynchronously.
+     * <p/>
+     * When autoSubscriptionCreationOverride is enabled, new subscriptions will be created upon connection,
+     * regardless of the broker level configuration.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>
+     *  {
+     *      "allowAutoSubscriptionCreation" : true
+     *  }
+     * </code>
+     * </pre>
+     *
+     * @param namespace
+     *            Namespace name
+     * @param autoSubscriptionCreationOverride
+     *            Override policies for auto subscription creation
+     */
+    CompletableFuture<Void> setAutoSubscriptionCreationAsync(
+            String namespace, AutoSubscriptionCreationOverride autoSubscriptionCreationOverride);
+
+    /**
+     * Removes the autoSubscriptionCreation policy for a given namespace.
+     * <p/>
+     * Allowing the broker to dictate the subscription auto-creation policy.
+     * <p/>
+     *
+     * @param namespace
+     *            Namespace name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeAutoSubscriptionCreation(String namespace) throws PulsarAdminException;
+
+    /**
+     * Removes the autoSubscriptionCreation policy for a given namespace asynchronously.
+     * <p/>
+     * Allowing the broker to dictate the subscription auto-creation policy.
+     * <p/>
+     *
+     * @param namespace
+     *            Namespace name
+     */
+    CompletableFuture<Void> removeAutoSubscriptionCreationAsync(String namespace);
 
     /**
      * Get the bundles split data.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
@@ -780,6 +781,51 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Void> removeAutoTopicCreationAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "autoTopicCreation");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void setAutoSubscriptionCreation(String namespace,
+            AutoSubscriptionCreationOverride autoSubscriptionCreationOverride) throws PulsarAdminException {
+        try {
+            setAutoSubscriptionCreationAsync(namespace, autoSubscriptionCreationOverride)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setAutoSubscriptionCreationAsync(String namespace,
+            AutoSubscriptionCreationOverride autoSubscriptionCreationOverride) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "autoSubscriptionCreation");
+        return asyncPostRequest(path, Entity.entity(autoSubscriptionCreationOverride, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeAutoSubscriptionCreation(String namespace) throws PulsarAdminException {
+        try {
+            removeAutoSubscriptionCreationAsync(namespace).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeAutoSubscriptionCreationAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "autoSubscriptionCreation");
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
@@ -363,6 +364,13 @@ public class PulsarAdminToolTest {
 
         namespaces.run(split("remove-auto-topic-creation myprop/clust/ns1"));
         verify(mockNamespaces).removeAutoTopicCreation("myprop/clust/ns1");
+
+        namespaces.run(split("set-auto-subscription-creation myprop/clust/ns1 -e"));
+        verify(mockNamespaces).setAutoSubscriptionCreation("myprop/clust/ns1",
+                new AutoSubscriptionCreationOverride(true));
+
+        namespaces.run(split("remove-auto-subscription-creation myprop/clust/ns1"));
+        verify(mockNamespaces).removeAutoSubscriptionCreation("myprop/clust/ns1");
 
         namespaces.run(split("get-message-ttl myprop/clust/ns1"));
         verify(mockNamespaces).getNamespaceMessageTTL("myprop/clust/ns1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.admin.cli.utils.IOUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
@@ -431,6 +432,33 @@ public class CmdNamespaces extends CmdBase {
             String namespace = validateNamespace(params);
 
             admin.namespaces().removeAutoTopicCreation(namespace);
+        }
+    }
+
+    @Parameters(commandDescription = "Enable autoSubscriptionCreation for a namespace, overriding broker settings")
+    private class SetAutoSubscriptionCreation extends CliCommand {
+        @Parameter(description = "tenant/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "--enable", "-e" }, description = "Enable allowAutoSubscriptionCreation on namespace")
+        private boolean enable = false;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            admin.namespaces().setAutoSubscriptionCreation(namespace, new AutoSubscriptionCreationOverride(enable));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove override of autoSubscriptionCreation for a namespace")
+    private class RemoveAutoSubscriptionCreation extends CliCommand {
+        @Parameter(description = "tenant/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            admin.namespaces().removeAutoSubscriptionCreation(namespace);
         }
     }
 
@@ -1598,6 +1626,9 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("set-auto-topic-creation", new SetAutoTopicCreation());
         jcommander.addCommand("remove-auto-topic-creation", new RemoveAutoTopicCreation());
+
+        jcommander.addCommand("set-auto-subscription-creation", new SetAutoSubscriptionCreation());
+        jcommander.addCommand("remove-auto-subscription-creation", new RemoveAutoSubscriptionCreation());
 
         jcommander.addCommand("get-retention", new GetRetention());
         jcommander.addCommand("set-retention", new SetRetention());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/AutoSubscriptionCreationOverride.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/AutoSubscriptionCreationOverride.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+/**
+ * Override of autoSubscriptionCreation settings on a namespace level.
+ */
+public class AutoSubscriptionCreationOverride {
+    public boolean allowAutoSubscriptionCreation;
+
+    public AutoSubscriptionCreationOverride() {
+    }
+
+    public AutoSubscriptionCreationOverride(boolean allowAutoSubscriptionCreation) {
+        this.allowAutoSubscriptionCreation = allowAutoSubscriptionCreation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(allowAutoSubscriptionCreation);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof AutoSubscriptionCreationOverride) {
+            AutoSubscriptionCreationOverride other = (AutoSubscriptionCreationOverride) obj;
+            return Objects.equals(this.allowAutoSubscriptionCreation, other.allowAutoSubscriptionCreation);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("allowAutoSubscriptionCreation", allowAutoSubscriptionCreation).toString();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -51,6 +51,8 @@ public class Policies {
     public Boolean deduplicationEnabled = null;
     // If set, it will override the broker settings for allowing auto topic creation
     public AutoTopicCreationOverride autoTopicCreationOverride = null;
+    // If set, it will override the broker settings for allowing auto subscription creation
+    public AutoSubscriptionCreationOverride autoSubscriptionCreationOverride = null;
     public Map<String, PublishRate> publishMaxMessageRate = Maps.newHashMap();
 
     @SuppressWarnings("checkstyle:MemberName")
@@ -112,7 +114,8 @@ public class Policies {
         return Objects.hash(auth_policies, replication_clusters,
                 backlog_quota_map, publishMaxMessageRate, clusterDispatchRate,
                 topicDispatchRate, subscriptionDispatchRate, replicatorDispatchRate,
-                clusterSubscribeRate, deduplicationEnabled, autoTopicCreationOverride, persistence,
+                clusterSubscribeRate, deduplicationEnabled, autoTopicCreationOverride,
+                autoSubscriptionCreationOverride, persistence,
                 bundles, latency_stats_sample_rate,
                 message_ttl_in_seconds, retention_policies,
                 encryption_required, delayed_delivery_policies,
@@ -144,6 +147,7 @@ public class Policies {
                     && Objects.equals(publishMaxMessageRate, other.publishMaxMessageRate)
                     && Objects.equals(deduplicationEnabled, other.deduplicationEnabled)
                     && Objects.equals(autoTopicCreationOverride, other.autoTopicCreationOverride)
+                    && Objects.equals(autoSubscriptionCreationOverride, other.autoSubscriptionCreationOverride)
                     && Objects.equals(persistence, other.persistence) && Objects.equals(bundles, other.bundles)
                     && Objects.equals(latency_stats_sample_rate, other.latency_stats_sample_rate)
                     && Objects.equals(message_ttl_in_seconds,
@@ -194,6 +198,7 @@ public class Policies {
                 .add("backlog_quota_map", backlog_quota_map).add("persistence", persistence)
                 .add("deduplicationEnabled", deduplicationEnabled)
                 .add("autoTopicCreationOverride", autoTopicCreationOverride)
+                .add("autoSubscriptionCreationOverride", autoSubscriptionCreationOverride)
                 .add("clusterDispatchRate", clusterDispatchRate)
                 .add("topicDispatchRate", topicDispatchRate)
                 .add("subscriptionDispatchRate", subscriptionDispatchRate)

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -827,6 +827,10 @@ Subcommands
 * `create`
 * `delete`
 * `set-deduplication`
+* `set-auto-topic-creation`
+* `remove-auto-topic-creation`
+* `set-auto-subscription-creation`
+* `remove-auto-subscription-creation`
 * `permissions`
 * `grant-permission`
 * `revoke-permission`
@@ -947,6 +951,50 @@ Options
 |`--enable`, `-e`|Enable message deduplication on the specified namespace|false|
 |`--disable`, `-d`|Disable message deduplication on the specified namespace|false|
 
+### `set-auto-topic-creation`
+Enable or disable autoTopicCreation for a namespace, overriding broker settings
+
+Usage
+```bash
+$ pulsar-admin namespaces set-auto-topic-creation tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|---|---|---|
+|`--enable`, `-e`|Enable allowAutoTopicCreation on namespace|false|
+|`--disable`, `-d`|Disable allowAutoTopicCreation on namespace|false|
+|`--type`, `-t`|Type of topic to be auto-created. Possible values: (partitioned, non-partitioned)|non-partitioned|
+|`--num-partitions`, `-n`|Default number of partitions of topic to be auto-created, applicable to partitioned topics only||
+
+### `remove-auto-topic-creation`
+Remove override of autoTopicCreation for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces remove-auto-topic-creation tenant/namespace
+```
+
+### `set-auto-subscription-creation`
+Enable autoSubscriptionCreation for a namespace, overriding broker settings
+
+Usage
+```bash
+$ pulsar-admin namespaces set-auto-subscription-creation tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|---|---|---|
+|`--enable`, `-e`|Enable allowAutoSubscriptionCreation on namespace|false|
+
+### `remove-auto-subscription-creation`
+Remove override of autoSubscriptionCreation for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces remove-auto-subscription-creation tenant/namespace
+```
 
 ### `permissions`
 Get the permissions on a namespace


### PR DESCRIPTION
### Motivation

Add a new namespace policy `autoSubscriptionCreationOverride` which will enable an override of broker `autoSubscriptionCreation` settings on the namespace level. Users can keep `autoSubscriptionCreation` disabled for the broker and allow it on a specific namespace using this feature.

### Modifications

* Add a new namespace policy: `autoSubscriptionCreationOverride` and associated API / CLI interface for setting and removing.
* When checking `autoSubscriptionCreation` configuration, the broker first retrieves namespace policies from zookeeper. If not set, it falls back to broker configuration. 
* Some minor improvement on `autoTopicCreationOverride` (e.g. v1 Namespaces API & cli md)