### PR TITLE
Issue 6702: add isSuperUser in AuthorizationProvider interface

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -48,6 +48,19 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
+     * Check if specified role is a super user
+     * @param role the role to check
+     * @param authenticationData authentication data related to the role
+     * @return a CompletableFuture containing a boolean in which true means the role is a super user
+     * and false if it is not
+     */
+    default CompletableFuture<Boolean> isSuperUser(String role,
+                                                   AuthenticationDataSource authenticationData,
+                                                   ServiceConfiguration serviceConfiguration) {
+        return isSuperUser(role, serviceConfiguration);
+    }
+
+    /**
      * Check if specified role is an admin of the tenant
      * @param tenant the tenant to check
      * @param role the role to check
@@ -137,7 +150,7 @@ public interface AuthorizationProvider extends Closeable {
 
     /**
      * Grant permission to roles that can access subscription-admin api
-     * 
+     *
      * @param namespace
      * @param subscriptionName
      * @param roles
@@ -147,7 +160,7 @@ public interface AuthorizationProvider extends Closeable {
      */
     CompletableFuture<Void> grantSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName, Set<String> roles,
             String authDataJson);
-    
+
     /**
      * Revoke subscription admin-api access for a role
      * @param namespace
@@ -157,7 +170,7 @@ public interface AuthorizationProvider extends Closeable {
      */
     CompletableFuture<Void> revokeSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
             String role, String authDataJson);
-    
+
     /**
      * Grant authorization-action permission on a topic to the given client
      *

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -70,9 +70,9 @@ public class AuthorizationService {
         }
     }
 
-    public CompletableFuture<Boolean> isSuperUser(String user) {
+    public CompletableFuture<Boolean> isSuperUser(String user, AuthenticationDataSource authenticationData) {
         if (provider != null) {
-           return provider.isSuperUser(user, conf);
+            return provider.isSuperUser(user, authenticationData, conf);
         }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
@@ -111,7 +111,7 @@ public class AuthorizationService {
 
     /**
      * Grant permission to roles that can access subscription-admin api
-     * 
+     *
      * @param namespace
      * @param subscriptionName
      * @param roles
@@ -130,7 +130,7 @@ public class AuthorizationService {
 
     /**
      * Revoke subscription admin-api access for a role
-     * 
+     *
      * @param namespace
      * @param subscriptionName
      * @param role
@@ -143,7 +143,7 @@ public class AuthorizationService {
         }
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
     }
-    
+
     /**
      * Grant authorization-action permission on a topic to the given client
      *
@@ -180,7 +180,7 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
         if (provider != null) {
-            return provider.isSuperUser(role, conf).thenComposeAsync(isSuperUser -> {
+            return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
                     return CompletableFuture.completedFuture(true);
                 } else {
@@ -207,7 +207,7 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
         if (provider != null) {
-            return provider.isSuperUser(role, conf).thenComposeAsync(isSuperUser -> {
+            return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
                 if (isSuperUser) {
                     return CompletableFuture.completedFuture(true);
                 } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -516,7 +516,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(), Mockito.any(), Mockito.any());
 
         // Test producer creation
         resetChannel();
@@ -546,7 +546,7 @@ public class ServerCnxTest {
         providerField.set(authorizationService, authorizationProvider);
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
-        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(),  Mockito.any());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationProvider).isSuperUser(Mockito.anyString(), Mockito.any(), Mockito.any());
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).checkPermission(any(TopicName.class), Mockito.anyString(),
                 any(AuthAction.class));
 
@@ -574,7 +574,7 @@ public class ServerCnxTest {
         providerField.setAccessible(true);
         PulsarAuthorizationProvider authorizationProvider = spy(new PulsarAuthorizationProvider(svcConfig, configCacheService));
         providerField.set(authorizationService, authorizationProvider);
-        doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).isSuperUser(Mockito.anyString(),  Mockito.any());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationProvider).isSuperUser(Mockito.anyString(), Mockito.any(), Mockito.any());
 
         // Test producer creation
         resetChannel();


### PR DESCRIPTION

Fixes #6702

### Motivation

Most of the methods in AuthorizationProvider take AuthenticationDataSource for authorization decision. However isSuperUser still takes the string role token. This has to be changed.

### Modifications

Add needed method
