### PR TITLE
limiting batch size to the minimum of the maxNumberOfMessages and maxSizeOfMessages

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -45,11 +45,15 @@ public class MessagesImpl<T> implements Messages<T> {
     }
 
     protected boolean canAdd(Message<T> message) {
-        if (maxNumberOfMessages <= 0 && maxSizeOfMessages <= 0) {
-            return true;
+        if (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 > maxNumberOfMessages) {
+            return false;
         }
-        return (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 <= maxNumberOfMessages)
-                && (maxSizeOfMessages > 0 && currentSizeOfMessages + message.getData().length <= maxSizeOfMessages);
+
+        if (maxSizeOfMessages > 0 && currentSizeOfMessages + message.getData().length > maxSizeOfMessages) {
+            return false;
+        }
+
+        return true;
     }
 
     protected void add(Message<T> message) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -49,7 +49,7 @@ public class MessagesImpl<T> implements Messages<T> {
             return true;
         }
         return (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 <= maxNumberOfMessages)
-                || (maxSizeOfMessages > 0 && currentSizeOfMessages + message.getData().length <= maxSizeOfMessages);
+                && (maxSizeOfMessages > 0 && currentSizeOfMessages + message.getData().length <= maxSizeOfMessages);
     }
 
     protected void add(Message<T> message) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -394,6 +394,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             } else {
                 pendingBatchReceives.add(OpBatchReceive.of(result));
             }
+            resumeReceivingFromPausedConsumersIfNeeded();
         } finally {
             lock.writeLock().unlock();
         }


### PR DESCRIPTION
Batch size is not limited to the minimum of the maxNumberOfMessages and maxSizeOfMessages from the BatchRecieve policy.

 1. Batch size is not limited to the minimum of the maxNumberOfMessages and maxSizeOfMessages from the BatchRecieve policy.
I think this issue can be easly fixed by changing the canAdd function in MessagesImpl from:
```
protected boolean canAdd(Message<T> message) {
    if (this.maxNumberOfMessages <= 0 && this.maxSizeOfMessages <= 0L) {
        return true;
    } else {
        return this.maxNumberOfMessages > 0 && this.currentNumberOfMessages + 1 <= this.maxNumberOfMessages || this.maxSizeOfMessages > 0L &&   this.currentSizeOfMessages + (long)message.getData().length <= this.maxSizeOfMessages;
    }
}
```
to (changing the condintion in the else to && instead of ||):
```
protected boolean canAdd(Message<T> message) {
    if (this.maxNumberOfMessages <= 0 && this.maxSizeOfMessages <= 0L) {
        return true;
    } else {
        return (this.maxNumberOfMessages > 0 && this.currentNumberOfMessages + 1 <= this.maxNumberOfMessages) && (this.maxSizeOfMessages > 0L &&   this.currentSizeOfMessages + (long)message.getData().length <= this.maxSizeOfMessages);
    }
}
```

2. When the batch size is higher than the recieveQ of the consumer (I used a batch size of 3000 and a receiveQ of 500) I noticed the following issues:
	a. In a mutliTopic (pattern) consumer the client stops receiving any messages I think it getting paused and never resumed when setting a timeout in the batch policy, only one batch is fetched and the client never resumed.

talked with @codelipenghui  and advised to open this pull request




