### PR TITLE
[doc] Clarify the impact of batch message in key_shared subscription

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -608,6 +608,22 @@ consumer2 receives the follwoing information.
 ("key-4", "message-4-2")
 ```
 
+If batch enabled at the producer side, messages with different key may add to a batch by default. The broker will dispatch the batch to the consumer, so the default batch mechanism may break the Key_Shared subscription guaranteed message distribution semantics. The producer need to use the `KeyBasedBatcher`.
+
+```java
+Producer producer = client.newProducer()
+        .topic("my-topic")
+        .batcherBuilder(BatcherBuilder.KEY_BASED)
+        .create();
+```
+Or the producer can disable the message batch mechanism.
+
+```java
+Producer producer = client.newProducer()
+        .topic("my-topic")
+        .enableBatching(false)
+        .create();
+```
 > Note:
 >
 > If the message key is not specified, messages without key are dispatched to one consumer in order by default.

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -616,7 +616,7 @@ Producer producer = client.newProducer()
         .batcherBuilder(BatcherBuilder.KEY_BASED)
         .create();
 ```
-Or the producer can disable the message batch mechanism.
+Or the producer can disable batching.
 
 ```java
 Producer producer = client.newProducer()

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -608,7 +608,7 @@ consumer2 receives the follwoing information.
 ("key-4", "message-4-2")
 ```
 
-If batch enabled at the producer side, messages with different key may add to a batch by default. The broker will dispatch the batch to the consumer, so the default batch mechanism may break the Key_Shared subscription guaranteed message distribution semantics. The producer need to use the `KeyBasedBatcher`.
+If batching is enabled at the producer side, messages with different keys are added to a batch by default. The broker will dispatch the batch to the consumer, so the default batch mechanism may break the Key_Shared subscription guaranteed message distribution semantics. The producer needs to use the `KeyBasedBatcher`.
 
 ```java
 Producer producer = client.newProducer()


### PR DESCRIPTION
Fixes #7121 

### Motivation

Following the java example at http://pulsar.apache.org/docs/en/client-libraries-java/#key_shared. The messages sometimes may send to only one consumer if the producer sends the batched messages. It's better to clarify in the doc to introduce the right way to use key_shared subscription.

### Modifications

Update Java client documentation.