### PR TITLE
[Issue 6761] Correct tokenSecretKey base64 inline description

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -506,14 +506,14 @@ anonymousUserRole=
 ## Symmetric key
 # Configure the secret key to be used to validate auth tokens
 # The key can be specified like:
-# tokenSecretKey=data:base64,xxxxxxxxx
+# tokenSecretKey=data:;base64,xxxxxxxxx
 # tokenSecretKey=file:///my/secret.key
 tokenSecretKey=
 
 ## Asymmetric public/private key pair
 # Configure the public key to be used to validate auth tokens
 # The key can be specified like:
-# tokenPublicKey=data:base64,xxxxxxxxx
+# tokenPublicKey=data:;base64,xxxxxxxxx
 # tokenPublicKey=file:///my/public.key
 tokenPublicKey=
 

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -178,14 +178,14 @@ httpNumThreads=
 ## Symmetric key
 # Configure the secret key to be used to validate auth tokens
 # The key can be specified like:
-# tokenSecretKey=data:base64,xxxxxxxxx
+# tokenSecretKey=data:;base64,xxxxxxxxx
 # tokenSecretKey=file:///my/secret.key
 tokenSecretKey=
 
 ## Asymmetric public/private key pair
 # Configure the public key to be used to validate auth tokens
 # The key can be specified like:
-# tokenPublicKey=data:base64,xxxxxxxxx
+# tokenPublicKey=data:;base64,xxxxxxxxx
 # tokenPublicKey=file:///my/public.key
 tokenPublicKey=
 

--- a/deployment/kubernetes/helm/pulsar/values.yaml
+++ b/deployment/kubernetes/helm/pulsar/values.yaml
@@ -889,7 +889,7 @@ pulsar_manager:
     LOG_LEVEL: DEBUG
     ## If you enabled authentication support
     ## JWT_TOKEN: <token>
-    ## SECRET_KEY: data:base64,<secret key>
+    ## SECRET_KEY: data:;base64,<secret key>
   ## Pulsar manager service
   ## templates/pulsar-manager-service.yaml
   ##

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -468,7 +468,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
                     doc = "Asymmetric public/private key pair.\n\n"
                         + "Configure the public key to be used to validate auth tokens"
                         + " The key can be specified like:\n\n"
-                        + "tokenPublicKey=data:base64,xxxxxxxxx\n"
+                        + "tokenPublicKey=data:;base64,xxxxxxxxx\n"
                         + "tokenPublicKey=file:///my/public.key")
             ),
             @PropertyContext(
@@ -478,7 +478,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
                     doc = "Symmetric key.\n\n"
                         + "Configure the secret key to be used to validate auth tokens"
                         + "The key can be specified like:\n\n"
-                        + "tokenSecretKey=data:base64,xxxxxxxxx\n"
+                        + "tokenSecretKey=data:;base64,xxxxxxxxx\n"
                         + "tokenSecretKey=file:///my/secret.key")
             )
         }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -164,8 +164,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerClientTlsCiphers| Specify the tls cipher the internal client will use to negotiate during TLS Handshake. (a comma-separated list of ciphers) e.g.  [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]||
 |brokerClientTlsProtocols|Specify the tls protocols the broker will use to negotiate during TLS handshake. (a comma-separated list of protocol names). e.g.  [TLSv1.2, TLSv1.1, TLSv1] ||
 |ttlDurationDefaultInSeconds|  The default ttl for namespaces if ttl is not configured at namespace policies.  |0|
