### PR TITLE
FunctionAssignmentTailer should use its own thread

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -110,8 +110,7 @@ public class FunctionAssignmentTailer implements AutoCloseable {
             try {
                 assignment = Assignment.parseFrom(msg.getData());
             } catch (IOException e) {
-                log.error("[{}] Received bad assignment update at message {}", reader.getTopic(), msg.getMessageId(),
-                  e);
+                log.error("[{}] Received bad assignment update at message {}", reader.getTopic(), msg.getMessageId(), e);
                 throw new RuntimeException(e);
             }
             log.info("Received assignment update: {}", assignment);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -66,7 +66,7 @@ public class FunctionAssignmentTailer implements AutoCloseable {
                         // TODO add mechanism to notify main thread
                     } else {
                         if (!(e instanceof InterruptedException)) {
-                            log.warn("Encountered error in when assignment tailer is not running", e);
+                            log.warn("Encountered error when assignment tailer is not running", e);
                         }
                     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -82,12 +82,6 @@ public class FunctionAssignmentTailer implements AutoCloseable {
     public void close() {
         log.info("Stopping function assignment tailer");
         try {
-            if (!isRunning) {
-                if (reader != null) {
-                    reader.close();
-                }
-                return;
-            }
             isRunning = false;
             if (tailerThread != null && tailerThread.isAlive()) {
                 tailerThread.interrupt();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -18,56 +18,91 @@
  */
 package org.apache.pulsar.functions.worker;
 
-import java.io.IOException;
-import java.util.function.Function;
-
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
-import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.functions.proto.Function.Assignment;
 
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
 
 @Slf4j
-public class FunctionAssignmentTailer
-    implements java.util.function.Consumer<Message<byte[]>>, Function<Throwable, Void>, AutoCloseable {
+public class FunctionAssignmentTailer implements AutoCloseable {
 
     private final FunctionRuntimeManager functionRuntimeManager;
+    @Getter
     private final Reader<byte[]> reader;
-    private boolean closed = false;
+    private volatile boolean running = false;
 
-    public FunctionAssignmentTailer(FunctionRuntimeManager functionRuntimeManager, Reader<byte[]> reader) {
+    private final Thread tailerThread;
+    
+    public FunctionAssignmentTailer(FunctionRuntimeManager functionRuntimeManager, ReaderBuilder readerBuilder, WorkerConfig workerConfig) throws PulsarClientException {
         this.functionRuntimeManager = functionRuntimeManager;
-        this.reader = reader;
+        
+        this.reader = readerBuilder
+          .subscriptionRolePrefix(workerConfig.getWorkerId() + "-function-runtime-manager")
+          .readerName(workerConfig.getWorkerId() + "-function-runtime-manager")
+          .topic(workerConfig.getFunctionAssignmentTopic())
+          .readCompacted(true)
+          .startMessageId(MessageId.earliest)
+          .create();
+
+        this.tailerThread = new Thread(() -> {
+            while(true) {
+                try {
+                    while(running) {
+                        Message<byte[]> msg = reader.readNext();
+                        processAssignment(msg);
+                    }
+                } catch (Exception e) {
+                    if (running) {
+                        log.error("Encountered error in assignment tailer", e);
+
+                        // trigger fatal error
+                        // TODO add mechanism to notify main thread
+                    } else {
+                        if (!(e instanceof InterruptedException)) {
+                            log.warn("Encountered error in when assignment tailer is not running", e);
+                        }
+                    }
+
+                }
+            }
+        });
+        this.tailerThread.setName("assignment-tailer-thread");
     }
 
     public void start() {
-        receiveOne();
-    }
-
-    private void receiveOne() {
-        reader.readNextAsync()
-                .thenAccept(this)
-                .exceptionally(this);
+        running = true;
+        tailerThread.start();
     }
 
     @Override
     public void close() {
-        if (closed) {
+        if (!running) {
             return;
         }
-        log.info("Stopping function state consumer");
+        log.info("Stopping function assignment tailer");
         try {
-            closed = true;
-            reader.close();
+            running = false;
+            if (tailerThread != null && tailerThread.isAlive()) {
+                tailerThread.interrupt();
+            }
+            if (reader != null) {
+                reader.close();
+            }
         } catch (IOException e) {
-            log.error("Failed to stop function state consumer", e);
+            log.error("Failed to stop function assignment tailer", e);
         }
-        log.info("Stopped function state consumer");
+        log.info("Stopped function assignment tailer");
     }
 
     public void processAssignment(Message<byte[]> msg) {
+
         if(msg.getData()==null || (msg.getData().length==0)) {
             log.info("Received assignment delete: {}", msg.getKey());
             this.functionRuntimeManager.deleteAssignment(msg.getKey());
@@ -77,41 +112,11 @@ public class FunctionAssignmentTailer
                 assignment = Assignment.parseFrom(msg.getData());
             } catch (IOException e) {
                 log.error("[{}] Received bad assignment update at message {}", reader.getTopic(), msg.getMessageId(),
-                        e);
-                // TODO: find a better way to handle bad request
+                  e);
                 throw new RuntimeException(e);
             }
             log.info("Received assignment update: {}", assignment);
             this.functionRuntimeManager.processAssignment(assignment);
-        }
-    }
-
-    @Override
-    public void accept(Message<byte[]> msg) {
-        processAssignment(msg);
-        // receive next request
-        receiveOne();
-    }
-
-    @Override
-    public Void apply(Throwable cause) {
-        Throwable realCause = FutureUtil.unwrapCompletionException(cause);
-        if (realCause instanceof AlreadyClosedException) {
-            // if reader is closed because tailer is closed, ignore the exception
-            if (closed) {
-                // ignore
-                return null;
-            } else {
-                log.error("Reader of assignment update topic is closed unexpectedly", cause);
-                throw new RuntimeException(
-                    "Reader of assignment update topic is closed unexpectedly",
-                    cause
-                );
-            }
-        } else {
-            log.error("Failed to retrieve messages from assignment update topic", cause);
-            // TODO: find a better way to handle consumer functions
-            throw new RuntimeException(cause);
         }
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -210,17 +210,12 @@ public class FunctionRuntimeManager implements AutoCloseable{
     public void initialize() {
         log.info("/** Initializing Runtime Manager **/");
         try {
-            Reader<byte[]> reader = this.getWorkerService().getClient().newReader()
-                    .readerName(workerConfig.getWorkerId() + "-function-runtime-manager")
-                    .topic(this.getWorkerConfig().getFunctionAssignmentTopic()).readCompacted(true)
-                    .startMessageId(MessageId.earliest).create();
-
-            this.functionAssignmentTailer = new FunctionAssignmentTailer(this, reader);
+            this.functionAssignmentTailer = new FunctionAssignmentTailer(this, this.getWorkerService().getClient().newReader(), workerConfig);
             // start init phase
             this.isInitializePhase = true;
             // read all existing messages
-            while (reader.hasMessageAvailable()) {
-                this.functionAssignmentTailer.processAssignment(reader.readNext());
+            while (this.functionAssignmentTailer.getReader().hasMessageAvailable()) {
+                this.functionAssignmentTailer.processAssignment(this.functionAssignmentTailer.getReader().readNext());
             }
             // init phase is done
             this.isInitializePhase = false;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -239,7 +239,6 @@ public class FunctionRuntimeManager implements AutoCloseable{
      */
     public void start() {
         log.info("/** Starting Function Runtime Manager **/");
-        log.info("Starting function assignment tailer...");
         this.functionAssignmentTailer.start();
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -563,6 +563,7 @@ public class FunctionRuntimeManagerTest {
         doReturn(readerBuilder).when(pulsarClient).newReader();
         doReturn(readerBuilder).when(readerBuilder).topic(anyString());
         doReturn(readerBuilder).when(readerBuilder).readerName(anyString());
+        doReturn(readerBuilder).when(readerBuilder).subscriptionRolePrefix(anyString());
         doReturn(readerBuilder).when(readerBuilder).startMessageId(any());
         doReturn(readerBuilder).when(readerBuilder).startMessageId(any());
         doReturn(readerBuilder).when(readerBuilder).readCompacted(anyBoolean());


### PR DESCRIPTION

### Motivation

Currently, the FunctionAssignmentTailer reads assignments and processes them using the pulsar-external-listener thread part of the pulsar-client. Processing assignments may take a "long" time and should not block pulsar-external-listener. Thus, FunctionAssignmentTailer should use its own thread for reading and processing assignments.



