### PR TITLE
Fix typo in getting-started-helm.md 

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -304,7 +304,7 @@ Then proceed with the following steps:
 1. By default, the `Pulsar Manager` is exposed as a separate `LoadBalancer`. You can open the Pulsar Manager UI using the following command:
 
     ```bash
-    minikube service pulsar-mini-pulsar-mananger
+    minikube service pulsar-mini-pulsar-manager
     ```
 
 2. The pulsar manager UI will be open in your browser. You can use username `pulsar` and password `pulsar` to log into Pulsar Manager.


### PR DESCRIPTION
Fixes a minor typo in the documentation.