-|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
-|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:;base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
+|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:;base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |tokenPublicAlg| Configure the algorithm to be used to validate auth tokens. This can be any of the asymettric algorithms supported by Java JWT (https://github.com/jwtk/jjwt#signature-algorithms-keys) |RS256|
 |tokenAuthClaim| Specify which of the token's claims will be used as the authentication "principal" or "role". The default "sub" claim will be used if this is left blank ||
 |tokenAudienceClaim| The token audience "claim" name, e.g. "aud", that will be used to get the audience from token. If not set, audience will not be verified. ||
@@ -499,8 +499,8 @@ The [Pulsar proxy](concepts-architecture-overview.md#pulsar-proxy) can be config
 |tlsRequireTrustedClientCertOnConnect|  Whether client certificates are required for TLS. Connections are rejected if the client certificate isn’t trusted. |false|
 |tlsProtocols|Specify the tls protocols the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLSv1.2```, ```TLSv1.1```, ```TLSv1``` ||
 |tlsCiphers|Specify the tls cipher the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256```||
-|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
-|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:;base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
+|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:;base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |tokenPublicAlg| Configure the algorithm to be used to validate auth tokens. This can be any of the asymettric algorithms supported by Java JWT (https://github.com/jwtk/jjwt#signature-algorithms-keys) |RS256|
 |tokenAuthClaim| Specify the token claim that will be used as the authentication "principal" or "role". The "subject" field will be used if this is left blank ||
 

--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -213,7 +213,7 @@ authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationPr
 # If using secret key
 tokenSecretKey=file:///path/to/secret.key
 # The key can also be passed inline:
-# tokenSecretKey=data:base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
+# tokenSecretKey=data:;base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key

--- a/site2/docs/security-token-admin.md
+++ b/site2/docs/security-token-admin.md
@@ -130,7 +130,7 @@ authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationPr
 # If using secret key
 tokenSecretKey=file:///path/to/secret.key
 # The key can also be passed inline:
-# tokenSecretKey=data:base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
+# tokenSecretKey=data:;base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key

--- a/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
@@ -152,8 +152,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |tlsProtocols|Specify the tls protocols the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLSv1.2```, ```TLSv1.1```, ```TLSv1``` ||
 |tlsCiphers|Specify the tls cipher the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256```||
 |ttlDurationDefaultInSeconds|  The default ttl for namespaces if ttl is not configured at namespace policies.  |0|
-|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
-|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:;base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
+|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:;base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |tokenPublicAlg| Configure the algorithm to be used to validate auth tokens. This can be any of the asymettric algorithms supported by Java JWT (https://github.com/jwtk/jjwt#signature-algorithms-keys) |RS256|
 |tokenAuthClaim| Specify which of the token's claims will be used as the authentication "principal" or "role". The default "sub" claim will be used if this is left blank ||
 |tokenAudienceClaim| The token audience "claim" name, e.g. "aud", that will be used to get the audience from token. If not set, audience will not be verified. ||
@@ -483,8 +483,8 @@ The [Pulsar proxy](concepts-architecture-overview.md#pulsar-proxy) can be config
 |tlsRequireTrustedClientCertOnConnect|  Whether client certificates are required for TLS. Connections are rejected if the client certificate isn’t trusted. |false|
 |tlsProtocols|Specify the tls protocols the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLSv1.2```, ```TLSv1.1```, ```TLSv1``` ||
 |tlsCiphers|Specify the tls cipher the broker will use to negotiate during TLS Handshake. Multiple values can be specified, separated by commas. Example:- ```TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256```||
-|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
-|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
+|tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:;base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`||
+|tokenPublicKey| Configure the public key to be used to validate auth tokens. The key can be specified like: `tokenPublicKey=data:;base64,xxxxxxxxx` or `tokenPublicKey=file:///my/secret.key`||
 |tokenPublicAlg| Configure the algorithm to be used to validate auth tokens. This can be any of the asymettric algorithms supported by Java JWT (https://github.com/jwtk/jjwt#signature-algorithms-keys) |RS256|
 |tokenAuthClaim| Specify the token claim that will be used as the authentication "principal" or "role". The "subject" field will be used if this is left blank ||
 

--- a/site2/website/versioned_docs/version-2.5.1/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-jwt.md
@@ -214,7 +214,7 @@ authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationPr
 # If using secret key
 tokenSecretKey=file:///path/to/secret.key
 # The key can also be passed inline:
-# tokenSecretKey=data:base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
+# tokenSecretKey=data:;base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
 
 # If using public/private
 # tokenPublicKey=file:///path/to/public.key

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/TokenAuthWithSymmetricKeys.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/TokenAuthWithSymmetricKeys.java
@@ -42,21 +42,21 @@ public class TokenAuthWithSymmetricKeys extends PulsarTokenAuthenticationBaseSui
 
         clientAuthToken = container
                 .execCmd(PulsarCluster.PULSAR_COMMAND_SCRIPT, "tokens", "create",
-                        "--secret-key", "data:base64," + secretKey,
+                        "--secret-key", "data:;base64," + secretKey,
                         "--subject", REGULAR_USER_ROLE)
                 .getStdout().trim();
         log.info("Created client token: {}", clientAuthToken);
 
         superUserAuthToken = container
                 .execCmd(PulsarCluster.PULSAR_COMMAND_SCRIPT, "tokens", "create",
-                        "--secret-key", "data:base64," + secretKey,
+                        "--secret-key", "data:;base64," + secretKey,
                         "--subject", SUPER_USER_ROLE)
                 .getStdout().trim();
         log.info("Created super-user token: {}", superUserAuthToken);
 
         proxyAuthToken = container
                 .execCmd(PulsarCluster.PULSAR_COMMAND_SCRIPT, "tokens", "create",
-                        "--secret-key", "data:base64," + secretKey,
+                        "--secret-key", "data:;base64," + secretKey,
                         "--subject", PROXY_ROLE)
                 .getStdout().trim();
         log.info("Created proxy token: {}", proxyAuthToken);
@@ -64,19 +64,19 @@ public class TokenAuthWithSymmetricKeys extends PulsarTokenAuthenticationBaseSui
 
     @Override
     protected void configureBroker(BrokerContainer brokerContainer) throws Exception {
-        brokerContainer.withEnv("tokenSecretKey", "data:base64," + secretKey);
+        brokerContainer.withEnv("tokenSecretKey", "data:;base64," + secretKey);
     }
 
     @Override
     protected void configureProxy(ProxyContainer proxyContainer) throws Exception {
-        proxyContainer.withEnv("tokenSecretKey", "data:base64," + secretKey);
+        proxyContainer.withEnv("tokenSecretKey", "data:;base64," + secretKey);
     }
 
     @Override
     protected String createClientTokenWithExpiry(long expiryTime, TimeUnit unit) throws Exception {
         return cmdContainer
                 .execCmd(PulsarCluster.PULSAR_COMMAND_SCRIPT, "tokens", "create",
-                        "--secret-key", "data:base64," + secretKey,
+                        "--secret-key", "data:;base64," + secretKey,
                         "--subject", REGULAR_USER_ROLE,
                         "--expiry-time", unit.toSeconds(expiryTime) + "s")
                 .getStdout().trim();


### PR DESCRIPTION
### Motivation

Fixes #6761

### Modifications

Correct tokenSecretKey base64 inline description in documents (based master & version 2.5.1) and examples.