### PR TITLE
[Issue 2793][Doc]--Update TLS hostname verification for CPP and Python clients

### DIFF
--- a/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
@@ -203,7 +203,7 @@ client = Client("pulsar+ssl://broker.example.com:6651/",
 ```c++
 #include <pulsar/Client.h>
 
-lientConfiguration config = ClientConfiguration();
+ClientConfiguration config = ClientConfiguration();
 config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);

--- a/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
@@ -148,7 +148,7 @@ When TLS transport encryption is enabled, you need to configure the client to us
 
 As the server certificate you generated above doesn't belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which it is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -160,7 +160,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You'll need to add the following parameters to that file to use TLS transport with Pulsar's CLI tools:
 
@@ -173,7 +173,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -187,25 +187,26 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+lientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```

--- a/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.3.2-security-tls-transport
+id: version-2.3.0-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.2.1-security-tls-transport
+id: version-2.3.2-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.3.2-security-tls-transport
+id: version-2.3.1-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.2.1-security-tls-transport
+id: version-2.3.2-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.3.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.2/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.2.1-security-tls-transport
+id: version-2.3.2-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.4.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.0/security-tls-transport.md
@@ -1,5 +1,5 @@
 ---
-id: version-2.2.1-security-tls-transport
+id: version-2.4.0-security-tls-transport
 title: Transport Encryption using TLS
 sidebar_label: Transport Encryption using TLS
 original_id: security-tls-transport

--- a/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
@@ -167,7 +167,7 @@ When you enable the TLS transport encryption, you need to configure the client t
 
 As the server certificate that you generated above does not belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which the hostname is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -179,7 +179,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You need to add the following parameters to that file to use TLS transport with the CLI tools of Pulsar:
 
@@ -192,7 +192,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -206,25 +206,26 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+ClientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```

--- a/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
@@ -167,7 +167,7 @@ When you enable the TLS transport encryption, you need to configure the client t
 
 As the server certificate that you generated above does not belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which the hostname is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -179,7 +179,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You need to add the following parameters to that file to use TLS transport with the CLI tools of Pulsar:
 
@@ -192,7 +192,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -206,25 +206,26 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+ClientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```

--- a/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
@@ -167,7 +167,7 @@ When you enable the TLS transport encryption, you need to configure the client t
 
 As the server certificate that you generated above does not belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which the hostname is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -179,7 +179,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You need to add the following parameters to that file to use TLS transport with the CLI tools of Pulsar:
 
@@ -192,7 +192,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -206,30 +206,31 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+ClientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```
 
-### Node.js client
+#### Node.js client
 
 ```JavaScript
 const Pulsar = require('pulsar-client');

--- a/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
@@ -169,7 +169,7 @@ When you enable the TLS transport encryption, you need to configure the client t
 
 As the server certificate that you generated above does not belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which the hostname is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -181,7 +181,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You need to add the following parameters to that file to use TLS transport with the CLI tools of Pulsar:
 
@@ -194,7 +194,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -208,30 +208,31 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+ClientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```
 
-### Node.js client
+#### Node.js client
 
 ```JavaScript
 const Pulsar = require('pulsar-client');

--- a/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
@@ -169,7 +169,7 @@ When you enable the TLS transport encryption, you need to configure the client t
 
 As the server certificate that you generated above does not belong to any of the default trust chains, you also need to either specify the path the **trust cert** (recommended), or tell the client to allow untrusted server certs.
 
-#### Hostname verification
+### Hostname verification
 
 Hostname verification is a TLS security feature whereby a client can refuse to connect to a server if the "CommonName" does not match the hostname to which the hostname is connecting. By default, Pulsar clients disable hostname verification, as it requires that each broker has a DNS record and a unique cert.
 
@@ -181,7 +181,7 @@ The examples below show hostname verification being disabled for the Java client
 
 ### CLI tools
 
-[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
+[Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools.md#pulsar-admin), [`pulsar-perf`](reference-cli-tools.md#pulsar-perf), and [`pulsar-client`](reference-cli-tools.md#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
 You need to add the following parameters to that file to use TLS transport with the CLI tools of Pulsar:
 
@@ -194,7 +194,7 @@ tlsTrustCertsFilePath=/path/to/ca.cert.pem
 tlsEnableHostnameVerification=false
 ```
 
-### Java client
+#### Java client
 
 ```java
 import org.apache.pulsar.client.api.PulsarClient;
@@ -208,30 +208,31 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### Python client
+#### Python client
 
 ```python
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
+                tls_hostname_verification=True,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
 
-### C++ client
+#### C++ client
 
 ```c++
 #include <pulsar/Client.h>
 
-pulsar::ClientConfiguration config;
-config.setUseTls(true);
-config.setTlsTrustCertsFilePath("/path/to/ca.cert.pem");
-config.setTlsAllowInsecureConnection(false); // defaults to false from v2.2.0 onwards
-
-pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
+ClientConfiguration config = ClientConfiguration();
+config.setUseTls(true);  // shouldn't be needed soon
+config.setTlsTrustCertsFilePath(caPath);
+config.setTlsAllowInsecureConnection(false);
+config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
+config.setValidateHostName(true);
 ```
 
-### Node.js client
+#### Node.js client
 
 ```JavaScript
 const Pulsar = require('pulsar-client');


### PR DESCRIPTION

Fixes #2793 



### Motivation
Based on description in issue #2793, code example of host verification for C++ and Python clients are not correct. Therefore, update the security-tls-transport.md doc.

Doc for master has been updated and merged. This PR is for updating docs for previous releases.



### Modifications

1: update the TLS hostname verification code example for C++ and Python clients.
2: fix link errors.
3: re-arrange doc heading levels.
4: update the docs for the following releases: 2.5.2---2.2.0

