### PR TITLE
Support set password to managed ledger from brokerconfg

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -955,6 +955,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private DigestType managedLedgerDigestType = DigestType.CRC32C;
 
     @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "Default  password to use when writing to BookKeeper. \n\nDefault is ``."
+        )
+        private String managedLedgerPassword = "";
+
+    @FieldContext(
         minValue = 1,
         category = CATEGORY_STORAGE_ML,
         doc = "Max number of bookies to use when creating a ledger"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -958,7 +958,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_STORAGE_ML,
             doc = "Default  password to use when writing to BookKeeper. \n\nDefault is ``."
         )
-        private String managedLedgerPassword = "";
+    private String managedLedgerPassword = "";
 
     @FieldContext(
         minValue = 1,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -994,6 +994,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             }
             managedLedgerConfig.setThrottleMarkDelete(persistencePolicies.getManagedLedgerMaxMarkDeleteRate());
             managedLedgerConfig.setDigestType(serviceConfig.getManagedLedgerDigestType());
+            managedLedgerConfig.setPassword(serviceConfig.getManagedLedgerPassword());
 
             managedLedgerConfig.setMaxUnackedRangesToPersist(serviceConfig.getManagedLedgerMaxUnackedRangesToPersist());
             managedLedgerConfig.setMaxUnackedRangesToPersistInZk(serviceConfig.getManagedLedgerMaxUnackedRangesToPersistInZooKeeper());


### PR DESCRIPTION
Master Issue: #6843
## Motivation

broker supports ManagedLedger configuration

## Modifications

This change can be supported managedLedgerPassword configuration

org.apache.pulsar.broker.ServiceConfiguration
```java
    @FieldContext(
            category = CATEGORY_STORAGE_ML,
            doc = "Default  password to use when writing to BookKeeper. \n\nDefault is ``."
        )
    private String managedLedgerPassword = "";
```
org.apache.pulsar.broker.service.BrokerService
```java
  managedLedgerConfig.setPassword(serviceConfig.getManagedLedgerPassword());
```