### PR TITLE
update topicName document to avoid confusion

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -136,8 +136,8 @@ public class TopicName implements ServiceUnitId {
             // new:    tenant/namespace/<localName>
             // legacy: tenant/cluster/namespace/<localName>
             // Examples of localName:
-            // 1. some/name/xyz//
-            // 2. /xyz-123/feeder-2
+            // 1. some, name, xyz
+            // 2. xyz-123, feeder-2
 
 
             parts = Splitter.on("/").limit(4).splitToList(rest);

--- a/site2/docs/getting-started-pulsar.md
+++ b/site2/docs/getting-started-pulsar.md
@@ -32,6 +32,7 @@ Two important changes have been made in Pulsar 2.0:
 * There is no longer a [cluster component](#no-cluster)
 * Properties have been [renamed to tenants](#tenants)
 * You can use a [flexible](#flexible-topic-naming) naming system to shorten many topic names
+* `/` is not allowed in topic name
 
 #### No cluster component
 


### PR DESCRIPTION
Fix #6620

### changes
1. update topic name document
2. update code annotation in TopicName.java to avoid topic name confusion