### PR TITLE
Remove PULSAR_PREFIX for k8s yaml and helm values file

### DIFF
--- a/deployment/kubernetes/generic/k8s-1-9-and-above/bookie.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/bookie.yaml
@@ -24,10 +24,10 @@ metadata:
     name: bookie-config
 data:
     BOOKIE_MEM: "\" -Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m\""
-    PULSAR_PREFIX_dbStorage_writeCacheMaxSizeMb: "32" # Write cache size (direct memory)
-    PULSAR_PREFIX_dbStorage_readAheadCacheMaxSizeMb: "32" # Read cache size (direct memory)
-    PULSAR_PREFIX_zkServers: zookeeper
-    PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+    dbStorage_writeCacheMaxSizeMb: "32" # Write cache size (direct memory)
+    dbStorage_readAheadCacheMaxSizeMb: "32" # Read cache size (direct memory)
+    zkServers: zookeeper
+    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 ---
 ##
 ## Define the Bookie headless service

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/broker.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/broker.yaml
@@ -26,15 +26,15 @@ data:
     # Tune for available memory. Increase the heap up to 24G to have
     # better GC behavior at high throughput
     PULSAR_MEM: "\" -Xms64m -Xmx128m -XX:MaxDirectMemorySize=128m\""
-    PULSAR_PREFIX_zookeeperServers: zookeeper
-    PULSAR_PREFIX_configurationStoreServers: zookeeper
-    PULSAR_PREFIX_clusterName: local
+    zookeeperServers: zookeeper
+    configurationStoreServers: zookeeper
+    clusterName: local
     # change the managed ledger settings if you have more bookies
-    PULSAR_PREFIX_managedLedgerDefaultEnsembleSize: "1"
-    PULSAR_PREFIX_managedLedgerDefaultWriteQuorum: "1"
-    PULSAR_PREFIX_managedLedgerDefaultAckQuorum: "1"
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
     # enable pulsar functions
-    PULSAR_PREFIX_functionsWorkerEnabled: "true"
+    functionsWorkerEnabled: "true"
     PF_pulsarFunctionsCluster: local
 ---
 ##

--- a/deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yaml
+++ b/deployment/kubernetes/generic/k8s-1-9-and-above/proxy.yaml
@@ -24,9 +24,9 @@ metadata:
     name: proxy-config
 data:
     PULSAR_MEM: "\" -Xms64m -Xmx128m -XX:MaxDirectMemorySize=128m\""
-    PULSAR_PREFIX_zookeeperServers: zookeeper
-    PULSAR_PREFIX_configurationStoreServers: zookeeper
-    PULSAR_PREFIX_clusterName: local
+    zookeeperServers: zookeeper
+    configurationStoreServers: zookeeper
+    clusterName: local
 ---
 ##
 ## Expose all nodes on port so that you can reach cluster from outside k8

--- a/deployment/kubernetes/generic/original/bookie.yaml
+++ b/deployment/kubernetes/generic/original/bookie.yaml
@@ -24,10 +24,10 @@ metadata:
     name: bookie-config
 data:
     BOOKIE_MEM: "\" -Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m\""
-    PULSAR_PREFIX_dbStorage_writeCacheMaxSizeMb: "32" # Write cache size (direct memory)
-    PULSAR_PREFIX_dbStorage_readAheadCacheMaxSizeMb: "32" # Read cache size (direct memory)
-    PULSAR_PREFIX_zkServers: zookeeper
-    PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+    dbStorage_writeCacheMaxSizeMb: "32" # Write cache size (direct memory)
+    dbStorage_readAheadCacheMaxSizeMb: "32" # Read cache size (direct memory)
+    zkServers: zookeeper
+    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 ---
 
 ## BookKeeper servers need to access the local disks and the pods

--- a/deployment/kubernetes/generic/original/broker.yaml
+++ b/deployment/kubernetes/generic/original/broker.yaml
@@ -26,15 +26,15 @@ data:
     # Tune for available memory. Increase the heap up to 24G to have
     # better GC behavior at high throughput
     PULSAR_MEM: "\" -Xms64m -Xmx128m -XX:MaxDirectMemorySize=128m\""
-    PULSAR_PREFIX_zookeeperServers: zookeeper
-    PULSAR_PREFIX_configurationStoreServers: zookeeper
-    PULSAR_PREFIX_clusterName: local
+    zookeeperServers: zookeeper
+    configurationStoreServers: zookeeper
+    clusterName: local
     # change the managed ledger settings if you have more bookies
