### PR TITLE
[C++] Release the unused spots of pending message queue

### DIFF
--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -58,7 +58,9 @@ class BatchMessageContainer {
 
     ~BatchMessageContainer();
 
-    void add(const Message& msg, SendCallback sendCallback, bool disableCheck = false);
+    // Returns true if a batch of messages was sent to producer's pending message queue or `msg` was the first
+    // message of batch
+    bool add(const Message& msg, SendCallback sendCallback, bool disableCheck = false);
 
     SharedBuffer getBatchedPayload();
 
@@ -109,7 +111,8 @@ class BatchMessageContainer {
 
     void startTimer();
 
-    void sendMessage(FlushCallback callback);
+    // Returns true if a batch of messages was sent to producer's pending message queue
+    bool sendMessage(FlushCallback callback);
 };
 
 bool BatchMessageContainer::hasSpaceInBatch(const Message& msg) const {

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -58,10 +58,10 @@ class BatchMessageContainer {
 
     ~BatchMessageContainer();
 
-    // Returns true only if the first message arrived and wasn't sent immediately.
-    // If returns true, the outer ProducerImpl::sendAync won't release the spot which was reserved before. The
-    // spot will be released until the batch message was passed to ProducerImpl::sendMessage,
-    // then pendingMessagesQueue_.push will release the spot.
+    // It was only called in ProducerImpl::sendAsync, while the producer has reserved a spot of pending
+    // message queue before.
+    // It returns true to tell the producer not to release the spot because the spot would be released when
+    // the batched message was pushed to the queue successfully in ProducerImpl::sendMessage.
     bool add(const Message& msg, SendCallback sendCallback, bool disableCheck = false);
 
     SharedBuffer getBatchedPayload();

--- a/pulsar-client-cpp/lib/BatchMessageContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.h
@@ -58,8 +58,10 @@ class BatchMessageContainer {
 
     ~BatchMessageContainer();
 
-    // Returns true if a batch of messages was sent to producer's pending message queue or `msg` was the first
-    // message of batch
+    // Returns true only if the first message arrived and wasn't sent immediately.
+    // If returns true, the outer ProducerImpl::sendAync won't release the spot which was reserved before. The
+    // spot will be released until the batch message was passed to ProducerImpl::sendMessage,
+    // then pendingMessagesQueue_.push will release the spot.
     bool add(const Message& msg, SendCallback sendCallback, bool disableCheck = false);
 
     SharedBuffer getBatchedPayload();

--- a/pulsar-client-cpp/lib/BlockingQueue.h
+++ b/pulsar-client-cpp/lib/BlockingQueue.h
@@ -262,6 +262,8 @@ class BlockingQueue {
 
     iterator end() { return queue_.end(); }
 
+    int reservedSpots() const { return reservedSpots_; }
+
    private:
     void releaseReservedSpot() {
         Lock lock(mutex_);

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -425,7 +425,9 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
 
     if (batchMessageContainer && !msg.impl_->metadata.has_deliver_at_time()) {
         // Batching is enabled and the message is not delayed
-        batchMessageContainer->add(msg, cb);
+        if (!batchMessageContainer->add(msg, cb)) {
+            pendingMessagesQueue_.release(1);
+        }
         return;
     }
     sendMessage(msg, cb);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -620,6 +620,10 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     result = producer.send(msg);
     ASSERT_EQ(ResultOk, result);
 
+    for (const auto &q : PulsarFriend::getProducerMessageQueue(producer, NonPartitioned)) {
+        ASSERT_EQ(0, q->reservedSpots());
+    }
+
     delete[] content;
 }
 

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -919,6 +919,10 @@ TEST(BatchMessageTest, testPartitionedTopics) {
 
     // Number of messages consumed
     ASSERT_EQ(i, numOfMessages - globalPublishCountQueueFull);
+
+    for (const auto& q : PulsarFriend::getProducerMessageQueue(producer, Partitioned)) {
+        ASSERT_EQ(0, q->reservedSpots());
+    }
 }
 
 TEST(BatchMessageTest, producerFailureResult) {
@@ -1027,6 +1031,10 @@ TEST(BatchMessageTest, testSendCallback) {
 
     latch.wait();
     ASSERT_EQ(sentIdSet, receivedIdSet);
+
+    for (const auto& q : PulsarFriend::getProducerMessageQueue(producer, NonPartitioned)) {
+        ASSERT_EQ(0, q->reservedSpots());
+    }
 
     consumer.close();
     producer.close();

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -993,10 +993,10 @@ TEST(BatchMessageTest, testSendCallback) {
     constexpr int numMessagesOfBatch = 3;
 
     ProducerConfiguration producerConfig;
-    producerConfig.setBatchingEnabled(5);
+    producerConfig.setBatchingEnabled(true);
     producerConfig.setBatchingMaxMessages(numMessagesOfBatch);
     producerConfig.setBatchingMaxPublishDelayMs(1000);  // 1 s, it's long enough for 3 messages batched
-    producerConfig.setMaxPendingMessages(numMessagesOfBatch);
+    producerConfig.setMaxPendingMessages(2);            // only 1 spot is actually used
 
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConfig, producer));
@@ -1022,6 +1022,7 @@ TEST(BatchMessageTest, testSendCallback) {
         Message msg;
         ASSERT_EQ(ResultOk, consumer.receive(msg));
         receivedIdSet.emplace(msg.getMessageId());
+        consumer.acknowledge(msg);
     }
 
     latch.wait();

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -18,6 +18,7 @@
  */
 
 #include <lib/ProducerImpl.h>
+#include <lib/PartitionedProducerImpl.h>
 #include <lib/ConsumerImpl.h>
 #include <string>
 
@@ -35,6 +36,21 @@ class PulsarFriend {
     static ProducerStatsImplPtr getProducerStatsPtr(Producer producer) {
         ProducerImpl* producerImpl = static_cast<ProducerImpl*>(producer.impl_.get());
         return std::static_pointer_cast<ProducerStatsImpl>(producerImpl->producerStatsBasePtr_);
+    }
+
+    static std::vector<ProducerImpl::MessageQueue*> getProducerMessageQueue(Producer producer,
+                                                                            ConsumerTopicType type) {
+        ProducerImplBasePtr producerBaseImpl = producer.impl_;
+        if (type == Partitioned) {
+            std::vector<ProducerImpl::MessageQueue*> queues;
+            for (const auto& producer :
+                 std::static_pointer_cast<PartitionedProducerImpl>(producerBaseImpl)->producers_) {
+                queues.emplace_back(&producer->pendingMessagesQueue_);
+            }
+            return queues;
+        } else {
+            return {&std::static_pointer_cast<ProducerImpl>(producerBaseImpl)->pendingMessagesQueue_};
+        }
     }
 
     template <typename T>


### PR DESCRIPTION
### Motivation

If messages were sent in batch, every single message would reserve one spot of producer's pending message queue, but only one batched message would be pushed to the queue. Therefore there may exist many unused spots when `ProducerQueueIsFull` happened.

Besides, if a message was too big or failed to be encrypted, `sendAsync` failed immediately but the reserved spot won't be released.

### Modifications

- Add a `bool` return value to `BatchMessageContainer::sendMessages` to indicate whether the batched message was pushed to producer's queue.
- Add a `bool` return value to `BatchMessageContainer::add` to indicate whether the reserved spot should be released. The spot would be retained only if the first message was batched and not sent immediately. The spot would be released when the batched message was pushed to the queue.
- Test sending a batch with a 2-spots pending message queue, one spot for storing the batched message, another spot for preventing `ProducerQueueIsFull` error.
- Test after all batched messages being sent, whether the reserved spots of producer's queue were  0.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `BatchMessageTest.testSendCallback`, `BatchMessageTest.testPartitionedTopics` and `BasicEndToEndTest.testMessageTooBig`.