### PR TITLE
[pulsar-proxy] add advertised address option for proxy

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -46,6 +46,10 @@ zooKeeperCacheExpirySeconds=300
 
 ### --- Server --- ###
 
+# Hostname or IP address the service advertises to the outside world.
+# If not set, the value of `InetAddress.getLocalHost().getHostname()` is used.
+advertisedAddress=
+
 # The port to use for server binary Protobuf requests
 servicePort=6650
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -133,6 +133,12 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
+        doc = "Hostname or IP address the service advertises to the outside world."
+            + " If not set, the value of `InetAddress.getLocalHost().getHostname()` is used."
+    )
+    private String advertisedAddress;
+    @FieldContext(
+        category = CATEGORY_SERVER,
         doc = "The port for serving binary protobuf request"
     )
     private Optional<Integer> servicePort = Optional.ofNullable(6650);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -37,17 +37,16 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
@@ -189,7 +188,8 @@ public class ProxyService implements Closeable {
 
         String hostname;
         try {
-            hostname = InetAddress.getLocalHost().getHostName();
+            hostname = StringUtils.isNotBlank(proxyConfig.getAdvertisedAddress()) ? proxyConfig.getAdvertisedAddress()
+                    : InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Motivation
We are running pulsar-proxy on env where we want to advertise different address that hostname. So, adding advertisedAddress into pulsar-proxy config.