### PR TITLE
[docs] Fix typo in the dotnet (C# client) docs

### DIFF
--- a/site2/docs/client-libraries-dotnet.md
+++ b/site2/docs/client-libraries-dotnet.md
@@ -1,5 +1,5 @@
 ---
-id: client-libraries-donet
+id: client-libraries-dotnet
 title: Pulsar C# client
 sidebar_label: C#
 ---

--- a/site2/docs/getting-started-clients.md
+++ b/site2/docs/getting-started-clients.md
@@ -12,7 +12,7 @@ Pulsar supports the following client libraries:
 - [C++ client](client-libraries-cpp.md)
 - [Node.js client](client-libraries-node.md)
 - [WebSocket client](client-libraries-websocket.md)
-- [C# client](client-libraries-donet.md)
+- [C# client](client-libraries-dotnet.md)
 
 ## Feature matrix
 Pulsar client feature matrix for different languages is listed on [Client Features Matrix](https://github.com/apache/pulsar/wiki/Client-Features-Matrix) page.

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -97,7 +97,7 @@
       "client-libraries-cpp",
       "client-libraries-node",
       "client-libraries-websocket",
-      "client-libraries-donet"
+      "client-libraries-dotnet"
     ],
     "Admin API": [
       "admin-api-overview",


### PR DESCRIPTION
### Modifications

Fix typo in the dotnet (C# client) docs