### PR TITLE
Update Jackson dependencies version to 2.10.1

### DIFF
--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -35,24 +35,23 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <jaskson.version>2.6.5</jaskson.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jaskson.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jaskson.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jaskson.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -31,13 +31,6 @@
     <artifactId>pulsar-sql</artifactId>
     <name>Pulsar SQL :: Parent</name>
 
-    <properties>
-        <jackson.version>2.8.11</jackson.version>
-        <!--fix Security Vulnerabilities-->
-        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.4</jackson.databind.version>
-    </properties>
-
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,17 +207,21 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.8.11.jar
-    - jackson-core-2.8.11.jar
-    - jackson-databind-2.8.11.4.jar
-    - jackson-dataformat-smile-2.8.11.jar
-    - jackson-datatype-guava-2.8.11.jar
-    - jackson-datatype-guava-2.8.11.jar
-    - jackson-datatype-jdk8-2.8.11.jar
-    - jackson-datatype-jdk8-2.8.11.jar
-    - jackson-datatype-joda-2.8.11.jar
-    - jackson-datatype-jsr310-2.8.11.jar
-    - jackson-dataformat-yaml-2.8.11.jar
+    - jackson-annotations-2.10.1.jar
+    - jackson-core-2.10.1.jar
+    - jackson-databind-2.10.1.jar
+    - jackson-dataformat-smile-2.10.1.jar
+    - jackson-datatype-guava-2.10.1.jar
+    - jackson-datatype-guava-2.10.1.jar
+    - jackson-datatype-jdk8-2.10.1.jar
+    - jackson-datatype-jdk8-2.10.1.jar
+    - jackson-datatype-joda-2.10.1.jar
+    - jackson-datatype-jsr310-2.10.1.jar
+    - jackson-dataformat-yaml-2.10.1.jar
+    - jackson-jaxrs-base-2.10.1.jar
+    - jackson-jaxrs-json-provider-2.10.1.jar
+    - jackson-module-jaxb-annotations-2.10.1.jar
+    - jackson-module-jsonSchema-2.10.1.jar
  * Guava
     - guava-25.1-jre.jar
  * Google Guice
@@ -383,7 +387,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-5.13.3.jar
   * SnakeYAML
-    - snakeyaml-1.17.jar
+    - snakeyaml-1.24.jar
   * Snappy Java
     - snappy-java-1.1.1.3.jar
   * Bean Validation API
@@ -428,11 +432,6 @@ The Apache Software License, Version 2.0
     - commons-logging-1.1.1.jar
   * GSON
     - gson-2.8.2.jar
-  * Jackson
-    - jackson-jaxrs-base-2.8.11.jar
-    - jackson-jaxrs-json-provider-2.8.11.jar
-    - jackson-module-jaxb-annotations-2.8.11.jar
-    - jackson-module-jsonSchema-2.8.11.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty
@@ -553,3 +552,7 @@ Creative Commons Attribution License
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
     - bouncy-castle-bc-shaded-2.6.0-SNAPSHOT.jar
+
+Eclipse Distribution License 1.0 -- licenses/LICENSE-EDL-1.0.txt
+ * Jakarta Activation -- jakarta.activation-jakarta.activation-api-1.2.1.jar
+ * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.2.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -23,9 +23,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache</groupId>
-        <artifactId>apache</artifactId>
-        <version>18</version>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-sql</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.pulsar</groupId>
@@ -42,10 +42,6 @@
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
-        <jackson.version>2.8.11</jackson.version>
-        <!--fix Security Vulnerabilities-->
-        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.4</jackson.databind.version>
         <com.ning.async.http.client.version>1.9.40</com.ning.async.http.client.version>
         <maven.version>3.0.5</maven.version>
         <guava.version>25.1-jre</guava.version>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -23,9 +23,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.pulsar</groupId>
-        <artifactId>pulsar-sql</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>18</version>
     </parent>
 
     <groupId>org.apache.pulsar</groupId>
@@ -42,6 +42,8 @@
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
+        <jackson.version>2.10.1</jackson.version>
+        <jackson.databind.version>2.10.1</jackson.databind.version>
         <com.ning.async.http.client.version>1.9.40</com.ning.async.http.client.version>
         <maven.version>3.0.5</maven.version>
         <guava.version>25.1-jre</guava.version>


### PR DESCRIPTION
# Motivation

Update Jackson dependencies version to 2.10.1 for some security reasons, the update details are as follows.

# Modify


1. org.apache.pulsar.examples:spark

```
# version 2.6.5 -> 2.10.1
com.fasterxml.jackson.core:jackson-core
com.fasterxml.jackson.core:jackson-databind
com.fasterxml.jackson.core:jackson-annotations
```

2. org.apache.pulsar:pulsar-sql

```
# version 2.8.11 -> 2.10.1
com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider
com.fasterxml.jackson.core:jackson-core
com.fasterxml.jackson.core:jackson-annotations
com.fasterxml.jackson.jaxrs:jackson-jaxrs-base
com.fasterxml.jackson.datatype:jackson-datatype-joda
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
com.fasterxml.jackson.module:jackson-module-jsonSchema
com.fasterxml.jackson.datatype:jackson-datatype-guava
com.fasterxml.jackson.datatype:jackson-datatype-jdk8
com.fasterxml.jackson.datatype:jackson-datatype-jsr310

# version 2.8.11.4 -> 2.10.1
com.fasterxml.jackson.core:jackson-databind
```

3. org.apache.pulsar:pulsar-presto-distribution

```
# version 2.8.11 -> 2.10.1
com.fasterxml.jackson.core:jackson-core
com.fasterxml.jackson.core:jackson-databind
com.fasterxml.jackson.core:jackson-annotations
com.fasterxml.jackson.datatype:jackson-datatype-joda
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
com.fasterxml.jackson.datatype:jackson-datatype-guava
com.fasterxml.jackson.datatype:jackson-datatype-jdk8
com.fasterxml.jackson.datatype:jackson-datatype-jsr310
com.fasterxml.jackson.dataformat:jackson-dataformat-smile

# version 2.8.11.4
com.fasterxml.jackson.core:jackson-databind
```