### PR TITLE
Fix localrunner netty dependency issue and add default log4j2 config file

### DIFF
--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -58,20 +58,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
                             </transformers>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>io.netty:netty-common</exclude>
-                                    <exclude>io.netty:netty-buffer</exclude>
-                                    <exclude>io.netty:netty-codec-http2</exclude>
-                                    <exclude>io.netty:netty-codec-http</exclude>
-                                    <exclude>io.netty:netty-codec-socks</exclude>
-                                    <exclude>io.netty:netty-codec</exclude>
-                                    <exclude>io.netty:netty-handler</exclude>
-                                    <exclude>io.netty:netty-handler-proxy</exclude>
-                                    <exclude>io.netty:netty-transport</exclude>
-                                    <exclude>io.netty:netty-resolver</exclude>
-                                </excludes>
-                            </artifactSet>
                             <filters>
                                 <filter>
                                     <!-- Shading signed JARs will fail without

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">


### PR DESCRIPTION

### Motivation


When pulling in pulsar-functions-local-runner as a dependency and attempting to run functions locally, netty libraries are missing and will cause class not found exception.  

There is also no default log4j2 config file for pulsar-functions-local-runner.  We should add a config file to log to console by default.