### PR TITLE
[Issue 6822][C++] Fix segmentation fault if handleSendTimeout() is called after closeAsync()

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -167,6 +167,10 @@ class ProducerImpl : public HandlerBase,
 
     Promise<Result, ProducerImplBaseWeakPtr> producerCreatedPromise_;
 
+    struct PendingCallbacks;
+    std::shared_ptr<PendingCallbacks> getPendingCallbacksWhenFailed();
+    std::shared_ptr<PendingCallbacks> getPendingCallbacksWhenFailedWithLock();
+
     void failPendingMessages(Result result);
 
     MessageCryptoPtr msgCrypto_;


### PR DESCRIPTION
Fixes #6822 

### Motivation

The program may cause segmentation fault after closed accidentally because  `ProducerImpl::handleSendTimeout()` doesn't check the state or other fields of `ProducerImpl`, which may cause that a null `sendTimer_` calls its methods.

### Modifications

- Acquire `mutex_` and check if the `state_` is `Ready` before handling the send timer callback;
- Devide `failPendingMessages()` into two parts which are `getPendingCallbacksWhenFailedWithLock()` and `PendingCallbacks::complete()`.

    - The 1st part needs to acquire `mutex_` to access class members safely. In addition, we already hold `mutex_` before `failPendingMessages()`, so we need a method to get necessary callbacks without the lock.
    - The 2nd part doesn't and shouldn't acquire `mutex_`, because we don't know how long user provided callbacks may cost. If lock this part, `mutex_` may be hold for a long time.
- Define a new struct contains a `BatchMessageContainer::MessageContainerListPtr` field, because nested classes can't be forward declared.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change can be verified as follows:
- Try to reproduce the error as #6822;
- From the log you can see no callbacks called after `closeAsync()` and the program exited normally.