### PR TITLE
[function] Function endpoint admin/v3/functions/{tenant}/{namespace} always returns 404

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
@@ -59,6 +59,8 @@ public class FunctionsApiV3Resource extends FunctionApiResource {
         this.functions = new FunctionsImpl(this);
     }
 
+    
+
     @POST
     @Path("/{tenant}/{namespace}/{functionName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -106,6 +108,14 @@ public class FunctionsApiV3Resource extends FunctionApiResource {
                                           final @PathParam("namespace") String namespace,
                                           final @PathParam("functionName") String functionName) {
         return functions.getFunctionInfo(tenant, namespace, functionName, clientAppId(), clientAuthData());
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/{tenant}/{namespace}")
+    public List<String> listSources(final @PathParam("tenant") String tenant,
+                                    final @PathParam("namespace") String namespace) {
+        return functions.listFunctions(tenant, namespace, clientAppId(), clientAuthData());
     }
 
     @GET

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
@@ -59,8 +59,6 @@ public class FunctionsApiV3Resource extends FunctionApiResource {
         this.functions = new FunctionsImpl(this);
     }
 
-    
-
     @POST
     @Path("/{tenant}/{namespace}/{functionName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)


### PR DESCRIPTION
Fix #6839 
### Motivation

The V3 endpoint that returns a list of all functions in a namespace always returns 404. The V2 version of the endpoint returns the actual list of functions in the namespace. It looks like during the switch from V2 to V3, the implementation for the endpoint was missed. This endpoint is part of the current API [documentation](https://pulsar.apache.org/functions-rest-api/?version=2.5.0#operation/listFunctions), so I don't think it was removed intentionally.

This endpoint is also used by the pulsar-admin command, so that always returns 404:

```
pulsar-admin functions list --tenant chris-kafkaesque-io --namespace local-useast2-aws
HTTP 404 Not Found

Reason: HTTP 404 Not Found
```

### Modifications

I have added the endpoint to `FunctionsApiV3Resource.java`. It is essentially a clone of the V2 version.

### Verifying this change

This is a pretty small change. I have confirmed that the V3 version of the endpoint now returns the same list of functions as the V2 version. I have also confirmed that the pulsar-admin command now works:

```
bin/pulsar-admin functions list --tenant chris-kafkaesque-io --namespace TTL
23:45:10.763 [main] INFO  org.apache.pulsar.common.util.SecurityUtility - Found and Instantiated Bouncy Castle provider in classpath BC
"exclaim"
"pulsar-functions-0.1"
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)