### PR TITLE
Reset msg backlog and backlog size

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
@@ -78,6 +78,7 @@ public class AggregatedNamespaceStats {
         storageSize += stats.storageSize;
         backlogSize += stats.backlogSize;
         offloadedStorageUsed += stats.offloadedStorageUsed;
+        backlogQuotaLimit = Math.max(backlogQuotaLimit, stats.backlogQuotaLimit);
 
         storageWriteRate += stats.storageWriteRate;
         storageReadRate += stats.storageReadRate;
@@ -128,10 +129,13 @@ public class AggregatedNamespaceStats {
         throughputOut = 0;
 
         storageSize = 0;
+        backlogSize = 0;
         msgBacklog = 0;
         msgDelayed = 0;
         storageWriteRate = 0;
         storageReadRate = 0;
+        offloadedStorageUsed = 0;
+        backlogQuotaLimit= 0;
 
         replicationStats.clear();
         subscriptionStats.clear();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -136,8 +136,6 @@ public class NamespaceStatsAggregator {
             subsStats.msgBacklog = subscriptionStats.msgBacklog;
             subsStats.msgDelayed = subscriptionStats.msgDelayed;
             subsStats.msgBacklogNoDelayed = subsStats.msgBacklog - subsStats.msgDelayed;
-            stats.rateOut += subsStats.msgRateOut;
-            stats.throughputOut += subsStats.msgThroughputOut;
             subscriptionStats.consumers.forEach(cStats -> {
                 stats.consumersCount++;
                 subsStats.unackedMessages += cStats.unackedMessages;
@@ -150,6 +148,8 @@ public class NamespaceStatsAggregator {
                     subsStats.blockedSubscriptionOnUnackedMsgs = true;
                 }
             });
+            stats.rateOut += subsStats.msgRateOut;
+            stats.throughputOut += subsStats.msgThroughputOut;
         });
 
         // Consumer stats can be a lot if a subscription has many consumers


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

There are a couple of prometheus stats issues.

- The backlogSize isn't reset after being collected by Prometheus. This result in backlogSize keeps growing.
- Pulsar out rate is 0

### Modifications

- reset a few counters in AggregatedNamespaceStats
- Fix the out rate being 0 isse
