### PR TITLE
[Issue 6981][docs] Fix bash scripts in the security-tls-transport docs

### DIFF
--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -43,25 +43,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -86,29 +86,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
       -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
@@ -42,25 +42,25 @@ The first step is to create the certificate for the CA. The CA will be used to s
 Create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/incubator-pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories needed for the CA.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 Create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 After answering the question prompts, this will store CA-related files in the `./my-ca` directory. Within that directory:
@@ -83,28 +83,28 @@ The following commands will ask you a few questions and then create the certific
 
 First generate the key.
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 Generate the certificate request...
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 ... and sign it with the certificate authority.
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which can be used along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
@@ -42,25 +42,25 @@ The first step is to create the certificate for the CA. The CA will be used to s
 Create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories needed for the CA.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 Create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 After answering the question prompts, this will store CA-related files in the `./my-ca` directory. Within that directory:
@@ -84,28 +84,28 @@ The following commands will ask you a few questions and then create the certific
 
 First generate the key.
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 Generate the certificate request...
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 ... and sign it with the certificate authority.
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which can be used along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.2.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.1/security-tls-transport.md
@@ -42,25 +42,25 @@ The first step is to create the certificate for the CA. The CA will be used to s
 Create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories needed for the CA.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 Create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 After answering the question prompts, this will store CA-related files in the `./my-ca` directory. Within that directory:
@@ -84,28 +84,28 @@ The following commands will ask you a few questions and then create the certific
 
 First generate the key.
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 Generate the certificate request...
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 ... and sign it with the certificate authority.
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which can be used along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
@@ -42,25 +42,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -85,29 +85,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
@@ -42,25 +42,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -85,29 +85,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
@@ -42,25 +42,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -85,29 +85,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
@@ -44,25 +44,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -87,29 +87,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.

--- a/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
@@ -44,25 +44,25 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 2. Entering the follwing command to create a directory for your CA, and place [this openssl configuration file](https://github.com/apache/pulsar/tree/master/site2/website/static/examples/openssl.cnf) in the directory. You may want to modify the default answers for company name and department in the configuration file. Export the location of the CA directory to the environment variable, CA_HOME. The configuration file uses this environment variable to find the rest of the files and directories that the CA needs.
 
 ```bash
-$ mkdir my-ca
-$ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
-$ export CA_HOME=$(pwd)
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+export CA_HOME=$(pwd)
 ```
 
 3. Enter the commands below to create the necessary directories, keys and certs.
 
 ```bash
-$ mkdir certs crl newcerts private
-$ chmod 700 private/
-$ touch index.txt
-$ echo 1000 > serial
-$ openssl genrsa -aes256 -out private/ca.key.pem 4096
-$ chmod 400 private/ca.key.pem
-$ openssl req -config openssl.cnf -key private/ca.key.pem \
-      -new -x509 -days 7300 -sha256 -extensions v3_ca \
-      -out certs/ca.cert.pem
-$ chmod 444 certs/ca.cert.pem
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
 ```
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
@@ -87,29 +87,29 @@ The following commands ask you a few questions and then create the certificates.
 1. Enter the command below to generate the key.
 
 ```bash
-$ openssl genrsa -out broker.key.pem 2048
+openssl genrsa -out broker.key.pem 2048
 ```
 
 The broker expects the key to be in [PKCS 8](https://en.wikipedia.org/wiki/PKCS_8) format, so enter the following command to convert it.
 
 ```bash
-$ openssl pkcs8 -topk8 -inform PEM -outform PEM \
-      -in broker.key.pem -out broker.key-pk8.pem -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform PEM \
+    -in broker.key.pem -out broker.key-pk8.pem -nocrypt
 ```
 
 2. Enter the follwing command to generate the certificate request.
 
 ```bash
-$ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.csr.pem
+openssl req -config openssl.cnf \
+    -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 3. Sign it with the certificate authority by entering the command below.
 
 ```bash
-$ openssl ca -config openssl.cnf -extensions server_cert \
-      -days 1000 -notext -md sha256 \
-      -in broker.csr.pem -out broker.cert.pem
+openssl ca -config openssl.cnf -extensions server_cert \
+    -days 1000 -notext -md sha256 \
+    -in broker.csr.pem -out broker.cert.pem
 ```
 
 At this point, you have a cert, `broker.cert.pem`, and a key, `broker.key-pk8.pem`, which you can use along with `ca.cert.pem` to configure TLS transport encryption for your broker and proxy nodes.


### PR DESCRIPTION
Fixes #6981 

### Motivation

This fix makes it possible to copy the scripts without further modifications.

### Modifications

Removed $ from the bash commands