### PR TITLE
Fixed ordering issue in KeyShared dispatcher when adding consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -111,4 +111,8 @@ public interface Dispatcher {
     default void cursorIsReset() {
         //No-op
     }
+
+    default void acknowledgementWasProcessed() {
+        // No-op
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -403,6 +405,9 @@ public class PersistentSubscription implements Subscription {
             // Notify all consumer that the end of topic was reached
             dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
         }
+
+        // Signal the dispatchers to give chance to take extra actions
+        dispatcher.acknowledgementWasProcessed();
     }
 
     /**


### PR DESCRIPTION
~Note: this is based on top of #6791, #7104 and #7105. Once these are merged, I'll rebase here. For the sake of this review, check commit ad2e39be36~


### Motivation

Fixes:  #6554

Ordering is broken in KeyShared dispatcher if a new consumer `c2` comes in and an existing consumer `c1` goes out. 

This is because messages with keys previously assigned to `c1` may now route to `c2`. 

The solution here is to have new consumers joining in a "paused" state.

For example, consider this sequence:

 1. Subscriptions has `c1` and `c2` consumers
 2. `c3` joins. Some of the keys are now supposed to go to `c3`.
 3. Instead of starting delivering to `c3`. We mark the current readPosition (let's call it `rp0_c3`) of the cursor for `c3`.
 4. Any message that now hashes to `c3` and that has `messageId >= rp0_c3` will be deferred for later re-delivery
 5. Any message that might get re-delivered (eg: originally sent to `c1`, but `c1` has failed) to `c3` and that has `messageId < rp0_c3` will be sent to `c3`
 6. When the markDelete position of the cursor will move past `rp0_c3` the restriction on `c3` will be lifted.

Essentially, `c3` joins but can only receive old messages, until everything that was read before joining gets acked.