### PR TITLE
[docs] Update admin-api-brokers.md

### DIFF
--- a/site2/docs/admin-api-brokers.md
+++ b/site2/docs/admin-api-brokers.md
@@ -89,10 +89,10 @@ But since all broker configuration in Pulsar is stored in ZooKeeper, configurati
 
 #### pulsar-admin
 
-The [`update-dynamic-config`](reference-pulsar-admin.md#brokers-update-dynamic-config) subcommand will update existing configuration. It takes two arguments: the name of the parameter and the new value. Here's an example for the [`brokerShutdownTimeoutMs`](reference-configuration.md#broker-brokerShutdownTimeoutMs) parameter:
+The [`update-dynamic-config`](reference-pulsar-admin.md#brokers-update-dynamic-config) subcommand will update existing configuration. It takes two arguments: the name of the parameter and the new value using the `config` and `value` flag respectively. Here's an example for the [`brokerShutdownTimeoutMs`](reference-configuration.md#broker-brokerShutdownTimeoutMs) parameter:
 
 ```shell
-$ pulsar-admin brokers update-dynamic-config brokerShutdownTimeoutMs 100
+$ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --value 100
 ```
 
 #### REST API


### PR DESCRIPTION
Fixed the example command for updating dynamic broker configuration by adding `config` and `value` flags.

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

I was going through the docs to learn how to update a broker configuration and the information given was not complete. 

### Modifications

I have added `config` and `value` flags to the example update command for updating broker dynamic configuration.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
