### PR TITLE
In HTTP authentication, throw exception from provider if there is one.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -84,12 +84,14 @@ public class AuthenticationService implements Closeable {
 
     public String authenticateHttpRequest(HttpServletRequest request) throws AuthenticationException {
         // Try to validate with any configured provider
+        AuthenticationException authenticationException = null;
         AuthenticationDataSource authData = new AuthenticationDataHttps(request);
         for (AuthenticationProvider provider : providers.values()) {
             try {
                 return provider.authenticate(authData);
             } catch (AuthenticationException e) {
-                // Ignore the exception because we don't know which authentication method is expected here.
+                // Store the exception so we can throw it later instead of a generic one
+                authenticationException = e;
             }
         }
 
@@ -99,7 +101,11 @@ public class AuthenticationService implements Closeable {
                 return anonymousUserRole;
             }
             // If at least a provider was configured, then the authentication needs to be provider
-            throw new AuthenticationException("Authentication required");
+            if (authenticationException != null) {
+                throw authenticationException;
+            } else {
+                throw new AuthenticationException("Authentication required");
+            }
         } else {
             // No authentication required
             return "<none>";


### PR DESCRIPTION
### Motivation

During HTTP authentication, we try to authenticate against all the configured AuthN providers. If there's an exception in the auth operation, we should bubble back the original exception instead of a generic "Authentication required" which will hide the reason of the failure.