### PR TITLE
Provide an example on how to use runtimeCustomizerClassName in the functions_worker config

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -160,6 +160,10 @@ functionRuntimeFactoryConfigs:
 #   ram: 1073741824
 #   disk: 10737418240
 
+## The full class-name of an instance of RuntimeCustomizer.
+## This class receives the customRuntimeOptions string and can customize details of how the runtime operates.
+#runtimeCustomizerClassName: "org.apache.pulsar.functions.runtime.kubernetes.KubernetesManifestCustomizer"
+
 ## Config admin CLI
 #configAdminCLI:
 


### PR DESCRIPTION
### Motivation

There are many other examples (which are commented out) in the configuration files, so it makes sense to include an example config for runtimeCustomizerClassName.

### Modifications

Added example on how to use the runtimeCustomizerClassName parameter in functions_worker.yml. 
