### PR TITLE
Issue-6931 LocalRunner

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -115,5 +115,5 @@ public class FunctionConfig {
     private String customRuntimeOptions;
     // Max pending async requests per instance to avoid large number of concurrent requests.
     // Only used in AsyncFunction. Default: 1000.
-    private Integer maxPendingAsyncRequests = 1000;
+    private Integer maxPendingAsyncRequests;
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -86,7 +86,7 @@ public class FunctionConfig {
     private String logTopic;
     private ProcessingGuarantees processingGuarantees;
     private Boolean retainOrdering;
-    private Boolean forwardSourceMessageProperty = true;
+    private Boolean forwardSourceMessageProperty;
     private Map<String, Object> userConfig;
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -367,6 +367,10 @@ public class FunctionConfigUtils {
         if (functionConfig.getParallelism() == null) {
             functionConfig.setParallelism(1);
         }
+        
+        if (functionConfig.getMaxPendingAsyncRequests() == null) {
+        	functionConfig.setMaxPendingAsyncRequests(Integer.valueOf(1000));
+        }
 
         if (functionConfig.getJar() != null) {
             functionConfig.setRuntime(FunctionConfig.Runtime.JAVA);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -48,6 +48,10 @@ import static org.apache.pulsar.functions.utils.FunctionCommon.loadJar;
 
 @Slf4j
 public class FunctionConfigUtils {
+	
+	static final Integer MAX_PENDING_ASYNC_REQUESTS_DEFAULT = Integer.valueOf(1000);
+	static final Boolean FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT = Boolean.TRUE;
+	
     public static FunctionDetails convert(FunctionConfig functionConfig, ClassLoader classLoader)
             throws IllegalArgumentException {
 
@@ -369,7 +373,11 @@ public class FunctionConfigUtils {
         }
         
         if (functionConfig.getMaxPendingAsyncRequests() == null) {
-        	functionConfig.setMaxPendingAsyncRequests(Integer.valueOf(1000));
+        	functionConfig.setMaxPendingAsyncRequests(MAX_PENDING_ASYNC_REQUESTS_DEFAULT);
+        }
+        
+        if (functionConfig.getForwardSourceMessageProperty() == null) {
+        	functionConfig.setForwardSourceMessageProperty(FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT);
         }
 
         if (functionConfig.getJar() != null) {


### PR DESCRIPTION
**Describe the bug**
The LocalRunner class does not start a local thread runner instance for Java functions.

**To Reproduce**
Steps to reproduce the behavior:
1. Create an instance of the LocalRunner class inside a Java class
2. Initialize it like so:
 
`FunctionConfig functionConfig = 
	   FunctionConfig.builder()
	    	.className(WordCountFunction.class.getName())
	    	.maxPendingAsyncRequests(Integer.valueOf(500))
	    	.name("word-counter")
	    	.runtime(FunctionConfig.Runtime.JAVA)
	    	.build()`

	  LocalRunner localRunner = 
	    	LocalRunner.builder()
	    		.brokerServiceUrl(BROKER_URL)
	    		.functionConfig(functionConfig)
	    		.build();`
3. Attach to the process with a debugger and set a breakpoint at line 360 of the LocalRunner class and attempt to step through to line 361
4. See a "silent" NullPointerException is thrown in the following call; 
`instanceConfig.setMaxPendingAsyncRequests(functionConfig.getMaxPendingAsyncRequests());`  This is because the call to `getMaxPendingAsyncRequests()` returns null, even though I set it to a value in the FunctionConfig

**Expected behavior**
One would expect the value I passed in to be set and for the LocalRunner to start the function inside a local thread

**Screenshots**
If applicable, add screenshots to help explain your problem.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS]

**Additional context**
I have the code fix and will attach it to this ticket. Basically the issue is that there is a default value for that field inside the FunctionConfig class that is set as a direct assignment. However, since the class is Lombok annotated, that assignment gets ignored AND prevents assignments from occurring inside the builder as well.

I have removed that assignment, and added an equivalent logic block to the `FunctionConfigUtils.inferMissingArguments` method to set a default value of 1000 if none is provided.
