### PR TITLE
[Dashboard]Fixed dashboard start failed

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -21,8 +21,11 @@ FROM python:3.7-stretch
 
 LABEL maintainer="Apache Pulsar <dev@pulsar.apache.org>"
 
+RUN bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main >> /etc/apt/sources.list.d/pgdg.list"
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
 RUN apt-get update
-RUN apt-get -y install postgresql python sudo nginx supervisor
+RUN apt-get -y install postgresql-11 postgresql-contrib libpq-dev python sudo nginx supervisor
 
 # Postgres configuration
 COPY conf/postgresql.conf /etc/postgresql/11/main/

--- a/dashboard/init-postgres.sh
+++ b/dashboard/init-postgres.sh
@@ -24,7 +24,7 @@ rm -rf /data/*
 chown -R postgres: /data
 chmod 700 /data
 sudo -u postgres /usr/lib/postgresql/11/bin/initdb /data/
-sudo -u postgres /etc/init.d/postgresql start
+sudo -u postgres /usr/lib/postgresql/11/bin/pg_ctl -D /data/ start
 sudo -u postgres psql --command "CREATE USER docker WITH PASSWORD 'docker';"
 sudo -u postgres createdb -O docker pulsar_dashboard
 


### PR DESCRIPTION


Master Issue: https://github.com/apache/pulsar/issues/5847

### Motivation

Installation error of dashboard database postgres 11 resulted in startup failure.

### Modifications

* Update apachepulsar/pulsar-dashboard:2.5.1 image https://hub.docker.com/layers/apachepulsar/pulsar-dashboard/2.5.1/images/sha256-61b47a7302639aba1357d09ca69a842c4a67bff38b230753d6bd638df0461c6b?context=explore
* Update Docker file for fix postgresql version 11.

### Verifying this change

Local test pass