### PR TITLE
[CI] Group disabled components under the same tag in the clusters values

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -30,7 +30,7 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
   pulsar_manager: false

--- a/.ci/clusters/values-broker-tls.yaml
+++ b/.ci/clusters/values-broker-tls.yaml
@@ -30,7 +30,7 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
   pulsar_manager: false

--- a/.ci/clusters/values-function.yaml
+++ b/.ci/clusters/values-function.yaml
@@ -30,7 +30,7 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
   pulsar_manager: false

--- a/.ci/clusters/values-jwt-asymmetric.yaml
+++ b/.ci/clusters/values-jwt-asymmetric.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-jwt-symmetric.yaml
+++ b/.ci/clusters/values-jwt-symmetric.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-local-pv.yaml
+++ b/.ci/clusters/values-local-pv.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-components:
-  pulsar_manager: false
-
 monitoring:
   prometheus: false
   grafana: false
@@ -33,9 +30,10 @@ volumes:
 affinity:
   anti_affinity: false
 
-# disable auto recovery
+# disable auto recovery and pulsar manager
 components:
   autorecovery: false
+  pulsar_manager: false
 
 zookeeper:
   replicaCount: 1


### PR DESCRIPTION
### Motivation

It is harder to maintain the values if they are defined in different places in the documents. Some yaml editors display an error for the duplicated tags.

### Modifications

The disabled components were grouped under the same tag (components)
