### PR TITLE
[Broker] Handle all exceptions from `topic.addProducer`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1007,7 +1007,7 @@ public class ServerCnx extends PulsarHandler {
                                 ServerError error = null;
                                 if(!existingProducerFuture.isDone()) {
                                     error = ServerError.ServiceNotReady;
-                                }else {
+                                } else {
                                     error = getErrorCode(existingProducerFuture);
                                     // remove producer with producerId as it's already completed with exception
                                     producers.remove(producerId);
@@ -1091,7 +1091,7 @@ public class ServerCnx extends PulsarHandler {
                                         producerFuture.completeExceptionally(
                                             new IllegalStateException("Producer created after connection was closed"));
                                     }
-                                } catch (BrokerServiceException ise) {
+                                } catch (Exception ise) {
                                     log.error("[{}] Failed to add producer to topic {}: {}", remoteAddress, topicName,
                                         ise.getMessage());
                                     ctx.writeAndFlush(Commands.newError(requestId,


### PR DESCRIPTION
Fixes #6872
Fixes #6416

### Motivation

If a producer tries to create a producer to a topic that is currently
unloading, we can get a `RuntimeException` from
`BrokerService.checkTopicNsOwnership` which is bubbled up through
`topic.addProducer`. By only handling a `BrokerServiceException` this
results in a future that never completes and results in producers not
being able to be created if this topic is scheduled back to this broker.

### Modifications

Change to handling all exceptions

### Verifying this change

This could use a test, but I am currently not sure where would be the best place to test it. Existing tests should pass.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): n
  - The public API: n
  - The schema: n
  - The default values of configurations: n
  - The wire protocol: n
  - The rest endpoints: n
  - The admin cli options: n
  - Anything that affects deployment: n

### Documentation

  - Does this pull request introduce a new feature? n

