### PR TITLE
[website][issue7002]fixes RESTAPIs and Cli button not working.

### DIFF
--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -64,7 +64,8 @@ window.addEventListener('load', function() {
     }
   });
 
-  const href = document.querySelector('a[href="/en/versions"]');
+  // retrieve current selected version from header
+  const href = document.getElementsByClassName("logo")[0].parentElement.nextSibling;
   let version = href.textContent;
 
   if (version === 'next') {


### PR DESCRIPTION
Fixes #7002 

### Motivation

the `REST APIs` and `Cli` button only work in English ver. website.

### Modifications

Currently, the site retrieve user selected version by `document.querySelector('a[href="/en/versions"]')`. Therefore, when the language changes, this path will no longer exists(it will become `a[href="/zh-CN/versions"]` for Chinese ver. for example).
So I changed another way that achieves the same goal, with the help of `logo` class.
The downside is that this new line of code might be ambiguous. So I added another line to comment it.

### Verifying this change

- [ yes ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.