### PR TITLE
[pulsar-client] Add support to load tls certs/key dynamically from inputstream

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.client.impl.auth;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.PrivateKey;
@@ -25,6 +28,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.function.Supplier;
 
+import org.apache.commons.compress.utils.IOUtils;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.common.util.FileModifiedTimeUpdater;
 import org.apache.pulsar.common.util.SecurityUtility;
@@ -37,7 +41,7 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
     private FileModifiedTimeUpdater certFile, keyFile;
     // key and cert using stream
     private InputStream certStream, keyStream;
-    private Supplier<InputStream> certStreamProvider, keyStreamProvider;
+    private Supplier<ByteArrayInputStream> certStreamProvider, keyStreamProvider;
 
     public AuthenticationDataTls(String certFilePath, String keyFilePath) throws KeyManagementException {
         if (certFilePath == null) {
@@ -52,8 +56,8 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
         this.tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemFile(keyFilePath);
     }
 
-    public AuthenticationDataTls(Supplier<InputStream> certStreamProvider, Supplier<InputStream> keyStreamProvider)
-            throws KeyManagementException {
+    public AuthenticationDataTls(Supplier<ByteArrayInputStream> certStreamProvider,
+            Supplier<ByteArrayInputStream> keyStreamProvider) throws KeyManagementException {
         if (certStreamProvider == null || certStreamProvider.get() == null) {
             throw new IllegalArgumentException("certStream provider or stream must not be null");
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.client.impl.auth;
 
+import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.function.Supplier;
 
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.common.util.FileModifiedTimeUpdater;
@@ -32,7 +34,10 @@ import org.slf4j.LoggerFactory;
 public class AuthenticationDataTls implements AuthenticationDataProvider {
     protected X509Certificate[] tlsCertificates;
     protected PrivateKey tlsPrivateKey;
-    protected FileModifiedTimeUpdater certFile, keyFile;
+    private FileModifiedTimeUpdater certFile, keyFile;
+    // key and cert using stream
+    private InputStream certStream, keyStream;
+    private Supplier<InputStream> certStreamProvider, keyStreamProvider;
 
     public AuthenticationDataTls(String certFilePath, String keyFilePath) throws KeyManagementException {
         if (certFilePath == null) {
@@ -47,6 +52,22 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
         this.tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemFile(keyFilePath);
     }
 
+    public AuthenticationDataTls(Supplier<InputStream> certStreamProvider, Supplier<InputStream> keyStreamProvider)
+            throws KeyManagementException {
+        if (certStreamProvider == null || certStreamProvider.get() == null) {
+            throw new IllegalArgumentException("certStream provider or stream must not be null");
+        }
+        if (keyStreamProvider == null || keyStreamProvider.get() == null) {
+            throw new IllegalArgumentException("keyStream provider or stream must not be null");
+        }
+        this.certStreamProvider = certStreamProvider;
+        this.keyStreamProvider = keyStreamProvider;
+        this.certStream = certStreamProvider.get();
+        this.keyStream = keyStreamProvider.get();
+        this.tlsCertificates = SecurityUtility.loadCertificatesFromPemStream(certStream);
+        this.tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemStream(keyStream);
+    }
+
     /*
      * TLS
      */
@@ -58,11 +79,19 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
 
     @Override
     public Certificate[] getTlsCertificates() {
-        if (this.certFile.checkAndRefresh()) {
+        if (certFile != null && certFile.checkAndRefresh()) {
             try {
                 this.tlsCertificates = SecurityUtility.loadCertificatesFromPemFile(certFile.getFileName());
             } catch (KeyManagementException e) {
                 LOG.error("Unable to refresh authData for cert {}: ", certFile.getFileName(), e);
+            }
+        } else if (certStreamProvider != null && certStreamProvider.get() != null
+                && !certStreamProvider.get().equals(certStream)) {
+            try {
+                certStream = certStreamProvider.get();
+                tlsCertificates = SecurityUtility.loadCertificatesFromPemStream(certStream);
+            } catch (KeyManagementException e) {
+                LOG.error("Unable to refresh authData from cert stream ", e);
             }
         }
         return this.tlsCertificates;
@@ -70,11 +99,19 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
 
     @Override
     public PrivateKey getTlsPrivateKey() {
-        if (this.keyFile.checkAndRefresh()) {
+        if (keyFile != null && keyFile.checkAndRefresh()) {
             try {
                 this.tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemFile(keyFile.getFileName());
             } catch (KeyManagementException e) {
                 LOG.error("Unable to refresh authData for cert {}: ", keyFile.getFileName(), e);
+            }
+        } else if (keyStreamProvider != null && keyStreamProvider.get() != null
+                && !keyStreamProvider.get().equals(keyStream)) {
+            try {
+                keyStream = keyStreamProvider.get();
+                tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemStream(keyStream);
+            } catch (KeyManagementException e) {
+                LOG.error("Unable to refresh authData from key stream ", e);
             }
         }
         return this.tlsPrivateKey;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.auth;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class AuthenticationTls implements Authentication, EncodedAuthenticationP
 
     private String certFilePath;
     private String keyFilePath;
-    private Supplier<InputStream> certStreamProvider, keyStreamProvider;
+    private Supplier<ByteArrayInputStream> certStreamProvider, keyStreamProvider;
 
     public AuthenticationTls() {
     }
@@ -54,7 +55,7 @@ public class AuthenticationTls implements Authentication, EncodedAuthenticationP
         this.keyFilePath = keyFilePath;
     }
 
-    public AuthenticationTls(Supplier<InputStream> certStreamProvider, Supplier<InputStream> keyStreamProvider) {
+    public AuthenticationTls(Supplier<ByteArrayInputStream> certStreamProvider, Supplier<ByteArrayInputStream> keyStreamProvider) {
         this.certStreamProvider = certStreamProvider;
         this.keyStreamProvider = keyStreamProvider;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -80,6 +80,9 @@ public class ClientConfigurationData implements Serializable, Cloneable {
         return authentication;
     }
 
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
+    }
     public boolean isUseTls() {
         if (useTls)
             return true;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -254,10 +254,13 @@ public class SecurityUtility {
         }
         CertificateFactory cf;
         try {
+            if (inStream.markSupported()) {
+                inStream.reset();
+            }
             cf = CertificateFactory.getInstance("X.509");
             Collection<X509Certificate> collection = (Collection<X509Certificate>) cf.generateCertificates(inStream);
             return collection.toArray(new X509Certificate[collection.size()]);
-        } catch (CertificateException e) {
+        } catch (CertificateException | IOException e) {
             throw new KeyManagementException("Certificate loading error", e);
         }
     }
@@ -285,8 +288,10 @@ public class SecurityUtility {
             return privateKey;
         }
 
-        //TODO: check if bufferReader should be closed or not
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inStream))) {
+            if (inStream.markSupported()) {
+                inStream.reset();
+            }
             StringBuilder sb = new StringBuilder();
             String currentLine = null;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -26,8 +26,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyManagementException;
@@ -40,6 +41,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.KeySpec;
@@ -238,14 +240,26 @@ public class SecurityUtility {
         }
 
         try (FileInputStream input = new FileInputStream(certFilePath)) {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            Collection<X509Certificate> collection = (Collection<X509Certificate>) cf.generateCertificates(input);
-            certificates = collection.toArray(new X509Certificate[collection.size()]);
+            certificates = loadCertificatesFromPemStream(input);
         } catch (GeneralSecurityException | IOException e) {
             throw new KeyManagementException("Certificate loading error", e);
         }
 
         return certificates;
+    }
+
+    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException  {
+        if (inStream == null) {
+            return null;
+        }
+        CertificateFactory cf;
+        try {
+            cf = CertificateFactory.getInstance("X.509");
+            Collection<X509Certificate> collection = (Collection<X509Certificate>) cf.generateCertificates(inStream);
+            return collection.toArray(new X509Certificate[collection.size()]);
+        } catch (CertificateException e) {
+            throw new KeyManagementException("Certificate loading error", e);
+        }
     }
 
     public static PrivateKey loadPrivateKeyFromPemFile(String keyFilePath) throws KeyManagementException {
@@ -255,7 +269,24 @@ public class SecurityUtility {
             return privateKey;
         }
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(keyFilePath))) {
+        try (FileInputStream input = new FileInputStream(keyFilePath)) {
+            privateKey = loadPrivateKeyFromPemStream(input);
+        } catch (IOException e) {
+            throw new KeyManagementException("Private key loading error", e);
+        }
+
+        return privateKey;
+    }
+
+    public static PrivateKey loadPrivateKeyFromPemStream(InputStream inStream) throws KeyManagementException {
+        PrivateKey privateKey = null;
+
+        if (inStream == null) {
+            return privateKey;
+        }
+
+        //TODO: check if bufferReader should be closed or not
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inStream))) {
             StringBuilder sb = new StringBuilder();
             String currentLine = null;
 


### PR DESCRIPTION
### Motivation
Right now, Pulsar-client provides tls authentication support and default TLS provider `AuthenticationTls` expects file path of cert and key files. However, there are usescases where it will be difficult for user-applications to store certs/key file locally for tls authentication.
eg:
1. Applications running on docker or K8s containers will not have certs at defined location and app uses KMS or various key-vault system whose API return streams of certs.
2. Operationally hard to manage key rotation in containers
3. Need to avoid storing key/trust store files on file system for stronger security

Therefore, it's good to have mechanism in default `AuthenticationTls` provider to read certs from memory/stream without storing certs on file-system.

### Modification
Add Stream support in `AuthenticationTls` to provide X509Certs and PrivateKey which also performs auto-refresh when stream changes in a given provider.
```
AuthenticationTls auth = new AuthenticationTls(certStreamProvider, keyStreamProvider);
```
It will be also address: #5241