### PR TITLE
[docs] Update README.md To Represent JDK 11 in Build Pulsar Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Learn more about Pulsar at https://pulsar.apache.org
 ## Build Pulsar
 
 Requirements:
- * Java JDK 1.8
+ * Java JDK 1.8 or Java JDK 11
  * Maven 3.3.9+
 
 Compile and install:


### PR DESCRIPTION
### Motivation
- In order for README.md to better reflect that JDK 11 is fine for working with Building Pulsar in the docs

### Modifications
- Updated README.md to call out that either Java 8 or Java 11 is acceptable prerequisite for building pulsar

### Verifying this change
- [ ] Make sure that the change passes the CI checks.

### Documentation
- updated one line in README.md, not sure this warrants a need for additional documentation about updating documentation 😆 
