### PR TITLE
Fixed KeyShared routing when messages are sent in batches of 1

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 
 import io.netty.buffer.ByteBuf;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -146,18 +147,45 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     }
 
     public static final String NONE_KEY = "NONE_KEY";
+
     protected byte[] peekStickyKey(ByteBuf metadataAndPayload) {
-        metadataAndPayload.markReaderIndex();
+        int readerIndex = metadataAndPayload.readerIndex();
         PulsarApi.MessageMetadata metadata = Commands.parseMessageMetadata(metadataAndPayload);
-        metadataAndPayload.resetReaderIndex();
-        String key = metadata.getPartitionKey();
-        if (log.isDebugEnabled()) {
-            log.debug("Parse message metadata, partition key is {}, ordering key is {}", key, metadata.getOrderingKey());
+
+        try {
+            if (metadata.hasNumMessagesInBatch()) {
+                // If the message was part of a batch (eg: a batch of 1 message), we need
+                // to read the key from the first single-message-metadata entry
+                PulsarApi.SingleMessageMetadata.Builder singleMessageMetadataBuilder = PulsarApi.SingleMessageMetadata
+                        .newBuilder();
+                ByteBuf singleMessagePayload = Commands.deSerializeSingleMessageInBatch(metadataAndPayload,
+                        singleMessageMetadataBuilder, 0, metadata.getNumMessagesInBatch());
+                try {
+                    if (singleMessageMetadataBuilder.hasOrderingKey()) {
+                        return singleMessageMetadataBuilder.getOrderingKey().toByteArray();
+                    } else if (singleMessageMetadataBuilder.hasPartitionKey()) {
+                        return singleMessageMetadataBuilder.getPartitionKey().getBytes();
+                    }
+                } finally {
+                    singleMessagePayload.release();
+                    singleMessageMetadataBuilder.recycle();
+                }
+            } else {
+                // Message was not part of a batch
+                if (metadata.hasOrderingKey()) {
+                    return metadata.getOrderingKey().toByteArray();
+                } else if (metadata.hasPartitionKey()) {
+                    return metadata.getPartitionKey().getBytes();
+                }
+            }
+
+            return NONE_KEY.getBytes();
+        } catch (IOException e) {
+            // If we fail to deserialize medata, return null key
+            return NONE_KEY.getBytes();
+        } finally {
+            metadataAndPayload.readerIndex(readerIndex);
+            metadata.recycle();
         }
-        if (StringUtils.isNotBlank(key) || metadata.hasOrderingKey()) {
-            return metadata.hasOrderingKey() ? metadata.getOrderingKey().toByteArray() : key.getBytes();
-        }
-        metadata.recycle();
-        return NONE_KEY.getBytes();
     }
 }


### PR DESCRIPTION
~Note: this is based on top of #6791, #7104, #7105 and #7106. Once these are merged, I'll rebase here. For the sake of this review, check commit 6ca3a75d20~

### Motivation

When messages are published in batches of 1 message (eg: from Go native client lib), the KeyShared dispatcher is failing to extract the key from the first message in batch, instead everything is routed using `NONE_KEY`, landing on 1 single consumer.

