### PR TITLE
[cpp] make able to set acktimeout to 0 in consumerconfig

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -92,7 +92,7 @@ void ConsumerConfiguration::setConsumerName(const std::string& consumerName) {
 long ConsumerConfiguration::getUnAckedMessagesTimeoutMs() const { return impl_->unAckedMessagesTimeoutMs; }
 
 void ConsumerConfiguration::setUnAckedMessagesTimeoutMs(const uint64_t milliSeconds) {
-    if (milliSeconds < 10000) {
+    if (milliSeconds < 10000 && milliSeconds != 0) {
         throw "Consumer Config Exception: Unacknowledged message timeout should be greater than 10 seconds.";
     }
     impl_->unAckedMessagesTimeoutMs = milliSeconds;

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -173,3 +173,16 @@ TEST(ConsumerConfigurationTest, testSubscriptionInitialPosition) {
     ASSERT_EQ(ResultOk, producer.close());
     ASSERT_EQ(ResultOk, client.close());
 }
+
+TEST(ConsumerConfigurationTest, testResetAckTimeOut) {
+    Result result;
+
+    uint64_t milliSeconds = 50000;
+    ConsumerConfiguration config;
+    config.setUnAckedMessagesTimeoutMs(milliSeconds);
+    ASSERT_EQ(milliSeconds, config.getUnAckedMessagesTimeoutMs());
+
+    // should be able to set it back to 0.
+    config.setUnAckedMessagesTimeoutMs(0);
+    ASSERT_EQ(milliSeconds, 0);
+}

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -184,5 +184,5 @@ TEST(ConsumerConfigurationTest, testResetAckTimeOut) {
 
     // should be able to set it back to 0.
     config.setUnAckedMessagesTimeoutMs(0);
-    ASSERT_EQ(milliSeconds, 0);
+    ASSERT_EQ(0, config.getUnAckedMessagesTimeoutMs());
 }


### PR DESCRIPTION
If user already set UnAckedMessagesTimeoutMs in consumer config, It is not able to set it back to 0. This change fix the issue.