### PR TITLE
[C++] Fix Result can't be serialized to string inside the library

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -86,8 +86,8 @@ enum Result
 
 // Return string representation of result code
 PULSAR_PUBLIC const char* strResult(Result result);
-}  // namespace pulsar
 
 PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, pulsar::Result result);
+}  // namespace pulsar
 
 #endif /* ERROR_HPP_ */

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -21,9 +21,9 @@
 
 #include <iostream>
 
-using namespace pulsar;
+namespace pulsar {
 
-const char* pulsar::strResult(Result result) {
+const char* strResult(Result result) {
     switch (result) {
         case ResultOk:
             return "Ok";
@@ -152,3 +152,5 @@ const char* pulsar::strResult(Result result) {
 }
 
 PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, Result result) { return s << strResult(result); }
+
+}  // namespace pulsar


### PR DESCRIPTION
### Motivation

When a `Result` was passed to `std::ostream::operator<<` inside the library, the overloaded `operator<<` wouldn't be called. Instead `Result` was treated as a integer. For example, if you subscribed to a topic of a namespace that didn't exist, the error log would be:

> ERROR ClientImpl:384 | Error Checking/Getting Partition Metadata while Subscribing on persistent://mytenant/myns/mytopic -- 5

Giving following code:

```c++
namespace pulsar {
    void foo() {
        std::stringstream ss;
        Result result = ResultOk;
        ss << result;  // "0"
    }
}

void foo() {
    std::stringstream ss;
    Result result = ResultOk;
    ss << result;  // "Ok"
}
```
`ss << result` inside namespace `pulsar` doesn't call `::operator(ss, result)`. Instead, it calls `pulsar::operator(ss, result)`, which hasn't been overloaded. Because nearly all methods are in namespace `pulsar`, the `LOG_XXX(... << result)` won't call `::operator<<(std::ostream&, Result)`.

### Modifications

- Change the overloaded `operator<<` for `Result` from global namespace to namespace `pulsar`. 