### PR TITLE
[pulsar-client] Fix incorrect partitioned producer stats

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -214,10 +214,10 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
         numBytesSent.add(stats.getNumBytesSent());
         numSendFailed.add(stats.getNumSendFailed());
         numAcksReceived.add(stats.getNumAcksReceived());
-        totalMsgsSent.add(stats.getNumMsgsSent());
-        totalBytesSent.add(stats.getNumBytesSent());
-        totalSendFailed.add(stats.getNumSendFailed());
-        totalAcksReceived.add(stats.getNumAcksReceived());
+        totalMsgsSent.add(stats.getTotalMsgsSent());
+        totalBytesSent.add(stats.getTotalBytesSent());
+        totalSendFailed.add(stats.getTotalSendFailed());
+        totalAcksReceived.add(stats.getTotalAcksReceived());
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Currently, partitioned producer returns incorrect total stats. In this PR, fix it and want to get correct stats.

### Modifications

Fix partitioned producer stats to corresponding internal producer stats.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
