### PR TITLE
[client] Change the default value of maxLookupRedirects of Java client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -67,7 +67,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean tlsHostnameVerificationEnable = false;
     private int concurrentLookupRequest = 5000;
     private int maxLookupRequest = 50000;
-    private int maxLookupRedirects = 100;
+    private int maxLookupRedirects = 20;
     private int maxNumberOfRejectedRequestPerConnection = 50;
     private int keepAliveIntervalSeconds = 30;
     private int connectionTimeoutMs = 10000;


### PR DESCRIPTION
Master Issue: #7041

I limited the number of times a lookup request was redirected in https://github.com/apache/pulsar/pull/7096 and set the default value to 100. However, the maximum value for C++ and Go libraries is 20, so change the default value for Java library to 20 as well.
https://github.com/apache/pulsar/blob/eea53b7b04f1883e0b4ff8d880731a8ee0c1c92d/pulsar-client-cpp/lib/HTTPLookupService.cc#L37
https://github.com/apache/pulsar-client-go/blob/6e5c7d340f7d0d53026ba228379a0a68e06342dd/pulsar/internal/lookup_service.go#L81-L82