### PR TITLE
[pulsar-client] Add deliver_at and deliver_after to python client

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -113,7 +113,7 @@ import re
 _retype = type(re.compile('x'))
 
 import certifi
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 
 class MessageId:

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -113,6 +113,7 @@ import re
 _retype = type(re.compile('x'))
 
 import certifi
+from datetime import datetime, timedelta
 
 
 class MessageId:
@@ -809,6 +810,8 @@ class Producer:
              replication_clusters=None,
              disable_replication=False,
              event_timestamp=None,
+             deliver_at=None,
+             deliver_after=None,
              ):
         """
         Publish a message on the topic. Blocks until the message is acknowledged
@@ -836,9 +839,17 @@ class Producer:
           Do not replicate this message.
         * `event_timestamp`:
           Timestamp in millis of the timestamp of event creation
+        * `deliver_at`:
+          Specify the this message should not be delivered earlier than the
+          specified timestamp.
+          The timestamp is milliseconds and based on UTC
+        * `deliver_after`:
+          Specify a delay in timedelta for the delivery of the messages.
+
         """
         msg = self._build_msg(content, properties, partition_key, sequence_id,
-                              replication_clusters, disable_replication, event_timestamp)
+                              replication_clusters, disable_replication, event_timestamp,
+                              deliver_at, deliver_after)
         return self._producer.send(msg)
 
     def send_async(self, content, callback,
@@ -847,7 +858,9 @@ class Producer:
                    sequence_id=None,
                    replication_clusters=None,
                    disable_replication=False,
-                   event_timestamp=None
+                   event_timestamp=None,
+                   deliver_at=None,
+                   deliver_after=None,
                    ):
         """
         Send a message asynchronously.
@@ -889,9 +902,16 @@ class Producer:
           Do not replicate this message.
         * `event_timestamp`:
           Timestamp in millis of the timestamp of event creation
+        * `deliver_at`:
+          Specify the this message should not be delivered earlier than the
+          specified timestamp.
+          The timestamp is milliseconds and based on UTC
+        * `deliver_after`:
+          Specify a delay in timedelta for the delivery of the messages.
         """
         msg = self._build_msg(content, properties, partition_key, sequence_id,
-                              replication_clusters, disable_replication, event_timestamp)
+                              replication_clusters, disable_replication, event_timestamp,
+                              deliver_at, deliver_after)
         self._producer.send_async(msg, callback)
 
 
@@ -910,7 +930,8 @@ class Producer:
         self._producer.close()
 
     def _build_msg(self, content, properties, partition_key, sequence_id,
-                   replication_clusters, disable_replication, event_timestamp):
+                   replication_clusters, disable_replication, event_timestamp,
+                   deliver_at, deliver_after):
         data = self._schema.encode(content)
 
         _check_type(bytes, data, 'data')
@@ -920,6 +941,8 @@ class Producer:
         _check_type_or_none(list, replication_clusters, 'replication_clusters')
         _check_type(bool, disable_replication, 'disable_replication')
         _check_type_or_none(int, event_timestamp, 'event_timestamp')
+        _check_type_or_none(int, deliver_at, 'deliver_at')
+        _check_type_or_none(timedelta, deliver_after, 'deliver_after')
 
         mb = _pulsar.MessageBuilder()
         mb.content(data)
@@ -936,6 +959,11 @@ class Producer:
             mb.disable_replication(disable_replication)
         if event_timestamp:
             mb.event_timestamp(event_timestamp)
+        if deliver_at:
+            mb.deliver_at(deliver_at)
+        if deliver_after:
+            mb.deliver_after(deliver_after)
+        
         return mb.build()
 
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -172,18 +172,18 @@ class PulsarTest(TestCase):
                                     'my-sub',
                                     consumer_type=ConsumerType.Shared)
         producer = client.create_producer('my-python-topic-deliver-at')
-        # Delay message in 500ms
-        producer.send(b'hello', deliver_at=int(round(time.time() * 1000)) + 500)
+        # Delay message in 1.1s
+        producer.send(b'hello', deliver_at=int(round(time.time() * 1000)) + 1100)
 
-        # Message should not be available before 500 ms delay
+        # Message should not be available in the next second
         try:
-            msg = consumer.receive(100)
+            msg = consumer.receive(1000)
             self.assertTrue(False)  # Should not reach this point
         except:
             pass  # Exception is expected
 
-        # Message should be published in the next 400ms
-        msg = consumer.receive(500)
+        # Message should be published now
+        msg = consumer.receive(TM)
         self.assertTrue(msg)
         self.assertEqual(msg.data(), b'hello')
         consumer.unsubscribe()
@@ -197,16 +197,16 @@ class PulsarTest(TestCase):
                                     consumer_type=ConsumerType.Shared)
         producer = client.create_producer('my-python-topic-deliver-after')
         # Delay message in 500ms
-        producer.send(b'hello', deliver_after=timedelta(milliseconds=500))
+        producer.send(b'hello', deliver_after=timedelta(milliseconds=1100))
 
-        # Message should not be available before 500 ms delay
+        # Message should not be available in the next second
         try:
-            msg = consumer.receive(100)
+            msg = consumer.receive(1000)
             self.assertTrue(False)  # Should not reach this point
         except:
             pass  # Exception is expected
 
