### PR TITLE
[PY] Fix serialization of enums with json/avro schemas

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/schema/__init__.py
@@ -17,8 +17,7 @@
 # under the License.
 #
 
+from .definition import Record, Field, Null, Boolean, Integer, Long, \
+            Float, Double, Bytes, String, Array, Map
 
-from .definition import *
-from .schema import *
-
-
+from .schema import Schema, BytesSchema, StringSchema, JsonSchema, AvroSchema


### PR DESCRIPTION
### Motivation

In Python client, the serialization of enums when using the schema is currently broken, throwing error because it's not possible to directly serialize them into json.

Instead, for both Avro and JSON, we need to handle the enum serialization on its own way.