### PR TITLE
[Docs] Fix the default values for auto-ack in the function CLI docs

### DIFF
--- a/site2/docs/functions-cli.md
+++ b/site2/docs/functions-cli.md
@@ -113,7 +113,7 @@ Update a Pulsar Function that has been deployed to a Pulsar cluster.
 
 Name | Description | Default
 ---|---|---
-auto-ack | Whether or not the framework acknowledges messages automatically. | true
+auto-ack | Whether or not the framework acknowledges messages automatically. | true |
 classname | The class name of a Pulsar Function. | |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime). | |
 custom-runtime-options | A string that encodes options to customize the runtime, see docs for configured runtime for details | |

--- a/site2/docs/functions-cli.md
+++ b/site2/docs/functions-cli.md
@@ -12,7 +12,7 @@ Run Pulsar Functions locally, rather than deploying it to the Pulsar cluster.
 
 Name | Description | Default
 ---|---|---
-auto-ack | Whether or not the framework acknowledges messages automatically. | false |
+auto-ack | Whether or not the framework acknowledges messages automatically. | true |
 broker-service-url | The URL for the Pulsar broker. | |
 classname | The class name of a Pulsar Function.| |
 client-auth-params | Client authentication parameter. | |
@@ -61,7 +61,7 @@ Create and deploy a Pulsar Function in cluster mode.
 
 Name | Description | Default
 ---|---|---
-auto-ack | Whether or not the framework acknowledges messages automatically. | false |
+auto-ack | Whether or not the framework acknowledges messages automatically. | true |
 classname | The class name of a Pulsar Function. |  |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime).| |
 custom-runtime-options | A string that encodes options to customize the runtime, see docs for configured runtime for details | |
@@ -113,7 +113,7 @@ Update a Pulsar Function that has been deployed to a Pulsar cluster.
 
 Name | Description | Default
 ---|---|---
-auto-ack | Whether or not the framework acknowledges messages automatically. | false
+auto-ack | Whether or not the framework acknowledges messages automatically. | true
 classname | The class name of a Pulsar Function. | |
 CPU | The CPU in cores that need to be allocated per function instance (applicable only to docker runtime). | |
 custom-runtime-options | A string that encodes options to customize the runtime, see docs for configured runtime for details | |


### PR DESCRIPTION
### Motivation

The documentation contains wrong default values for the auto-ack field. As far as I can see from running functions and code, this value is set to true by default.

### Modifications

The default value was changed from false to true in the documentation.
