### PR TITLE
Don't run synchronous I/O in cache callback

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1694,7 +1694,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             // update message-rate for each topic
             forEachTopic(topic -> {
                 if (topic.getDispatchRateLimiter().isPresent()) {
-                    topic.getDispatchRateLimiter().get().updateDispatchRate();
+                    topic.getDispatchRateLimiter().get().updateDispatchRate(
+                            pulsar().getConfiguration().getClusterName(),
+                            PersistentTopic.getPolicies(BrokerService.this, topic.getName()));
                 }
             });
         });
@@ -1706,8 +1708,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             forEachTopic(topic -> {
                 topic.getSubscriptions().forEach((subName, persistentSubscription) -> {
                     Dispatcher dispatcher = persistentSubscription.getDispatcher();
-                    if (dispatcher != null) {
-                        dispatcher.getRateLimiter().ifPresent(DispatchRateLimiter::updateDispatchRate);
+                    if (dispatcher != null && dispatcher.getRateLimiter().isPresent()) {
+                        dispatcher.getRateLimiter().get()
+                            .updateDispatchRate(
+                                    pulsar().getConfiguration().getClusterName(),
+                                    PersistentTopic.getPolicies(BrokerService.this, topic.getName()));
                     }
                 });
             });
@@ -1720,7 +1725,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             forEachTopic(topic ->
                 topic.getReplicators().forEach((name, persistentReplicator) -> {
                     if (persistentReplicator.getRateLimiter().isPresent()) {
-                        persistentReplicator.getRateLimiter().get().updateDispatchRate();
+                        persistentReplicator.getRateLimiter().get().updateDispatchRate(
+                            pulsar().getConfiguration().getClusterName(),
+                            PersistentTopic.getPolicies(BrokerService.this, topic.getName()));
                     }
                 }));
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -83,7 +83,8 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
         this.serviceConfig = topic.getBrokerService().pulsar().getConfiguration();
         this.readBatchSize = serviceConfig.getDispatcherMaxReadBatchSize();
         this.redeliveryTracker = RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED;
-        this.initializeDispatchRateLimiterIfNeeded(Optional.empty());
+
+        initializeDispatchRateLimiterIfNeeded(PersistentTopic.getPolicies(topic.getBrokerService(), topic.getName()));
     }
 
     protected void scheduleReadOnActiveConsumer() {
@@ -543,7 +544,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
     public void initializeDispatchRateLimiterIfNeeded(Optional<Policies> policies) {
         if (!dispatchRateLimiter.isPresent() && DispatchRateLimiter
                 .isDispatchRateNeeded(topic.getBrokerService(), policies, topic.getName(), Type.SUBSCRIPTION)) {
-            this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.SUBSCRIPTION));
+            this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.SUBSCRIPTION, policies));
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -123,7 +123,8 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         readMaxSizeBytes = topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadSizeBytes();
         producerQueueThreshold = (int) (producerQueueSize * 0.9);
 
-        this.initializeDispatchRateLimiterIfNeeded(Optional.empty());
+        this.initializeDispatchRateLimiterIfNeeded(
+            PersistentTopic.getPolicies(topic.getBrokerService(), topic.getName()));
 
         startProducer();
     }
@@ -718,7 +719,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
     public void initializeDispatchRateLimiterIfNeeded(Optional<Policies> policies) {
         if (!dispatchRateLimiter.isPresent() && DispatchRateLimiter
             .isDispatchRateNeeded(topic.getBrokerService(), policies, topic.getName(), Type.REPLICATOR)) {
-            this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.REPLICATOR));
+            this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.REPLICATOR, policies));
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -920,19 +920,19 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         DispatchRate topicDispatchRate = new DispatchRate(200, 1024, 1);
 
         // (1) If both clusterDispatchRate and topicDispatchRate are empty, dispatch throttling is disabled
