### PR TITLE
[Issue 7049][WebSocket] Make WebSocketService.MaxTextFrameSize configurable

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -902,6 +902,9 @@ webSocketConnectionsPerBroker=8
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 
+# The maximum size of a text message during parsing in WebSocket proxy
+webSocketMaxTextFrameSize=1048576
+
 ### --- Metrics --- ###
 
 # Enable topic level metrics

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -673,6 +673,9 @@ webSocketConnectionsPerBroker=8
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 
+# The maximum size of a text message during parsing in WebSocket proxy
+webSocketMaxTextFrameSize=1048576
+
 ### --- Metrics --- ###
 
 # Enable topic level metrics

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -60,6 +60,9 @@ webSocketConnectionsPerBroker=8
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 
+# The maximum size of a text message during parsing in WebSocket proxy
+webSocketMaxTextFrameSize=1048576
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -467,6 +467,8 @@ webSocketNumIoThreads=8
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=8
 
+# The maximum size of a text message during parsing in WebSocket proxy
+webSocketMaxTextFrameSize=1048576
 
 ### --- Metrics --- ###
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1497,7 +1497,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_WEBSOCKET,
         doc = "The maximum size of a text message during parsing in WebSocket proxy"
     )
-    private int webSocketMaxTextFrameSize = 300000;
+    private int webSocketMaxTextFrameSize = 1048576;
 
     /**** --- Metrics --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1493,6 +1493,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int webSocketSessionIdleTimeoutMillis = 300000;
 
+    @FieldContext(
+        category = CATEGORY_WEBSOCKET,
+        doc = "The maximum size of a text message during parsing in WebSocket proxy"
+    )
+    private int webSocketMaxTextFrameSize = 300000;
+
     /**** --- Metrics --- ****/
     @FieldContext(
         category = CATEGORY_METRICS,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1495,7 +1495,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
-        doc = "The maximum size of a text message during parsing in WebSocket proxy"
+        doc = "The maximum size of a text message during parsing in WebSocket proxy."
     )
     private int webSocketMaxTextFrameSize = 1048576;
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
@@ -36,7 +36,7 @@ public class WebSocketConsumerServlet extends WebSocketServlet {
 
     @Override
     public void configure(WebSocketServletFactory factory) {
-        factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
+        factory.getPolicy().setMaxTextMessageSize(service.getConfig().getWebSocketMaxTextFrameSize());
         if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
             factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
         }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
@@ -35,7 +35,7 @@ public class WebSocketProducerServlet extends WebSocketServlet {
 
     @Override
     public void configure(WebSocketServletFactory factory) {
-        factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
+        factory.getPolicy().setMaxTextMessageSize(service.getConfig().getWebSocketMaxTextFrameSize());
         if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
             factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
         }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
@@ -36,7 +36,7 @@ public class WebSocketReaderServlet extends WebSocketServlet {
 
     @Override
     public void configure(WebSocketServletFactory factory) {
-        factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
+        factory.getPolicy().setMaxTextMessageSize(service.getConfig().getWebSocketMaxTextFrameSize());
         if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
             factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
         }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -62,8 +62,6 @@ import io.netty.util.concurrent.DefaultThreadFactory;
  */
 public class WebSocketService implements Closeable {
 
-    public static final int MaxTextFrameSize = 1024 * 1024;
-
     AuthenticationService authenticationService;
     AuthorizationService authorizationService;
     PulsarClient pulsarClient;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -66,6 +66,8 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private Optional<Integer> webServicePortTls = Optional.empty();
     // Hostname or IP address the service binds on, default is 0.0.0.0.
     private String bindAddress;
+    // The maximum size of a text message during parsing in WebSocket proxy
+    private int webSocketMaxTextFrameSize = 1024 * 1024;
     // --- Authentication ---
     // Enable authentication
     private boolean authenticationEnabled;
@@ -230,6 +232,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     public void setBindAddress(String bindAddress) {
         this.bindAddress = bindAddress;
+    }
+
+    public int getWebSocketMaxTextFrameSize() {
+        return webSocketMaxTextFrameSize;
+    }
+
+    public void setWebSocketMaxTextFrameSize(int webSocketMaxTextFrameSize) {
+        this.webSocketMaxTextFrameSize = webSocketMaxTextFrameSize;
     }
 
     public boolean isAuthenticationEnabled() {


### PR DESCRIPTION
**Motivation**
fix [https://github.com/apache/pulsar/issues/7049](https://github.com/apache/pulsar/issues/7049)
Make WebSocketService.MaxTextFrameSize configurable.

**Modifications**
Add config of webSocketMaxTextFrameSize in websocket.conf, standalone.conf, broker.conf, and the default value is 1024*1024byte.