### PR TITLE
Mention pulsar-io.yaml file is required in NAR file

### DIFF
--- a/site2/docs/io-develop.md
+++ b/site2/docs/io-develop.md
@@ -182,7 +182,7 @@ Pulsar uses the same mechanism for packaging **all** [built-in connectors](io-co
 The easiest approach to package a Pulsar connector is to create a NAR package using
 [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin).
 
-All you need to do is to include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin) in your maven project for your connector as below. 
+Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin) in your maven project for your connector as below. 
 
 ```xml
 <plugins>
@@ -193,6 +193,17 @@ All you need to do is to include this [nifi-nar-maven-plugin](https://mvnreposit
   </plugin>
 </plugins>
 ```
+
+You must also create a `resources/META-INF/services/pulsar-io.yaml` file with the following contents:
+
+```yaml
+name: connector name
+description: connector description
+sourceClass: fully qualified class name (only if source connector)
+sinkClass: fully qualified class name (only if sink connector)
+```
+
+If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.5.0/io-develop.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-develop.md
@@ -183,7 +183,7 @@ Pulsar uses the same mechanism for packaging **all** [built-in connectors](io-co
 The easiest approach to package a Pulsar connector is to create a NAR package using
 [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin).
 
-All you need to do is to include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin) in your maven project for your connector as below. 
+Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apache.nifi/nifi-nar-maven-plugin) in your maven project for your connector as below. 
 
 ```xml
 <plugins>
@@ -194,6 +194,17 @@ All you need to do is to include this [nifi-nar-maven-plugin](https://mvnreposit
   </plugin>
 </plugins>
 ```
+
+You must also create a `resources/META-INF/services/pulsar-io.yaml` file with the following contents:
+
+```yaml
+name: connector name
+description: connector description
+sourceClass: fully qualified class name (only if source connector)
+sinkClass: fully qualified class name (only if sink connector)
+```
+
+If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
 
 > #### Tip
 > 


### PR DESCRIPTION
### Motivation

Updating docs to indicate that a pulsar-io.yaml file is required when building a NAR file for a custom Pulsar IO Connector.   At this time, the docs don't mention this.

### Modifications

I modified the section of the documentation discussing NAR file creation in both the 2.5.0 versioned docs and future docs source.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

None

### Documentation

No new features
