### PR TITLE
[functions] Don't auth functions worker metrics endpoint

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -101,6 +101,17 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     )
     private Integer workerPortTls;
     @FieldContext(
+            category = CATEGORY_WORKER,
+            doc = "Whether the '/metrics' endpoint requires authentication. Defaults to true."
+                    + "'authenticationEnabled' must also be set for this to take effect."
+    )
+    private boolean authenticateMetricsEndpoint = true;
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            doc = "Whether the '/metrics' endpoint should return default prometheus metrics. Defaults to false."
+    )
+    private boolean includeStandardPrometheusMetrics = false;
+    @FieldContext(
         category = CATEGORY_WORKER,
         doc = "Classname of Pluggable JVM GC metrics logger that can log GC specific metrics")
     private String jvmGCMetricsLoggerClassName;


### PR DESCRIPTION
### Motivation


The broker and proxy both allow for hitting the metrics endpoint without auth. The functions
worker should allow that to be configurable as well. This adds an option to
allow for metrics endpoint to allow the endpoint to be hit without auth
    
Additionally, the functions worker doesn't expose the default prometheus
metrics (such as JVM info, etc).
    
This commit implements and adds an option to support that


### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): n
  - The public API: n
  - The schema: n
  - The default values of configurations: n
  - The wire protocol: n
  - The rest endpoints: n
  - The admin cli options: n
  - Anything that affects deployment: n

### Documentation

  - Does this pull request introduce a new feature? n
