### PR TITLE
Make the json node field in GenericRecord public

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.client.api.schema.Field;
 /**
  * Generic json record.
  */
-class GenericJsonRecord extends VersionedGenericRecord {
+public class GenericJsonRecord extends VersionedGenericRecord {
 
     private final JsonNode jn;
 
@@ -39,7 +39,7 @@ class GenericJsonRecord extends VersionedGenericRecord {
         this.jn = jn;
     }
 
-    JsonNode getJsonNode() {
+    public JsonNode getJsonNode() {
         return jn;
     }
 


### PR DESCRIPTION
### Motivation

It is possible to [reach](https://github.com/apache/pulsar/blob/f90fab280c931d457877de87c12b7d59074f6f6c/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroRecord.java#L64) the field containing the native Avro record, but GenericJsonRecord hides the JsonNode field. It makes sense to even it out and make the JsonNode publicly available.

### Modifications

The public access modifier was added to the getter for JsonNode and the GenericJsonRecord class.
