### PR TITLE
fix typos and remove unused import

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -92,7 +92,7 @@ flushInterval=60000
 
 # Whether the bookie should use its hostname to register with the
 # co-ordination service(eg: Zookeeper service).
-# When false, bookie will use its ipaddress for the registration.
+# When false, bookie will use its ip address for the registration.
 # Defaults to false.
 useHostNameAsBookieID=false
 
@@ -292,7 +292,7 @@ journalFormatVersionToWrite=5
 journalMaxSizeMB=2048
 
 # Max number of old journal file to kept
-# Keep a number of old journal files would help data recovery in specia case
+# Keep a number of old journal files would help data recovery in special case
 journalMaxBackups=5
 
 # How much space should we pre-allocate at a time in the journal.
@@ -348,7 +348,7 @@ ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
 # For example:
 # ledgerDirectories=/tmp/bk1-data,/tmp/bk2-data
 #
-# Ideally ledger dirs and journal dir are each in a differet device,
+# Ideally ledger dirs and journal dir are each in a different device,
 # which reduce the contention between random i/o and sequential write.
 # It is possible to run with a single disk, but performance will be significantly lower.
 ledgerDirectories=data/bookkeeper/ledgers
@@ -363,7 +363,7 @@ ledgerDirectories=data/bookkeeper/ledgers
 auditorPeriodicCheckInterval=604800
 
 # Whether sorted-ledger storage enabled (default true)
-# sortedLedgerStorageEnabled=ture
+# sortedLedgerStorageEnabled=true
 
 # The skip list data size limitation (default 64MB) in EntryMemTable
 # skipListSizeLimit=67108864L
@@ -391,7 +391,7 @@ fileInfoFormatVersionToWrite=0
 
 # Size of a index page in ledger cache, in bytes
 # A larger index page can improve performance writing page to disk,
-# which is efficent when you have small number of ledgers and these
+# which is efficient when you have small number of ledgers and these
 # ledgers have similar number of entries.
 # If you have large number of ledgers and each ledger has fewer entries,
 # smaller index page would improve memory usage.
@@ -404,7 +404,7 @@ fileInfoFormatVersionToWrite=0
 # pageLimit*pageSize should not more than JVM max memory limitation,
 # otherwise you would got OutOfMemoryException.
 # In general, incrementing pageLimit, using smaller index page would
-# gain bettern performance in lager number of ledgers with fewer entries case
+# gain better performance in lager number of ledgers with fewer entries case
 # If pageLimit is -1, bookie server will use 1/3 of JVM memory to compute
 # the limitation of number of index pages.
 pageLimit=0
@@ -418,7 +418,7 @@ pageLimit=0
 # and garbage collected. Try to read 'BookKeeper Internals' for detail info.
 # ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
 
-# @Drepcated - `ledgerManagerType` is deprecated in favor of using `ledgerManagerFactoryClass`.
+# @Deprecated - `ledgerManagerType` is deprecated in favor of using `ledgerManagerFactoryClass`.
 # ledgerManagerType=hierarchical
 
 # Root Zookeeper path to store ledger metadata
@@ -536,7 +536,7 @@ readOnlyModeEnabled=true
 # Whether the bookie is force started in read only mode or not
 # forceReadOnlyBookie=false
 
-# Persiste the bookie status locally on the disks. So the bookies can keep their status upon restarts
+# Persist the bookie status locally on the disks. So the bookies can keep their status upon restarts
 # @Since 4.6
 # persistBookieStatusEnabled=false
 
@@ -546,7 +546,7 @@ readOnlyModeEnabled=true
 
 # For each ledger dir, maximum disk space which can be used.
 # Default is 0.95f. i.e. 95% of disk can be used at most after which nothing will
-# be written to that partition. If all ledger dir partions are full, then bookie
+# be written to that partition. If all ledger dir partitions are full, then bookie
 # will turn to readonly mode if 'readOnlyModeEnabled=true' is set, else it will
 # shutdown.
 # Valid values should be in between 0 and 1 (exclusive).

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -299,7 +299,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Max pending publish requests per connection to avoid keeping large number of pending "
                 + "requests in memory. Default: 1000"
     )
-    private int maxPendingPublishdRequestsPerConnection = 1000;
+    private int maxPendingPublishRequestsPerConnection = 1000;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "How frequently to proactively check and purge expired messages"
@@ -870,7 +870,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String bookkeeperClientAuthenticationPlugin;
     @FieldContext(
         category = CATEGORY_STORAGE_BK,
-        doc = "BookKeeper auth plugin implementatation specifics parameters name and values"
+        doc = "BookKeeper auth plugin implementation specifics parameters name and values"
     )
     private String bookkeeperClientAuthenticationParametersName;
     @FieldContext(
@@ -1426,7 +1426,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Duration to check replication policy to avoid replicator "
                     + "inconsistency due to missing ZooKeeper watch (disable with value 0)"
         )
-    private int replicatioPolicyCheckDurationSeconds = 600;
+    private int replicationPolicyCheckDurationSeconds = 600;
     @Deprecated
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -454,7 +454,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     protected void startCheckReplicationPolicies() {
-        int interval = pulsar.getConfig().getReplicatioPolicyCheckDurationSeconds();
+        int interval = pulsar.getConfig().getReplicationPolicyCheckDurationSeconds();
         if (interval > 0) {
             messageExpiryMonitor.scheduleAtFixedRate(safeRun(this::checkReplicationPolicies), interval, interval,
                     TimeUnit.SECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -190,7 +190,7 @@ public class ServerCnx extends PulsarHandler {
         this.authenticateOriginalAuthData = service.pulsar().getConfiguration().isAuthenticateOriginalAuthData();
         this.schemaValidationEnforced = pulsar.getConfiguration().isSchemaValidationEnforced();
         this.maxMessageSize = pulsar.getConfiguration().getMaxMessageSize();
-        this.maxPendingSendRequests = pulsar.getConfiguration().getMaxPendingPublishdRequestsPerConnection();
+        this.maxPendingSendRequests = pulsar.getConfiguration().getMaxPendingPublishRequestsPerConnection();
         this.resumeReadsThreshold = maxPendingSendRequests / 2;
         this.preciseDispatcherFlowControl = pulsar.getConfiguration().isPreciseDispatcherFlowControl();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.mledger.Position;


### PR DESCRIPTION
Fixes #7128

### Motivation
This PR is a minor update to fix typos in `ServiceConfiguration` & broker.conf  and remove unused import



