### PR TITLE
Clear backlog quota before test in ReplicatorTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -93,6 +93,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @BeforeMethod
     public void beforeMethod(Method m) throws Exception {
         methodName = m.getName();
+        admin1.namespaces().removeBacklogQuota("pulsar/ns");
+        admin1.namespaces().removeBacklogQuota("pulsar/ns1");
+        admin1.namespaces().removeBacklogQuota("pulsar/global/ns");
     }
 
     @Override


### PR DESCRIPTION
### Motivation

All tests in Replicator test use the same instance of pulsar and same
namespaces. Depending on the order the tests run in, which is somewhat
random, the backlog quota may be set to something small, which can
cause creation of producers to fail.

To avoid this, this change removes the backlog quota before each test.
