### PR TITLE
[hotfix] Add clean disk step in workflow

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -50,6 +50,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: build pacakge
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR package -DskipTests

--- a/.github/workflows/ci-unit-broker.yml
+++ b/.github/workflows/ci-unit-broker.yml
@@ -49,6 +49,15 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: clean disk
+        if: steps.docs.outputs.changed_only == 'no'
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
       - name: Set up Maven
         uses: apache/pulsar-test-infra/setup-maven@master
         if: steps.docs.outputs.changed_only == 'no'


### PR DESCRIPTION
# Motivation

Currently, the `CI - CPP, Python Tests` and `CI - Unit - Broker` workflow is always failed, and we found ```Not enough non-faulty bookies available``` error logs. Thus I want to add a clean disk step in the `CI - CPP, Python Tests` and `CI - Unit - Broker` workflow.

### Error Log
```
[ERROR] Tests run: 7, Failures: 4, Errors: 0, Skipped: 2, Time elapsed: 205.455 s <<< FAILURE! - in org.apache.pulsar.broker.service.PeerReplicatorTest
[ERROR] testPeerClusterInReplicationClusterListChange(org.apache.pulsar.broker.service.PeerReplicatorTest)  Time elapsed: 80.848 s  <<< FAILURE!
org.apache.pulsar.client.api.PulsarClientException$BrokerPersistenceException: org.apache.bookkeeper.mledger.ManagedLedgerException: Not enough non-faulty bookies available
	at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:691)
	at org.apache.pulsar.client.impl.ProducerBuilderImpl.create(ProducerBuilderImpl.java:93)
	at org.apache.pulsar.broker.service.PeerReplicatorTest.testPeerClusterInReplicationClusterListChange(PeerReplicatorTest.java:215)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
	at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```