### PR TITLE
[build] Bump netty version to 4.1.48.Final

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -346,23 +346,23 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.19.jar
     - org.apache.commons-commons-lang3-3.4.jar
  * Netty
-    - io.netty-netty-buffer-4.1.45.Final.jar
-    - io.netty-netty-codec-4.1.45.Final.jar
-    - io.netty-netty-codec-dns-4.1.45.Final.jar
-    - io.netty-netty-codec-http-4.1.45.Final.jar
-    - io.netty-netty-codec-http2-4.1.45.Final.jar
-    - io.netty-netty-codec-socks-4.1.45.Final.jar
-    - io.netty-netty-common-4.1.45.Final.jar
-    - io.netty-netty-handler-4.1.45.Final.jar
-    - io.netty-netty-handler-proxy-4.1.45.Final.jar
-    - io.netty-netty-resolver-4.1.45.Final.jar
-    - io.netty-netty-resolver-dns-4.1.45.Final.jar
-    - io.netty-netty-transport-4.1.45.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.45.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.45.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.45.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.45.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.26.Final.jar
+    - io.netty-netty-buffer-4.1.48.Final.jar
+    - io.netty-netty-codec-4.1.48.Final.jar
+    - io.netty-netty-codec-dns-4.1.48.Final.jar
+    - io.netty-netty-codec-http-4.1.48.Final.jar
+    - io.netty-netty-codec-http2-4.1.48.Final.jar
+    - io.netty-netty-codec-socks-4.1.48.Final.jar
+    - io.netty-netty-common-4.1.48.Final.jar
+    - io.netty-netty-handler-4.1.48.Final.jar
+    - io.netty-netty-handler-proxy-4.1.48.Final.jar
+    - io.netty-netty-resolver-4.1.48.Final.jar
+    - io.netty-netty-resolver-dns-4.1.48.Final.jar
+    - io.netty-netty-transport-4.1.48.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.48.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.48.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.48.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.48.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.30.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,8 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.10.0</bookkeeper.version>
     <zookeeper.version>3.5.7</zookeeper.version>
-    <netty.version>4.1.45.Final</netty.version>
-    <netty-tc-native.version>2.0.26.Final</netty-tc-native.version>
+    <netty.version>4.1.48.Final</netty.version>
+    <netty-tc-native.version>2.0.30.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.20.v20190813</jetty.version>
     <jersey.version>2.27</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,23 +231,23 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.4.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.45.Final.jar
-    - netty-codec-4.1.45.Final.jar
-    - netty-codec-dns-4.1.45.Final.jar
-    - netty-codec-http-4.1.45.Final.jar
-    - netty-codec-socks-4.1.45.Final.jar
-    - netty-common-4.1.45.Final.jar
-    - netty-handler-4.1.45.Final.jar
-    - netty-handler-proxy-4.1.45.Final.jar
+    - netty-buffer-4.1.48.Final.jar
+    - netty-codec-4.1.48.Final.jar
+    - netty-codec-dns-4.1.48.Final.jar
+    - netty-codec-http-4.1.48.Final.jar
+    - netty-codec-socks-4.1.48.Final.jar
+    - netty-common-4.1.48.Final.jar
+    - netty-handler-4.1.48.Final.jar
+    - netty-handler-proxy-4.1.48.Final.jar
     - netty-reactive-streams-2.0.0.jar
-    - netty-resolver-4.1.45.Final.jar
-    - netty-resolver-dns-4.1.45.Final.jar
-    - netty-tcnative-boringssl-static-2.0.26.Final.jar
-    - netty-transport-4.1.45.Final.jar
-    - netty-transport-native-epoll-4.1.45.Final.jar
-    - netty-transport-native-epoll-4.1.45.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.45.Final.jar
-    - netty-transport-native-unix-common-4.1.45.Final-linux-x86_64.jar
+    - netty-resolver-4.1.48.Final.jar
+    - netty-resolver-dns-4.1.48.Final.jar
+    - netty-tcnative-boringssl-static-2.0.30.Final.jar
+    - netty-transport-4.1.48.Final.jar
+    - netty-transport-native-epoll-4.1.48.Final.jar
+    - netty-transport-native-epoll-4.1.48.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.48.Final.jar
+    - netty-transport-native-unix-common-4.1.48.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.9.9.jar
     - joda-time-2.10.1.jar


### PR DESCRIPTION
Netty 4.1.45 has a security vulnerability. This issue has been fixed in 4.1.46 and later versions.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11612