-    PULSAR_PREFIX_managedLedgerDefaultEnsembleSize: "1"
-    PULSAR_PREFIX_managedLedgerDefaultWriteQuorum: "1"
-    PULSAR_PREFIX_managedLedgerDefaultAckQuorum: "1"
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
     # enable pulsar functions
-    PULSAR_PREFIX_functionsWorkerEnabled: "true"
+    functionsWorkerEnabled: "true"
     PF_pulsarFunctionsCluster: local
 ---
 ##

--- a/deployment/kubernetes/generic/original/proxy.yaml
+++ b/deployment/kubernetes/generic/original/proxy.yaml
@@ -24,9 +24,9 @@ metadata:
     name: proxy-config
 data:
     PULSAR_MEM: "\" -Xms64m -Xmx128m -XX:MaxDirectMemorySize=128m\""
-    PULSAR_PREFIX_zookeeperServers: zookeeper
-    PULSAR_PREFIX_configurationStoreServers: zookeeper
-    PULSAR_PREFIX_clusterName: local
+    zookeeperServers: zookeeper
+    configurationStoreServers: zookeeper
+    clusterName: local
 ---
 ##
 ## Proxy deployment definition

--- a/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
@@ -46,11 +46,11 @@ metadata:
 data:
   PULSAR_MEM: "\" -Xms4g -Xmx4g -XX:MaxDirectMemorySize=4g\""
   PULSAR_GC: "\" -XX:+UseG1GC \""
-  PULSAR_PREFIX_dbStorage_writeCacheMaxSizeMb: "1024"
-  PULSAR_PREFIX_dbStorage_readAheadCacheMaxSizeMb: "1024"
-  PULSAR_PREFIX_zkServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-  PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
-  PULSAR_PREFIX_useHostNameAsBookieID: "true"
+  dbStorage_writeCacheMaxSizeMb: "1024"
+  dbStorage_readAheadCacheMaxSizeMb: "1024"
+  zkServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+  useHostNameAsBookieID: "true"
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet

--- a/deployment/kubernetes/google-kubernetes-engine/broker.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/broker.yaml
@@ -25,9 +25,9 @@ metadata:
 data:
     PULSAR_MEM: "\" -Xms8g -Xmx8g -XX:MaxDirectMemorySize=4g\""
     PULSAR_GC: "\" -XX:+UseG1GC \""
-    PULSAR_PREFIX_zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-    PULSAR_PREFIX_configurationStoreServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-    PULSAR_PREFIX_clusterName: pulsar-gke
+    zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    configurationStoreServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    clusterName: pulsar-gke
 ---
 ##
 ## Broker deployment definition

--- a/deployment/kubernetes/google-kubernetes-engine/proxy.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/proxy.yaml
@@ -23,9 +23,9 @@ metadata:
   name: pulsar-proxy-config
 data:
   PULSAR_MEM: "\" -Xms4g -Xmx4g -XX:MaxDirectMemorySize=4g\""
-  PULSAR_PREFIX_zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-  PULSAR_PREFIX_configurationStoreServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-  PULSAR_PREFIX_clusterName: pulsar-gke
+  zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+  configurationStoreServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+  clusterName: pulsar-gke
 
 ---
 apiVersion: apps/v1beta1

