### PR TITLE
Introduce messages fence mechanism for Key_Shared subscription

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -143,6 +143,11 @@ subscriptionExpiryCheckIntervalInMinutes=5
 # Enable Key_Shared subscription (default is enabled)
 subscriptionKeySharedEnable=true
 
+# Max fenced messages for Key_Shared subscription. In Key_Shared subscription
+# the broker will dispatch messages to the new consumer until all previous messages are acknowledged.
+# Otherwise, the messages will be fenced. After the previous messages acknowledged, the fenced messages will be lifted.
+maxFencedMessagesForKeySharedSubscription=10000
+
 # Set the default behavior for message deduplication in the broker
 # This can be overridden per-namespace. If enabled, broker will reject
 # messages that were already stored in the topic

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -337,6 +337,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean subscriptionKeySharedEnable = true;
 
     @FieldContext(
+            category = CATEGORY_POLICIES,
+            doc = "Max fenced messages for Key_Shared subscription. In Key_Shared subscription,\n"
+                + "the broker will dispatch messages to the new consumer until all previous messages are acknowledged. \n"
+                + "Otherwise, the messages will be fenced. After the previous messages acknowledged, the fenced messages will be lifted."
+    )
+    private int maxFencedMessagesForKeySharedSubscription = 10000;
+
+    @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Set the default behavior for message deduplication in the broker.\n\n"
             + "This can be overridden per-namespace. If enabled, broker will reject"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -111,6 +111,7 @@ public class Consumer {
     private final Map<String, String> metadata;
 
     private final PulsarApi.KeySharedMeta keySharedMeta;
+    private PositionImpl fencePositionForKeyShared;
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
@@ -651,6 +652,14 @@ public class Consumer {
     private void clearUnAckedMsgs() {
         int unaAckedMsgs = UNACKED_MESSAGES_UPDATER.getAndSet(this, 0);
         subscription.addUnAckedMessages(-unaAckedMsgs);
+    }
+
+    public PositionImpl getFencePositionForKeyShared() {
+        return fencePositionForKeyShared;
+    }
+
+    public void setFencePositionForKeyShared(PositionImpl fencePositionForKeyShared) {
+        this.fencePositionForKeyShared = fencePositionForKeyShared;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Consumer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -106,4 +106,8 @@ public interface Dispatcher {
     default void cursorIsReset() {
         //No-op
     }
+
+    default void onMarkDeletePositionChanged(PositionImpl markDeletePosition) {
+        //No-op
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -24,19 +24,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.EntryBatchSizes;
+import org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
+import org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,14 +50,38 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     private final StickyKeyConsumerSelector selector;
 
+    // The fenced message means that the messages can't be delivered at this time. In Key_Shared subscription,
+    // the new consumer need to wait all messages before the first message that deliver to this consumer are acknowledged.
+    // The `fencedMessagesContainer` maintains all fenced messages by a map (mark-delete-position -> fenced messages).
+    // When the mark delete position of the cursor is greater than the mark-delete-position in the `fencedMessagesContainer`,
+    // it means the fenced messages will be lifted.
+    private final ConcurrentSkipListMap<PositionImpl, ConcurrentSortedLongPairSet> fencedMessagesContainer;
+
+    // Max fenced messages of the dispatcher. If the current fenced messages exceeds
+    // the max fenced messages, the dispatcher never add more fenced messages to the `fencedMessagesContainer`.
+    // The dispatcher will replay the new messages until the `fencedMessagesContainer` have place to add the new fenced messages.
+    private final int maxFencedMessages;
+
     PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
-           Subscription subscription, StickyKeyConsumerSelector selector) {
+           Subscription subscription, StickyKeyConsumerSelector selector, int maxFencedMessages) {
         super(topic, cursor, subscription);
         this.selector = selector;
+        fencedMessagesContainer = new ConcurrentSkipListMap<>();
+        this.maxFencedMessages = maxFencedMessages;
     }
 
     @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
+        // Set the fence position for the consumer. Only the positions of the entry are lower that the fence position
+        // or current mark delete position of the cursor is greater than the fence position of the consumer,
+        // the entries can be deliver to this consumer.
+        if (selector instanceof HashRangeAutoSplitStickyKeyConsumerSelector) {
+            if (consumerList.isEmpty()) {
+                consumer.setFencePositionForKeyShared(PositionImpl.latest);
+            } else {
+                consumer.setFencePositionForKeyShared((PositionImpl) cursor.getReadPosition());
+            }
+        }
         super.addConsumer(consumer);
         selector.addConsumer(consumer);
     }
@@ -71,6 +101,29 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             readMoreEntries();
             return;
         }
+
+        PositionImpl mdPosition = (PositionImpl) cursor.getMarkDeletedPosition();
+        if (checkAndLiftMessages(mdPosition)) {
+            if (ReadType.Replay == readType) {
+                entries.forEach(entry -> {
+                    messagesToRedeliver.add(entry.getLedgerId(), entry.getEntryId());
+                    entry.release();
+                });
+            } else {
+                cursor.seek(entries.get(0).getPosition());
+                entries.forEach(Entry::release);
+            }
+            readMoreEntries();
+            return;
+        }
+
+        // If the fenced messages are exceeds max fenced messages, stop reads more entries and reset the read position.
+        if (getFencedMessages() >= maxFencedMessages && ReadType.Replay != readType) {
+            cursor.seek(entries.get(0).getPosition());
+            entries.forEach(Entry::release);
+            return;
+        }
+
         final Map<Integer, List<Entry>> groupedEntries = new HashMap<>();
         for (Entry entry : entries) {
             int key = Murmur3_32Hash.getInstance().makeHash(peekStickyKey(entry.getDataBuffer())) % selector.getRangeSize();
@@ -79,6 +132,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         }
         final Iterator<Map.Entry<Integer, List<Entry>>> iterator = groupedEntries.entrySet().iterator();
         AtomicInteger keyNumbers = new AtomicInteger(groupedEntries.size());
+        CompletableFuture<Void> readMoreFuture = new CompletableFuture<>();
         while (iterator.hasNext() && totalAvailablePermits > 0 && isAtleastOneConsumerAvailable()) {
             final Map.Entry<Integer, List<Entry>> entriesWithSameKey = iterator.next();
             //TODO: None key policy
@@ -88,7 +142,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 log.info("[{}] rewind because no available consumer found for key {} from total {}", name,
                         entriesWithSameKey.getKey(), consumerList.size());
                 entriesWithSameKey.getValue().forEach(Entry::release);
-                cursor.rewind();
+                cursor.seek(entries.get(0).getPosition());
+                readMoreEntries();
                 return;
             }
 
@@ -108,6 +163,31 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 if (readType == ReadType.Replay) {
                     subList.forEach(entry -> messagesToRedeliver.remove(entry.getLedgerId(), entry.getEntryId()));
                 }
+                if (selector instanceof HashRangeAutoSplitStickyKeyConsumerSelector) {
+                    PositionImpl startPosition = (PositionImpl) subList.get(0).getPosition();
+
+                    // To fence messages if current mark delete position of the cursor is lower than fence position of the consumer.
+                    if (mdPosition.getNext().compareTo(consumer.getFencePositionForKeyShared()) < 0) {
+                        if (startPosition.compareTo(consumer.getFencePositionForKeyShared()) >= 0) {
+                            fencedMessagesContainer.putIfAbsent(consumer.getFencePositionForKeyShared(), new ConcurrentSortedLongPairSet(128, 2));
+                            subList.forEach(entry -> fencedMessagesContainer.get(consumer.getFencePositionForKeyShared()).add(entry.getLedgerId(), entry.getEntryId()));
+                            entriesWithSameKey.getValue().removeAll(subList);
+                            if (entriesWithSameKey.getValue().size() == 0) {
+                                iterator.remove();
+                            }
+                            if (keyNumbers.decrementAndGet() == 0) {
+                                readMoreFuture.complete(null);
+                            }
+                            continue;
+                        } else {
+                            // Only deliver the entries that the position of the entries are lower that fence position of the consumer
+                            // This is usually caused by the message redelivery(consumer disconnect from the broker).
+                            subList = subList.stream().filter(entry ->
+                                    ((PositionImpl) entry.getPosition()).compareTo(consumer.getFencePositionForKeyShared()) <= 0)
+                                    .collect(Collectors.toList());
+                        }
+                    }
+                }
 
                 SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
                 EntryBatchSizes batchSizes = EntryBatchSizes.get(subList.size());
@@ -115,9 +195,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
                 consumer.sendMessages(subList, batchSizes, sendMessageInfo.getTotalMessages(),
                         sendMessageInfo.getTotalBytes(), getRedeliveryTracker()).addListener(future -> {
-                            if (future.isSuccess() && keyNumbers.decrementAndGet() == 0) {
-                                readMoreEntries();
-                            }
+                    if (keyNumbers.decrementAndGet() == 0) {
+                        readMoreFuture.complete(null);
+                    }
                 });
 
                 for (int i = 0; i < messagesForC; i++) {
@@ -159,6 +239,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                         laterReplay);
             }
         }
