### PR TITLE
[Pulsar Functions] Support config admin CLI in funtions runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ pulsar-broker/tmp.*
 pulsar-broker/src/test/resources/log4j2.yaml
 pulsar-functions/worker/test-tenant/
 pulsar-broker/src/test/resources/pulsar-functions-api-examples.jar
+pulsar-functions/runtime/src/test/resources/
+pulsar-functions/worker/src/test/resources/
 *.log
 *.nar
 

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -160,6 +160,9 @@ functionRuntimeFactoryConfigs:
 #   ram: 1073741824
 #   disk: 10737418240
 
+## Config admin CLI
+#configAdminCLI:
+
 ############################################
 # security settings for worker service
 ############################################

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -133,6 +133,7 @@ public class KubernetesRuntime implements Runtime {
     private final String pulsarDockerImageName;
     private final String imagePullPolicy;
     private final String pulsarRootDir;
+    private final String configAdminCLI;
     private final String userCodePkgUrl;
     private final String originalCodeFileName;
     private final String pulsarAdminUrl;
@@ -160,6 +161,7 @@ public class KubernetesRuntime implements Runtime {
                       String instanceFile,
                       String extraDependenciesDir,
                       String logDirectory,
+                      String configAdminCLI,
                       String userCodePkgUrl,
                       String originalCodeFileName,
                       String pulsarServiceUrl,
@@ -184,6 +186,7 @@ public class KubernetesRuntime implements Runtime {
         this.pulsarDockerImageName = pulsarDockerImageName;
         this.imagePullPolicy = imagePullPolicy;
         this.pulsarRootDir = pulsarRootDir;
+        this.configAdminCLI = configAdminCLI;
         this.userCodePkgUrl = userCodePkgUrl;
         this.originalCodeFileName = pulsarRootDir + "/" + originalCodeFileName;
         this.pulsarAdminUrl = pulsarAdminUrl;
@@ -804,7 +807,7 @@ public class KubernetesRuntime implements Runtime {
                     && isNotBlank(authConfig.getClientAuthenticationParameters())
                     && instanceConfig.getFunctionAuthenticationSpec() != null) {
                 return Arrays.asList(
-                        pulsarRootDir + "/bin/pulsar-admin",
+                        pulsarRootDir + configAdminCLI,
                         "--auth-plugin",
                         authConfig.getClientAuthenticationPlugin(),
                         "--auth-params",
@@ -825,7 +828,7 @@ public class KubernetesRuntime implements Runtime {
         }
 
         return Arrays.asList(
-                pulsarRootDir + "/bin/pulsar-admin",
+                pulsarRootDir + configAdminCLI,
                 "--admin-url",
                 pulsarAdminUrl,
                 "functions",

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
@@ -69,6 +69,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     private String pulsarDockerImageName;
     private String imagePullPolicy;
     private String pulsarRootDir;
+    private String configAdminCLI;
     private String pulsarAdminUrl;
     private String pulsarServiceUrl;
     private String pythonDependencyRepository;
@@ -150,6 +151,11 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             this.pulsarRootDir = factoryConfig.getPulsarRootDir();
         } else {
             this.pulsarRootDir = "/pulsar";
+        }
+        if (!isEmpty(factoryConfig.getConfigAdminCLI())) {
+            this.configAdminCLI = factoryConfig.getConfigAdminCLI();
+        } else {
+            this.configAdminCLI = "/bin/pulsar-admin";
         }
 
         this.submittingInsidePod = factoryConfig.getSubmittingInsidePod();
@@ -270,6 +276,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             instanceFile,
             extraDependenciesDir,
             logDirectory,
+            configAdminCLI,
             codePkgUrl,
             originalCodeFileName,
             pulsarServiceUrl,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
@@ -53,6 +53,12 @@ public class KubernetesRuntimeFactoryConfig {
     )
     protected String pulsarRootDir;
     @FieldContext(
+            doc = "The config admin CLI allows users to customize the configuration of the admin cli tool, such as:"
+                    + " `/bin/pulsar-admin and /bin/pulsarctl`. By default it is `/bin/pulsar-admin`. If you want to use `pulsarctl` "
+                    + " you need to set this setting accordingly"
+    )
+    protected String configAdminCLI;
+    @FieldContext(
         doc = "This setting only takes effects if `k8Uri` is set to null. If your function worker is"
             + " also running as a k8s pod, set this to `true` is let function worker to submit functions to"
             + " the same k8s cluster as function worker is running. Set this to `false` if your function worker"


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation

Sometimes, users want to use a customized admin CLI tool. Currently, in the k8s runtime, hardcode is used in `getdownloadcommands()`. This change will support users to configure the CLI tool they want. The default value is: `/bin/pulsar-admin`.

### Modifications

- Support config admin CLI