--- a/deployment/kubernetes/helm/pulsar/templates/broker-deployment.yaml
+++ b/deployment/kubernetes/helm/pulsar/templates/broker-deployment.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- $ensembleSize := .Values.broker.configData.PULSAR_PREFIX_managedLedgerDefaultEnsembleSize }}
+{{- $ensembleSize := .Values.broker.configData.managedLedgerDefaultEnsembleSize }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployment/kubernetes/helm/pulsar/values-mini.yaml
+++ b/deployment/kubernetes/helm/pulsar/values-mini.yaml
@@ -183,11 +183,11 @@ bookkeeper:
   configData:
     BOOKIE_MEM: "\"-Xms128m -Xmx256m -XX:MaxDirectMemorySize=128m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem\""
     BOOKIE_GC: "\"-XX:+UseG1GC -XX:MaxGCPauseMillis=10\""
-    PULSAR_PREFIX_dbStorage_writeCacheMaxSizeMb: "32"
-    PULSAR_PREFIX_dbStorage_readAheadCacheMaxSizeMb: "32"
-    PULSAR_PREFIX_journalMaxSizeMB: "2048"
-    PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
-    PULSAR_PREFIX_useHostNameAsBookieID: "true"
+    dbStorage_writeCacheMaxSizeMb: "32"
+    dbStorage_readAheadCacheMaxSizeMb: "32"
+    journalMaxSizeMB: "2048"
+    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+    useHostNameAsBookieID: "true"
   ## Bookkeeper configmap
   ## templates/bookkeeper-service.yaml
   ##
@@ -227,11 +227,11 @@ broker:
   configData:
     PULSAR_MEM: "\"-Xms128m -Xmx256m -XX:MaxDirectMemorySize=128m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem\""
     PULSAR_GC: "\"-XX:+UseG1GC -XX:MaxGCPauseMillis=10\""
-    PULSAR_PREFIX_managedLedgerDefaultEnsembleSize: "2"
-    PULSAR_PREFIX_managedLedgerDefaultWriteQuorum: "2"
-    PULSAR_PREFIX_managedLedgerDefaultAckQuorum: "2"
-    PULSAR_PREFIX_deduplicationEnabled: "false"
-    PULSAR_PREFIX_exposeTopicLevelMetricsInPrometheus: "true"
+    managedLedgerDefaultEnsembleSize: "2"
+    managedLedgerDefaultWriteQuorum: "2"
+    managedLedgerDefaultAckQuorum: "2"
+    deduplicationEnabled: "false"
+    exposeTopicLevelMetricsInPrometheus: "true"
   ## Broker service
   ## templates/broker-service.yaml
   ##

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -183,12 +183,12 @@ bookkeeper:
   configData:
     BOOKIE_MEM: "\"-Xms15g -Xmx15g -XX:MaxDirectMemorySize=15g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintHeapAtGC -verbosegc -XX:G1LogLevel=finest\""
     BOOKIE_GC: "\"-XX:+UseG1GC -XX:MaxGCPauseMillis=10\""
-    PULSAR_PREFIX_dbStorage_writeCacheMaxSizeMb: "2048"
-    PULSAR_PREFIX_dbStorage_readAheadCacheMaxSizeMb: "2048"
-    PULSAR_PREFIX_dbStorage_rocksDB_blockCacheSize: "268435456"
-    PULSAR_PREFIX_journalMaxSizeMB: "2048"
-    PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
-    PULSAR_PREFIX_useHostNameAsBookieID: "true"
+    dbStorage_writeCacheMaxSizeMb: "2048"
+    dbStorage_readAheadCacheMaxSizeMb: "2048"
+    dbStorage_rocksDB_blockCacheSize: "268435456"
+    journalMaxSizeMB: "2048"
+    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+    useHostNameAsBookieID: "true"
   ## Bookkeeper configmap
   ## templates/bookkeeper-service.yaml
   ##
@@ -228,11 +228,11 @@ broker:
   configData:
     PULSAR_MEM: "\"-Xms15g -Xmx15g -XX:MaxDirectMemorySize=15g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem\""
     PULSAR_GC: "\"-XX:+UseG1GC -XX:MaxGCPauseMillis=10\""
-    PULSAR_PREFIX_managedLedgerDefaultEnsembleSize: "3"
-    PULSAR_PREFIX_managedLedgerDefaultWriteQuorum: "3"
-    PULSAR_PREFIX_managedLedgerDefaultAckQuorum: "2"
-    PULSAR_PREFIX_deduplicationEnabled: "false"
-    PULSAR_PREFIX_exposeTopicLevelMetricsInPrometheus: "true"
+    managedLedgerDefaultEnsembleSize: "3"
+    managedLedgerDefaultWriteQuorum: "3"
+    managedLedgerDefaultAckQuorum: "2"
+    deduplicationEnabled: "false"
+    exposeTopicLevelMetricsInPrometheus: "true"
   ## Broker service
   ## templates/broker-service.yaml
   ##


### PR DESCRIPTION
*Motivation*

For versions older than 2.5.0, PULSAR_PREFIX is used for appending settings
that don't exist in existing configuration files.

*Modifications*

Remove `PULSAR_PREFIX` for backward compatibility

