### PR TITLE
Fix flaky ReplicatorTest.testUpdateGlobalTopicPartition

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -868,7 +868,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         final String cluster1 = pulsar1.getConfig().getClusterName();
         final String cluster2 = pulsar2.getConfig().getClusterName();
-        final String namespace = "pulsar/global/ns3";
+        final String namespace = "pulsar/ns-" + System.nanoTime();
         final String topicName = "persistent://" + namespace + "/topic1";
         int startPartitions = 4;
         int newPartitions = 8;


### PR DESCRIPTION
### Motivation

The test has been failing frequently in CI with this error:

```
[ERROR] testUpdateGlobalTopicPartition(org.apache.pulsar.broker.service.ReplicatorTest)  Time elapsed: 0.034 s  <<< FAILURE!
org.apache.pulsar.client.admin.PulsarAdminException$ConflictException: Namespace already exists
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:223)
	at org.apache.pulsar.client.admin.internal.BaseResource$1.failed(BaseResource.java:133)
	at org.glassfish.jersey.client.JerseyInvocation$4.failed(JerseyInvocation.java:1030)
	at org.glassfish.jersey.client.JerseyInvocation$4.completed(JerseyInvocation.java:1017)
	at org.glassfish.jersey.client.ClientRuntime.processResponse(ClientRuntime.java:227)
```
