### PR TITLE
Adding Intercept Interface

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -22,16 +22,18 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Charsets;
+
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.api.DigestType;
-
 import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
-
 import org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSet;
 
 /**
@@ -71,6 +73,9 @@ public class ManagedLedgerConfig {
     private Map<String, Object> bookKeeperEnsemblePlacementPolicyProperties;
     private LedgerOffloader ledgerOffloader = NullLedgerOffloader.INSTANCE;
     private Clock clock = Clock.systemUTC();
+    @Getter
+    @Setter
+    private Runnable createFunctionInterceptFunc;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;
@@ -558,7 +563,7 @@ public class ManagedLedgerConfig {
     /**
      * Managed-ledger can setup different custom EnsemblePlacementPolicy (eg: affinity to write ledgers to only setup of
      * group of bookies).
-     * 
+     *
      * @return
      */
     public Class<? extends EnsemblePlacementPolicy> getBookKeeperEnsemblePlacementPolicyClassName() {
@@ -567,7 +572,7 @@ public class ManagedLedgerConfig {
 
     /**
      * Returns EnsemblePlacementPolicy configured for the Managed-ledger.
-     * 
+     *
      * @param bookKeeperEnsemblePlacementPolicyClassName
      */
     public void setBookKeeperEnsemblePlacementPolicyClassName(
@@ -577,7 +582,7 @@ public class ManagedLedgerConfig {
 
     /**
      * Returns properties required by configured bookKeeperEnsemblePlacementPolicy.
-     * 
+     *
      * @return
      */
     public Map<String, Object> getBookKeeperEnsemblePlacementPolicyProperties() {
@@ -587,7 +592,7 @@ public class ManagedLedgerConfig {
     /**
      * Managed-ledger can setup different custom EnsemblePlacementPolicy which needs
      * bookKeeperEnsemblePlacementPolicy-Properties.
-     * 
+     *
      * @param bookKeeperEnsemblePlacementPolicyProperties
      */
     public void setBookKeeperEnsemblePlacementPolicyProperties(

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -357,7 +357,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     callback.initializeFailed(new ManagedLedgerException(e));
                 }
             }
-        });
+        }, config.getCreateFunctionInterceptFunc());
 
         scheduleTimeoutTask();
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.List;
+
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
@@ -50,8 +51,12 @@ public interface MetaStore {
      *            whether the managed ledger metadata should be created if it doesn't exist already
      * @throws MetaStoreException
      */
-    void getManagedLedgerInfo(String ledgerName, boolean createIfMissing, MetaStoreCallback<ManagedLedgerInfo> callback);
+    void getManagedLedgerInfo(String ledgerName, boolean createIfMissing, MetaStoreCallback<ManagedLedgerInfo> callback,
+            Runnable createTopicIntercept);
 
+    default void getManagedLedgerInfo(String ledgerName, boolean createIfMissing, MetaStoreCallback<ManagedLedgerInfo> callback) {
+        getManagedLedgerInfo(ledgerName, createIfMissing, callback, null);
+    }
     /**
      *
      * @param ledgerName

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-admin-original</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -193,6 +193,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(category = CATEGORY_SERVER, doc = "Whether to enable the acknowledge of batch local index")
     private boolean acknowledgmentAtBatchIndexLevelEnabled = false;
 
+    @FieldContext(category = CATEGORY_SERVER, doc = "The class name of Intercept provider")
+    private String interceptProvider;
+
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Enable the WebSocket API service in broker"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/FunctionsInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/FunctionsInterceptProvider.java
@@ -1,0 +1,23 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.io.SinkConfig;
+import org.apache.pulsar.common.io.SourceConfig;
+
+public interface FunctionsInterceptProvider {
+    /**
+     * Intercept call for create function
+     *
+     * @param functionConfig function config of the function to be created
+     * @param clientRole the role used to create function
+     */
+    default void createFunction(FunctionConfig functionConfig, String clientRole) throws InterceptException {}
+
+    /**
+     * Intercept call for update function
+     *  @param functionConfig function config of the function to be updated
+     * @param existingFunctionConfig
+     * @param clientRole the role used to update function
+     */
+    default void updateFunction(FunctionConfig functionConfig, FunctionConfig existingFunctionConfig, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/FunctionsInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/FunctionsInterceptService.java
@@ -1,0 +1,34 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.functions.FunctionConfig;
+
+public class FunctionsInterceptService {
+
+    private final FunctionsInterceptProvider provider;
+
+    public FunctionsInterceptService(FunctionsInterceptProvider functionsInterceptProvider) {
+        this.provider = functionsInterceptProvider;
+    }
+
+    /**
+     * Intercept call for create function
+     *
+     * @param functionConfig function config of the function to be created
+     * @param clientRole the role used to create function
+     */
+    public void createFunction(FunctionConfig functionConfig, String clientRole) throws InterceptException {
+        provider.createFunction(functionConfig, clientRole);
+    }
+
+    /**
+     * Intercept call for update source
+     *
+     * @param updates updates to this function's function config
+     * @param existingFunctionConfig the existing function config
+     * @param clientRole the role used to update function
+     */
+    public void updateFunction(FunctionConfig updates, FunctionConfig existingFunctionConfig, String clientRole) throws InterceptException {
+        provider.updateFunction(updates, existingFunctionConfig, clientRole);
+    }
+
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptException.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptException.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Getter
+@NoArgsConstructor
+public class InterceptException extends Exception {
+
+    private Optional<Integer> errorCode = Optional.empty();
+
+    public InterceptException(Integer errorCode, String errorMessage) {
+        super(errorMessage);
+        this.errorCode = Optional.of(errorCode);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptProvider.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+/**
+ * This class provides a mechanism to intercept various API calls
+ */
+public interface InterceptProvider {
+
+    default TenantsInterceptProvider getTenantInterceptProvider() {
+        return new TenantsInterceptProvider() {};
+    }
+
+    default NamespacesInterceptProvider getNamespaceInterceptProvider() {
+        return new NamespacesInterceptProvider() {};
+    }
+
+    default TopicsInterceptProvider getTopicInterceptProvider() {
+        return new TopicsInterceptProvider() {};
+    }
+
+    default FunctionsInterceptProvider getFunctionsInterceptProvider() {
+        return new FunctionsInterceptProvider() {};
+    }
+
+    default SourcesInterceptProvider getSourcesInterceptProvider() {
+        return new SourcesInterceptProvider() {};
+    }
+
+    default SinksInterceptProvider getSinksInterceptProvider() {
+        return new SinksInterceptProvider() {};
+    }
+
+    /**
+     * Perform initialization for the intercept provider
+     *
+     * @param conf broker config object
+     */
+    default void initialize(ServiceConfiguration conf, PulsarAdmin pulsarAdmin) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/InterceptService.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import com.google.common.annotations.Beta;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Service that manages intercepting API calls to a pulsar cluster
+ */
+@Beta
+public class InterceptService {
+    private static final Logger log = LoggerFactory.getLogger(InterceptService.class);
+
+    private InterceptProvider provider;
+    private final ServiceConfiguration conf;
+    private final TenantsInterceptService tenantInterceptService;
+    private final NamespacesInterceptService namespaceInterceptService;
+    private final TopicInterceptService topicInterceptService;
+    private final FunctionsInterceptService functionInterceptService;
+    private final SinksInterceptService sinkInterceptService;
+    private final SourcesInterceptService sourceInterceptService;
+
+    public InterceptService(ServiceConfiguration conf, PulsarAdmin pulsarAdmin)
+            throws PulsarServerException {
+        this.conf = conf;
+
+        try {
+            final String providerClassname = conf.getInterceptProvider();
+            if (StringUtils.isNotBlank(providerClassname)) {
+                provider = (InterceptProvider) Class.forName(providerClassname).newInstance();
+                provider.initialize(conf, pulsarAdmin);
+                log.info("Interceptor {} has been loaded.", providerClassname);
+            } else {
+                provider = new InterceptProvider() {};
+            }
+
+            tenantInterceptService = new TenantsInterceptService(provider.getTenantInterceptProvider());
+            namespaceInterceptService = new NamespacesInterceptService(provider.getNamespaceInterceptProvider());
+            topicInterceptService = new TopicInterceptService(provider.getTopicInterceptProvider());
+            functionInterceptService = new FunctionsInterceptService(provider.getFunctionsInterceptProvider());
+            sourceInterceptService = new SourcesInterceptService(provider.getSourcesInterceptProvider());
+            sinkInterceptService = new SinksInterceptService(provider.getSinksInterceptProvider());
+
+        } catch (Throwable e) {
+            throw new PulsarServerException("Failed to load an intercept provider.", e);
+        }
+    }
+
+    public TenantsInterceptService tenants() {
+        return tenantInterceptService;
+    }
+
+    public NamespacesInterceptService namespaces() {
+        return namespaceInterceptService;
+    }
+
+    public TopicInterceptService topics() {
+        return topicInterceptService;
+    }
+
+    public FunctionsInterceptService functions() {
+         return functionInterceptService;
+    }
+
+    public SourcesInterceptService sources() {
+        return sourceInterceptService;
+    }
+
+    public SinksInterceptService sinks() {
+        return sinkInterceptService;
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/NamespacesInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/NamespacesInterceptProvider.java
@@ -1,0 +1,142 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
+import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
+
+import java.util.List;
+import java.util.Set;
+
+public interface NamespacesInterceptProvider {
+    /**
+     * Intercept call for creating namespace
+     *
+     * @param namespaceName the namespace name
+     * @param policies polices for this namespace
+     * @param clientRole the role used to create namespace
+     */
+    default void createNamespace(NamespaceName namespaceName, Policies policies, String clientRole) throws InterceptException {}
+
+    default void deleteNamespace(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void deleteNamespaceBundle(NamespaceName namespaceName, String bundleRange, String clientRole) throws InterceptException {}
+
+    default void setNamespaceMessageTTL(NamespaceName namespaceName, int messageTTL, String clientRole) throws InterceptException {}
+
+    default void grantPermissionOnNamespace(NamespaceName namespaceName, String role, Set<AuthAction> actions, String clientRole) throws InterceptException {}
+
+    default void grantPermissionOnSubscription(NamespaceName namespaceName, String subscription, Set<String> roles, String clientRole) throws InterceptException {}
+
+    default void revokePermissionsOnNamespace(NamespaceName namespaceName, String role, String clientRole) throws InterceptException {}
+
+    default void revokePermissionsOnSubscription(NamespaceName namespaceName, String subscriptionName, String role, String clientRole) throws InterceptException {}
+
+    default void getNamespaceReplicationClusters(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setNamespaceReplicationClusters(NamespaceName namespaceName, List<String> clusterIds, String clientRole) throws InterceptException {}
+
+    default void modifyDeduplication(NamespaceName namespaceName, boolean enableDeduplication, String clientRole) {}
+
+    default void getTenantNamespaces(NamespaceName namespaceName, String tenant, String clientRole) throws InterceptException {}
+
+    default void unloadNamespace(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setBookieAffinityGroup(NamespaceName namespaceName, BookieAffinityGroupData bookieAffinityGroup, String clientRole) throws InterceptException {}
+
+    default void getBookieAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void unloadNamespaceBundle(NamespaceName namespaceName, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void splitNamespaceBundle(NamespaceName namespaceName, String bundleRange, boolean authoritative, boolean unload, String clientRole) throws InterceptException {}
+
+    default void setTopicDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {}
+
+    default void getTopicDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException  {}
+
+    default void setSubscriptionDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {}
+
+    default void getSubscriptionDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setSubscribeRate(NamespaceName namespaceName, SubscribeRate subscribeRate, String clientRole) throws InterceptException {}
+
+    default void getSubscribeRate(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setReplicatorDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {}
+
+    default void getReplicatorDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setBacklogQuota(NamespaceName namespaceName, BacklogQuota.BacklogQuotaType backlogQuotaType, BacklogQuota backlogQuota, String clientRole) throws InterceptException {}
+
+    default void removeBacklogQuota(NamespaceName namespaceName, BacklogQuota.BacklogQuotaType backlogQuotaType, String clientRole) throws InterceptException {}
+
+    default void setRetention(NamespaceName namespaceName, RetentionPolicies retention, String clientRole) throws InterceptException {}
+
+    default void setPersistence(NamespaceName namespaceName, PersistencePolicies persistence, String clientRole) throws InterceptException {}
+
+    default void getPersistence(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void clearNamespaceBacklog(NamespaceName namespaceName, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void clearNamespaceBundleBacklog(NamespaceName namespaceName, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void clearNamespaceBacklogForSubscription(NamespaceName namespaceName, String subscription, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void clearNamespaceBundleBacklogForSubscription(NamespaceName namespaceName, String subscription, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void unsubscribeNamespace(NamespaceName namespaceName, String subscription, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void unsubscribeNamespaceBundle(NamespaceName namespaceName, String subscription, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {}
+
+    default void setSubscriptionAuthMode(NamespaceName namespaceName, SubscriptionAuthMode subscriptionAuthMode, String clientRole) throws InterceptException {}
+
+    default void modifyEncryptionRequired(NamespaceName namespaceName, boolean encryptionRequired, String clientRole) throws InterceptException {}
+
+    default void setNamespaceAntiAffinityGroup(NamespaceName namespaceName, String antiAffinityGroup, String clientRole) throws InterceptException {}
+
+    default void getNamespaceAntiAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void removeNamespaceAntiAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void getAntiAffinityNamespaces(NamespaceName namespaceName, String cluster, String antiAffinityGroup, String clientRole) throws InterceptException {}
+
+    default void getMaxProducersPerTopic(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setMaxProducersPerTopic(NamespaceName namespaceName, int maxProducersPerTopic, String clientRole) throws InterceptException {}
+
+    default void getMaxConsumersPerTopic(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setMaxConsumersPerTopic(NamespaceName namespaceName, int maxConsumersPerTopic, String clientRole) throws InterceptException {}
+
+    default void getMaxConsumersPerSubscription(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setMaxConsumersPerSubscription(NamespaceName namespaceName, int maxConsumersPerSubscription, String clientRole) throws InterceptException {}
+
+    default void getCompactionThreshold(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setCompactionThreshold(NamespaceName namespaceName, long newThreshold, String clientRole) throws InterceptException {}
+
+    default void getOffloadThreshold(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setOffloadThreshold(NamespaceName namespaceName, long newThreshold, String clientRole) throws InterceptException {}
+
+    default void getOffloadDeletionLag(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setOffloadDeletionLag(NamespaceName namespaceName, Long newDeletionLagMs, String clientRole) throws InterceptException {}
+
+    default void getSchemaAutoUpdateCompatibilityStrategy(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setSchemaAutoUpdateCompatibilityStrategy(NamespaceName namespaceName,
+                                                         SchemaAutoUpdateCompatibilityStrategy strategy, String clientRole) throws InterceptException {}
+
+    default void getSchemaValidationEnforced(NamespaceName namespaceName, String clientRole) throws InterceptException {}
+
+    default void setSchemaValidationEnforced(NamespaceName namespaceName, boolean schemaValidationEnforced, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/NamespacesInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/NamespacesInterceptService.java
@@ -1,0 +1,265 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
+import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
+
+import java.util.List;
+import java.util.Set;
+
+public class NamespacesInterceptService {
+
+    private final NamespacesInterceptProvider provider;
+
+    public NamespacesInterceptService(NamespacesInterceptProvider namespaceInterceptProvider) {
+        this.provider = namespaceInterceptProvider;
+    }
+
+    /**
+     * Intercept call for creating namespace
+     *
+     * @param namespaceName the namespace name
+     * @param policies polices for this namespace
+     * @param clientRole the role used to create namespace
+     */
+    public void createNamespace(NamespaceName namespaceName, Policies policies, String clientRole) throws InterceptException {
+        provider.createNamespace(namespaceName, policies, clientRole);
+    }
+
+    public void deleteNamespace(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.deleteNamespace(namespaceName, clientRole);
+    }
+
+    public void deleteNamespaceBundle(NamespaceName namespaceName, String bundleRange, String clientRole) throws InterceptException {
+        provider.deleteNamespaceBundle(namespaceName, bundleRange, clientRole);
+    }
+
+    public void setNamespaceMessageTTL(NamespaceName namespaceName, int messageTTL, String clientRole) throws InterceptException {
+        provider.setNamespaceMessageTTL(namespaceName, messageTTL, clientRole);
+    }
+
+    public void grantPermissionOnNamespace(NamespaceName namespaceName, String role, Set<AuthAction> actions, String clientRole) throws InterceptException {
+        provider.grantPermissionOnNamespace(namespaceName, role, actions, clientRole);
+    }
+
+    public void grantPermissionOnSubscription(NamespaceName namespaceName, String subscription, Set<String> roles, String clientRole) throws InterceptException {
+        provider.grantPermissionOnSubscription(namespaceName, subscription, roles, clientRole);
+    }
+
+    public void revokePermissionsOnNamespace(NamespaceName namespaceName, String role, String clientRole) throws InterceptException {
+        provider.revokePermissionsOnNamespace(namespaceName, role, clientRole);
+    }
+
+    public void revokePermissionsOnSubscription(NamespaceName namespaceName, String subscriptionName, String role, String clientRole) throws InterceptException {
+        provider.revokePermissionsOnSubscription(namespaceName, subscriptionName, role, clientRole);
+    }
+
+    public void getNamespaceReplicationClusters(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getNamespaceReplicationClusters(namespaceName, clientRole);
+    }
+
+    public void setNamespaceReplicationClusters(NamespaceName namespaceName, List<String> clusterIds, String clientRole) throws InterceptException {
+        provider.setNamespaceReplicationClusters(namespaceName, clusterIds, clientRole);
+    }
+
+    public void modifyDeduplication(NamespaceName namespaceName, boolean enableDeduplication, String clientRole) throws InterceptException {
+        provider.modifyDeduplication(namespaceName, enableDeduplication, clientRole);
+    }
+
+    public void getTenantNamespaces(NamespaceName namespaceName, String tenant, String clientRole) throws InterceptException {
+        provider.getTenantNamespaces(namespaceName, tenant, clientRole);
+    }
+
+    public void unloadNamespace(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.unloadNamespace(namespaceName, clientRole);
+    }
+
+    public void setBookieAffinityGroup(NamespaceName namespaceName, BookieAffinityGroupData bookieAffinityGroup, String clientRole) throws InterceptException {
+        provider.setBookieAffinityGroup(namespaceName, bookieAffinityGroup, clientRole);
+    }
+
+    public void getBookieAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getBookieAffinityGroup(namespaceName, clientRole);
+    }
+
+    public void unloadNamespaceBundle(NamespaceName namespaceName, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {
+        provider.unloadNamespaceBundle(namespaceName, bundleRange, authoritative, clientRole);
+    }
+
+    public void splitNamespaceBundle(NamespaceName namespaceName, String bundleRange, boolean authoritative, boolean unload, String clientRole) throws InterceptException {
+        provider.splitNamespaceBundle(namespaceName, bundleRange, authoritative, unload, clientRole);
+    }
+
+    public void setTopicDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {
+        provider.setTopicDispatchRate(namespaceName, dispatchRate, clientRole);
+    }
+
+    public void getTopicDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException  {
+        provider.getTopicDispatchRate(namespaceName, clientRole);
+    }
+
+    public void setSubscriptionDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {
+        provider.setSubscriptionDispatchRate(namespaceName, dispatchRate, clientRole);
+    }
+
+    public void getSubscriptionDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getSubscriptionDispatchRate(namespaceName, clientRole);
+    }
+
+    public void setSubscribeRate(NamespaceName namespaceName, SubscribeRate subscribeRate, String clientRole) throws InterceptException {
+        provider.setSubscribeRate(namespaceName, subscribeRate, clientRole);
+    }
+
+    public void getSubscribeRate(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getSubscribeRate(namespaceName, clientRole);
+    }
+
+    public void setReplicatorDispatchRate(NamespaceName namespaceName, DispatchRate dispatchRate, String clientRole) throws InterceptException {
+        provider.setReplicatorDispatchRate(namespaceName, dispatchRate, clientRole);
+    }
+
+    public void getReplicatorDispatchRate(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getReplicatorDispatchRate(namespaceName, clientRole);
+    }
+
+    public void setBacklogQuota(NamespaceName namespaceName, BacklogQuota.BacklogQuotaType backlogQuotaType, BacklogQuota backlogQuota, String clientRole) throws InterceptException {
+        provider.setBacklogQuota(namespaceName, backlogQuotaType, backlogQuota, clientRole);
+    }
+
+    public void removeBacklogQuota(NamespaceName namespaceName, BacklogQuota.BacklogQuotaType backlogQuotaType, String clientRole) throws InterceptException {
+        provider.removeBacklogQuota(namespaceName, backlogQuotaType, clientRole);
+    }
+
+    public void setRetention(NamespaceName namespaceName, RetentionPolicies retention, String clientRole) throws InterceptException {
+        provider.setRetention(namespaceName, retention, clientRole);
+    }
+
+    public void setPersistence(NamespaceName namespaceName, PersistencePolicies persistence, String clientRole) throws InterceptException {
+        provider.setPersistence(namespaceName, persistence, clientRole);
+    }
+
+    public void getPersistence(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getPersistence(namespaceName, clientRole);
+    }
+
+    public void clearNamespaceBacklog(NamespaceName namespaceName, boolean authoritative, String clientRole) throws InterceptException {
+        provider.clearNamespaceBacklog(namespaceName, authoritative, clientRole);
+    }
+
+    public void clearNamespaceBundleBacklog(NamespaceName namespaceName, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {
+        provider.clearNamespaceBundleBacklog(namespaceName, bundleRange, authoritative, clientRole);
+    }
+
+    public void clearNamespaceBacklogForSubscription(NamespaceName namespaceName, String subscription, boolean authoritative, String clientRole) throws InterceptException {
+        provider.clearNamespaceBacklogForSubscription(namespaceName, subscription, authoritative, clientRole);
+    }
+
+    public void clearNamespaceBundleBacklogForSubscription(NamespaceName namespaceName, String subscription, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {
+        provider.clearNamespaceBundleBacklogForSubscription(namespaceName, subscription, bundleRange, authoritative, clientRole);
+    }
+
+    public void unsubscribeNamespace(NamespaceName namespaceName, String subscription, boolean authoritative, String clientRole) throws InterceptException {
+        provider.unsubscribeNamespace(namespaceName, subscription, authoritative, clientRole);
+    }
+
+    public void unsubscribeNamespaceBundle(NamespaceName namespaceName, String subscription, String bundleRange, boolean authoritative, String clientRole) throws InterceptException {
+        provider.unsubscribeNamespaceBundle(namespaceName, subscription, bundleRange, authoritative, clientRole);
+    }
+
+    public void setSubscriptionAuthMode(NamespaceName namespaceName, SubscriptionAuthMode subscriptionAuthMode, String clientRole) throws InterceptException {
+        provider.setSubscriptionAuthMode(namespaceName, subscriptionAuthMode, clientRole);
+    }
+
+    public void modifyEncryptionRequired(NamespaceName namespaceName, boolean encryptionRequired, String clientRole) throws InterceptException {
+        provider.modifyEncryptionRequired(namespaceName, encryptionRequired, clientRole);
+    }
+
+    public void setNamespaceAntiAffinityGroup(NamespaceName namespaceName, String antiAffinityGroup, String clientRole) throws InterceptException {
+        provider.setNamespaceAntiAffinityGroup(namespaceName, antiAffinityGroup, clientRole);
+    }
+
+    public void getNamespaceAntiAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getNamespaceAntiAffinityGroup(namespaceName, clientRole);
+    }
+
+    public void removeNamespaceAntiAffinityGroup(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.removeNamespaceAntiAffinityGroup(namespaceName, clientRole);
+    }
+
+    public void getAntiAffinityNamespaces(NamespaceName namespaceName, String cluster, String antiAffinityGroup, String clientRole) throws InterceptException {
+        provider.getAntiAffinityNamespaces(namespaceName, cluster, antiAffinityGroup, clientRole);
+    }
+
+    public void getMaxProducersPerTopic(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getMaxProducersPerTopic(namespaceName, clientRole);
+    }
+
+    public void setMaxProducersPerTopic(NamespaceName namespaceName, int maxProducersPerTopic, String clientRole) throws InterceptException {
+        provider.setMaxProducersPerTopic(namespaceName, maxProducersPerTopic, clientRole);
+    }
+
+    public void getMaxConsumersPerTopic(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getMaxConsumersPerTopic(namespaceName, clientRole);
+    }
+
+    public void setMaxConsumersPerTopic(NamespaceName namespaceName, int maxConsumersPerTopic, String clientRole) throws InterceptException {
+        provider.setMaxConsumersPerTopic(namespaceName, maxConsumersPerTopic, clientRole);
+    }
+
+    public void getMaxConsumersPerSubscription(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getMaxConsumersPerSubscription(namespaceName, clientRole);
+    }
+
+    public void setMaxConsumersPerSubscription(NamespaceName namespaceName, int maxConsumersPerSubscription, String clientRole) throws InterceptException {
+        provider.setMaxConsumersPerSubscription(namespaceName, maxConsumersPerSubscription, clientRole);
+    }
+
+    public void getCompactionThreshold(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getCompactionThreshold(namespaceName, clientRole);
+    }
+
+    public void setCompactionThreshold(NamespaceName namespaceName, long newThreshold, String clientRole) throws InterceptException {
+        provider.setCompactionThreshold(namespaceName, newThreshold, clientRole);
+    }
+
+    public void getOffloadThreshold(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getOffloadThreshold(namespaceName, clientRole);
+    }
+
+    public void setOffloadThreshold(NamespaceName namespaceName, long newThreshold, String clientRole) throws InterceptException {
+        provider.setOffloadThreshold(namespaceName, newThreshold, clientRole);
+    }
+
+    public void getOffloadDeletionLag(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getOffloadDeletionLag(namespaceName, clientRole);
+    }
+
+    public void setOffloadDeletionLag(NamespaceName namespaceName, Long newDeletionLagMs, String clientRole) throws InterceptException {
+        provider.setOffloadDeletionLag(namespaceName, newDeletionLagMs, clientRole);
+    }
+
+    public void getSchemaAutoUpdateCompatibilityStrategy(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getSchemaAutoUpdateCompatibilityStrategy(namespaceName, clientRole);
+    }
+
+    public void setSchemaAutoUpdateCompatibilityStrategy(NamespaceName namespaceName,
+                                                         SchemaAutoUpdateCompatibilityStrategy strategy, String clientRole) throws InterceptException {
+        provider.setSchemaAutoUpdateCompatibilityStrategy(namespaceName, strategy, clientRole);
+    }
+
+    public void getSchemaValidationEnforced(NamespaceName namespaceName, String clientRole) throws InterceptException {
+        provider.getSchemaValidationEnforced(namespaceName, clientRole);
+    }
+
+    public void setSchemaValidationEnforced(NamespaceName namespaceName, boolean schemaValidationEnforced, String clientRole) throws InterceptException {
+        provider.setSchemaValidationEnforced(namespaceName, schemaValidationEnforced, clientRole);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SinksInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SinksInterceptProvider.java
@@ -1,0 +1,21 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.io.SinkConfig;
+
+public interface SinksInterceptProvider {
+    /**
+     * Intercept call for create sink
+     *
+     * @param sinkConfig the sink config of the sink to be created
+     * @param clientRole the role used to create sink
+     */
+    default void createSink(SinkConfig sinkConfig, String clientRole) throws InterceptException {} ;
+
+    /**
+     * Intercept call for update sink
+     *  @param sinkConfig the sink config of the sink to be updated
+     * @param existingSinkConfig
+     * @param clientRole the role used to update sink
+     */
+    default void updateSink(SinkConfig sinkConfig, SinkConfig existingSinkConfig, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SinksInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SinksInterceptService.java
@@ -1,0 +1,32 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.io.SinkConfig;
+
+public class SinksInterceptService {
+
+    private final SinksInterceptProvider provider;
+
+    public SinksInterceptService(SinksInterceptProvider sinksInterceptProvider) {
+        this.provider = sinksInterceptProvider;
+    }
+
+    /**
+     * Intercept call for create sink
+     *
+     * @param sinkConfig the sink config of the sink to be created
+     * @param clientRole the role used to create sink
+     */
+    public void createSink(SinkConfig sinkConfig, String clientRole) throws InterceptException {
+        provider.createSink(sinkConfig, clientRole);
+    }
+
+    /**
+     * Intercept call for update sink
+     *  @param updates updates to this sink's source config
+     * @param existingSinkConfig the existing source config
+     * @param clientRole the role used to update sink
+     */
+    public void updateSink(SinkConfig updates, SinkConfig existingSinkConfig, String clientRole) throws InterceptException {
+        provider.updateSink(updates, existingSinkConfig, clientRole);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SourcesInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SourcesInterceptProvider.java
@@ -1,0 +1,21 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.io.SourceConfig;
+
+public interface SourcesInterceptProvider {
+    /**
+     * Intercept call for create source
+     *
+     * @param sourceConfig the source config of the source to be created
+     * @param clientRole the role used to create source
+     */
+    default void createSource(SourceConfig sourceConfig, String clientRole) throws InterceptException {}
+
+    /**
+     * Intercept call for update source
+     *  @param sourceConfig the source config of the source to be updated
+     * @param existingSourceConfig
+     * @param clientRole the role used to update source
+     */
+    default void updateSource(SourceConfig sourceConfig, SourceConfig existingSourceConfig, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SourcesInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/SourcesInterceptService.java
@@ -1,0 +1,32 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.io.SourceConfig;
+
+public class SourcesInterceptService {
+
+    private SourcesInterceptProvider provider;
+
+    public SourcesInterceptService(SourcesInterceptProvider sourcesInterceptProvider) {
+        this.provider = sourcesInterceptProvider;
+    }
+
+    /**
+     * Intercept call for create source
+     *
+     * @param sourceConfig the source config of the source to be created
+     * @param clientRole the role used to create source
+     */
+    public void createSource(SourceConfig sourceConfig, String clientRole) throws InterceptException {
+        provider.createSource(sourceConfig, clientRole);
+    }
+
+    /**
+     * Intercept call for update source
+     *  @param updates updates to this source's source config
+     * @param existingSourceConfig the existing source config
+     * @param clientRole the role used to update source
+     */
+    public void updateSource(SourceConfig updates, SourceConfig existingSourceConfig, String clientRole) throws InterceptException {
+        provider.updateSource(updates, existingSourceConfig, clientRole);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TenantsInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TenantsInterceptProvider.java
@@ -1,0 +1,14 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.policies.data.TenantInfo;
+
+public interface TenantsInterceptProvider {
+    /**
+     * Intercept call for create tenant
+     *
+     * @param tenant tenant name
+     * @param tenantInfo tenant info
+     * @param clientRole the role used to create tenant
+     */
+    default void createTenant(String tenant, TenantInfo tenantInfo, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TenantsInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TenantsInterceptService.java
@@ -1,0 +1,23 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.policies.data.TenantInfo;
+
+public class TenantsInterceptService {
+
+    private final TenantsInterceptProvider provider;
+
+    public TenantsInterceptService(TenantsInterceptProvider tenantInterceptProvider) {
+        this.provider = tenantInterceptProvider;
+    }
+
+    /**
+     * Intercept call for create tenant
+     *
+     * @param tenant tenant name
+     * @param tenantInfo tenant info
+     * @param clientRole the role used to create tenant
+     */
+    public void createTenant(String tenant, TenantInfo tenantInfo, String clientRole) throws InterceptException {
+        provider.createTenant(tenant, tenantInfo, clientRole);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TopicInterceptService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TopicInterceptService.java
@@ -1,0 +1,43 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+
+public class TopicInterceptService {
+
+    private final TopicsInterceptProvider provider;
+
+    public TopicInterceptService(TopicsInterceptProvider topicInterceptProvider) {
+        this.provider = topicInterceptProvider;
+    }
+
+    /*
+     * Intercept create partitioned topic
+     * @param topicName the topic name
+     * @param partitionedTopicMetadata metadata related to the partioned topic
+     * @param clientRole the role used to create partitioned topic
+     */
+    public void createPartitionedTopic(TopicName topicName, PartitionedTopicMetadata partitionedTopicMetadata, String clientRole) throws InterceptException {
+        provider.createPartitionedTopic(topicName, partitionedTopicMetadata, clientRole);
+    }
+
+    /**
+     * Intercept call for create topic
+     *
+     * @param topicName the topic name
+     * @param clientRole the role used to create topic
+     */
+    public void createTopic(TopicName topicName, String clientRole) throws InterceptException {
+        provider.createTopic(topicName, clientRole);
+    }
+
+    /**
+     * Intercept update partitioned topic
+     * @param topicName the topic name
+     * @param partitionedTopicMetadata metadata related to the partioned topic
+     * @param clientRole the role used to update partitioned topic
+     */
+    public void updatePartitionedTopic(TopicName topicName, PartitionedTopicMetadata partitionedTopicMetadata, String clientRole) throws InterceptException {
+        provider.updatePartitionedTopic(topicName, partitionedTopicMetadata, clientRole);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TopicsInterceptProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/intercept/TopicsInterceptProvider.java
@@ -1,0 +1,30 @@
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+
+public interface TopicsInterceptProvider {
+    /**
+     * Intercept call for create topic
+     *
+     * @param topicName the topic name
+     * @param clientRole the role used to create topic
+     */
+    default void createTopic(TopicName topicName, String clientRole) throws InterceptException {}
+
+    /**
+     * Intercept create partitioned topic
+     *  @param topicName the topic name
+     * @param numPartitions number of partitions to create for this partitioned topic
+     * @param clientRole the role used to create partitioned topic
+     */
+    default void createPartitionedTopic(TopicName topicName, PartitionedTopicMetadata numPartitions, String clientRole) throws InterceptException {}
+
+    /**
+     * Intercept update partitioned topic
+     *  @param topicName the topic name
+     * @param numPartitions number of partitions to update to
+     * @param clientRole the role used to update partitioned topic
+     */
+    default void updatePartitionedTopic(TopicName topicName, PartitionedTopicMetadata numPartitions, String clientRole) throws InterceptException {}
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService.LeaderListener;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -551,7 +552,9 @@ public class PulsarService implements AutoCloseable {
             acquireSLANamespace();
 
             // start function worker service if necessary
-            this.startWorkerService(brokerService.getAuthenticationService(), brokerService.getAuthorizationService());
+            this.startWorkerService(brokerService.getAuthenticationService(),
+                    brokerService.getAuthorizationService(),
+                    brokerService.getInterceptService());
 
             final String bootstrapMessage = "bootstrap service "
                     + (config.getWebServicePort().isPresent() ? "port = " + config.getWebServicePort().get() : "")
@@ -1155,7 +1158,8 @@ public class PulsarService implements AutoCloseable {
     }
 
     private void startWorkerService(AuthenticationService authenticationService,
-                                    AuthorizationService authorizationService)
+                                    AuthorizationService authorizationService,
+                                    InterceptService interceptService)
             throws InterruptedException, IOException, KeeperException {
         if (functionWorkerService.isPresent()) {
             LOG.info("Starting function worker service");
@@ -1255,7 +1259,8 @@ public class PulsarService implements AutoCloseable {
                 throw ioe;
             }
             LOG.info("Function worker service setup completed");
-            functionWorkerService.get().start(dlogURI, authenticationService, authorizationService);
+            functionWorkerService.get().start(dlogURI, authenticationService, authorizationService,
+                    interceptService);
             LOG.info("Function worker service started");
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.admin.ZkAdminPaths;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.intercept.InterceptException;
 import org.apache.pulsar.broker.service.BrokerServiceException.AlreadyRunningException;
 import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
@@ -455,6 +456,17 @@ public class PersistentTopicsBase extends AdminResource {
         }
 
         try {
+            pulsar().getBrokerService()
+                    .getInterceptService()
+                    .topics()
+                    .createTopic(topicName, clientAppId());
+        } catch (InterceptException e) {
+            throw new RestException(
+                    e.getErrorCode().orElse(Status.INTERNAL_SERVER_ERROR.getStatusCode()),
+                    e.getMessage());
+        }
+
+        try {
             Topic createdTopic = getOrCreateTopic(topicName);
             log.info("[{}] Successfully created non-partitioned topic {}", clientAppId(), createdTopic);
         } catch (Exception e) {
@@ -542,6 +554,18 @@ public class PersistentTopicsBase extends AdminResource {
         if (numPartitions <= 0) {
             throw new RestException(Status.NOT_ACCEPTABLE, "Number of partitions should be more than 0");
         }
+
+        try {
+            pulsar().getBrokerService()
+                    .getInterceptService()
+                    .topics()
+                    .updatePartitionedTopic(topicName, new PartitionedTopicMetadata(numPartitions), clientAppId());
+        } catch (InterceptException e) {
+            throw new RestException(
+                    e.getErrorCode().orElse(Status.INTERNAL_SERVER_ERROR.getStatusCode()),
+                    e.getMessage());
+        }
+
         try {
             tryCreatePartitionsAsync(numPartitions).get();
             updatePartitionedTopic(topicName, numPartitions).get();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.intercept.InterceptException;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamedEntity;
@@ -102,6 +103,16 @@ public class TenantsBase extends AdminResource {
         validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
         validateClusters(config);
+        try {
+            pulsar().getBrokerService()
+                    .getInterceptService()
+                    .tenants()
+                    .createTenant(tenant, config, clientAppId());
+        } catch (InterceptException e) {
+            throw new RestException(
+                    e.getErrorCode().orElse(Status.INTERNAL_SERVER_ERROR.getStatusCode()),
+                    e.getMessage());
+        }
 
         try {
             NamedEntity.checkName(tenant);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -49,7 +49,6 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.web.RestException;
-import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -57,7 +56,6 @@ import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,7 +172,6 @@ public class NonPersistentTopics extends PersistentTopics {
             @PathParam("topic") @Encoded String encodedTopic,
             @ApiParam(value = "The number of partitions for the topic", required = true, type = "int", defaultValue = "0")
             int numPartitions) {
-
         try {
             validateGlobalNamespaceOwnership(tenant,namespace);
             validateTopicName(tenant, namespace, encodedTopic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -287,7 +287,7 @@ public class PulsarWorkerAssignmentTest {
         final URI dlUri = functionsWorkerService.getDlogUri();
         functionsWorkerService.stop();
         functionsWorkerService = new WorkerService(workerConfig);
-        functionsWorkerService.start(dlUri, new AuthenticationService(PulsarConfigurationLoader.convertFrom(workerConfig)), null);
+        functionsWorkerService.start(dlUri, new AuthenticationService(PulsarConfigurationLoader.convertFrom(workerConfig)), null, null);
         final FunctionRuntimeManager runtimeManager2 = functionsWorkerService.getFunctionRuntimeManager();
         retryStrategically((test) -> {
             try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Resources.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Resources.java
@@ -34,10 +34,10 @@ public class Resources {
 
     private static final Resources DEFAULT = new Resources();
 
-    // Default cpu is 1 core
-    private Double cpu = 1d;
-    // Default memory is 1GB
-    private Long ram = 1073741824L;
+    // Default cpu is 0.5 core
+    private Double cpu = 0.5d;
+    // Default memory is 256MB
+    private Long ram = 256 * (long) Math.pow(2, 20);
     // Default disk is 10GB
     private Long disk = 10737418240L;
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -33,6 +33,7 @@ import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.distributedlog.api.namespace.NamespaceBuilder;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -65,6 +66,7 @@ public class WorkerService {
     private final ScheduledExecutorService statsUpdater;
     private AuthenticationService authenticationService;
     private AuthorizationService authorizationService;
+    private InterceptService interceptService;
     private ConnectorsManager connectorsManager;
     private PulsarAdmin brokerAdmin;
     private PulsarAdmin functionAdmin;
@@ -84,7 +86,8 @@ public class WorkerService {
 
     public void start(URI dlogUri,
                       AuthenticationService authenticationService,
-                      AuthorizationService authorizationService) throws InterruptedException {
+                      AuthorizationService authorizationService,
+                      InterceptService interceptService) throws InterruptedException {
         log.info("Starting worker {}...", workerConfig.getWorkerId());
 
         try {
@@ -196,6 +199,8 @@ public class WorkerService {
             this.authenticationService = authenticationService;
 
             this.authorizationService = authorizationService;
+
+            this.interceptService = interceptService;
 
             // Starting cluster services
             log.info("Start cluster services...");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1149,7 +1149,7 @@ public abstract class ComponentImpl {
             log.error("{}/{}/{} Failed to authorize [{}]", tenant, namespace, functionName, e);
             throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
         }
-        
+
         if (!key.equals(state.getKey())) {
             log.error("{}/{}/{} Bad putFunction Request, path key doesn't match key in json", tenant, namespace, functionName);
             throw new RestException(Status.BAD_REQUEST, "Path key doesn't match key in json");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -18,11 +18,35 @@
  */
 package org.apache.pulsar.functions.worker.rest.api;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.functions.auth.FunctionAuthUtils.getFunctionAuthData;
+import static org.apache.pulsar.functions.worker.WorkerUtils.isFunctionCodeBuiltin;
+import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
+
 import com.google.protobuf.ByteString;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.intercept.InterceptException;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.functions.Utils;
@@ -43,22 +67,6 @@ import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Supplier;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.pulsar.functions.auth.FunctionAuthUtils.getFunctionAuthData;
-import static org.apache.pulsar.functions.worker.WorkerUtils.isFunctionCodeBuiltin;
-import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 
 @Slf4j
 public class SinksImpl extends ComponentImpl {
@@ -223,6 +231,19 @@ public class SinksImpl extends ComponentImpl {
             }
 
             functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
+
+            try {
+                worker().getInterceptService()
+                        .sinks()
+                        .createSink(SinkConfigUtils.convertFromDetails(
+                                functionMetaDataBuilder.build().getFunctionDetails()),
+                                clientRole);
+            } catch (InterceptException e) {
+                throw new RestException(
+                        e.getErrorCode().orElse(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()),
+                        e.getMessage());
+            }
+
             updateRequest(functionMetaDataBuilder.build());
         } finally {
 
@@ -416,6 +437,16 @@ public class SinksImpl extends ComponentImpl {
             }
 
             functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
+
+            try {
+                worker().getInterceptService()
+                        .sinks()
+                        .updateSink(sinkConfig, existingSinkConfig, clientRole);
+            } catch (InterceptException e) {
+                throw new RestException(
+                        e.getErrorCode().orElse(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()),
+                        e.getMessage());
+            }
 
             updateRequest(functionMetaDataBuilder.build());
         } finally {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -56,6 +56,8 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -166,6 +168,7 @@ public class FunctionApiV2ResourceTest {
         when(mockedWorkerService.getDlogNamespace()).thenReturn(mockedNamespace);
         when(mockedWorkerService.isInitialized()).thenReturn(true);
         when(mockedWorkerService.getBrokerAdmin()).thenReturn(mockedPulsarAdmin);
+        when(mockedWorkerService.getInterceptService()).thenReturn(new InterceptService(new ServiceConfiguration(), null));
         when(mockedPulsarAdmin.tenants()).thenReturn(mockedTenants);
         when(mockedPulsarAdmin.namespaces()).thenReturn(mockedNamespaces);
         when(mockedTenants.getTenantInfo(any())).thenReturn(mockedTenantInfo);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -53,6 +53,8 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -170,6 +172,7 @@ public class FunctionApiV3ResourceTest {
         when(mockedWorkerService.getDlogNamespace()).thenReturn(mockedNamespace);
         when(mockedWorkerService.isInitialized()).thenReturn(true);
         when(mockedWorkerService.getBrokerAdmin()).thenReturn(mockedPulsarAdmin);
+        when(mockedWorkerService.getInterceptService()).thenReturn(new InterceptService(new ServiceConfiguration(), null));
         when(mockedPulsarAdmin.tenants()).thenReturn(mockedTenants);
         when(mockedPulsarAdmin.namespaces()).thenReturn(mockedNamespaces);
         when(mockedTenants.getTenantInfo(any())).thenReturn(mockedTenantInfo);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Lists;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -150,6 +152,7 @@ public class SinkApiV3ResourceTest {
         when(mockedWorkerService.getDlogNamespace()).thenReturn(mockedNamespace);
         when(mockedWorkerService.isInitialized()).thenReturn(true);
         when(mockedWorkerService.getBrokerAdmin()).thenReturn(mockedPulsarAdmin);
+        when(mockedWorkerService.getInterceptService()).thenReturn(new InterceptService(new ServiceConfiguration(), null));
         when(mockedPulsarAdmin.tenants()).thenReturn(mockedTenants);
         when(mockedPulsarAdmin.namespaces()).thenReturn(mockedNamespaces);
         when(mockedTenants.getTenantInfo(any())).thenReturn(mockedTenantInfo);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -46,6 +46,8 @@ import javax.ws.rs.core.Response;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.intercept.InterceptService;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -147,6 +149,7 @@ public class SourceApiV3ResourceTest {
         when(mockedWorkerService.getDlogNamespace()).thenReturn(mockedNamespace);
         when(mockedWorkerService.isInitialized()).thenReturn(true);
         when(mockedWorkerService.getBrokerAdmin()).thenReturn(mockedPulsarAdmin);
+        when(mockedWorkerService.getInterceptService()).thenReturn(new InterceptService(new ServiceConfiguration(), null));
         when(mockedPulsarAdmin.tenants()).thenReturn(mockedTenants);
         when(mockedPulsarAdmin.namespaces()).thenReturn(mockedNamespaces);
         when(mockedTenants.getTenantInfo(any())).thenReturn(mockedTenantInfo);


### PR DESCRIPTION

### Motivation

Interceptor provider interface. Allow plugin implementations to trace and reject all operations happening in brokers. (eg: new topic, new namepsace, new producer, etc...)