### PR TITLE
add topic type validation before update topic partitions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -356,6 +356,19 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
+    protected void validatePartitionedTopicMetadata(String tenant, String namespace, String encodedTopic) {
+        String completeTopicName = tenant + "/" + namespace + "/" +  Codec.decode(encodedTopic);
+        try {
+            PartitionedTopicMetadata partitionedTopicMetadata =
+                    pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(TopicName.get(completeTopicName)).get();
+            if (partitionedTopicMetadata.partitions < 1) {
+                throw new RestException(Status.CONFLICT, "Topic is not partitioned topic");
+            }
+        } catch (Exception e) {
+            throw new RestException(Status.INTERNAL_SERVER_ERROR, "Check topic partition meta failed.");
+        }
+    }
+
     @Deprecated
     protected void validateTopicName(String property, String cluster, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -364,7 +365,7 @@ public abstract class AdminResource extends PulsarWebResource {
             if (partitionedTopicMetadata.partitions < 1) {
                 throw new RestException(Status.CONFLICT, "Topic is not partitioned topic");
             }
-        } catch (Exception e) {
+        } catch ( InterruptedException  | ExecutionException e) {
             throw new RestException(Status.INTERNAL_SERVER_ERROR, "Check topic partition meta failed.");
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -252,9 +252,9 @@ public class PersistentTopics extends PersistentTopicsBase {
      * well. Therefore, it can violate partition ordering at producers until all producers are restarted at application.
      *
      * @param tenant
-     * @param cluster
      * @param namespace
-     * @param topic
+     * @param namespace
+     * @param encodedTopic
      * @param numPartitions
      */
     @POST
@@ -283,6 +283,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "The number of partitions for the topic", required = true, type = "int", defaultValue = "0")
             int numPartitions) {
         validatePartitionedTopicName(tenant, namespace, encodedTopic);
+        validatePartitionedTopicMetadata(tenant, namespace, encodedTopic);
         internalUpdatePartitionedTopic(numPartitions, updateLocalTopicOnly, authoritative);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -253,7 +253,6 @@ public class PersistentTopics extends PersistentTopicsBase {
      *
      * @param tenant
      * @param namespace
-     * @param namespace
      * @param encodedTopic
      * @param numPartitions
      */

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceTest.java
@@ -22,14 +22,29 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import javax.ws.rs.core.Response.Status;
+import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.util.Codec;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
  * Unit test {@link AdminResource}.
  */
-public class AdminResourceTest {
+public class AdminResourceTest extends BrokerTestBase {
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
 
     private static AdminResource mockResource() {
         return new AdminResource() {
@@ -66,4 +81,30 @@ public class AdminResourceTest {
         }
     }
 
+    @Test
+    public void testValidatePartitionedTopicMetadata() throws Exception {
+        String tenant = "prop";
+        String namespace = "ns-abc";
+        String partitionedTopic = "partitionedTopic";
+        String nonPartitionedTopic = "notPartitionedTopic";
+        int partitions = 3;
+
+        String completePartitionedTopic = tenant + "/" + namespace + "/" + partitionedTopic;
+        String completeNonPartitionedTopic = tenant + "/" + namespace + "/" + nonPartitionedTopic;
+
+        admin.topics().createNonPartitionedTopic(completeNonPartitionedTopic);
+        admin.topics().createPartitionedTopic(completePartitionedTopic, partitions);
+
+        AdminResource resource = mockResource();
+        resource.setPulsar(pulsar);
+        // validate should pass when topic is partitioned topic
+        resource.validatePartitionedTopicMetadata(tenant, namespace, Codec.encode(partitionedTopic));
+        // validate should failed when topic is non-partitioned topic
+        try {
+            resource.validatePartitionedTopicMetadata(tenant, namespace, Codec.encode(nonPartitionedTopic));
+            fail("Should fail validation on non-partitioned topic");
+        } catch (RestException re) {
+            assertEquals(Status.CONFLICT.getStatusCode(), re.getResponse().getStatus());
+        }
+    }
 }


### PR DESCRIPTION

Fixes #7152 

### Motivation
This PR add topic type validation before update partition numbers of partitioned-topic. 
This can prevent  creating new partitions for non-partitoned topics.

