### PR TITLE
Make ServerCnx, Producer and Consumer independent of Netty

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2311,8 +2311,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         }
     }
 
-    private void foreachCnx(Consumer<ServerCnx> consumer) {
-        Set<ServerCnx> cnxSet = new HashSet<>();
+    private void foreachCnx(Consumer<TransportCnx> consumer) {
+        Set<TransportCnx> cnxSet = new HashSet<>();
         topics.forEach((n, t) -> {
             Optional<Topic> topic = extractTopic(t);
             topic.ifPresent(value -> value.getProducers().values().forEach(producer -> cnxSet.add(producer.getCnx())));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -218,7 +218,9 @@ public class Consumer {
             if (batchIndexesAcks != null) {
                 batchIndexesAcks.recycle();
             }
-            return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
+            final Promise<Void> writePromise = cnx.newPromise();
+            writePromise.setSuccess(null);
+            return writePromise;
         }
 
         // Note

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -23,12 +23,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +33,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -54,10 +50,8 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
-import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
-import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -72,7 +66,7 @@ import org.slf4j.LoggerFactory;
 public class Consumer {
     private final Subscription subscription;
     private final SubType subType;
-    private final ServerCnx cnx;
+    private final TransportCnx cnx;
     private final String appId;
     private AuthenticationDataSource authenticationData;
     private final String topicName;
@@ -134,7 +128,7 @@ public class Consumer {
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
-                    int maxUnackedMessages, ServerCnx cnx, String appId,
+                    int maxUnackedMessages, TransportCnx cnx, String appId,
                     Map<String, String> metadata, boolean readCompacted, InitialPosition subscriptionInitialPosition,
                     PulsarApi.KeySharedMeta keySharedMeta) throws BrokerServiceException {
 
@@ -194,18 +188,11 @@ public class Consumer {
     }
 
     void notifyActiveConsumerChange(Consumer activeConsumer) {
-        if (!Commands.peerSupportsActiveConsumerListener(cnx.getRemoteEndpointProtocolVersion())) {
-            // if the client is older than `v12`, we don't need to send consumer group changes.
-            return;
-        }
-
         if (log.isDebugEnabled()) {
             log.debug("notify consumer {} - that [{}] for subscription {} has new active consumer : {}",
                 consumerId, topicName, subscription.getName(), activeConsumer);
         }
-        cnx.ctx().writeAndFlush(
-            Commands.newActiveConsumerChange(consumerId, this == activeConsumer),
-            cnx.ctx().voidPromise());
+        cnx.getCommandSender().sendActiveConsumerChange(consumerId, this == activeConsumer);
     }
 
     public boolean readCompacted() {
@@ -218,24 +205,20 @@ public class Consumer {
      *
      * @return a SendMessageInfo object that contains the detail of what was sent to consumer
      */
-
-    public ChannelPromise sendMessages(final List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
+    public Future<Void> sendMessages(final List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
                int totalMessages, long totalBytes, long totalChunkedMessages, RedeliveryTracker redeliveryTracker) {
         this.lastConsumedTimestamp = System.currentTimeMillis();
-        final ChannelHandlerContext ctx = cnx.ctx();
-        final ChannelPromise writePromise = ctx.newPromise();
 
         if (entries.isEmpty() || totalMessages == 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}-{}] List of messages is empty, triggering write future immediately for consumerId {}",
                         topicName, subscription, consumerId);
             }
-            writePromise.setSuccess();
             batchSizes.recyle();
             if (batchIndexesAcks != null) {
                 batchIndexesAcks.recycle();
             }
-            return writePromise;
+            return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
         }
 
         // Note
@@ -266,66 +249,8 @@ public class Consumer {
         bytesOutCounter.add(totalBytes);
         chuckedMessageRate.recordMultipleEvents(totalChunkedMessages, 0);
 
-        ctx.channel().eventLoop().execute(() -> {
-            for (int i = 0; i < entries.size(); i++) {
-                Entry entry = entries.get(i);
-                if (entry == null) {
-                    // Entry was filtered out
-                    continue;
-                }
-
-                int batchSize = batchSizes.getBatchSize(i);
-
-                if (batchSize > 1 && !cnx.isBatchMessageCompatibleVersion()) {
-                    log.warn("[{}-{}] Consumer doesn't support batch messages -  consumerId {}, msg id {}-{}",
-                            topicName, subscription,
-                            consumerId, entry.getLedgerId(), entry.getEntryId());
-                    ctx.close();
-                    entry.release();
-                    continue;
-                }
-
-                MessageIdData.Builder messageIdBuilder = MessageIdData.newBuilder();
-                MessageIdData messageId = messageIdBuilder
-                    .setLedgerId(entry.getLedgerId())
-                    .setEntryId(entry.getEntryId())
-                    .setPartition(partitionIdx)
-                    .build();
-
-                ByteBuf metadataAndPayload = entry.getDataBuffer();
-                // increment ref-count of data and release at the end of process: so, we can get chance to call entry.release
-                metadataAndPayload.retain();
-                // skip checksum by incrementing reader-index if consumer-client doesn't support checksum verification
-                if (cnx.getRemoteEndpointProtocolVersion() < ProtocolVersion.v11.getNumber()) {
-                    Commands.skipChecksumIfPresent(metadataAndPayload);
-                }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}-{}] Sending message to consumerId {}, msg id {}-{}", topicName, subscription,
-                            consumerId, entry.getLedgerId(), entry.getEntryId());
-                }
-
-                int redeliveryCount = 0;
-                PositionImpl position = PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId());
-                if (redeliveryTracker.contains(position)) {
-                    redeliveryCount = redeliveryTracker.incrementAndGetRedeliveryCount(position);
-                }
-                ctx.write(cnx.newMessageAndIntercept(consumerId, messageId, redeliveryCount, metadataAndPayload,
-                    batchIndexesAcks == null ? null : batchIndexesAcks.getAckSet(i), topicName), ctx.voidPromise());
-                messageId.recycle();
-                messageIdBuilder.recycle();
-                entry.release();
-            }
-
-            // Use an empty write here so that we can just tie the flush with the write promise for last entry
-            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER, writePromise);
-            batchSizes.recyle();
-            if (batchIndexesAcks != null) {
-                batchIndexesAcks.recycle();
-            }
-        });
-
-        return writePromise;
+        return cnx.getCommandSender().sendMessagesToConsumer(consumerId, topicName, subscription, partitionIdx,
+                entries, batchSizes, batchIndexesAcks, redeliveryTracker);
     }
 
     private void incrementUnackedMessages(int ackedMessages) {
@@ -338,10 +263,6 @@ public class Consumer {
 
     public boolean isWritable() {
         return cnx.isWritable();
-    }
-
-    public void sendError(ByteBuf error) {
-        cnx.ctx().writeAndFlush(error).addListener(ChannelFutureListener.CLOSE);
     }
 
     /**
@@ -371,23 +292,20 @@ public class Consumer {
         }
     }
 
-    void doUnsubscribe(final long requestId) {
-        final ChannelHandlerContext ctx = cnx.ctx();
-
+    public void doUnsubscribe(final long requestId) {
         subscription.doUnsubscribe(this).thenAccept(v -> {
             log.info("Unsubscribed successfully from {}", subscription);
             cnx.removedConsumer(this);
-            ctx.writeAndFlush(Commands.newSuccess(requestId));
+            cnx.getCommandSender().sendSuccess(requestId);
         }).exceptionally(exception -> {
             log.warn("Unsubscribe failed for {}", subscription, exception);
-            ctx.writeAndFlush(
-                    Commands.newError(requestId, BrokerServiceException.getClientErrorCode(exception),
-                            exception.getCause().getMessage()));
+            cnx.getCommandSender().sendError(requestId, BrokerServiceException.getClientErrorCode(exception),
+                    exception.getCause().getMessage());
             return null;
         });
     }
 
-    CompletableFuture<Void> messageAcked(CommandAck ack) {
+    public CompletableFuture<Void> messageAcked(CommandAck ack) {
         this.lastAckedTimestamp = System.currentTimeMillis();
         Map<String,Long> properties = Collections.emptyMap();
         if (ack.getPropertiesCount() > 0) {
@@ -463,7 +381,7 @@ public class Consumer {
         }
     }
 
-    void flowPermits(int additionalNumberOfMessages) {
+    public void flowPermits(int additionalNumberOfMessages) {
         checkArgument(additionalNumberOfMessages > 0);
 
         // block shared consumer when unacked-messages reaches limit
@@ -513,11 +431,7 @@ public class Consumer {
     }
 
     public void reachedEndOfTopic() {
-        // Only send notification if the client understand the command
-        if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v9_VALUE) {
-            log.info("[{}] Notifying consumer that end of topic has been reached", this);
-            cnx.ctx().writeAndFlush(Commands.newReachedEndOfTopic(consumerId));
-        }
+        cnx.getCommandSender().sendReachedEndOfTopic(consumerId);
     }
 
     /**
@@ -568,10 +482,6 @@ public class Consumer {
     public String toString() {
         return MoreObjects.toStringHelper(this).add("subscription", subscription).add("consumerId", consumerId)
                 .add("consumerName", consumerName).add("address", this.cnx.clientAddress()).toString();
-    }
-
-    public ChannelHandlerContext ctx() {
-        return cnx.ctx();
     }
 
     public void checkPermissions() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.scurrilous.circe.checksum.Crc32cIntChecksum.computeChecksum;
+import static org.apache.pulsar.broker.service.AbstractReplicator.REPL_PRODUCER_NAME_DELIMITER;
 import static org.apache.pulsar.common.protocol.Commands.hasChecksum;
 import static org.apache.pulsar.common.protocol.Commands.readChecksum;
 
@@ -42,25 +43,24 @@ import org.apache.pulsar.broker.service.Topic.PublishContext;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.transaction.TxnID;
-import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.NonPersistentPublisherStats;
 import org.apache.pulsar.common.policies.data.PublisherStats;
+import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.apache.pulsar.broker.service.AbstractReplicator.REPL_PRODUCER_NAME_DELIMITER;
 
 /**
  * Represents a currently connected producer
  */
 public class Producer {
     private final Topic topic;
-    private final ServerCnx cnx;
+    private final TransportCnx cnx;
     private final String producerName;
     private final long epoch;
     private final boolean userProvidedProducerName;
@@ -89,7 +89,7 @@ public class Producer {
 
     private final SchemaVersion schemaVersion;
 
-    public Producer(Topic topic, ServerCnx cnx, long producerId, String producerName, String appId,
+    public Producer(Topic topic, TransportCnx cnx, long producerId, String producerName, String appId,
             boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
             boolean userProvidedProducerName) {
         this.topic = topic;
@@ -141,41 +141,42 @@ public class Producer {
 
     public void publishMessage(long producerId, long sequenceId, ByteBuf headersAndPayload, long batchSize,
             boolean isChunked) {
-        beforePublish(producerId, sequenceId, headersAndPayload, batchSize);
-        publishMessageToTopic(headersAndPayload, sequenceId, batchSize, isChunked);
+        if (checkAndStartPublish(producerId, sequenceId, headersAndPayload, batchSize)) {
+            publishMessageToTopic(headersAndPayload, sequenceId, batchSize, isChunked);
+        }
     }
 
     public void publishMessage(long producerId, long lowestSequenceId, long highestSequenceId,
-           ByteBuf headersAndPayload, long batchSize, boolean isChunked) {
+            ByteBuf headersAndPayload, long batchSize, boolean isChunked) {
         if (lowestSequenceId > highestSequenceId) {
-            cnx.ctx().channel().eventLoop().execute(() -> {
+            cnx.execute(() -> {
                 cnx.getCommandSender().sendSendError(producerId, highestSequenceId, ServerError.MetadataError,
                         "Invalid lowest or highest sequence id");
                 cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
             return;
         }
-        beforePublish(producerId, highestSequenceId, headersAndPayload, batchSize);
-        publishMessageToTopic(headersAndPayload, lowestSequenceId, highestSequenceId, batchSize, isChunked);
+        if (checkAndStartPublish(producerId, highestSequenceId, headersAndPayload, batchSize)) {
+            publishMessageToTopic(headersAndPayload, lowestSequenceId, highestSequenceId, batchSize, isChunked);
+        }
     }
 
-    public void beforePublish(long producerId, long sequenceId, ByteBuf headersAndPayload, long batchSize) {
+    public boolean checkAndStartPublish(long producerId, long sequenceId, ByteBuf headersAndPayload, long batchSize) {
         if (isClosed) {
-            cnx.ctx().channel().eventLoop().execute(() -> {
+            cnx.execute(() -> {
                 cnx.getCommandSender().sendSendError(producerId, sequenceId, ServerError.PersistenceError,
                         "Producer is closed");
                 cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
-
-            return;
+            return false;
         }
 
         if (!verifyChecksum(headersAndPayload)) {
-            cnx.ctx().channel().eventLoop().execute(() -> {
+            cnx.execute(() -> {
                 cnx.getCommandSender().sendSendError(producerId, sequenceId, ServerError.ChecksumError, "Checksum failed on the broker");
                 cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
             });
-            return;
+            return false;
         }
 
         if (topic.isEncryptionRequired()) {
@@ -188,16 +189,17 @@ public class Producer {
             // Check whether the message is encrypted or not
             if (encryptionKeysCount < 1) {
                 log.warn("[{}] Messages must be encrypted", getTopic().getName());
-                cnx.ctx().channel().eventLoop().execute(() -> {
+                cnx.execute(() -> {
                     cnx.getCommandSender().sendSendError(producerId, sequenceId, ServerError.MetadataError,
                             "Messages must be encrypted");
                     cnx.completedSendOperation(isNonPersistentTopic, headersAndPayload.readableBytes());
                 });
-                return;
+                return false;
             }
         }
 
         startPublishOperation((int) batchSize, headersAndPayload.readableBytes());
+        return true;
     }
 
     private void publishMessageToTopic(ByteBuf headersAndPayload, long sequenceId, long batchSize, boolean isChunked) {
@@ -267,7 +269,7 @@ public class Producer {
 
     /**
      * Return the sequence id of
-     * @return
+     * @return the sequence id
      */
     public long getLastSequenceId() {
         if (isNonPersistentTopic) {
@@ -277,7 +279,7 @@ public class Producer {
         }
     }
 
-    public ServerCnx getCnx() {
+    public TransportCnx getCnx() {
         return this.cnx;
     }
 
@@ -355,7 +357,7 @@ public class Producer {
                 ServerError serverError = (exception instanceof TopicTerminatedException)
                         ? ServerError.TopicTerminatedError : ServerError.PersistenceError;
 
-                producer.cnx.ctx().channel().eventLoop().execute(() -> {
+                producer.cnx.execute(() -> {
                     if (!(exception instanceof TopicClosedException)) {
                         // For TopicClosed exception there's no need to send explicit error, since the client was
                         // already notified
@@ -375,7 +377,7 @@ public class Producer {
 
                 this.ledgerId = ledgerId;
                 this.entryId = entryId;
-                producer.cnx.ctx().channel().eventLoop().execute(this);
+                producer.cnx.execute(this);
             }
         }
 
@@ -418,7 +420,7 @@ public class Producer {
         }
 
         static MessagePublishContext get(Producer producer, long lowestSequenceId, long highestSequenceId, Rate rateIn,
-                 int msgSize, long batchSize, boolean chunked, long startTimeNs) {
+                int msgSize, long batchSize, boolean chunked, long startTimeNs) {
             MessagePublishContext callback = RECYCLER.get();
             callback.producer = producer;
             callback.sequenceId = lowestSequenceId;
@@ -440,7 +442,7 @@ public class Producer {
         }
 
         private static final Recycler<MessagePublishContext> RECYCLER = new Recycler<MessagePublishContext>() {
-            protected MessagePublishContext newObject(Recycler.Handle<MessagePublishContext> handle) {
+            protected MessagePublishContext newObject(Handle<MessagePublishContext> handle) {
                 return new MessagePublishContext(handle);
             }
         };
@@ -508,7 +510,7 @@ public class Producer {
         return closeFuture;
     }
 
-    void closeNow(boolean removeFromTopic) {
+    public void closeNow(boolean removeFromTopic) {
         if (removeFromTopic) {
             topic.removeProducer(this);
         }
@@ -529,7 +531,7 @@ public class Producer {
     public CompletableFuture<Void> disconnect() {
         if (!closeFuture.isDone()) {
             log.info("Disconnecting producer: {}", this);
-            cnx.ctx().executor().execute(() -> {
+            cnx.execute(() -> {
                 cnx.closeProducer(this);
                 closeNow(true);
             });
@@ -610,7 +612,7 @@ public class Producer {
 
     public void publishTxnMessage(TxnID txnID, long producerId, long sequenceId, long highSequenceId,
                                   ByteBuf headersAndPayload, long batchSize, boolean isChunked) {
-        beforePublish(producerId, sequenceId, headersAndPayload, batchSize);
+        checkAndStartPublish(producerId, sequenceId, headersAndPayload, batchSize);
         topic.publishTxnMessage(txnID, headersAndPayload,
                 MessagePublishContext.get(this, sequenceId, highSequenceId, msgIn,
                         headersAndPayload.readableBytes(), batchSize, isChunked, System.nanoTime()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -137,7 +137,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             try {
                 cnx.refreshAuthenticationCredentials();
             } catch (Throwable t) {
-                log.warn("[{}] Failed to refresh auth credentials", cnx.getRemoteAddress());
+                log.warn("[{}] Failed to refresh auth credentials", cnx.clientAddress());
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -29,92 +29,50 @@ import java.util.List;
 
 public interface PulsarCommandSender {
 
-    default void sendPartitionMetadataResponse(PulsarApi.ServerError error, String errorMsg, long requestId) {
-        // No-op
-    }
+    void sendPartitionMetadataResponse(PulsarApi.ServerError error, String errorMsg, long requestId);
 
-    default void sendPartitionMetadataResponse(int partitions, long requestId) {
-        // No-op
-    }
+    void sendPartitionMetadataResponse(int partitions, long requestId);
 
-    default void sendSuccessResponse(long requestId) {
-        // No-op
-    }
+    void sendSuccessResponse(long requestId);
 
-    default void sendErrorResponse(long requestId, PulsarApi.ServerError error, String message) {
-        // No-op
-    }
+    void sendErrorResponse(long requestId, PulsarApi.ServerError error, String message);
 
-    default void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion) {
-        // No-op
-    }
+    void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion);
 
-    default void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
-                                     SchemaVersion schemaVersion) {
-        // No-op
-    }
+    void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
+                                     SchemaVersion schemaVersion);
 
-    default void sendSendReceiptResponse(long producerId, long sequenceId, long highestId, long ledgerId,
-                                 long entryId) {
-        // No-op
-    }
+    void sendSendReceiptResponse(long producerId, long sequenceId, long highestId, long ledgerId,
+                                 long entryId);
 
-    default void sendSendError(long producerId, long sequenceId, PulsarApi.ServerError error, String errorMsg) {
-        // No-op
-    }
+    void sendSendError(long producerId, long sequenceId, PulsarApi.ServerError error, String errorMsg);
 
-    default void sendGetTopicsOfNamespaceResponse(List<String> topics, long requestId) {
-        // No-op
-    }
+    void sendGetTopicsOfNamespaceResponse(List<String> topics, long requestId);
 
-    default void sendGetSchemaResponse(long requestId, SchemaInfo schema, SchemaVersion version) {
-        // No-op
-    }
+    void sendGetSchemaResponse(long requestId, SchemaInfo schema, SchemaVersion version);
 
-    default void sendGetSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage) {
-        // No-op
-    }
+    void sendGetSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage);
 
-    default void sendGetOrCreateSchemaResponse(long requestId, SchemaVersion schemaVersion) {
-        // No-op
-    }
+    void sendGetOrCreateSchemaResponse(long requestId, SchemaVersion schemaVersion);
 
-    default void sendGetOrCreateSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage) {
-        // No-op
-    }
+    void sendGetOrCreateSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage);
 
-    default void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize) {
-        // No-op
-    }
+    void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize);
 
-    default void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
-                            PulsarApi.CommandLookupTopicResponse.LookupType response, long requestId, boolean proxyThroughServiceUrl) {
-        // No-op
-    }
+    void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
+                            PulsarApi.CommandLookupTopicResponse.LookupType response, long requestId, boolean proxyThroughServiceUrl);
 
-    default void sendLookupResponse(PulsarApi.ServerError error, String errorMsg, long requestId) {
-        // No-op
-    }
+    void sendLookupResponse(PulsarApi.ServerError error, String errorMsg, long requestId);
 
-    default void sendActiveConsumerChange(long consumerId, boolean isActive) {
-        // No-op
-    }
+    void sendActiveConsumerChange(long consumerId, boolean isActive);
 
-    default void sendSuccess(long requestId) {
-        // No-op
-    }
+    void sendSuccess(long requestId);
 
-    default void sendError(long requestId, PulsarApi.ServerError error, String message) {
-        // No-op
-    }
+    void sendError(long requestId, PulsarApi.ServerError error, String message);
 
-    default void sendReachedEndOfTopic(long consumerId) {
-        // No-op
-    }
+    void sendReachedEndOfTopic(long consumerId);
 
-    default Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
+    Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
             int partitionIdx, final List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
-            RedeliveryTracker redeliveryTracker) {
-        return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
-    }
+            RedeliveryTracker redeliveryTracker);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.broker.service;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -26,39 +29,92 @@ import java.util.List;
 
 public interface PulsarCommandSender {
 
+    default void sendPartitionMetadataResponse(PulsarApi.ServerError error, String errorMsg, long requestId) {
+        // No-op
+    }
 
-    void sendPartitionMetadataResponse(PulsarApi.ServerError error, String errorMsg, long requestId);
+    default void sendPartitionMetadataResponse(int partitions, long requestId) {
+        // No-op
+    }
 
-    void sendPartitionMetadataResponse(int partitions, long requestId);
+    default void sendSuccessResponse(long requestId) {
+        // No-op
+    }
 
-    void sendSuccessResponse(long requestId);
+    default void sendErrorResponse(long requestId, PulsarApi.ServerError error, String message) {
+        // No-op
+    }
 
-    void sendErrorResponse(long requestId, PulsarApi.ServerError error, String message);
+    default void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion) {
+        // No-op
+    }
 
-    void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion);
+    default void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
+                                     SchemaVersion schemaVersion) {
+        // No-op
+    }
 
-    void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
-                                     SchemaVersion schemaVersion);
+    default void sendSendReceiptResponse(long producerId, long sequenceId, long highestId, long ledgerId,
+                                 long entryId) {
+        // No-op
+    }
 
-    void sendSendReceiptResponse(long producerId, long sequenceId, long highestId, long ledgerId,
-                                 long entryId);
+    default void sendSendError(long producerId, long sequenceId, PulsarApi.ServerError error, String errorMsg) {
+        // No-op
+    }
 
-    void sendSendError(long producerId, long sequenceId, PulsarApi.ServerError error, String errorMsg);
+    default void sendGetTopicsOfNamespaceResponse(List<String> topics, long requestId) {
+        // No-op
+    }
 
-    void sendGetTopicsOfNamespaceResponse(List<String> topics, long requestId);
+    default void sendGetSchemaResponse(long requestId, SchemaInfo schema, SchemaVersion version) {
+        // No-op
+    }
 
-    void sendGetSchemaResponse(long requestId, SchemaInfo schema, SchemaVersion version);
+    default void sendGetSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage) {
+        // No-op
+    }
 
-    void sendGetSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage);
+    default void sendGetOrCreateSchemaResponse(long requestId, SchemaVersion schemaVersion) {
+        // No-op
+    }
 
-    void sendGetOrCreateSchemaResponse(long requestId, SchemaVersion schemaVersion);
+    default void sendGetOrCreateSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage) {
+        // No-op
+    }
 
-    void sendGetOrCreateSchemaErrorResponse(long requestId, PulsarApi.ServerError error, String errorMessage);
+    default void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize) {
+        // No-op
+    }
 
-    void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize);
+    default void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
+                            PulsarApi.CommandLookupTopicResponse.LookupType response, long requestId, boolean proxyThroughServiceUrl) {
+        // No-op
+    }
 
-    void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
-                            PulsarApi.CommandLookupTopicResponse.LookupType response, long requestId, boolean proxyThroughServiceUrl);
+    default void sendLookupResponse(PulsarApi.ServerError error, String errorMsg, long requestId) {
+        // No-op
+    }
 
-    void sendLookupResponse(PulsarApi.ServerError error, String errorMsg, long requestId);
+    default void sendActiveConsumerChange(long consumerId, boolean isActive) {
+        // No-op
+    }
+
+    default void sendSuccess(long requestId) {
+        // No-op
+    }
+
+    default void sendError(long requestId, PulsarApi.ServerError error, String message) {
+        // No-op
+    }
+
+    default void sendReachedEndOfTopic(long consumerId) {
+        // No-op
+    }
+
+    default Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
+            int partitionIdx, final List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
+            RedeliveryTracker redeliveryTracker) {
+        return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -34,6 +34,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.Promise;
 
 import java.net.SocketAddress;
 import java.util.List;
@@ -2102,6 +2103,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     public String getRole() {
         return authRole;
+    }
+
+    @Override
+    public Promise<Void> newPromise() {
+        return ctx.newPromise();
     }
 
     boolean hasConsumer(long consumerId) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -106,7 +106,7 @@ public interface Topic {
      */
     void recordAddLatency(long latency, TimeUnit unit);
 
-    CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
+    CompletableFuture<Consumer> subscribe(TransportCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
             long startMessageRollbackDurationSec, boolean replicateSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -28,9 +28,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface TransportCnx {
 
-    default String getClientVersion() {
-        return null;
-    }
+    String getClientVersion();
 
     SocketAddress clientAddress();
 
@@ -38,76 +36,42 @@ public interface TransportCnx {
 
     PulsarCommandSender getCommandSender();
 
-    default boolean isBatchMessageCompatibleVersion() {
-        return true;
-    }
+    boolean isBatchMessageCompatibleVersion();
 
     /**
      * The security role for this connection
      * @return the role
      */
-    default String getAuthRole() {
-        return null;
-    }
+    String getAuthRole();
 
-    default AuthenticationDataSource getAuthenticationData() {
-        return null;
-    }
+    AuthenticationDataSource getAuthenticationData();
 
-    default boolean isActive() {
-        return true;
-    }
+    boolean isActive();
 
-    default boolean isWritable() {
-        return true;
-    }
+    boolean isWritable();
 
-    default void completedSendOperation(boolean isNonPersistentTopic, int msgSize) {
-        // No-op
-    }
+    void completedSendOperation(boolean isNonPersistentTopic, int msgSize);
 
-    default void removedProducer(Producer producer) {
-        // No-op
-    }
+    void removedProducer(Producer producer);
 
-    default void closeProducer(Producer producer) {
-        // No-op
-    }
+    void closeProducer(Producer producer);
 
-    default long getMessagePublishBufferSize() {
-        return Long.MAX_VALUE;
-    }
+    long getMessagePublishBufferSize();
 
-    default void cancelPublishRateLimiting() {
-        // No-op
-    }
+    void cancelPublishRateLimiting();
 
-    default void cancelPublishBufferLimiting() {
-        // No-op
-    }
+    void cancelPublishBufferLimiting();
 
-    default void disableCnxAutoRead() {
-        // No-op
-    }
+    void disableCnxAutoRead();
 
-    default void enableCnxAutoRead() {
-        // No-op
-    }
+    void enableCnxAutoRead();
 
-    default void execute(Runnable runnable) {
-        CompletableFuture.runAsync(runnable);
-    }
+    void execute(Runnable runnable);
 
-    default void removedConsumer(Consumer consumer) {
-        // No-op
-    }
+    void removedConsumer(Consumer consumer);
 
-    default void closeConsumer(Consumer consumer) {
-        // No-op
-    }
+    void closeConsumer(Consumer consumer);
 
-    default boolean isPreciseDispatcherFlowControl() {
-        return false;
-    }
+    boolean isPreciseDispatcherFlowControl();
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import io.netty.util.concurrent.Promise;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
@@ -73,5 +74,7 @@ public interface TransportCnx {
     void closeConsumer(Consumer consumer);
 
     boolean isPreciseDispatcherFlowControl();
+
+    Promise<Void> newPromise();
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface TransportCnx {
+
+    default String getClientVersion() {
+        return null;
+    }
+
+    SocketAddress clientAddress();
+
+    BrokerService getBrokerService();
+
+    PulsarCommandSender getCommandSender();
+
+    default boolean isBatchMessageCompatibleVersion() {
+        return true;
+    }
+
+    /**
+     * The security role for this connection
+     * @return the role
+     */
+    default String getAuthRole() {
+        return null;
+    }
+
+    default AuthenticationDataSource getAuthenticationData() {
+        return null;
+    }
+
+    default boolean isActive() {
+        return true;
+    }
+
+    default boolean isWritable() {
+        return true;
+    }
+
+    default void completedSendOperation(boolean isNonPersistentTopic, int msgSize) {
+        // No-op
+    }
+
+    default void removedProducer(Producer producer) {
+        // No-op
+    }
+
+    default void closeProducer(Producer producer) {
+        // No-op
+    }
+
+    default long getMessagePublishBufferSize() {
+        return Long.MAX_VALUE;
+    }
+
+    default void cancelPublishRateLimiting() {
+        // No-op
+    }
+
+    default void cancelPublishBufferLimiting() {
+        // No-op
+    }
+
+    default void disableCnxAutoRead() {
+        // No-op
+    }
+
+    default void enableCnxAutoRead() {
+        // No-op
+    }
+
+    default void execute(Runnable runnable) {
+        CompletableFuture.runAsync(runnable);
+    }
+
+    default void removedConsumer(Consumer consumer) {
+        // No-op
+    }
+
+    default void closeConsumer(Consumer consumer) {
+        // No-op
+    }
+
+    default boolean isPreciseDispatcherFlowControl() {
+        return false;
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -56,7 +56,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedVersio
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.Replicator;
-import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.StreamingStats;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -240,7 +240,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
-    public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
+    public CompletableFuture<Consumer> subscribe(final TransportCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
             long resetStartMessageBackInSec, boolean replicateSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta) {
@@ -294,7 +294,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
 
         try {
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName, 0,
-                    cnx, cnx.getRole(), metadata, readCompacted, initialPosition, keySharedMeta);
+                    cnx, cnx.getAuthRole(), metadata, readCompacted, initialPosition, keySharedMeta);
             addConsumerToSubscription(subscription, consumer);
             if (!cnx.isActive()) {
                 consumer.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -87,7 +87,7 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.Replicator;
-import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.StreamingStats;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -524,7 +524,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
-    public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
+    public CompletableFuture<Consumer> subscribe(final TransportCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
             Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition,
             long startMessageRollbackDurationSec, boolean replicatedSubscriptionState, PulsarApi.KeySharedMeta keySharedMeta) {
@@ -581,9 +581,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return future;
         }
 
-        if (cnx.getRemoteAddress() != null && cnx.getRemoteAddress().toString().contains(":")) {
+        if (cnx.clientAddress() != null && cnx.clientAddress().toString().contains(":")) {
             SubscribeRateLimiter.ConsumerIdentifier consumer = new SubscribeRateLimiter.ConsumerIdentifier(
-                    cnx.getRemoteAddress().toString().split(":")[0], consumerName, consumerId);
+                    cnx.clientAddress().toString().split(":")[0], consumerName, consumerId);
             if (subscribeRateLimiter.isPresent() && !subscribeRateLimiter.get().subscribeAvailable(consumer) || !subscribeRateLimiter.get().tryAcquire(consumer)) {
                 log.warn("[{}] Failed to create subscription for {} {} limited by {}, available {}",
                         topic, subscriptionName, consumer, subscribeRateLimiter.get().getSubscribeRate(),
@@ -621,7 +621,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         subscriptionFuture.thenAccept(subscription -> {
             try {
                 Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
-                                                 maxUnackedMessages, cnx, cnx.getRole(), metadata, readCompacted, initialPosition, keySharedMeta);
+                                                 maxUnackedMessages, cnx, cnx.getAuthRole(), metadata, readCompacted, initialPosition, keySharedMeta);
                 addConsumerToSubscription(subscription, consumer);
 
                 checkBackloggedCursors();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  */
@@ -56,7 +55,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .create();
         Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
         Assert.assertNotNull(topicRef);
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(Long.MAX_VALUE / 2);
+        TransportCnx cnx = ((AbstractTopic) topicRef).producers.get("producer-name").getCnx();
+        ((ServerCnx) cnx).setMessagePublishBufferSize(Long.MAX_VALUE / 2);
         Thread.sleep(20);
         Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         List<CompletableFuture<MessageId>> futures = new ArrayList<>();
@@ -86,14 +86,15 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .create();
         Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
         Assert.assertNotNull(topicRef);
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(Long.MAX_VALUE / 2);
+        TransportCnx cnx = ((AbstractTopic) topicRef).producers.get("producer-name").getCnx();
+        ((ServerCnx) cnx).setMessagePublishBufferSize(Long.MAX_VALUE / 2);
         Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         // The first message can publish success, but the second message should be blocked
         producer.sendAsync(new byte[1024]).get(1, TimeUnit.SECONDS);
         getPulsar().getBrokerService().checkMessagePublishBuffer();
         Assert.assertTrue(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
 
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(0L);
+        ((ServerCnx) cnx).setMessagePublishBufferSize(0L);
         getPulsar().getBrokerService().checkMessagePublishBuffer();
         Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         List<CompletableFuture<MessageId>> futures = new ArrayList<>();
@@ -122,7 +123,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .create();
         Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
         Assert.assertNotNull(topicRef);
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(Long.MAX_VALUE / 2);
+        TransportCnx cnx = ((AbstractTopic) topicRef).producers.get("producer-name").getCnx();
+        ((ServerCnx) cnx).setMessagePublishBufferSize(Long.MAX_VALUE / 2);
         Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         producer.sendAsync(new byte[1024]).get(1, TimeUnit.SECONDS);
 
@@ -131,15 +133,15 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         Assert.assertTrue(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
 
         // Block by publish rate.
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setMessagePublishBufferSize(0L);
+        ((ServerCnx) cnx).setMessagePublishBufferSize(0L);
         getPulsar().getBrokerService().checkMessagePublishBuffer();
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setAutoReadDisabledRateLimiting(true);
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().disableCnxAutoRead();
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().enableCnxAutoRead();
+        ((ServerCnx) cnx).setAutoReadDisabledRateLimiting(true);
+        cnx.disableCnxAutoRead();
+        cnx.enableCnxAutoRead();
 
         // Resume message publish.
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().setAutoReadDisabledRateLimiting(false);
-        ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().enableCnxAutoRead();
+        ((ServerCnx) cnx).setAutoReadDisabledRateLimiting(false);
+        cnx.enableCnxAutoRead();
         Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
         List<CompletableFuture<MessageId>> futures = new ArrayList<>();
         // Make sure the producer can publish succeed.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -173,6 +172,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         doReturn(new InetSocketAddress("localhost", 1234)).when(serverCnx).clientAddress();
         when(serverCnx.getRemoteEndpointProtocolVersion()).thenReturn(ProtocolVersion.v12.getNumber());
         when(serverCnx.ctx()).thenReturn(channelCtx);
+        doReturn(new PulsarCommandSenderImpl(null, serverCnx))
+                .when(serverCnx).getCommandSender();
 
         serverCnxWithOldVersion = spy(new ServerCnx(pulsar));
         doReturn(true).when(serverCnxWithOldVersion).isActive();
@@ -182,6 +183,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         when(serverCnxWithOldVersion.getRemoteEndpointProtocolVersion())
             .thenReturn(ProtocolVersion.v11.getNumber());
         when(serverCnxWithOldVersion.ctx()).thenReturn(channelCtx);
+        doReturn(new PulsarCommandSenderImpl(null, serverCnxWithOldVersion))
+                .when(serverCnxWithOldVersion).getCommandSender();
 
         NamespaceService nsSvc = mock(NamespaceService.class);
         doReturn(nsSvc).when(pulsar).getNamespaceService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -198,6 +198,8 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(true).when(serverCnx).isActive();
         doReturn(true).when(serverCnx).isWritable();
         doReturn(new InetSocketAddress("localhost", 1234)).when(serverCnx).clientAddress();
+        doReturn(new PulsarCommandSenderImpl(null, serverCnx))
+                .when(serverCnx).getCommandSender();
 
         NamespaceService nsSvc = mock(NamespaceService.class);
         doReturn(nsSvc).when(pulsar).getNamespaceService();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

This PR is a first step to implement [PIP 59: gRPC Protocol Handler](https://github.com/apache/pulsar/wiki/PIP-59%3A-gPRC-Protocol-Handler)
It separates `ServerCnx` used by `Consumer` and `Producer` into an interface and an implementation. Alternate protocol handlers that use Pulsar's topics, consumers and producer will implement the interface with their own implementation.

See also #271

![ServerCnx](https://user-images.githubusercontent.com/11633333/83862886-db686500-a722-11ea-880a-cc499cff7283.png)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
```
mvn verify
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
