### PR TITLE
[Issue 7022][Prometheus]Fix for topic out Prometheus metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -136,8 +136,6 @@ public class NamespaceStatsAggregator {
             subsStats.msgBacklog = subscriptionStats.msgBacklog;
             subsStats.msgDelayed = subscriptionStats.msgDelayed;
             subsStats.msgBacklogNoDelayed = subsStats.msgBacklog - subsStats.msgDelayed;
-            stats.rateOut += subsStats.msgRateOut;
-            stats.throughputOut += subsStats.msgThroughputOut;
             subscriptionStats.consumers.forEach(cStats -> {
                 stats.consumersCount++;
                 subsStats.unackedMessages += cStats.unackedMessages;
@@ -150,6 +148,8 @@ public class NamespaceStatsAggregator {
                     subsStats.blockedSubscriptionOnUnackedMsgs = true;
                 }
             });
+            stats.rateOut += subsStats.msgRateOut;
+            stats.throughputOut += subsStats.msgThroughputOut;
         });
 
         // Consumer stats can be a lot if a subscription has many consumers


### PR DESCRIPTION

Fixes #7022

### Motivation

Prometheus out metrics for topics are always zero in 2.5.2 but worked in 2.5.1.

