### PR TITLE
Support KeyValue Schema Use Null Key And Null Value

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -158,8 +158,8 @@ public class MessageImpl<T> implements Message<T> {
             msgMetadataBuilder.setNullValue(singleMessageMetadata.hasNullValue());
         }
 
-        if (singleMessageMetadata.hasNullKey()) {
-            msgMetadataBuilder.setNullKey(singleMessageMetadata.hasNullKey());
+        if (singleMessageMetadata.hasNullPartitionKey()) {
+            msgMetadataBuilder.setNullPartitionKey(singleMessageMetadata.hasNullPartitionKey());
         }
 
         this.schema = schema;
@@ -303,7 +303,7 @@ public class MessageImpl<T> implements Message<T> {
         byte[] schemaVersion = getSchemaVersion();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             return (T) kvSchema.decode(
-                    msgMetadataBuilder.hasNullKey() ? null : getKeyBytes(),
+                    msgMetadataBuilder.hasNullPartitionKey() ? null : getKeyBytes(),
                     msgMetadataBuilder.hasNullValue() ? null : getData(), schemaVersion);
         } else {
             return schema.decode(getData(), schemaVersion);
@@ -314,7 +314,7 @@ public class MessageImpl<T> implements Message<T> {
         KeyValueSchema kvSchema = (KeyValueSchema) schema;
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             return (T) kvSchema.decode(
-                    msgMetadataBuilder.hasNullKey() ? null : getKeyBytes(),
+                    msgMetadataBuilder.hasNullPartitionKey() ? null : getKeyBytes(),
                     msgMetadataBuilder.hasNullValue() ? null : getData(), null);
         } else {
             return schema.decode(getData());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -158,6 +158,10 @@ public class MessageImpl<T> implements Message<T> {
             msgMetadataBuilder.setNullValue(singleMessageMetadata.hasNullValue());
         }
 
+        if (singleMessageMetadata.hasNullKey()) {
+            msgMetadataBuilder.setNullKey(singleMessageMetadata.hasNullKey());
+        }
+
         this.schema = schema;
     }
 
@@ -269,9 +273,6 @@ public class MessageImpl<T> implements Message<T> {
     @Override
     public T getValue() {
         checkNotNull(msgMetadataBuilder);
-        if (msgMetadataBuilder.hasNullValue()) {
-            return null;
-        }
         if (schema.getSchemaInfo() != null && SchemaType.KEY_VALUE == schema.getSchemaInfo().getType()) {
             if (schema.supportSchemaVersioning()) {
                 return getKeyValueBySchemaVersion();
@@ -279,6 +280,9 @@ public class MessageImpl<T> implements Message<T> {
                 return getKeyValue();
             }
         } else {
+            if (msgMetadataBuilder.hasNullValue()) {
+                return null;
+            }
             // check if the schema passed in from client supports schema versioning or not
             // this is an optimization to only get schema version when necessary
             if (schema.supportSchemaVersioning()) {
@@ -298,7 +302,9 @@ public class MessageImpl<T> implements Message<T> {
         KeyValueSchema kvSchema = (KeyValueSchema) schema;
         byte[] schemaVersion = getSchemaVersion();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
-            return (T) kvSchema.decode(getKeyBytes(), getData(), schemaVersion);
+            return (T) kvSchema.decode(
+                    msgMetadataBuilder.hasNullKey() ? null : getKeyBytes(),
+                    msgMetadataBuilder.hasNullValue() ? null : getData(), schemaVersion);
         } else {
             return schema.decode(getData(), schemaVersion);
         }
@@ -307,7 +313,9 @@ public class MessageImpl<T> implements Message<T> {
     private T getKeyValue() {
         KeyValueSchema kvSchema = (KeyValueSchema) schema;
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
-            return (T) kvSchema.decode(getKeyBytes(), getData(), null);
+            return (T) kvSchema.decode(
+                    msgMetadataBuilder.hasNullKey() ? null : getKeyBytes(),
+                    msgMetadataBuilder.hasNullValue() ? null : getData(), null);
         } else {
             return schema.decode(getData());
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -112,7 +112,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             checkArgument(!(kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED),
                     "This method is not allowed to set keys when in encoding type is SEPARATED");
             if (key == null) {
-                msgMetadataBuilder.setNullKey(true);
+                msgMetadataBuilder.setNullPartitionKey(true);
                 return this;
             }
         }
@@ -128,7 +128,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             checkArgument(!(kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED),
                     "This method is not allowed to set keys when in encoding type is SEPARATED");
             if (key == null) {
-                msgMetadataBuilder.setNullKey(true);
+                msgMetadataBuilder.setNullPartitionKey(true);
                 return this;
             }
         }
@@ -159,7 +159,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                             Base64.getEncoder().encodeToString(kvSchema.getKeySchema().encode(kv.getKey())));
                     msgMetadataBuilder.setPartitionKeyB64Encoded(true);
                 } else {
-                    this.msgMetadataBuilder.setNullKey(true);
+                    this.msgMetadataBuilder.setNullPartitionKey(true);
                 }
 
                 // set value as the payload

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -111,6 +111,10 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             KeyValueSchema kvSchema = (KeyValueSchema) schema;
             checkArgument(!(kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED),
                     "This method is not allowed to set keys when in encoding type is SEPARATED");
+            if (key == null) {
+                msgMetadataBuilder.setNullKey(true);
+                return this;
+            }
         }
         msgMetadataBuilder.setPartitionKey(key);
         msgMetadataBuilder.setPartitionKeyB64Encoded(false);
@@ -123,6 +127,10 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             KeyValueSchema kvSchema = (KeyValueSchema) schema;
             checkArgument(!(kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED),
                     "This method is not allowed to set keys when in encoding type is SEPARATED");
+            if (key == null) {
+                msgMetadataBuilder.setNullKey(true);
+                return this;
+            }
         }
         msgMetadataBuilder.setPartitionKey(Base64.getEncoder().encodeToString(key));
         msgMetadataBuilder.setPartitionKeyB64Encoded(true);
@@ -146,11 +154,20 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) value;
             if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
                 // set key as the message key
-                msgMetadataBuilder.setPartitionKey(
-                        Base64.getEncoder().encodeToString(kvSchema.getKeySchema().encode(kv.getKey())));
-                msgMetadataBuilder.setPartitionKeyB64Encoded(true);
+                if (kv.getKey() != null) {
+                    msgMetadataBuilder.setPartitionKey(
+                            Base64.getEncoder().encodeToString(kvSchema.getKeySchema().encode(kv.getKey())));
+                    msgMetadataBuilder.setPartitionKeyB64Encoded(true);
+                } else {
+                    this.msgMetadataBuilder.setNullKey(true);
+                }
+
                 // set value as the payload
-                this.content = ByteBuffer.wrap(kvSchema.getValueSchema().encode(kv.getValue()));
+                if (kv.getValue() != null) {
+                    this.content = ByteBuffer.wrap(kvSchema.getValueSchema().encode(kv.getValue()));
+                } else {
+                    this.msgMetadataBuilder.setNullValue(true);
+                }
                 return this;
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
@@ -132,6 +132,9 @@ public class KeyValueSchema<K, V> implements Schema<KeyValue<K, V>> {
                 valueSchema
             );
         } else {
+            if (message.getValue() == null) {
+                return null;
+            }
             return valueSchema.encode(message.getValue());
         }
     }
