### PR TITLE
[Issue: 7029] Fix presto SQL does not start prometheus service by default

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnector.java
@@ -81,6 +81,10 @@ public class PulsarConnector implements Connector {
         return recordSetProvider;
     }
 
+    public void initConnectorCache() throws Exception {
+        PulsarConnectorCache.getConnectorCache(pulsarConnectorConfig);
+    }
+
     @Override
     public final void shutdown() {
         try {

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorFactory.java
@@ -67,7 +67,9 @@ public class PulsarConnectorFactory implements ConnectorFactory {
                     .setRequiredConfigurationProperties(config)
                     .initialize();
 
-            return injector.getInstance(PulsarConnector.class);
+            PulsarConnector connector = injector.getInstance(PulsarConnector.class);
+            connector.initConnectorCache();
+            return connector;
         } catch (Exception e) {
             throwIfUnchecked(e);
             throw new RuntimeException(e);


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #7029 

### Motivation

As described in # 7029, when starting `sql-worker`, users expect to be able to correctly access the service port of Prometheus: 9092

### Modifications

- When start sql-worker, go to initialize the Connector's cache.

