### PR TITLE
Remove the bundle load data info before performing the split

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -700,9 +700,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                             .canSplitBundle(namespaceBundleFactory.getBundle(namespaceName, bundleRange))) {
                         continue;
                     }
-                    log.info("Load-manager splitting bundle {} and unloading {}", bundleName, unloadSplitBundles);
-                    pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
-                        unloadSplitBundles, null);
+
                     // Make sure the same bundle is not selected again.
                     loadData.getBundleData().remove(bundleName);
                     localData.getLastStats().remove(bundleName);
@@ -710,6 +708,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                     this.pulsar.getNamespaceService().getNamespaceBundleFactory()
                             .invalidateBundleCache(NamespaceName.get(namespaceName));
                     deleteBundleDataFromZookeeper(bundleName);
+
+                    log.info("Load-manager splitting bundle {} and unloading {}", bundleName, unloadSplitBundles);
+                    pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
+                        unloadSplitBundles, null);
+
                     log.info("Successfully split namespace bundle {}", bundleName);
                 } catch (Exception e) {
                     log.error("Failed to split namespace bundle {}", bundleName, e);


### PR DESCRIPTION
### Motivation

When a namespace bundle split operation fails by timeout, we're not cleaning up the current in-memory metadata of the old bundles. This lead to the broker to treat the operation as "non-succeeded" while in fact it might have gone through.

In this case, the broker keep thinking that it has to split a particular bundle (based on the old load report information) and that fails with ZK bad-version errors, and again we're not cleaning up the stale metadata.

### Modifications

Reverse the logic to first remove the bundle load data and then perform the split.

If the split were to fail, its load data will be re-added in any case with the next broker load report.

This will ensure that the leader load manager won't be keeping track of a non-existing bundle after a timeout in the split operation.
