### PR TITLE
Skip helm chart testing if the changes are docs-only changes

### DIFF
--- a/.github/workflows/pulsar.yml
+++ b/.github/workflows/pulsar.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -41,4 +51,4 @@ jobs:
         run: |
           .ci/chart_test.sh .ci/clusters/values-local-pv.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_bk_tls.yml
+++ b/.github/workflows/pulsar_bk_tls.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -41,4 +51,4 @@ jobs:
         run: |
           .ci/chart_test.sh .ci/clusters/values-bk-tls.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_broker_tls.yml
+++ b/.github/workflows/pulsar_broker_tls.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -41,4 +51,4 @@ jobs:
         run: |
           .ci/chart_test.sh .ci/clusters/values-broker-tls.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_function.yml
+++ b/.github/workflows/pulsar_function.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -43,4 +53,4 @@ jobs:
         env:
           FUNCTION: "true"
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_image.yml
+++ b/.github/workflows/pulsar_image.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -41,4 +51,4 @@ jobs:
         run: |
           .ci/chart_test.sh .ci/clusters/values-pulsar-image.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_jwt_asymmetric.yml
+++ b/.github/workflows/pulsar_jwt_asymmetric.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
 
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -43,4 +53,4 @@ jobs:
         env:
           SYMMETRIC: "false"
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_jwt_symmetric.yml
+++ b/.github/workflows/pulsar_jwt_symmetric.yml
@@ -29,11 +29,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run chart-testing (lint)
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
+
+      - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
@@ -43,4 +53,4 @@ jobs:
         env:
           SYMMETRIC: "true"
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_tls.yml
+++ b/.github/workflows/pulsar_tls.yml
@@ -29,16 +29,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run chart-testing (lint)
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
+
+      - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
-      - name: Run chart-testing (install)
+      - name: Install chart
         run: |
           .ci/chart_test.sh .ci/clusters/values-tls.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_zk_tls.yml
+++ b/.github/workflows/pulsar_zk_tls.yml
@@ -29,16 +29,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run chart-testing (lint)
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
+
+      - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
-      - name: Run chart-testing (install)
+      - name: Install chart
         run: |
           .ci/chart_test.sh .ci/clusters/values-zk-tls.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/pulsar_zkbk_tls.yml
+++ b/.github/workflows/pulsar_zkbk_tls.yml
@@ -29,16 +29,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run chart-testing (lint)
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
+
+      - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@master
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           command: lint
 
-      - name: Run chart-testing (install)
+      - name: Install chart
         run: |
           .ci/chart_test.sh .ci/clusters/values-zkbk-tls.yaml
         # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true' && steps.docs.outputs.changed_only == 'no'


### PR DESCRIPTION
*Motivation*

We don't need to run chart tests if the change only changes documentation

