### PR TITLE
change nondurable cursor to active

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -858,6 +858,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, config, this, cursorName,
                 (PositionImpl) startCursorPosition);
+        cursor.setActive();
 
         log.info("[{}] Opened new cursor: {}", name, cursor);
         synchronized (this) {
@@ -2894,7 +2895,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     public boolean isCursorActive(ManagedCursor cursor) {
-        return cursor.isDurable() && activeCursors.get(cursor.getName()) != null;
+        return activeCursors.get(cursor.getName()) != null;
     }
 
     private boolean currentLedgerIsFull() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -93,21 +93,6 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
     }
 
     @Override
-    public void setActive() {
-        /// No-Op
-    }
-
-    @Override
-    public boolean isActive() {
-        return false;
-    }
-
-    @Override
-    public void setInactive() {
-        /// No-Op
-    }
-
-    @Override
     public void asyncClose(CloseCallback callback, Object ctx) {
         // No-Op
         callback.closeComplete(ctx);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -3001,6 +3001,17 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    void testNonDurableCursorActive() throws Exception {
+        ManagedLedger ml = factory.open("testInactive");
+        ManagedCursor cursor = ml.newNonDurableCursor(PositionImpl.latest, "c1");
+
+        assertTrue(cursor.isActive());
+
+        cursor.setInactive();
+        assertFalse(cursor.isActive());
+    }
+
+    @Test
     public void deleteMessagesCheckhMarkDelete() throws Exception {
         ManagedLedger ledger = factory.open("my_test_ledger");
         ManagedCursorImpl c1 = (ManagedCursorImpl) ledger.openCursor("c1");


### PR DESCRIPTION

### Motivation

When use non-durable subscription the cursor is not active which lead to the written entries are not put into cache. This situation would degrade reading performance.

### Modifications

Change the `NonDurableCursorImpl` to active and remove the three override methods: `setActive()/isActive()/setInactive()`

### Verifying this change

This change added tests and can be verified as follows:

*ManagedCursorTest.testNonDurableCursorActive()*
  - add test to check `NonDurableCursorImpl` activity
