### PR TITLE
[Issue 6690] More accurately load the private key from PEM file

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -257,16 +257,17 @@ public class SecurityUtility {
 
         try (BufferedReader reader = new BufferedReader(new FileReader(keyFilePath))) {
             StringBuilder sb = new StringBuilder();
-            String previousLine = "";
             String currentLine = null;
 
-            // Skip the first line (-----BEGIN RSA PRIVATE KEY-----)
-            reader.readLine();
-            while ((currentLine = reader.readLine()) != null) {
-                sb.append(previousLine);
-                previousLine = currentLine;
+            // Jump to the first line after -----BEGIN [RSA] PRIVATE KEY-----
+            while (!reader.readLine().startsWith("-----BEGIN")) {
+                reader.readLine();
             }
-            // Skip the last line (-----END RSA PRIVATE KEY-----)
+
+            // Stop (and skip) at the last line that has, say, -----END [RSA] PRIVATE KEY-----
+            while ((currentLine = reader.readLine()) != null && !currentLine.startsWith("-----END")) {
+                sb.append(currentLine);
+            }
 
             KeyFactory kf = KeyFactory.getInstance("RSA");
             KeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(sb.toString()));


### PR DESCRIPTION

Fixes #6690 

### Motivation

See #6690 - I'd received new certs, but because my pem file had attributes, pulsar proxy was unable to load the private key.

### Modifications

How pulsar loads the private key from a PEM file

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

However, need assistance in verifying this, as I do not have many cycles to test/verify

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: don't know
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: don't know

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? `bugfix`
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation - N/A