-        DispatchRate dispatchRate = DispatchRateLimiter.getPoliciesDispatchRate(cluster, policies,
+        Optional<DispatchRate> dispatchRate = DispatchRateLimiter.getPoliciesDispatchRate(cluster, policies,
                 DispatchRateLimiter.Type.TOPIC);
-        Assert.assertNull(dispatchRate);
+        Assert.assertFalse(dispatchRate.isPresent());
 
         // (2) If topicDispatchRate is empty, clusterDispatchRate is effective
         policies.get().clusterDispatchRate.put(cluster, clusterDispatchRate);
         dispatchRate = DispatchRateLimiter.getPoliciesDispatchRate(cluster, policies, DispatchRateLimiter.Type.TOPIC);
-        Assert.assertEquals(dispatchRate, clusterDispatchRate);
+        Assert.assertEquals(dispatchRate.get(), clusterDispatchRate);
 
         // (3) If topicDispatchRate is not empty, topicDispatchRate is effective
         policies.get().topicDispatchRate.put(cluster, topicDispatchRate);
         dispatchRate = DispatchRateLimiter.getPoliciesDispatchRate(cluster, policies, DispatchRateLimiter.Type.TOPIC);
-        Assert.assertEquals(dispatchRate, topicDispatchRate);
+        Assert.assertEquals(dispatchRate.get(), topicDispatchRate);
     }
 
     @SuppressWarnings("deprecation")
@@ -944,7 +944,8 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(cluster));
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
-        DispatchRateLimiter dispatchRateLimiter = new DispatchRateLimiter(topic, DispatchRateLimiter.Type.TOPIC);
+        DispatchRateLimiter dispatchRateLimiter = new DispatchRateLimiter(topic, DispatchRateLimiter.Type.TOPIC,
+                Optional.empty());
 
         Policies policies = new Policies();
         DispatchRate clusterDispatchRate = new DispatchRate(100, 512, 1);

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -432,18 +432,17 @@ public class ZookeeperCacheTest {
         zkClient.create(key1, value.getBytes(), null, null);
         zkClient.create(key2, value.getBytes(), null, null);
 
-        CountDownLatch latch = new CountDownLatch(1);
+        CompletableFuture<Void> promise = new CompletableFuture<>();
 
         zkCache.getAsync(key).thenAccept(val -> {
             try {
                 zkCache.get(key1);
             } catch (Exception e) {
-                fail("failed to get " + key2, e);
+                promise.completeExceptionally(e);
             }
-            latch.countDown();
+            promise.complete(null);
         });
-
-        latch.await();
+        promise.get();
         executor.shutdown();
         zkExecutor.shutdown();
         scheduledExecutor.shutdown();


### PR DESCRIPTION
### Motivation

PersistentTopic registers a listener for updates to the policies of
the topic.

PersistentTopic#initializeDispatchRateLimiterIfNeeded runs under a
lock on the dispatchRateLimiter object. This method is called from the
constructor and also from the a listener callback. If the listener
callback triggers during the initial read, then the callbacks will
wait on the lock. This occupies one ForkJoinPool.commonPool
thread. Multiple triggers on the callbacks will occupy multiple
ForkJoinPool.commonPool threads. There needs to be a free thread to
complete the initial read, so this read eventually times out.

This change fixes this in two ways.

Firstly it moves reading from the ZK cache outside of the lock. This
has a knock-on effect in other parts of the code, as
DispatchRateLimiter and SubscriptionRateLimiter no longer read the
Policies for themselves, but require the policies be passed in.

Secondly, it makes the zookeeper cache use its own executor rather
than ForkJoinPool.commonPool. This can help avoid deadlocks but
cannot eliminate them completely if we allow synchronous calls
from within callbacks.

If we allow this kind of call, we are susceptible to
deadlocks, no matter how many threads we add. To allow N threads to
call synchronous calls in callbacks we need N+1 threads. Fixing this
properly would involve ensuring that sychronous calls do not depend on
the async callback executor, which seems like a fairly big change.

This problem was the root cause of some flakes on ReplicatorTest.
