### PR TITLE
fix get partitioned metadata  throws NullPointerException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1919,7 +1919,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     public CompletableFuture<PartitionedTopicMetadata> fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(TopicName topicName) {
         if(pulsar.getNamespaceService() == null){
-            return CompletableFuture.completedFuture(null);
+            return FutureUtil.failedFuture(new NullPointerException("namespaceService is null"));
         }
         return pulsar.getNamespaceService().checkTopicExists(topicName)
                 .thenCompose(topicExists -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1918,6 +1918,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     public CompletableFuture<PartitionedTopicMetadata> fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(TopicName topicName) {
+        if(pulsar.getNamespaceService() == null){
+            return CompletableFuture.completedFuture(null);
+        }
         return pulsar.getNamespaceService().checkTopicExists(topicName)
                 .thenCompose(topicExists -> {
                     return fetchPartitionedTopicMetadataAsync(topicName)


### PR DESCRIPTION
Master Issue: #7163
## Motivation

Sometimes get partitioned metadata will throws NullPointerException, because the NamespaceService not initialized yet , so needed a judgment .

## Modifications
BrokerService
```java
        if(pulsar.getNamespaceService() == null){
            return CompletableFuture.completedFuture(null);
        }
```
