### PR TITLE
[CI] Fix typo in the value for pulsar_manager in values-bk-tls

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -33,7 +33,7 @@ affinity:
 # disable auto recovery
 components:
   autorecovery: false
-  pulsar_manager: fales
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1


### PR DESCRIPTION
### Modifications

The typo was fixed in the values-bk-tls file.