### PR TITLE
Fix typo in io-debezium-source.md

### DIFF
--- a/site2/docs/io-debezium-source.md
+++ b/site2/docs/io-debezium-source.md
@@ -1,6 +1,6 @@
 ---
 id: io-debezium-source
-title: Debezium source onnector
+title: Debezium source connector
 sidebar_label: Debezium source connector
 ---
 


### PR DESCRIPTION
# Motivation

Fix the title `Debezium source onnector` to `Debezium source connector`.