### PR TITLE
[docs] Specify namespace when launching pulsar-manager

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -303,7 +303,7 @@ Then you can proceed with the following steps:
 1. By default, the `Pulsar Manager` is exposed as a separate `LoadBalancer`. You can open the Pulsar Manager UI using the following command:
 
     ```bash
-    minikube service pulsar-mini-pulsar-manager
+    minikube service -n pulsar pulsar-mini-pulsar-manager 
     ```
 
 2. The Pulsar Manager UI will be open in your browser. You can use the username `pulsar` and password `pulsar` to log into Pulsar Manager.


### PR DESCRIPTION
In the `Get started in Kubernetes` quickstart tutorial, one of the commands is insufficient and throws an error. I have proposed a solution to this by specifying the `pulsar` namespace to the command to fix the issue. There is no associated issue that I created as the work and fix is rather trivial.

### Modifications

- added the namespace to the command `minikube service pulsar-mini-pulsar-manager` in step 4 of `Get started in Kubernetes`

Sample output of `minikube service list`:
```
|----------------------|----------------------------|--------------|---------------------------|
|      NAMESPACE       |            NAME            | TARGET PORT  |            URL            |
|----------------------|----------------------------|--------------|---------------------------|
| default              | kubernetes                 | No node port |
| kube-system          | kube-dns                   | No node port |
| kubernetes-dashboard | dashboard-metrics-scraper  | No node port |
| kubernetes-dashboard | kubernetes-dashboard       | No node port |
| pulsar               | pulsar-mini-bookie         | No node port |
| pulsar               | pulsar-mini-broker         | No node port |
| pulsar               | pulsar-mini-grafana        | server/3000  | http://192.168.64.2:31042 |
| pulsar               | pulsar-mini-prometheus     | No node port |
| pulsar               | pulsar-mini-proxy          | http/80      | http://192.168.64.2:31019 |
|                      |                            | pulsar/6650  | http://192.168.64.2:31621 |
| pulsar               | pulsar-mini-pulsar-manager | server/9527  | http://192.168.64.2:32267 |
| pulsar               | pulsar-mini-toolset        | No node port |
| pulsar               | pulsar-mini-zookeeper      | No node port |
|----------------------|----------------------------|--------------|---------------------------|
```

Thus, `minikube service pulsar pulsar-mini-pulsar-manager` is an insufficient command, it returns
```
💣  Service 'pulsar-mini-pulsar-manager' was not found in 'default' namespace.
You may select another namespace by using 'minikube service pulsar-mini-pulsar-manager -n <namespace>'. Or list out all the services using 'minikube service list'
```

By changing the command to `minikube service -n pulsar pulsar-mini-pulsar-manager` this specifies the correct namespace and results in the Pulsar Manager UI being opened in the default browser.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