+
+        readMoreFuture.thenAccept(v -> readMoreEntries());
     }
 
     @Override
@@ -173,4 +255,43 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);
 
+    @Override
+    public void onMarkDeletePositionChanged(PositionImpl markDeletePosition) {
+        boolean hasLifted = checkAndLiftMessages(markDeletePosition);
+        if (hasLifted) {
+            readMoreEntries();
+        }
+    }
+
+    private boolean checkAndLiftMessages(PositionImpl markDeletePosition) {
+        boolean hasLifted = false;
+        if (selector instanceof HashRangeAutoSplitStickyKeyConsumerSelector) {
+            // If the mark delete position of the fenced messages is lower than current mark delete position of the cursor.
+            // the fenced messages should be lifted. To lift fenced messages, it's simpler to move the fenced messages to
+            // messagesToRedeliver and reset the read position. When new read entries triggered, the fenced messages will be
+            // deliver to consumers.
+            if (!fencedMessagesContainer.isEmpty()) {
+                Iterator<Map.Entry<PositionImpl, ConcurrentSortedLongPairSet>> iterator = fencedMessagesContainer.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<PositionImpl, ConcurrentSortedLongPairSet> entry = iterator.next();
+                    if (markDeletePosition.getNext().compareTo(entry.getKey()) >= 0) {
+                        entry.getValue().forEach((ledgerId, entryId) -> messagesToRedeliver.add(ledgerId, entryId));
+                        iterator.remove();
+                        hasLifted = true;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        return hasLifted;
+    }
+
+    private int getFencedMessages() {
+        int size = 0;
+        for (ConcurrentSortedLongPairSet value : fencedMessagesContainer.values()) {
+            size += value.size();
+        }
+        return size;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -167,7 +167,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     PositionImpl startPosition = (PositionImpl) subList.get(0).getPosition();
 
                     // To fence messages if current mark delete position of the cursor is lower than fence position of the consumer.
-                    if (mdPosition.getNext().compareTo(consumer.getFencePositionForKeyShared()) < 0) {
+                    if (consumer.getFencePositionForKeyShared() != null && mdPosition.getNext().compareTo(consumer.getFencePositionForKeyShared()) < 0) {
                         if (startPosition.compareTo(consumer.getFencePositionForKeyShared()) >= 0) {
                             fencedMessagesContainer.putIfAbsent(consumer.getFencePositionForKeyShared(), new ConcurrentSortedLongPairSet(128, 2));
                             subList.forEach(entry -> fencedMessagesContainer.get(consumer.getFencePositionForKeyShared()).add(entry.getLedgerId(), entry.getEntryId()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -116,7 +116,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
         ).thenReturn(false);
 
         persistentDispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(
-                topicMock, cursorMock, subscriptionMock, new HashRangeAutoSplitStickyKeyConsumerSelector());
+                topicMock, cursorMock, subscriptionMock, new HashRangeAutoSplitStickyKeyConsumerSelector(), 1000);
         persistentDispatcher.addConsumer(consumerMock);
         persistentDispatcher.consumerFlow(consumerMock, 1000);
     }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -144,6 +144,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |statusFilePath|  Path for the file used to determine the rotation status for the broker when responding to service discovery health checks ||
 |preferLaterVersions| If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to use only brokers running the latest software version (to minimize impact to bundles)  |false|
 |maxNumPartitionsPerPartitionedTopic|Max number of partitions per partitioned topic. Use 0 or negative number to disable the check|0|
+|subscriptionKeySharedEnable| Enable Key_Shared subscription |true|
+|maxFencedMessagesForKeySharedSubscription| Max fenced messages for Key_Shared subscription. Messages for the new consumer will be fenced until the previous messages are acknowledged |10000|
 |tlsEnabled|  Enable TLS  |false|
 |tlsCertificateFilePath|  Path for the TLS certificate file ||
 |tlsKeyFilePath|  Path for the TLS private key file ||

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -144,8 +144,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |statusFilePath|  Path for the file used to determine the rotation status for the broker when responding to service discovery health checks ||
 |preferLaterVersions| If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to use only brokers running the latest software version (to minimize impact to bundles)  |false|
 |maxNumPartitionsPerPartitionedTopic|Max number of partitions per partitioned topic. Use 0 or negative number to disable the check|0|
-|subscriptionKeySharedEnable| Enable Key_Shared subscription |true|
-|maxFencedMessagesForKeySharedSubscription| Max fenced messages for Key_Shared subscription. Messages for the new consumer will be fenced until the previous messages are acknowledged |10000|
+|subscriptionKeySharedEnable| Enable Key_Shared subscription. |true|
+|maxFencedMessagesForKeySharedSubscription| Set the maximum number of fenced messages for Key_Shared subscription. Messages for a new consumer are fenced until the previous messages are acknowledged. |10000|
 |tlsEnabled|  Enable TLS  |false|
 |tlsCertificateFilePath|  Path for the TLS certificate file ||
 |tlsKeyFilePath|  Path for the TLS private key file ||


### PR DESCRIPTION
Fixes #6554

### Motivation

Introduce messages fence mechanism for Key_Shared subscription to guarantee ordering dispatching.

The fenced message means that the messages can't be delivered at this time. In Key_Shared subscription, the new consumer needs to wait for all messages before the first message that delivers to this consumer are acknowledged. The `fencedMessagesContainer` maintains all fenced messages by a map (mark-delete-position -> fenced messages).  When the mark delete position of the cursor is greater than the mark-delete-position in the `fencedMessagesContainer`, it means the fenced messages will be lifted.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

New unit tests added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