@@ -150,16 +153,25 @@ public class KeyValueSchema<K, V> implements Schema<KeyValue<K, V>> {
 
     public KeyValue<K, V> decode(byte[] keyBytes, byte[] valueBytes, byte[] schemaVersion) {
         K k;
-        if (keySchema.supportSchemaVersioning() && schemaVersion != null) {
-            k = keySchema.decode(keyBytes, schemaVersion);
+        if (keyBytes == null) {
+            k = null;
         } else {
-            k = keySchema.decode(keyBytes);
+            if (keySchema.supportSchemaVersioning() && schemaVersion != null) {
+                k = keySchema.decode(keyBytes, schemaVersion);
+            } else {
+                k = keySchema.decode(keyBytes);
+            }
         }
+
         V v;
-        if (valueSchema.supportSchemaVersioning() && schemaVersion != null) {
-            v = valueSchema.decode(valueBytes, schemaVersion);
+        if (valueBytes == null) {
+            v = null;
         } else {
-            v = valueSchema.decode(valueBytes);
+            if (valueSchema.supportSchemaVersioning() && schemaVersion != null) {
+                v = valueSchema.decode(valueBytes, schemaVersion);
+            } else {
+                v = valueSchema.decode(valueBytes);
+            }
         }
         return new KeyValue<>(k, v);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -3719,9 +3719,9 @@ public final class PulsarApi {
     boolean hasChunkId();
     int getChunkId();
     
-    // optional bool null_key = 30 [default = false];
-    boolean hasNullKey();
-    boolean getNullKey();
+    // optional bool null_partition_key = 30 [default = false];
+    boolean hasNullPartitionKey();
+    boolean getNullPartitionKey();
   }
   public static final class MessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -4164,14 +4164,14 @@ public final class PulsarApi {
       return chunkId_;
     }
     
-    // optional bool null_key = 30 [default = false];
-    public static final int NULL_KEY_FIELD_NUMBER = 30;
-    private boolean nullKey_;
-    public boolean hasNullKey() {
+    // optional bool null_partition_key = 30 [default = false];
+    public static final int NULL_PARTITION_KEY_FIELD_NUMBER = 30;
+    private boolean nullPartitionKey_;
+    public boolean hasNullPartitionKey() {
       return ((bitField0_ & 0x01000000) == 0x01000000);
     }
-    public boolean getNullKey() {
-      return nullKey_;
+    public boolean getNullPartitionKey() {
+      return nullPartitionKey_;
     }
     
     private void initFields() {
@@ -4202,7 +4202,7 @@ public final class PulsarApi {
       numChunksFromMsg_ = 0;
       totalChunkMsgSize_ = 0;
       chunkId_ = 0;
-      nullKey_ = false;
+      nullPartitionKey_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4327,7 +4327,7 @@ public final class PulsarApi {
         output.writeInt32(29, chunkId_);
       }
       if (((bitField0_ & 0x01000000) == 0x01000000)) {
-        output.writeBool(30, nullKey_);
+        output.writeBool(30, nullPartitionKey_);
       }
     }
     
@@ -4452,7 +4452,7 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x01000000) == 0x01000000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeBoolSize(30, nullKey_);
+          .computeBoolSize(30, nullPartitionKey_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -4621,7 +4621,7 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x02000000);
         chunkId_ = 0;
         bitField0_ = (bitField0_ & ~0x04000000);
-        nullKey_ = false;
+        nullPartitionKey_ = false;
         bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
@@ -4771,7 +4771,7 @@ public final class PulsarApi {
         if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
           to_bitField0_ |= 0x01000000;
         }
-        result.nullKey_ = nullKey_;
+        result.nullPartitionKey_ = nullPartitionKey_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -4880,8 +4880,8 @@ public final class PulsarApi {
         if (other.hasChunkId()) {
           setChunkId(other.getChunkId());
         }
-        if (other.hasNullKey()) {
-          setNullKey(other.getNullKey());
+        if (other.hasNullPartitionKey()) {
+          setNullPartitionKey(other.getNullPartitionKey());
         }
         return this;
       }
@@ -5079,7 +5079,7 @@ public final class PulsarApi {
             }
             case 240: {
               bitField0_ |= 0x08000000;
-              nullKey_ = input.readBool();
+              nullPartitionKey_ = input.readBool();
               break;
             }
           }
@@ -5913,23 +5913,23 @@ public final class PulsarApi {
         return this;
       }
       
-      // optional bool null_key = 30 [default = false];
-      private boolean nullKey_ ;
-      public boolean hasNullKey() {
+      // optional bool null_partition_key = 30 [default = false];
+      private boolean nullPartitionKey_ ;
+      public boolean hasNullPartitionKey() {
         return ((bitField0_ & 0x08000000) == 0x08000000);
       }
-      public boolean getNullKey() {
-        return nullKey_;
+      public boolean getNullPartitionKey() {
+        return nullPartitionKey_;
       }
-      public Builder setNullKey(boolean value) {
+      public Builder setNullPartitionKey(boolean value) {
         bitField0_ |= 0x08000000;
-        nullKey_ = value;
+        nullPartitionKey_ = value;
         
         return this;
       }
-      public Builder clearNullKey() {
+      public Builder clearNullPartitionKey() {
         bitField0_ = (bitField0_ & ~0x08000000);
-        nullKey_ = false;
+        nullPartitionKey_ = false;
         
         return this;
       }
@@ -5986,9 +5986,9 @@ public final class PulsarApi {
     boolean hasNullValue();
     boolean getNullValue();
     
-    // optional bool null_key = 10 [default = false];
-    boolean hasNullKey();
-    boolean getNullKey();
+    // optional bool null_partition_key = 10 [default = false];
+    boolean hasNullPartitionKey();
+    boolean getNullPartitionKey();
   }
   public static final class SingleMessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -6148,14 +6148,14 @@ public final class PulsarApi {
       return nullValue_;
     }
     
-    // optional bool null_key = 10 [default = false];
-    public static final int NULL_KEY_FIELD_NUMBER = 10;
-    private boolean nullKey_;
-    public boolean hasNullKey() {
+    // optional bool null_partition_key = 10 [default = false];
+    public static final int NULL_PARTITION_KEY_FIELD_NUMBER = 10;
+    private boolean nullPartitionKey_;
+    public boolean hasNullPartitionKey() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
-    public boolean getNullKey() {
-      return nullKey_;
+    public boolean getNullPartitionKey() {
+      return nullPartitionKey_;
     }
     
     private void initFields() {
@@ -6168,7 +6168,7 @@ public final class PulsarApi {
       orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
       sequenceId_ = 0L;
       nullValue_ = false;
-      nullKey_ = false;
+      nullPartitionKey_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -6225,7 +6225,7 @@ public final class PulsarApi {
         output.writeBool(9, nullValue_);
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeBool(10, nullKey_);
+        output.writeBool(10, nullPartitionKey_);
       }
     }
     
@@ -6273,7 +6273,7 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeBoolSize(10, nullKey_);
+          .computeBoolSize(10, nullPartitionKey_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -6406,7 +6406,7 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000080);
         nullValue_ = false;
         bitField0_ = (bitField0_ & ~0x00000100);
-        nullKey_ = false;
+        nullPartitionKey_ = false;
         bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
@@ -6481,7 +6481,7 @@ public final class PulsarApi {
         if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
           to_bitField0_ |= 0x00000100;
         }
-        result.nullKey_ = nullKey_;
+        result.nullPartitionKey_ = nullPartitionKey_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -6522,8 +6522,8 @@ public final class PulsarApi {
         if (other.hasNullValue()) {
           setNullValue(other.getNullValue());
         }
-        if (other.hasNullKey()) {
-          setNullKey(other.getNullKey());
+        if (other.hasNullPartitionKey()) {
+          setNullPartitionKey(other.getNullPartitionKey());
         }
         return this;
       }
@@ -6612,7 +6612,7 @@ public final class PulsarApi {
             }
             case 80: {
               bitField0_ |= 0x00000200;
-              nullKey_ = input.readBool();
+              nullPartitionKey_ = input.readBool();
               break;
             }
           }
@@ -6896,23 +6896,23 @@ public final class PulsarApi {
         return this;
       }
       
-      // optional bool null_key = 10 [default = false];
-      private boolean nullKey_ ;
-      public boolean hasNullKey() {
+      // optional bool null_partition_key = 10 [default = false];
+      private boolean nullPartitionKey_ ;
+      public boolean hasNullPartitionKey() {
         return ((bitField0_ & 0x00000200) == 0x00000200);
       }
-      public boolean getNullKey() {
-        return nullKey_;
+      public boolean getNullPartitionKey() {
+        return nullPartitionKey_;
       }
-      public Builder setNullKey(boolean value) {
+      public Builder setNullPartitionKey(boolean value) {
         bitField0_ |= 0x00000200;
-        nullKey_ = value;
+        nullPartitionKey_ = value;
         
         return this;
       }
-      public Builder clearNullKey() {
+      public Builder clearNullPartitionKey() {
         bitField0_ = (bitField0_ & ~0x00000200);
-        nullKey_ = false;
+        nullPartitionKey_ = false;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -3718,6 +3718,10 @@ public final class PulsarApi {
     // optional int32 chunk_id = 29;
     boolean hasChunkId();
     int getChunkId();
+    
+    // optional bool null_key = 30 [default = false];
+    boolean hasNullKey();
+    boolean getNullKey();
   }
   public static final class MessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -4160,6 +4164,16 @@ public final class PulsarApi {
       return chunkId_;
     }
     
+    // optional bool null_key = 30 [default = false];
+    public static final int NULL_KEY_FIELD_NUMBER = 30;
+    private boolean nullKey_;
+    public boolean hasNullKey() {
+      return ((bitField0_ & 0x01000000) == 0x01000000);
+    }
+    public boolean getNullKey() {
+      return nullKey_;
+    }
+    
     private void initFields() {
       producerName_ = "";
       sequenceId_ = 0L;
@@ -4188,6 +4202,7 @@ public final class PulsarApi {
       numChunksFromMsg_ = 0;
       totalChunkMsgSize_ = 0;
       chunkId_ = 0;
+      nullKey_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4311,6 +4326,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00800000) == 0x00800000)) {
         output.writeInt32(29, chunkId_);
       }
+      if (((bitField0_ & 0x01000000) == 0x01000000)) {
+        output.writeBool(30, nullKey_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -4431,6 +4449,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00800000) == 0x00800000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeInt32Size(29, chunkId_);
+      }
+      if (((bitField0_ & 0x01000000) == 0x01000000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeBoolSize(30, nullKey_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -4599,6 +4621,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x02000000);
         chunkId_ = 0;
         bitField0_ = (bitField0_ & ~0x04000000);
+        nullKey_ = false;
+        bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
       
@@ -4744,6 +4768,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00800000;
         }
         result.chunkId_ = chunkId_;
+        if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
+          to_bitField0_ |= 0x01000000;
+        }
+        result.nullKey_ = nullKey_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -4851,6 +4879,9 @@ public final class PulsarApi {
         }
         if (other.hasChunkId()) {
           setChunkId(other.getChunkId());
+        }
+        if (other.hasNullKey()) {
+          setNullKey(other.getNullKey());
         }
         return this;
       }
@@ -5044,6 +5075,11 @@ public final class PulsarApi {
             case 232: {
               bitField0_ |= 0x04000000;
               chunkId_ = input.readInt32();
+              break;
+            }
+            case 240: {
+              bitField0_ |= 0x08000000;
+              nullKey_ = input.readBool();
               break;
             }
           }
@@ -5877,6 +5913,27 @@ public final class PulsarApi {
         return this;
       }
       
+      // optional bool null_key = 30 [default = false];
+      private boolean nullKey_ ;
+      public boolean hasNullKey() {
+        return ((bitField0_ & 0x08000000) == 0x08000000);
+      }
+      public boolean getNullKey() {
+        return nullKey_;
+      }
+      public Builder setNullKey(boolean value) {
+        bitField0_ |= 0x08000000;
+        nullKey_ = value;
+        
+        return this;
+      }
+      public Builder clearNullKey() {
+        bitField0_ = (bitField0_ & ~0x08000000);
+        nullKey_ = false;
+        
+        return this;
+      }
+      
       // @@protoc_insertion_point(builder_scope:pulsar.proto.MessageMetadata)
     }
     
@@ -5928,6 +5985,10 @@ public final class PulsarApi {
     // optional bool null_value = 9 [default = false];
     boolean hasNullValue();
     boolean getNullValue();
+    
+    // optional bool null_key = 10 [default = false];
+    boolean hasNullKey();
+    boolean getNullKey();
   }
   public static final class SingleMessageMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -6087,6 +6148,16 @@ public final class PulsarApi {
       return nullValue_;
     }
     
+    // optional bool null_key = 10 [default = false];
+    public static final int NULL_KEY_FIELD_NUMBER = 10;
+    private boolean nullKey_;
+    public boolean hasNullKey() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    public boolean getNullKey() {
+      return nullKey_;
+    }
+    
     private void initFields() {
       properties_ = java.util.Collections.emptyList();
       partitionKey_ = "";
@@ -6097,6 +6168,7 @@ public final class PulsarApi {
       orderingKey_ = org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.EMPTY;
       sequenceId_ = 0L;
       nullValue_ = false;
+      nullKey_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -6152,6 +6224,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeBool(9, nullValue_);
       }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeBool(10, nullKey_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -6195,6 +6270,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeBoolSize(9, nullValue_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeBoolSize(10, nullKey_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -6327,6 +6406,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000080);
         nullValue_ = false;
         bitField0_ = (bitField0_ & ~0x00000100);
+        nullKey_ = false;
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
       
@@ -6397,6 +6478,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000080;
         }
         result.nullValue_ = nullValue_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.nullKey_ = nullKey_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -6436,6 +6521,9 @@ public final class PulsarApi {
         }
         if (other.hasNullValue()) {
           setNullValue(other.getNullValue());
+        }
+        if (other.hasNullKey()) {
+          setNullKey(other.getNullKey());
         }
         return this;
       }
@@ -6520,6 +6608,11 @@ public final class PulsarApi {
             case 72: {
               bitField0_ |= 0x00000100;
               nullValue_ = input.readBool();
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000200;
+              nullKey_ = input.readBool();
               break;
             }
           }
@@ -6799,6 +6892,27 @@ public final class PulsarApi {
       public Builder clearNullValue() {
         bitField0_ = (bitField0_ & ~0x00000100);
         nullValue_ = false;
+        
+        return this;
+      }
+      
+      // optional bool null_key = 10 [default = false];
+      private boolean nullKey_ ;
+      public boolean hasNullKey() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      public boolean getNullKey() {
+        return nullKey_;
+      }
+      public Builder setNullKey(boolean value) {
+        bitField0_ |= 0x00000200;
+        nullKey_ = value;
+        
+        return this;
+      }
+      public Builder clearNullKey() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        nullKey_ = false;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1678,8 +1678,8 @@ public class Commands {
             singleMessageMetadataBuilder.setNullValue(msgBuilder.hasNullValue());
         }
 
-        if (msgBuilder.hasNullKey()) {
-            singleMessageMetadataBuilder.setNullKey(msgBuilder.hasNullKey());
+        if (msgBuilder.hasNullPartitionKey()) {
+            singleMessageMetadataBuilder.setNullPartitionKey(msgBuilder.hasNullPartitionKey());
         }
 
         try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1678,6 +1678,10 @@ public class Commands {
             singleMessageMetadataBuilder.setNullValue(msgBuilder.hasNullValue());
         }
 
+        if (msgBuilder.hasNullKey()) {
+            singleMessageMetadataBuilder.setNullKey(msgBuilder.hasNullKey());
+        }
+
         try {
             return serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder, payload, batchBuffer);
         } finally {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -143,6 +143,9 @@ message MessageMetadata {
 	optional int32 num_chunks_from_msg = 27;
 	optional int32 total_chunk_msg_size = 28;
 	optional int32 chunk_id = 29;
+
+    // Indicate if the message key is set
+    optional bool null_key = 30 [default = false];
 }
 
 message SingleMessageMetadata {
@@ -161,6 +164,8 @@ message SingleMessageMetadata {
     optional uint64 sequence_id = 8;
     // Indicate if the message payload value is set
     optional bool null_value = 9 [ default = false ];
+    // Indicate if the message key is set
+    optional bool null_key = 10 [ default = false];
 }
 
 enum ServerError {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -144,8 +144,8 @@ message MessageMetadata {
 	optional int32 total_chunk_msg_size = 28;
 	optional int32 chunk_id = 29;
 
-    // Indicate if the message key is set
-    optional bool null_key = 30 [default = false];
+    // Indicate if the message partition key is set
+    optional bool null_partition_key = 30 [default = false];
 }
 
 message SingleMessageMetadata {
@@ -164,8 +164,8 @@ message SingleMessageMetadata {
     optional uint64 sequence_id = 8;
     // Indicate if the message payload value is set
     optional bool null_value = 9 [ default = false ];
-    // Indicate if the message key is set
-    optional bool null_key = 10 [ default = false];
+    // Indicate if the message partition key is set
+    optional bool null_partition_key = 10 [ default = false];
 }
 
 enum ServerError {


### PR DESCRIPTION
Fixes #4804  

Thanks, @nlu90, work at #6384.

### Motivation

Currently, the KeyValue schema doesn't handle `null` key and `null` value well.

### Modifications

Make the KeyValue schema support `null` key and `null` value

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Add unit test.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (yes)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)