-        # Message should be published in the next 400ms
+        # Message should be published in the next 500ms
         msg = consumer.receive(500)
         self.assertTrue(msg)
         self.assertEqual(msg.data(), b'hello')

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -196,7 +196,7 @@ class PulsarTest(TestCase):
                                     'my-sub',
                                     consumer_type=ConsumerType.Shared)
         producer = client.create_producer('my-python-topic-deliver-after')
-        # Delay message in 500ms
+        # Delay message in 1.1s
         producer.send(b'hello', deliver_after=timedelta(milliseconds=1100))
 
         # Message should not be available in the next second
@@ -207,7 +207,7 @@ class PulsarTest(TestCase):
             pass  # Exception is expected
 
         # Message should be published in the next 500ms
-        msg = consumer.receive(500)
+        msg = consumer.receive(TM)
         self.assertTrue(msg)
         self.assertEqual(msg.data(), b'hello')
         consumer.unsubscribe()

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -18,6 +18,7 @@
  */
 #include "utils.h"
 
+#include <datetime.h>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
@@ -85,8 +86,58 @@ const MessageId& Message_getMessageId(const Message& msg) {
     return msg.getMessageId();
 }
 
+struct chrono_milliseconds_from_python_delta
+{
+    chrono_milliseconds_from_python_delta()
+    {
+        boost::python::converter::registry::push_back(
+        &convertible,
+        &construct,
+        boost::python::type_id<std::chrono::milliseconds>());
+    }
+
+    static void* convertible(PyObject* obj_ptr)
+    {
+        if (!PyString_Check(obj_ptr)) return 0;
+        return obj_ptr;
+    }
+
+    static void construct(
+        PyObject* obj_ptr,
+        boost::python::converter::rvalue_from_python_stage1_data* data)
+    {
+        PyDateTime_Delta const* pydelta
+            = reinterpret_cast<PyDateTime_Delta*>(obj_ptr);
+
+        long days = pydelta->days;
+        bool is_negative = (days < 0);
+        if (is_negative)
+            days = -days;
+
+        // Create chrono duration object
+        std::chrono::milliseconds
+            duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::hours(24)*days
+                    + std::chrono::seconds(pydelta->seconds)
+                    + std::chrono::microseconds(pydelta->microseconds)
+            );
+        if (is_negative)
+            duration = duration * -1;
+
+        void* storage = (
+                (boost::python::converter::rvalue_from_python_storage<std::chrono::milliseconds>*)
+                data)->storage.bytes;
+        new (storage)
+        std::chrono::milliseconds(duration);
+        data->convertible = storage;
+    }
+};
+
 void export_message() {
     using namespace boost::python;
+
+    PyDateTime_IMPORT;
+    chrono_milliseconds_from_python_delta();
 
     MessageBuilder& (MessageBuilder::*MessageBuilderSetContentString)(const std::string&) = &MessageBuilder::setContent;
 
@@ -95,6 +146,8 @@ void export_message() {
             .def("property", &MessageBuilder::setProperty, return_self<>())
             .def("properties", &MessageBuilder::setProperties, return_self<>())
             .def("sequence_id", &MessageBuilder::setSequenceId, return_self<>())
+            .def("deliver_after", &MessageBuilder::setDeliverAfter, return_self<>())
+            .def("deliver_at", &MessageBuilder::setDeliverAt, return_self<>())
             .def("partition_key", &MessageBuilder::setPartitionKey, return_self<>())
             .def("event_timestamp", &MessageBuilder::setEventTimestamp, return_self<>())
             .def("replication_clusters", &MessageBuilder::setReplicationClusters, return_self<>())

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -86,12 +86,14 @@ const MessageId& Message_getMessageId(const Message& msg) {
     return msg.getMessageId();
 }
 
-void deliverAfter(MessageBuilder* const builder, py::object obj_delta) {
-    PyDateTime_Delta const* pydelta = reinterpret_cast<PyDateTime_Delta*>(&obj_delta);
+void deliverAfter(MessageBuilder* const builder, PyObject* obj_delta) {
+    PyDateTime_Delta const* pydelta = reinterpret_cast<PyDateTime_Delta*>(obj_delta);
+
     long days = pydelta->days;
-    bool is_negative = (days < 0);
-    if (is_negative)
+    const bool is_negative = days < 0;
+    if (is_negative) {
         days = -days;
+    }
 
     // Create chrono duration object
     std::chrono::milliseconds
@@ -100,8 +102,10 @@ void deliverAfter(MessageBuilder* const builder, py::object obj_delta) {
                 + std::chrono::seconds(pydelta->seconds)
                 + std::chrono::microseconds(pydelta->microseconds)
                 );
-    if (is_negative)
+
+    if (is_negative) {
         duration = duration * -1;
+    }
 
     builder->setDeliverAfter(duration);
 }


### PR DESCRIPTION
# Motivation
Delayed message delivery is available in C++ client but not in Python client, as a Python client user, I would like to benefit from this feature as well.

### Modifications
Update of the C++ messagebuilder Python binding to expose `deliver_at` and `deliver_after` to the Python API.
Update of the Python client to add these features to the producer sending method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Extended python integration test to validate both `deliver_at` and `deliver_after`*

### Does this pull request potentially affect one of the following parts:
This PR affects the python public API with new parameters for python producer `send` and `sendAsync` methods `deliver_at` and `deliver_after`.

### Documentation
This feature is documented in the python source code.
