### PR TITLE
[pulsar-client-tools] add tls truststore and hn-verification option to argument

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -70,19 +70,21 @@ public class PulsarClientTool {
     CmdConsume consumeCommand;
 
     public PulsarClientTool(Properties properties) {
-        this.serviceURL = StringUtils.isNotBlank(properties.getProperty("brokerServiceUrl"))
+        this.serviceURL = isNotBlank(properties.getProperty("brokerServiceUrl"))
                 ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
         // fallback to previous-version serviceUrl property to maintain backward-compatibility
         if (StringUtils.isBlank(this.serviceURL)) {
             this.serviceURL = properties.getProperty("serviceUrl");
         }
-        this.authPluginClassName = properties.getProperty("authPlugin");
-        this.authParams = properties.getProperty("authParams");
-        this.tlsAllowInsecureConnection = Boolean
-                .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
-        this.tlsEnableHostnameVerification = Boolean
-                .parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
-        this.tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
+        this.authPluginClassName = isNotBlank(authPluginClassName) ? authPluginClassName
+                : properties.getProperty("authPlugin");
+        this.authParams = isNotBlank(authParams) ? authParams : properties.getProperty("authParams");
+        this.tlsAllowInsecureConnection = tlsAllowInsecureConnection != null ? tlsAllowInsecureConnection
+                : Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
+        this.tlsEnableHostnameVerification = tlsEnableHostnameVerification != null ? tlsEnableHostnameVerification
+                : Boolean.parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
+        this.tlsTrustCertsFilePath = isNotBlank(tlsTrustCertsFilePath) ? tlsTrustCertsFilePath
+                : properties.getProperty("tlsTrustCertsFilePath");
 
         produceCommand = new CmdProduce();
         consumeCommand = new CmdConsume();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -53,12 +53,17 @@ public class PulsarClientTool {
             "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
     String authParams = null;
 
+    @Parameter(names = { "--tls-trust-cert-path" }, description = "Allow TLS trust cert file path")
+    String tlsTrustCertsFilePath;
+
+    @Parameter(names = { "--tls-allow-insecure" }, description = "Allow TLS insecure connection")
+    Boolean tlsAllowInsecureConnection = null;
+
+    @Parameter(names = { "--tls-hostname-verification" }, description = "Enable TLS hostname verification")
+    Boolean tlsEnableHostnameVerification = null;
+
     @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
     boolean help;
-
-    boolean tlsAllowInsecureConnection = false;
-    boolean tlsEnableHostnameVerification = false;
-    String tlsTrustCertsFilePath = null;
 
     JCommander commandParser;
     CmdProduce produceCommand;


### PR DESCRIPTION
### Motivation
Allow configure `tlsTrustCertsFilePath` `tlsAllowInsecureConnection` `tlsEnableHostnameVerification` using CLI argument in pulsar-client tools.