### PR TITLE
[C++] Auto update topic partitions

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
@@ -149,6 +149,22 @@ class PULSAR_PUBLIC ClientConfiguration {
      */
     const unsigned int& getStatsIntervalInSeconds() const;
 
+    /**
+     * Set partitions update interval in seconds.
+     * If a partitioned topic is produced or subscribed and `intervalInSeconds` is not 0, every
+     * `intervalInSeconds` seconds the partition number will be retrieved by sending lookup requests. If
+     * partition number has been increased, more producer/consumer of increased partitions will be created.
+     * Default is 60 seconds.
+     *
+     * @param intervalInSeconds the seconds between two lookup request for partitioned topic's metadata
+     */
+    ClientConfiguration& setPartititionsUpdateInterval(unsigned int intervalInSeconds);
+
+    /**
+     * Get partitions update interval in seconds.
+     */
+    unsigned int getPartitionsUpdateInterval() const;
+
     friend class ClientImpl;
     friend class PulsarWrapper;
 

--- a/pulsar-client-cpp/lib/ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/ClientConfiguration.cc
@@ -119,4 +119,13 @@ ClientConfiguration& ClientConfiguration::setStatsIntervalInSeconds(
 const unsigned int& ClientConfiguration::getStatsIntervalInSeconds() const {
     return impl_->statsIntervalInSeconds;
 }
+
+ClientConfiguration& ClientConfiguration::setPartititionsUpdateInterval(unsigned int intervalInSeconds) {
+    impl_->partitionsUpdateInterval = intervalInSeconds;
+    return *this;
+}
+
+unsigned int ClientConfiguration::getPartitionsUpdateInterval() const {
+    return impl_->partitionsUpdateInterval;
+}
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -36,6 +36,7 @@ struct ClientConfigurationImpl {
     unsigned int statsIntervalInSeconds;
     LoggerFactoryPtr loggerFactory;
     bool validateHostName;
+    unsigned int partitionsUpdateInterval;
 
     ClientConfigurationImpl()
         : authenticationPtr(AuthFactory::Disabled()),
@@ -48,7 +49,9 @@ struct ClientConfigurationImpl {
           tlsAllowInsecureConnection(false),
           statsIntervalInSeconds(600),  // 10 minutes
           loggerFactory(),
-          validateHostName(false) {}
+          validateHostName(false),
+          partitionsUpdateInterval(60)  // 1 minute
+    {}
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/LogUtils.cc
+++ b/pulsar-client-cpp/lib/LogUtils.cc
@@ -26,7 +26,7 @@
 namespace pulsar {
 
 void LogUtils::init(const std::string& logfilePath) {
-// If this is called explicitely, we fallback to Log4cxx config, if enabled
+    // If this is called explicitely, we fallback to Log4cxx config, if enabled
 
 #ifdef USE_LOG4CXX
     if (!logfilePath.empty()) {

--- a/pulsar-client-cpp/lib/LogUtils.cc
+++ b/pulsar-client-cpp/lib/LogUtils.cc
@@ -26,7 +26,7 @@
 namespace pulsar {
 
 void LogUtils::init(const std::string& logfilePath) {
-    // If this is called explicitely, we fallback to Log4cxx config, if enabled
+// If this is called explicitely, we fallback to Log4cxx config, if enabled
 
 #ifdef USE_LOG4CXX
     if (!logfilePath.empty()) {

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -84,6 +84,8 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     const ConsumerConfiguration conf_;
     typedef std::vector<ConsumerImplPtr> ConsumerList;
     ConsumerList consumers_;
+    // consumersMutex_ is used to share consumers_ and numPartitions_
+    mutable std::mutex consumersMutex_;
     std::mutex mutex_;
     std::mutex pendingReceiveMutex_;
     PartitionedConsumerState state_;
@@ -94,7 +96,14 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     const std::string topic_;
     const std::string name_;
     const std::string partitionStr_;
+    ExecutorServicePtr internalListenerExecutor_;
+    DeadlineTimerPtr partitionsUpdateTimer_;
+    boost::posix_time::time_duration partitionsUpdateInterval_;
+    LookupServicePtr lookupServicePtr_;
     /* methods */
+    unsigned int getNumPartitionsWithLock() const;
+    ConsumerConfiguration getSinglePartitionConsumerConfig() const;
+    ConsumerImplPtr newInternalConsumer(unsigned int partition, const ConsumerConfiguration& config) const;
     void setState(PartitionedConsumerState state);
     void handleUnsubscribeAsync(Result result, unsigned int consumerIndex, ResultCallback callback);
     void handleSinglePartitionConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumerImplBaseWeakPtr,
@@ -109,6 +118,9 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     Promise<Result, ConsumerImplBaseWeakPtr> partitionedConsumerCreatedPromise_;
     UnAckedMessageTrackerScopedPtr unAckedMessageTrackerPtr_;
     std::queue<ReceiveCallback> pendingReceives_;
+    void runPartitionUpdateTask();
+    void getPartitionMetadata();
+    void handleGetPartitions(const Result result, const LookupDataResultPtr& lookupDataResult);
 };
 typedef std::weak_ptr<PartitionedConsumerImpl> PartitionedConsumerImplWeakPtr;
 typedef std::shared_ptr<PartitionedConsumerImpl> PartitionedConsumerImplPtr;

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -101,6 +101,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     boost::posix_time::time_duration partitionsUpdateInterval_;
     LookupServicePtr lookupServicePtr_;
     /* methods */
+    unsigned int getNumPartitions() const;
     unsigned int getNumPartitionsWithLock() const;
     ConsumerConfiguration getSinglePartitionConsumerConfig() const;
     ConsumerImplPtr newInternalConsumer(unsigned int partition, const ConsumerConfiguration& config) const;

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -110,6 +110,9 @@ class PartitionedProducerImpl : public ProducerImplBase,
     // producersMutex_ is used to share producers_ and topicMetadata_
     mutable std::mutex producersMutex_;
 
+    unsigned int getNumPartitions() const;
+    unsigned int getNumPartitionsWithLock() const;
+
     ProducerImplPtr newInternalProducer(unsigned int partition) const;
 
     MessageRoutingPolicyPtr routerPolicy_;

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -107,6 +107,11 @@ class PartitionedProducerImpl : public ProducerImplBase,
 
     ProducerList producers_;
 
+    // producersMutex_ is used to share producers_ and topicMetadata_
+    mutable std::mutex producersMutex_;
+
+    ProducerImplPtr newInternalProducer(unsigned int partition) const;
+
     MessageRoutingPolicyPtr routerPolicy_;
 
     // mutex_ is used to share state_, and numProducersCreated_
@@ -121,6 +126,15 @@ class PartitionedProducerImpl : public ProducerImplBase,
 
     std::atomic<int> flushedPartitions_;
     std::shared_ptr<Promise<Result, bool_type>> flushPromise_;
+
+    ExecutorServicePtr listenerExecutor_;
+    DeadlineTimerPtr partitionsUpdateTimer_;
+    boost::posix_time::time_duration partitionsUpdateInterval_;
+    LookupServicePtr lookupServicePtr_;
+
+    void runPartitionUpdateTask();
+    void getPartitionMetadata();
+    void handleGetPartitions(const Result result, const LookupDataResultPtr& partitionMetadata);
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/tests/HttpHelper.cc
+++ b/pulsar-client-cpp/tests/HttpHelper.cc
@@ -30,7 +30,9 @@ static int makeRequest(const std::string& method, const std::string& url, const 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    if (!body.empty()) {
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    }
     int res = curl_easy_perform(curl);
     curl_slist_free_all(list); /* free the list again */
 
@@ -49,3 +51,5 @@ int makePutRequest(const std::string& url, const std::string& body) { return mak
 int makePostRequest(const std::string& url, const std::string& body) {
     return makeRequest("POST", url, body);
 }
+
+int makeDeleteRequest(const std::string& url) { return makeRequest("DELETE", url, ""); }

--- a/pulsar-client-cpp/tests/HttpHelper.h
+++ b/pulsar-client-cpp/tests/HttpHelper.h
@@ -23,5 +23,6 @@
 
 int makePutRequest(const std::string& url, const std::string& body);
 int makePostRequest(const std::string& url, const std::string& body);
+int makeDeleteRequest(const std::string& url);
 
 #endif /* end of include guard: HTTP_HELPER */

--- a/pulsar-client-cpp/tests/PartitionsUpdateTest.cc
+++ b/pulsar-client-cpp/tests/PartitionsUpdateTest.cc
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+
+#include <set>
+#include <chrono>
+#include <thread>
+
+#include "HttpHelper.h"
+
+using namespace pulsar;
+
+static const std::string serviceUrl = "pulsar://localhost:6650";
+static const std::string adminUrl = "http://localhost:8080/";
+static const std::string topicOperateUrl = adminUrl + "admin/v2/persistent/";
+
+static const std::string topicNameSuffix = "public/default/partitions-update-test-topic";
+static const std::string topicName = "persistent://" + topicNameSuffix;
+
+static constexpr int initialNumPartitions = 2;
+static constexpr int latestNumPartitions = 5;
+
+static const ProducerConfiguration producerConfig =
+    ProducerConfiguration().setPartitionsRoutingMode(ProducerConfiguration::RoundRobinDistribution);
+static const std::string subName = "SubscriptionName";
+
+static bool updateNumPartitions() {
+    int res = makePostRequest(topicOperateUrl + topicNameSuffix + "/partitions",
+                              std::to_string(latestNumPartitions));
+    return (res == 204 || res == 409);
+}
+
+static void waitForPartitionsUpdated() {
+    // Assume producer and consumer have updated partitions in 3 seconds if enabled
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+class PartitionsUpdateTest : public ::testing::Test {
+   protected:
+    PartitionsUpdateTest() : clientForProducer_(serviceUrl), clientForConsumer_(serviceUrl) {
+        // Ensure `topicName` doesn't exist before created
+        makeDeleteRequest(topicOperateUrl + topicNameSuffix);
+        makeDeleteRequest(topicOperateUrl + topicNameSuffix + "/partitions");
+    }
+
+    void SetUp() override {
+        // Create a partitioned topic
+        int res = makePutRequest(topicOperateUrl + topicNameSuffix + "/partitions",
+                                 std::to_string(initialNumPartitions));
+        ASSERT_TRUE(res == 204 || res == 409);
+    }
+
+    void TearDown() override {
+        // Close producer and consumer first, otherwise delete will fail
+        consumer_.close();
+        clientForConsumer_.close();
+
+        producer_.close();
+        clientForProducer_.close();
+
+        int res = makeDeleteRequest(topicOperateUrl + topicNameSuffix + "/partitions");
+        ASSERT_TRUE(res == 204 || res == 409);
+    }
+
+    bool initProducer(bool enablePartitionsUpdateForProducer) {
+        if (enablePartitionsUpdateForProducer) {
+            clientForProducer_ = Client(serviceUrl, ClientConfiguration().setPartititionsUpdateInterval(1));
+        } else {
+            clientForProducer_ = Client(serviceUrl, ClientConfiguration().setPartititionsUpdateInterval(0));
+        }
+        return clientForProducer_.createProducer(topicName, producerConfig, producer_) == ResultOk;
+    }
+
+    bool initConsumer(bool enablePartitionsUpdateForConsumer) {
+        if (enablePartitionsUpdateForConsumer) {
+            clientForConsumer_ = Client(serviceUrl, ClientConfiguration().setPartititionsUpdateInterval(1));
+        } else {
+            clientForConsumer_ = Client(serviceUrl, ClientConfiguration().setPartititionsUpdateInterval(0));
+        }
+        return clientForConsumer_.subscribe(topicName, subName, consumer_) == ResultOk;
+    }
+
+    void sendMessages(int numMessages) {
+        for (int i = 0; i < numMessages; i++) {
+            producer_.send(MessageBuilder().setContent("a").build());
+        }
+    }
+
+    void receiveMessages(int numMessages) {
+        partitionNames_.clear();
+        while (numMessages > 0) {
+            Message msg;
+            if (consumer_.receive(msg, 100) == ResultOk) {
+                partitionNames_.emplace(msg.getTopicName());
+                numMessages--;
+            }
+        }
+    }
+
+    Client clientForProducer_;
+    Producer producer_;
+
+    Client clientForConsumer_;
+    Consumer consumer_;
+
+    std::set<std::string> partitionNames_;
+};
+
+TEST_F(PartitionsUpdateTest, testConfigPartitionsUpdateInterval) {
+    ClientConfiguration clientConfig;
+    ASSERT_EQ(60, clientConfig.getPartitionsUpdateInterval());
+
+    clientConfig.setPartititionsUpdateInterval(0);
+    ASSERT_EQ(0, clientConfig.getPartitionsUpdateInterval());
+
+    clientConfig.setPartititionsUpdateInterval(1);
+    ASSERT_EQ(1, clientConfig.getPartitionsUpdateInterval());
+
+    clientConfig.setPartititionsUpdateInterval(-1);
+    ASSERT_EQ(static_cast<unsigned int>(-1), clientConfig.getPartitionsUpdateInterval());
+}
+
+TEST_F(PartitionsUpdateTest, testOnlyProducerEnabled) {
+    ASSERT_TRUE(initProducer(true));
+    ASSERT_TRUE(initConsumer(false));
+
+    updateNumPartitions();
+    waitForPartitionsUpdated();
+
+    // Only `initialNumPartitions / latestNumPartitions` of produced messages could be consumed
+    sendMessages(latestNumPartitions * latestNumPartitions);
+    receiveMessages(initialNumPartitions * latestNumPartitions);
+
+    ASSERT_EQ(initialNumPartitions, partitionNames_.size());
+}
+
+TEST_F(PartitionsUpdateTest, testOnlyConsumerEnabled) {
+    ASSERT_TRUE(initProducer(false));
+    ASSERT_TRUE(initConsumer(true));
+
+    updateNumPartitions();
+    waitForPartitionsUpdated();
+
+    sendMessages(latestNumPartitions);
+    receiveMessages(latestNumPartitions);
+
+    ASSERT_EQ(initialNumPartitions, partitionNames_.size());
+}
+
+TEST_F(PartitionsUpdateTest, testBothEnabled) {
+    ASSERT_TRUE(initProducer(true));
+    ASSERT_TRUE(initConsumer(true));
+
+    updateNumPartitions();
+    waitForPartitionsUpdated();
+
+    sendMessages(latestNumPartitions);
+    receiveMessages(latestNumPartitions);
+
+    ASSERT_EQ(latestNumPartitions, partitionNames_.size());
+}
+
+TEST_F(PartitionsUpdateTest, testBothDisabled) {
+    ASSERT_TRUE(initProducer(false));
+    ASSERT_TRUE(initConsumer(false));
+
+    updateNumPartitions();
+    waitForPartitionsUpdated();
+
+    sendMessages(latestNumPartitions);
+    receiveMessages(latestNumPartitions);
+
+    ASSERT_EQ(initialNumPartitions, partitionNames_.size());
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

We need to increase producers or consumers when partitions updated.

Java client has implemented this feature, see [#3513](https://github.com/apache/pulsar/pull/3513). This PR trys to implement the same feature in C++ client.

### Modifications

- Add a `boost::asio::deadline_timer` to `PartitionedConsumerImpl` and `PartitionedProducerImpl` to register lookup task to detect partitions changes periodly;
- Add an `unsigned int` configuration parameter to indicate the period seconds of detecting partitions change (default: 60 seconds);
- Unlock the `mutex_` in `PartitionedConsumerImpl::receive` after `state_` were checked. 
> Explain: When new consumers are created, `handleSinglePartitionConsumerCreated` will be called finally, which tried to lock the `mutex_`. It may happen that `receive` acquire the lock again and again so that `handleSinglePartitionConsumerCreated` 
are blocked in `lock.lock()` for a long time.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Run  `PartitionsUpdateTest` test suite after the cmake build.

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
