### PR TITLE
Suggest adjust bookkeekper.conf default FlushEntryLogBytes to 256MB to improve bookie io throughput

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -442,7 +442,7 @@ entryLogFilePreallocationEnabled=true
 # happens on log rotation.
 # Flushing in smaller chunks but more frequently reduces spikes in disk
 # I/O. Flushing too frequently may also affect performance negatively.
-# flushEntrylogBytes=0
+flushEntrylogBytes=268435456
 
 # The number of bytes we should use as capacity for BufferedReadChannel. Default is 512 bytes.
 readBufferSizeBytes=4096


### PR DESCRIPTION
### Motivation
When AddEntry to bookie, entries will be written to memtable first and then written to the journal log. If it blocked in memtable write, the total AddEntry operation will be blocked, and the 99th AddEntry latency will increase.

When memtable full or checkpoint scheduled by timer, memtable will be swapped with backup one. However, if the backup memtable has not been flushed to disk complete yet, the memtable swap will be blocked, and the `AddEntry` operation will be blocked. So in which situation the backup memtable will be blocked?

When pulsar doing `catch-up read`, large amount of data will be read from ledger disk, and ledger disk io util will increase. At the same time, backup memtable will flush data from PageCache to disk triggered by OS (default is 30s) or rolling file no matter for HDD or SSD. It is hard to control the flush frequency and batch size in each flush cycle. In most cases, the flush batch size of each flush cycle is from 500MB to 1GB, which will lead to the ledger disk io util to 100% from 1s to 10s+, especially when large amount of read from the ledger disk in the same time.

### Changes
In order to decrease ledger disk high io util duration, we can control the backup memtable flush batch size from pageCache to disk. In my practice, the flush batch set to 256MB may perform better for HDD disk.

So I suggest adjust the default configuration `FlushEntryLogBytes` to 256MB in bookkeeper.conf to increase bookie io throughput. 