### PR TITLE
Fixed increasing number of partitions with attached readers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1014,6 +1014,7 @@ public class PersistentSubscription implements Subscription {
         subStats.msgBacklogNoDelayed = subStats.msgBacklog - subStats.msgDelayed;
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
         subStats.isReplicated = isReplicated();
+        subStats.isDurable = cursor.isDurable();
         return subStats;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -39,6 +39,8 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import java.util.Collections;
+
 import lombok.Cleanup;
 
 public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
@@ -151,12 +153,8 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.topics().getSubscriptions(partitionedTopicName.getPartition(0).toString()).size(), 1);
 
-        // Partition-1 should not have a subscription and it shouldn't exist yet
-        try {
-            admin.topics().getSubscriptions(partitionedTopicName.getPartition(1).toString()).size();
-            fail("The partition topic should not exist yet");
-        } catch (NotFoundException e) {
-            // Expected
-        }
+        // Partition-1 should not have subscriptions
+        assertEquals(admin.topics().getSubscriptions(partitionedTopicName.getPartition(1).toString()),
+                Collections.emptyList());
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -82,6 +82,9 @@ public class SubscriptionStats {
     /** List of connected consumers on this subscription w/ their stats. */
     public List<ConsumerStats> consumers;
 
+    /** Tells whether this subscription is durable or ephemeral (eg.: from a reader). */
+    public boolean isDurable;
+
     /** Mark that the subscription state is kept in sync across different regions. */
     public boolean isReplicated;
 
@@ -117,6 +120,7 @@ public class SubscriptionStats {
         this.unackedMessages += stats.unackedMessages;
         this.msgRateExpired += stats.msgRateExpired;
         this.isReplicated |= stats.isReplicated;
+        this.isDurable |= stats.isDurable;
         if (this.consumers.size() != stats.consumers.size()) {
             for (int i = 0; i < stats.consumers.size(); i++) {
                 ConsumerStats consumerStats = new ConsumerStats();


### PR DESCRIPTION
### Motivation

When we're increasing the number of partitions in a topic, we typically also pre-create the subscriptions on those topics. In this case, we're also pre-creating the non-durable subscriptions of the readers.

These are getting created as durable subscriptions on the new partitions and will be leaked and causing backlogs.

Instead, we don't need to pre-create anything for readers (non-durable subscriptions).
