### PR TITLE
[C++] Support cumulative acknowledgement when consuming partitioned topics

### DIFF
--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -203,7 +203,10 @@ void PartitionedConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCal
 }
 
 void PartitionedConsumerImpl::acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) {
-    callback(ResultOperationNotSupported);
+    int32_t partition = msgId.partition();
+    assert(partition < numPartitions_ && partition >= 0 && consumers_.size() > partition);
+    unAckedMessageTrackerPtr_->removeMessagesTill(msgId);
+    consumers_[partition]->acknowledgeCumulativeAsync(msgId, callback);
 }
 
 void PartitionedConsumerImpl::negativeAcknowledge(const MessageId& msgId) {

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -193,18 +193,14 @@ void PartitionedConsumerImpl::handleUnsubscribeAsync(Result result, unsigned int
 
 void PartitionedConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCallback callback) {
     int32_t partition = msgId.partition();
-#ifndef NDEBUG
-    Lock consumersLock(consumersMutex_);
-    assert(partition < getNumPartitions() && partition >= 0 && consumers_.size() > partition);
-    consumersLock.unlock();
-#endif
+    assertPartitionIsValid(partition);
     unAckedMessageTrackerPtr_->remove(msgId);
     consumers_[partition]->acknowledgeAsync(msgId, callback);
 }
 
 void PartitionedConsumerImpl::acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) {
     int32_t partition = msgId.partition();
-    assert(partition < numPartitions_ && partition >= 0 && consumers_.size() > partition);
+    assertPartitionIsValid(partition);
     unAckedMessageTrackerPtr_->removeMessagesTill(msgId);
     consumers_[partition]->acknowledgeCumulativeAsync(msgId, callback);
 }

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -103,6 +103,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     /* methods */
     unsigned int getNumPartitions() const;
     unsigned int getNumPartitionsWithLock() const;
+    void assertPartitionIsValid(int32_t partition) const;
     ConsumerConfiguration getSinglePartitionConsumerConfig() const;
     ConsumerImplPtr newInternalConsumer(unsigned int partition, const ConsumerConfiguration& config) const;
     void setState(PartitionedConsumerState state);
@@ -126,5 +127,13 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
 };
 typedef std::weak_ptr<PartitionedConsumerImpl> PartitionedConsumerImplWeakPtr;
 typedef std::shared_ptr<PartitionedConsumerImpl> PartitionedConsumerImplPtr;
+
+inline void PartitionedConsumerImpl::assertPartitionIsValid(int32_t partition) const {
+#ifndef NDEBUG
+    Lock consumersLock(consumersMutex_);
+    assert(partition < getNumPartitions() && partition >= 0 && consumers_.size() > partition);
+#endif
+}
+
 }  // namespace pulsar
 #endif  // PULSAR_PARTITIONED_CONSUMER_HEADER


### PR DESCRIPTION
### Motivation

For C++ client, when a consumer of partitioned topics calls `acknowledgeCumulative()`, it just simply set result to `ResultOperationNotSupported` before.

### Modifications

- Implement `PartitionedConsumerImpl::acknowledgeCumulative`;
- Add an unit test to verify that cumulative acknowledgement works.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Run `BasicEndToEndTest.testCumulativeAcknowledgeForPartitionedTopic`.