### PR TITLE
Using Readers still causes backlog quota to be observed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -894,6 +894,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      * @return true if at least a cursor exists
      */
     public boolean hasActiveCursors() {
+        // Use hasCursors instead of isEmpty because isEmpty does not take into account non-durable cursors
         return !activeCursors.isEmpty();
     }
 
@@ -1998,7 +1999,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             }
 
             long slowestReaderLedgerId = -1;
-            if (cursors.isEmpty()) {
+            if (!cursors.hasDurableCursors()) {
                 // At this point the lastLedger will be pointing to the
                 // ledger that has just been closed, therefore the +1 to
                 // include lastLedger in the trimming.
@@ -2911,7 +2912,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         synchronized (activeCursors) {
             if (activeCursors.get(cursor.getName()) != null) {
                 activeCursors.removeCursor(cursor.getName());
-                if (activeCursors.isEmpty()) {
+                if (!activeCursors.hasDurableCursors()) {
                     // cleanup cache if there is no active subscription
                     entryCache.clear();
                 } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -383,12 +383,12 @@ public class ManagedCursorContainerTest {
         container.removeCursor(cursor1.getName());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(4, 0));
 
-        assertFalse(container.isEmpty());
+        assertTrue(container.hasDurableCursors());
 
         container.removeCursor(cursor4.getName());
         assertNull(container.getSlowestReaderPosition());
 
-        assertTrue(container.isEmpty());
+        assertFalse(container.hasDurableCursors());
 
         ManagedCursor cursor6 = new MockManagedCursor(container, "test6", new PositionImpl(6, 5));
         container.add(cursor6);
@@ -487,7 +487,7 @@ public class ManagedCursorContainerTest {
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(7, 1));
         container.removeCursor("test3");
 
-        assertTrue(container.isEmpty());
+        assertFalse(container.hasDurableCursors());
     }
 
     @Test
@@ -552,7 +552,7 @@ public class ManagedCursorContainerTest {
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(8, 5));
         container.removeCursor("test3");
 
-        assertTrue(container.isEmpty());
+        assertFalse(container.hasDurableCursors());
     }
 
     @Test
@@ -617,6 +617,6 @@ public class ManagedCursorContainerTest {
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(8, 5));
         container.removeCursor("test3");
 
-        assertTrue(container.isEmpty());
+        assertFalse(container.hasDurableCursors());
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -652,23 +652,25 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
 
         ManagedCursor nonCursor1 = ledger.newNonDurableCursor(p2, nc1);
-        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+        // The slowest reader should still be the durable cursor since non-durable readers are not taken into account
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
 
         PositionImpl earliestPos = new PositionImpl(-1, -2);
 
         ManagedCursor nonCursorEarliest = ledger.newNonDurableCursor(earliestPos, ncEarliest);
-        PositionImpl expectedPos = new PositionImpl(((PositionImpl) p1).getLedgerId(), -1);
-        assertEquals(expectedPos, ledger.getCursors().getSlowestReaderPosition());
 
-        // move non-durable cursor should update the slowest reader position
+        // The slowest reader should still be the durable cursor since non-durable readers are not taken into account
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
+
+        // move non-durable cursor should NOT update the slowest reader position
         nonCursorEarliest.markDelete(p1);
-        assertEquals(p1, ledger.getCursors().getSlowestReaderPosition());
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
 
         nonCursorEarliest.markDelete(p2);
-        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
 
         nonCursorEarliest.markDelete(p3);
-        assertEquals(p2, ledger.getCursors().getSlowestReaderPosition());
+        assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());
 
         nonCursor1.markDelete(p3);
         assertEquals(p3, ledger.getCursors().getSlowestReaderPosition());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -24,25 +24,20 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
-
-import java.net.URL;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.pulsar.broker.ConfigHelper;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
@@ -51,6 +46,13 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  */
@@ -64,12 +66,11 @@ public class BacklogQuotaManagerTest {
     LocalBookkeeperEnsemble bkEnsemble;
 
     private static final int TIME_TO_CHECK_BACKLOG_QUOTA = 5;
+    private static final int MAX_ENTRIES_PER_LEDGER = 5;
 
     @BeforeMethod
     void setup() throws Exception {
         try {
-
-
             // start local bookie and zookeeper
             bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
             bkEnsemble.start();
@@ -84,7 +85,7 @@ public class BacklogQuotaManagerTest {
             config.setAuthorizationEnabled(false);
             config.setAuthenticationEnabled(false);
             config.setBacklogQuotaCheckIntervalInSeconds(TIME_TO_CHECK_BACKLOG_QUOTA);
-            config.setManagedLedgerMaxEntriesPerLedger(5);
+            config.setManagedLedgerMaxEntriesPerLedger(MAX_ENTRIES_PER_LEDGER);
             config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
             config.setAllowAutoTopicCreationType("non-partitioned");
 
@@ -123,6 +124,80 @@ public class BacklogQuotaManagerTest {
 
     private void rolloverStats() {
         pulsar.getBrokerService().updateRates();
+    }
+
+    /**
+     * Readers should not effect backlog quota
+     */
+    @Test
+    public void testBacklogQuotaWithReader() throws Exception {
+        assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
+          ConfigHelper.backlogQuotaMap(config));
+        admin.namespaces().setBacklogQuota("prop/ns-quota",
+          new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.producer_exception));
+        try (PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS).build();) {
+            final String topic1 = "persistent://prop/ns-quota/topic1";
+            final int numMsgs = 20;
+
+            Reader<byte[]> reader = client.newReader().topic(topic1).receiverQueueSize(1).startMessageId(MessageId.latest).create();
+
+            org.apache.pulsar.client.api.Producer<byte[]> producer = client.newProducer().topic(topic1).sendTimeout(2, TimeUnit.SECONDS).create();
+
+            byte[] content = new byte[1024];
+            for (int i = 0; i < numMsgs; i++) {
+                content[0] = (byte) (content[0] + 1);
+                MessageId msgId = producer.send(content);
+            }
+
+            Thread.sleep((TIME_TO_CHECK_BACKLOG_QUOTA + 1) * 1000);
+
+            rolloverStats();
+
+            TopicStats stats = admin.topics().getStats(topic1);
+
+            // overall backlogSize should be zero because we only have readers
+            assertEquals(stats.backlogSize, 0, "backlog size is [" + stats.backlogSize + "]");
+
+            // non-durable mes should still
+            assertEquals(stats.subscriptions.size(), 1);
+            long nonDurableSubscriptionBacklog = stats.subscriptions.values().iterator().next().msgBacklog;
+            assertEquals(nonDurableSubscriptionBacklog, numMsgs,
+              "non-durable subscription backlog is [" + nonDurableSubscriptionBacklog + "]"); ;
+
+            try {
+                // try to send over backlog quota and make sure it fails
+                for (int i = 0; i < numMsgs; i++) {
+                    content[0] = (byte) (content[0] + 1);
+                    MessageId msgId = producer.send(content);
+                }
+            } catch (PulsarClientException ce) {
+                fail("Should not have gotten exception: " + ce.getMessage());
+            }
+
+            // make sure ledgers are trimmed
+            PersistentTopicInternalStats internalStats =
+              admin.topics().getInternalStats(topic1);
+
+            // check there is only one ledger left
+            // TODO in theory there shouldn't be any ledgers left if we are using readers.
+            //  However, trimming of ledgers are piggy packed onto ledger operations.
+            //  So if there isn't new data coming in, trimming never occurs.
+            //  We need to trigger trimming on a schedule to actually delete all remaining ledgers
+            assertEquals(internalStats.ledgers.size(), 1);
+
+            // check if its the expected ledger id given MAX_ENTRIES_PER_LEDGER
+            assertEquals(internalStats.ledgers.get(0).ledgerId, (2 * numMsgs / MAX_ENTRIES_PER_LEDGER) - 1);
+
+            // check reader can still read with out error
+
+            while (true) {
+                Message<byte[]> msg = reader.readNext(5, TimeUnit.SECONDS);
+                if (msg == null) {
+                    break;
+                }
+                LOG.info("msg read: {} - {}", msg.getMessageId(), msg.getData()[0]);
+            }
+        }
     }
 
     @Test

--- a/site2/docs/concepts-clients.md
+++ b/site2/docs/concepts-clients.md
@@ -35,6 +35,12 @@ The reader interface is helpful for use cases like using Pulsar to provide [effe
 
 Internally, the reader interface is implemented as a consumer using an exclusive, non-durable subscription to the topic with a randomly-allocated name.
 
+[ **IMPORTANT** ]
+
+Unlike subscription/consumer, readers are non-durable in nature and will not prevent data in a topic from being deleted, thus it is ***strongly*** advised that [data retention](cookbooks-retention-expiry.md) be configured.   If data retention for a topic is not configured for an adequate amount of time, messages that the reader has not yet read might be deleted .  This will cause readers to essentially skip messages.  Configuring the data retention for a topic guarantees the reader with have a certain duration to read a message.
+
+Please also note that a reader can have a "backlog", but the metric is just to allow users to know how behind the reader is and is not considered for any backlog quota calculations. 
+
 ![The Pulsar consumer and reader interfaces](assets/pulsar-reader-consumer-interfaces.png)
 
 > ### Non-partitioned topics only


### PR DESCRIPTION
### Motivation

When using Readers API, backlog quotas are still enforced on these ephemeral readers.

### Modifications

If a cursor is non-durable then we don't add it to the min-heap we are using keep track of the slowest cursor.  

We use in the min-heap to access the slowest cursor for backlog and quota calculations.  

It is also used to determine up to which ledger we can trim.  Thus, with this change, reader's ephemeral subscriptions won't be preventing ledgers from being clean up as well which is what you expect the behavior to be.

There are some caveats to the above.  Since triggering of trimming of ledgers is piggy packed on top of ledger operations, if there is no new data coming in ledgers will not be trimmed.  The most recently closed ledger we be persisted past any retention.  Perhaps in a subsequent PR, we implement the trimming to be trigger on a schedule as well.

**Please note this PR includes changes from:**

https://github.com/apache/pulsar/pull/6769


### Verifying this change

Added a test to verify that readers don't cause any backlog issues
