### PR TITLE
Allow to delete topics that are failing to recover

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 
 import java.util.function.Supplier;
 
+import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
@@ -132,6 +133,24 @@ public interface ManagedLedgerFactory {
      *            opaque context
      */
     void asyncGetManagedLedgerInfo(String name, ManagedLedgerInfoCallback callback, Object ctx);
+
+    /**
+     * Delete a managed ledger. If it's not open, it's metadata will get regardless deleted.
+     *
+     * @param name
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    void delete(String name) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Delete a managed ledger. If it's not open, it's metadata will get regardless deleted.
+     *
+     * @param name
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    void asyncDelete(String name, DeleteLedgerCallback callback, Object ctx);
 
     /**
      * Releases all the resources maintained by the ManagedLedgerFactory.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
@@ -40,6 +40,7 @@ public class ManagedLedgerInfo {
         public Long entries;
         public Long size;
         public Long timestamp;
+        public boolean isOffloaded;
     }
 
     public static class CursorInfo {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -20,13 +20,19 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Cleanup;
 
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -40,6 +46,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.zookeeper.ZooKeeper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -298,6 +305,56 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         consumer.close();
         producer.close();
         client.close();
+    }
+
+
+    @Test
+    public void testDeleteTopicWithMissingData() throws Exception {
+        String namespace = "prop/usc-" + System.nanoTime();
+        admin.namespaces().createNamespace(namespace);
+
+        String topic = namespace + "/my-topic-" + System.nanoTime();
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        @Cleanup
+        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("test").subscribe();
+
+        @Cleanup
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        producer.send("Hello");
+
+        // Stop all bookies, to get all data offline
+        bkEnsemble.stopBK();
+
+        // Unload the topic. Since all the bookies are down, the recovery
+        // will fail and the topic will not get reloaded.
+        admin.topics().unload(topic);
+
+        Thread.sleep(1000);
+
+        CompletableFuture<Optional<Topic>> future = pulsar.getBrokerService().getTopicIfExists(topic);
+        try {
+            future.get();
+            fail("Should have thrown exception");
+        } catch (ExecutionException e) {
+            // Expected
+        }
+
+        // Deletion must succeed
+        admin.topics().delete(topic);
+
+        // Topic will not be there after
+        assertEquals(pulsar.getBrokerService().getTopicIfExists(topic).join(), Optional.empty());
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class RackAwareTest extends BrokerBkEnsemblesTests {
+public class RackAwareTest extends BkEnsemblesTestBase {
 
     private static final int NUM_BOOKIES = 6;
     private final List<BookieServer> bookies = new ArrayList<>();

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.AsyncCallback.DeleteCallback;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
+import org.apache.bookkeeper.client.api.DeleteBuilder;
 import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.OpenBuilderBase;
@@ -215,6 +216,32 @@ public class PulsarMockBookKeeper extends BookKeeper {
                                                                                   lh.getLedgerMetadata(), lh.entries));
                             }
                         });
+            }
+        };
+    }
+
+    @Override
+    public DeleteBuilder newDeleteLedgerOp() {
+        return new DeleteBuilder() {
+            private long ledgerId;
+
+            @Override
+            public CompletableFuture<Void> execute() {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                asyncDeleteLedger(ledgerId, (res, ctx) -> {
+                    if (res == BKException.Code.OK) {
+                        future.complete(null);
+                    } else {
+                        future.completeExceptionally(BKException.create(res));
+                    }
+                }, null);
+                return future;
+            }
+
+            @Override
+            public DeleteBuilder withLedgerId(long ledgerId) {
+                this.ledgerId = ledgerId;
+                return this;
             }
         };
     }


### PR DESCRIPTION
### Motivation

If a topic is failing to recover, it's currently practically impossible to force the deletion, other than going to delete the metadata from ZK directly.

The failure to recover can happen when data for the last ledger is missing and the ledger fails causing the topic to be offline. This could be due to manual error (eg: increasing and decreasing the bookie replicas without waiting to auto-recovery).

If we want to delete a topic and move on, we shouldn't fail if the data itself is corrupted/missing.