### PR TITLE
introduce precise topic publish rate limiting

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -421,7 +421,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)"
         )
     private int topicPublisherThrottlingTickTimeMillis = 5;
-
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Enable precise rate limit for topic publish"
+    )
+    private boolean preciseTopicPublishRateLimiterEnable = false;
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiter.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pulsar.broker.service;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
+import org.apache.pulsar.common.util.RateLimitFunction;
+import org.apache.pulsar.common.util.RateLimiter;
 
 public interface PublishRateLimiter {
 
@@ -66,6 +69,83 @@ public interface PublishRateLimiter {
      * @param clusterName
      */
     void update(PublishRate maxPublishRate);
+
+    /**
+     * try to acquire permit
+     * @param numbers
+     * @param bytes
+     * */
+    boolean tryAcquire(int numbers, long bytes);
+}
+
+class PrecisPublishLimiter implements PublishRateLimiter {
+    protected volatile int publishMaxMessageRate = 0;
+    protected volatile long publishMaxByteRate = 0;
+    protected volatile boolean publishThrottlingEnabled = false;
+    // precise mode for publish rate limiter
+    private RateLimiter topicPublishRateLimiterOnMessage;
+    private RateLimiter topicPublishRateLimiterOnByte;
+    private final RateLimitFunction rateLimitFunction;
+
+    public PrecisPublishLimiter(Policies policies, String clusterName, RateLimitFunction rateLimitFunction) {
+        this.rateLimitFunction = rateLimitFunction;
+        update(policies, clusterName);
+    }
+
+    @Override
+    public void checkPublishRate() {
+       // No-op
+    }
+
+    @Override
+    public void incrementPublishCount(int numOfMessages, long msgSizeInBytes) {
+       // No-op
+    }
+
+    @Override
+    public boolean resetPublishCount() {
+        return true;
+    }
+
+    @Override
+    public boolean isPublishRateExceeded() {
+        return false;
+    }
+
+
+    @Override
+    public void update(Policies policies, String clusterName) {
+        final PublishRate maxPublishRate = policies.publishMaxMessageRate != null
+                ? policies.publishMaxMessageRate.get(clusterName)
+                : null;
+        this.update(maxPublishRate);
+    }
+    public void update(PublishRate maxPublishRate) {
+        if (maxPublishRate != null
+                && (maxPublishRate.publishThrottlingRateInMsg > 0 || maxPublishRate.publishThrottlingRateInByte > 0)) {
+            this.publishThrottlingEnabled = true;
+            this.publishMaxMessageRate = Math.max(maxPublishRate.publishThrottlingRateInMsg, 0);
+            this.publishMaxByteRate = Math.max(maxPublishRate.publishThrottlingRateInByte, 0);
+            if (this.publishMaxMessageRate > 0) {
+                topicPublishRateLimiterOnMessage = new RateLimiter(publishMaxMessageRate, 1, TimeUnit.SECONDS, rateLimitFunction);
+            }
+            if (this.publishMaxByteRate > 0) {
+                topicPublishRateLimiterOnByte = new RateLimiter(publishMaxByteRate, 1, TimeUnit.SECONDS);
+            }
+        } else {
+            this.publishMaxMessageRate = 0;
+            this.publishMaxByteRate = 0;
+            this.publishThrottlingEnabled = false;
+            topicPublishRateLimiterOnMessage = null;
+            topicPublishRateLimiterOnByte = null;
+        }
+    }
+
+    @Override
+    public boolean tryAcquire(int numbers, long bytes) {
+        return (topicPublishRateLimiterOnMessage == null || topicPublishRateLimiterOnMessage.tryAcquire(numbers)) &&
+                (topicPublishRateLimiterOnByte == null || topicPublishRateLimiterOnByte.tryAcquire(bytes));
+    }
 }
 
 class PublishRateLimiterImpl implements PublishRateLimiter {
@@ -153,6 +233,11 @@ class PublishRateLimiterImpl implements PublishRateLimiter {
             resetPublishCount();
         }
     }
+
+    @Override
+    public boolean tryAcquire(int numbers, long bytes) {
+        return false;
+    }
 }
 
 class PublishRateLimiterDisable implements PublishRateLimiter {
@@ -189,4 +274,11 @@ class PublishRateLimiterDisable implements PublishRateLimiter {
     public void update(PublishRate maxPublishRate) {
         // No-op
     }
+
+    @Override
+    public boolean tryAcquire(int numbers, long bytes) {
+        // No-op
+        return false;
+    }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -149,6 +149,14 @@ public interface Topic {
 
     boolean isPublishRateExceeded();
 
+    boolean isTopicPublishRateExceeded(int msgSize, int numMessages);
+
+    boolean isBrokerPublishRateExceeded();
+
+    void disableCnxAutoRead();
+
+    void enableCnxAutoRead();
+
     CompletableFuture<Void> onPoliciesUpdate(Policies data);
 
     boolean isBacklogQuotaExceeded(String producerName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.service;
 
 import org.apache.pulsar.client.api.MessageId;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
@@ -1,0 +1,135 @@
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.PublishRate;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class PrecisTopicPublishRateThrottleTest extends BrokerTestBase{
+
+    @Override
+    protected void setup() throws Exception {
+        //No-op
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        //No-op
+    }
+
+    @Test
+    public void testPrecisTopicPublishRateLimitingDisabled() throws Exception {
+        PublishRate publishRate = new PublishRate(1,10);
+        // disable precis topic publish rate limiting
+        conf.setPreciseTopicPublishRateLimiterEnable(false);
+        conf.setMaxPendingPublishdRequestsPerConnection(0);
+        super.baseSetup();
+        final String topic = "persistent://prop/ns-abc/testPrecisTopicPublishRateLimiting";
+        org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .producerName("producer-name")
+                .create();
+        Policies policies = new Policies();
+        policies.publishMaxMessageRate = new HashMap<>();
+        policies.publishMaxMessageRate.put("test", publishRate);
+
+        Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
+        Assert.assertNotNull(topicRef);
+        ((AbstractTopic)topicRef).updateMaxPublishRate(policies);
+        MessageId messageId = null;
+        try {
+            // first will be success
+            messageId = producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.assertNotNull(messageId);
+            // second will be success
+            messageId = producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.assertNotNull(messageId);
+        } catch (TimeoutException e) {
+            // No-op
+        }
+        Thread.sleep(1000);
+        try {
+            messageId = producer.sendAsync(new byte[10]).get(1, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // No-op
+        }
+        Assert.assertNotNull(messageId);
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testProducerBlockedByPrecisTopicPublishRateLimiting() throws Exception {
+        PublishRate publishRate = new PublishRate(1,10);
+        conf.setPreciseTopicPublishRateLimiterEnable(true);
+        conf.setMaxPendingPublishdRequestsPerConnection(0);
+        super.baseSetup();
+        final String topic = "persistent://prop/ns-abc/testPrecisTopicPublishRateLimiting";
+        org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .producerName("producer-name")
+                .create();
+        Policies policies = new Policies();
+        policies.publishMaxMessageRate = new HashMap<>();
+        policies.publishMaxMessageRate.put("test", publishRate);
+
+        Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
+        Assert.assertNotNull(topicRef);
+        ((AbstractTopic)topicRef).updateMaxPublishRate(policies);
+        MessageId messageId = null;
+        try {
+            // first will be success, and will set auto read to false
+            messageId = producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.assertNotNull(messageId);
+            // second will be blocked
+            producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.fail("should failed, because producer blocked by topic publish rate limiting");
+        } catch (TimeoutException e) {
+            // No-op
+        }
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testPrecisTopicPublishRateLimitingProduceRefresh() throws Exception {
+        PublishRate publishRate = new PublishRate(1,10);
+        conf.setPreciseTopicPublishRateLimiterEnable(true);
+        conf.setMaxPendingPublishdRequestsPerConnection(0);
+        super.baseSetup();
+        final String topic = "persistent://prop/ns-abc/testPrecisTopicPublishRateLimiting";
+        org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .producerName("producer-name")
+                .create();
+        Policies policies = new Policies();
+        policies.publishMaxMessageRate = new HashMap<>();
+        policies.publishMaxMessageRate.put("test", publishRate);
+
+        Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
+        Assert.assertNotNull(topicRef);
+        ((AbstractTopic)topicRef).updateMaxPublishRate(policies);
+        MessageId messageId = null;
+        try {
+            // first will be success, and will set auto read to false
+            messageId = producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.assertNotNull(messageId);
+            // second will be blocked
+            producer.sendAsync(new byte[10]).get(500, TimeUnit.MILLISECONDS);
+            Assert.fail("should failed, because producer blocked by topic publish rate limiting");
+        } catch (TimeoutException e) {
+            // No-op
+        }
+        Thread.sleep(1000);
+        try {
+            messageId = producer.sendAsync(new byte[10]).get(1, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // No-op
+        }
+        Assert.assertNotNull(messageId);
+        super.internalCleanup();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.PublishRate;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class PublishRateLimiterTest {
+    private final String CLUSTER_NAME = "clusterName";
+    private final Policies policies = new Policies();
+    private final PublishRate publishRate = new PublishRate(10, 100);
+    private final PublishRate newPublishRate = new PublishRate(20, 200);
+
+    private PrecisPublishLimiter precisPublishLimiter;
+    private PublishRateLimiterImpl publishRateLimiter;
+
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        policies.publishMaxMessageRate = new HashMap<>();
+        policies.publishMaxMessageRate.put(CLUSTER_NAME, publishRate);
+        precisPublishLimiter = new PrecisPublishLimiter(policies, CLUSTER_NAME,
+                () -> System.out.print("Refresh permit"));
+        publishRateLimiter = new PublishRateLimiterImpl(policies, CLUSTER_NAME);
+    }
+
+    @Test
+    public void testPublishRateLimiterImplExceed() throws Exception {
+        // increment not exceed
+        publishRateLimiter.incrementPublishCount(5, 50);
+        publishRateLimiter.checkPublishRate();
+        assertFalse(publishRateLimiter.isPublishRateExceeded());
+        publishRateLimiter.resetPublishCount();
+
+        // numOfMessages increment exceeded
+        publishRateLimiter.incrementPublishCount(11, 100);
+        publishRateLimiter.checkPublishRate();
+        assertTrue(publishRateLimiter.isPublishRateExceeded());
+        publishRateLimiter.resetPublishCount();
+
+        // msgSizeInBytes increment exceeded
+        publishRateLimiter.incrementPublishCount(9, 110);
+        publishRateLimiter.checkPublishRate();
+        assertTrue(publishRateLimiter.isPublishRateExceeded());
+
+    }
+
+    @Test
+    public void testPublishRateLimiterImplUpdate() throws Exception {
+        publishRateLimiter.incrementPublishCount(11, 110);
+        publishRateLimiter.checkPublishRate();
+        assertTrue(publishRateLimiter.isPublishRateExceeded());
+
+        // update
+        publishRateLimiter.update(newPublishRate);
+        publishRateLimiter.incrementPublishCount(11, 110);
+        publishRateLimiter.checkPublishRate();
+        assertFalse(publishRateLimiter.isPublishRateExceeded());
+
+    }
+
+    @Test
+    public void testPrecisePublishRateLimiterUpdate() throws Exception {
+        assertFalse(precisPublishLimiter.tryAcquire(15, 150));
+
+        //update
+        precisPublishLimiter.update(newPublishRate);
+        assertTrue(precisPublishLimiter.tryAcquire(15, 150));
+    }
+
+    @Test
+    public void testPrecisePublishRateLimiterAcquire() throws Exception {
+        // tryAcquire not exceeded
+        assertTrue(precisPublishLimiter.tryAcquire(1, 10));
+        Thread.sleep(1100);
+
+        // tryAcquire numOfMessages exceeded
+        assertFalse(precisPublishLimiter.tryAcquire(11, 100));
+        Thread.sleep(1100);
+
+        // tryAcquire msgSizeInBytes exceeded
+        assertFalse(precisPublishLimiter.tryAcquire(10, 101));
+        Thread.sleep(1100);
+
+        // tryAcquire not exceeded
+        assertTrue(precisPublishLimiter.tryAcquire(10, 100));
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimitFunction.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimitFunction.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+/**
+ * Function use when rate limiter renew permit.
+ * */
+public interface RateLimitFunction {
+    void apply();
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
+
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -60,9 +61,16 @@ public class RateLimiter implements AutoCloseable{
     private boolean isClosed;
     // permitUpdate helps to update permit-rate at runtime
     private Supplier<Long> permitUpdater;
+    private RateLimitFunction rateLimitFunction;
 
     public RateLimiter(final long permits, final long rateTime, final TimeUnit timeUnit) {
         this(null, permits, rateTime, timeUnit, null);
+    }
+
+    public RateLimiter(final long permits, final long rateTime, final TimeUnit timeUnit,
+                       RateLimitFunction autoReadResetFunction) {
+        this(null, permits, rateTime, timeUnit, null);
+        this.rateLimitFunction = autoReadResetFunction;
     }
 
     public RateLimiter(final ScheduledExecutorService service, final long permits, final long rateTime,
@@ -243,6 +251,9 @@ public class RateLimiter implements AutoCloseable{
             if (newPermitRate > 0) {
                 setRate(newPermitRate);
             }
+        }
+        if (rateLimitFunction != null) {
+            rateLimitFunction.apply();
         }
         notifyAll();
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/RateLimiterTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/RateLimiterTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertEquals;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.testng.annotations.Test;
@@ -175,4 +176,19 @@ public class RateLimiterTest {
         Thread.sleep(rateTime*3*1000);
         assertEquals(limiter.getAvailablePermits(), newUpdatedRateLimit);
     }
+
+    @Test
+    public void testRateLimiterWithFunction()throws Exception {
+        final AtomicInteger atomicInteger = new AtomicInteger(0);
+        long permits = 10;
+        long rateTime = 1;
+        int reNewTime = 3;
+        RateLimitFunction rateLimitFunction = atomicInteger::incrementAndGet;
+        RateLimiter rateLimiter = new RateLimiter(permits, rateTime, TimeUnit.SECONDS, rateLimitFunction);
+        for (int i = 0 ; i < reNewTime; i++) {
+            rateLimiter.renew();
+        }
+        assertEquals(reNewTime, atomicInteger.get());
+    }
+
 }


### PR DESCRIPTION
Fixes #6975 
### Motivation

  For now,  pulsar limits  publish rate of topic by a period task runs every `topicPublisherThrottlingTickTimeMillis`. That means in the time `topicPublisherThrottlingTickTimeMillis`, the limit can't take effect. 
  This PR enable precise topic publish rate limit on broker.


