### PR TITLE
[broker]Handle BadVersionException thrown by updateSchemaLocator()

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -264,7 +264,29 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 //don't check the schema whether already exist
                 return readSchemaEntry(locator.getIndexList().get(0).getPosition())
                         .thenCompose(schemaEntry -> addNewSchemaEntryToStore(schemaId, locator.getIndexList(), data).thenCompose(
-                        position -> updateSchemaLocator(schemaId, optLocatorEntry.get(), position, hash)));
+                        position -> {
+                            CompletableFuture<Long> future = new CompletableFuture<>();
+                            updateSchemaLocator(schemaId, optLocatorEntry.get(), position, hash)
+                                    .thenAccept(future::complete)
+                                    .exceptionally(ex -> {
+                                        if (ex.getCause() instanceof KeeperException.BadVersionException) {
+                                            // There was a race condition on the schema creation. Since it has now been created,
+                                            // retry the whole operation so that we have a chance to recover without bubbling error
+                                            putSchema(schemaId, data, hash)
+                                                    .thenAccept(future::complete)
+                                                    .exceptionally(ex2 -> {
+                                                        future.completeExceptionally(ex2);
+                                                        return null;
+                                                    });
+                                        } else {
+                                            // For other errors, just fail the operation
+                                            future.completeExceptionally(ex);
+                                        }
+                                        return null;
+                                    });
+                            return future;
+                        })
+                );
             } else {
                 // No schema was defined yet
                 CompletableFuture<Long> future = new CompletableFuture<>();


### PR DESCRIPTION
`putShema()` still throws `KeeperException.BadVersionException` even after https://github.com/apache/pulsar/pull/5563 was merged when health check api is requested.

After GC, health check api returns `ok` but `PutShema()` throws `KeeperException.BadVersionException`.
( By https://github.com/apache/pulsar/pull/6577, the client reconnects when getting the exception and so health check api returns `ok` . )
```
curl -v http://127.0.0.1:8080/admin/v2/brokers/health
ok

# Waiting for more than 60 seconds, waiting for the topic pulsar/standalone/127.0.0.1:8080/healthcheck to be deleted

# Api returns ok, but putShema() throws KeeperException.BadVersionException.
curl -v http://127.0.0.1:8080/admin/v2/brokers/health
ok
```

```
13:47:37.286 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:54360][persistent://pulsar/standalone/localhost:8080/healthcheck][reader-27cd902283] Failed to create consumer: KeeperErrorCode = BadVersion
java.util.concurrent.CompletionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_202]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_202]
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$updateSchemaLocator$24(BookkeeperSchemaStorage.java:427) ~[pulsar-broker.jar:2.6.0-SNAPSHOT]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$22$1.processResult(ZooKeeperClient.java:1091) [bookkeeper-server-4.10.0.jar:4.10.0]
	at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:592) [zookeeper-3.5.7.jar:3.5.7]
	at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:510) [zookeeper-3.5.7.jar:3.5.7]
Caused by: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:122) ~[zookeeper-3.5.7.jar:3.5.7]
	... 4 more
13:47:37.288 [pulsar-client-io-92-1] WARN  org.apache.pulsar.client.impl.ClientCnx - [id: 0x8625b158, L:/127.0.0.1:54360 - R:localhost/127.0.0.1:6650] Received error from server: KeeperErrorCode = BadVersion
13:47:37.288 [pulsar-client-io-92-1] WARN  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/standalone/localhost:8080/healthcheck][reader-27cd902283] Failed to subscribe to topic on localhost/127.0.0.1:6650
13:47:37.288 [pulsar-client-io-92-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://pulsar/standalone/localhost:8080/healthcheck] [reader-27cd902283] Could not get connection to broker: KeeperErrorCode = BadVersion -- Will try again in 0.1 s
13:47:37.389 [pulsar-timer-94-1] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://pulsar/standalone/localhost:8080/healthcheck] [reader-27cd902283] Reconnecting after connection was closed
13:47:37.390 [pulsar-client-io-92-1] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/standalone/localhost:8080/healthcheck][reader-27cd902283] Subscribing to topic on cnx [id: 0x8625b158, L:/127.0.0.1:54360 - R:localhost/127.0.0.1:6650]
13:47:37.391 [pulsar-io-51-3] INFO  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:54360] Subscribing on topic persistent://pulsar/standalone/localhost:8080/healthcheck / reader-27cd902283
```

