### PR TITLE
[Grafana] Add tags to all grafana dashboards

### DIFF
--- a/docker/grafana/dashboards/bookkeeper.json
+++ b/docker/grafana/dashboards/bookkeeper.json
@@ -1435,7 +1435,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "bookkeeper"
+  ],
   "templating": {
     "list": [
       {

--- a/docker/grafana/dashboards/jvm.json
+++ b/docker/grafana/dashboards/jvm.json
@@ -2443,7 +2443,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "pulsar"
+  ],
   "templating": {
     "list": [
       {

--- a/docker/grafana/dashboards/namespace.json
+++ b/docker/grafana/dashboards/namespace.json
@@ -1404,7 +1404,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "pulsar"
+  ],
   "templating": {
     "list": [
       {

--- a/docker/grafana/dashboards/topic.json
+++ b/docker/grafana/dashboards/topic.json
@@ -1059,7 +1059,9 @@
   "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "pulsar"
+  ],
   "templating": {
     "list": [
       {

--- a/docker/grafana/dashboards/zookeeper.json
+++ b/docker/grafana/dashboards/zookeeper.json
@@ -865,7 +865,9 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "zookeeper"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
### Motivation

Currently, only the Prometheus dashboard contains an appropriate tag. The idea is to add tags to all dashboards, for visibility and fast filtering.

![image](https://user-images.githubusercontent.com/7816474/79693638-0dedf980-826c-11ea-9d5a-2b6fd7604087.png)

### Modifications

Appropriate tags were added to all grafana dashboards shipped with Pulsar.
