### PR TITLE
fix brokerPublisherThrottlingTickTimeMillis in broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -207,7 +207,7 @@ topicPublisherThrottlingTickTimeMillis=10
 # Tick time to schedule task that checks broker publish rate limiting across all topics
 # Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
-brokerPublisherThrPottlingTickTimeMillis=50
+brokerPublisherThrottlingTickTimeMillis=50
 
 # Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
 # (Disable message rate limit with value 0)

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -161,7 +161,7 @@ topicPublisherThrottlingTickTimeMillis=2
 # Tick time to schedule task that checks broker publish rate limiting across all topics
 # Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
-brokerPublisherThrPottlingTickTimeMillis=50
+brokerPublisherThrottlingTickTimeMillis=50
 
 # Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
 # (Disable message rate limit with value 0)


### PR DESCRIPTION
Master Issue: #6876
## Motivation

the brokerPublisherThrPottlingTickTimeMillis config spelling mistake

## Modifications

broker.conf
```java
  # Tick time to schedule task that checks broker publish rate limiting across all topics
# Reducing to lower value can give more accuracy while throttling publish but
# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
brokerPublisherThrottlingTickTimeMillis=50
```
