### PR TITLE
[Test] Removed double retain in mocked ledger handle

### DIFF
--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -166,7 +166,6 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
 
     @Override
     public void asyncAddEntry(final ByteBuf data, final AddCallback cb, final Object ctx) {
-        data.retain();
         bk.getProgrammedFailure().thenComposeAsync((res) -> {
                 try {
                     Thread.sleep(1);


### PR DESCRIPTION
### Motivation

The `PulsarMockLedgerHandle.asyncAddEntry()` is retaining the bytebuf before starting the operation. This makes it "ref-count neutral", though the real BK client implementation is only doing the release. 

This results in buffer leaks during the unit tests (which are caught by the Netty leak detector).  