### PR TITLE
[hotfix] Fix flaky test in InfluxDBSinkTest

### DIFF
--- a/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkTest.java
+++ b/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkTest.java
@@ -106,8 +106,8 @@ public class InfluxDBSinkTest {
 
         assertEquals("cpu", record.getField("measurement"));
 
-        // FIXME: GenericJsonRecord will parse long to string or int, depends on whether the value is greater than max Integer. We should modify the behavior of GenericJsonSchema
-        assertEquals(timestamp+"", record.getField("timestamp"));
+        // compare the String type
+        assertEquals(timestamp + "", record.getField("timestamp").toString());
 
         assertEquals("server-1", ((GenericRecord)record.getField("tags")).getField("host"));
         assertEquals(10, ((GenericRecord)record.getField("fields")).getField("value"));


### PR DESCRIPTION
### Motivation

In some new added pull requests the `CI - Unit / unit-tests` failed as below:

```
[ERROR] testJsonSchema on testJsonSchema(org.apache.pulsar.io.influxdb.v2.InfluxDBSinkTest)(org.apache.pulsar.io.influxdb.v2.InfluxDBSinkTest)  Time elapsed: 0.026 s  <<< FAILURE!
java.lang.AssertionError: expected: java.lang.String<1586235436221> but was: java.lang.Long<1586235436221>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.apache.pulsar.io.influxdb.v2.InfluxDBSinkTest.testJsonSchema(InfluxDBSinkTest.java:110)
```

### Modifications

Just compare the `String` type when using `GenericJsonSchema` to pass the unit tests.