### PR TITLE
add feature: enable maxSizePerLedger settings in configuration

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -704,6 +704,9 @@ managedLedgerMinLedgerRolloverTimeMinutes=10
 # Maximum time before forcing a ledger rollover for a topic
 managedLedgerMaxLedgerRolloverTimeMinutes=240
 
+# Maximum ledger size before triggering a rollover for a topic (MB)
+managedLedgerMaxSizePerLedgerMbytes=2048
+
 # Delay between a ledger being successfully offloaded to long term storage
 # and the ledger being deleted from bookkeeper (default is 4 hours)
 managedLedgerOffloadDeletionLagMs=14400000

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -519,6 +519,9 @@ managedLedgerCursorMaxEntriesPerLedger=50000
 # Max time before triggering a rollover on a cursor ledger
 managedLedgerCursorRolloverTimeInSeconds=14400
 
+# Maximum ledger size before triggering a rollover for a topic (MB)
+managedLedgerMaxSizePerLedgerMbytes=2048
+
 # Max number of "acknowledgment holes" that are going to be persistently stored.
 # When acknowledging out of order, a consumer will leave holes that are supposed
 # to be quickly filled by acking all the messages. The information of which

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1096,6 +1096,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int managedLedgerMaxLedgerRolloverTimeMinutes = 240;
     @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "Maximum ledger size before triggering a rollover for a topic (MB)"
+    )
+    private int managedLedgerMaxSizePerLedgerMbytes = 2048;
+    @FieldContext(
         category = CATEGORY_STORAGE_OFFLOADING,
         doc = "Delay between a ledger being successfully offloaded to long term storage,"
             + " and the ledger being deleted from bookkeeper"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1043,7 +1043,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                     TimeUnit.MINUTES);
             managedLedgerConfig.setMaximumRolloverTime(serviceConfig.getManagedLedgerMaxLedgerRolloverTimeMinutes(),
                     TimeUnit.MINUTES);
-            managedLedgerConfig.setMaxSizePerLedgerMb(2048);
+            managedLedgerConfig.setMaxSizePerLedgerMb(serviceConfig.getManagedLedgerMaxSizePerLedgerMbytes());
 
             managedLedgerConfig.setMetadataOperationsTimeoutSeconds(
                     serviceConfig.getManagedLedgerMetadataOperationsTimeoutSeconds());


### PR DESCRIPTION
### Motivation
This pull request implements an entrance to set max size per ledger in configuration file (`conf/broker.conf`). Currently the default ledger rollover size is hardcode to `2048MB` when initializing broker in `BrokerService`.

### Expected behaviors
If the user does not use the setting, the behaviors are the same as before. If the user sets `managedLedgerMaxSizePerLedgerMbytes` in `conf/broker.conf`, then the setting value will be used.

### Modifications
- two configuration files (`conf/broker.conf` and `ServiceConfiguration`)
- one modification in initializing broker (`BrokerService`)