### PR TITLE
function to read compacted topics

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -547,7 +547,9 @@ public class PulsarFunctionE2ETest {
                 sourceTopic, sinkTopic, subscriptionName);
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
         ConsumerConfig consumerConfig = new ConsumerConfig();
-        consumerConfig.setReadCompacted(true);
+        Map<String,String> consumerProperties = new HashMap<>();
+        consumerProperties.put("readCompacted","true");
+        consumerConfig.setConsumerProperties(consumerProperties);
         inputSpecs.put(sourceTopic, consumerConfig);
         functionConfig.setInputSpecs(inputSpecs);
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-functions-api-examples.jar").getFile();
@@ -611,7 +613,9 @@ public class PulsarFunctionE2ETest {
         // 4 Setup sink
         SinkConfig sinkConfig = createSinkConfig(tenant, namespacePortion, sinkName, sourceTopic, subscriptionName);
         sinkConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE);
-        sinkConfig.setInputSpecs(Collections.singletonMap(sourceTopic, ConsumerConfig.builder().readCompacted(true).build()));
+        Map<String,String> consumerProperties = new HashMap<>();
+        consumerProperties.put("readCompacted","true");
+        sinkConfig.setInputSpecs(Collections.singletonMap(sourceTopic, ConsumerConfig.builder().consumerProperties(consumerProperties).build()));
         String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-io-data-generator.nar").getFile();
         admin.sink().createSinkWithUrl(sinkConfig, jarFilePathUrl);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpServer;
 
@@ -54,6 +55,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -73,6 +76,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -90,6 +94,7 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.compaction.TwoPhaseCompactor;
 import org.apache.pulsar.functions.LocalRunner;
 import org.apache.pulsar.functions.instance.InstanceUtils;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory;
@@ -499,6 +504,73 @@ public class PulsarFunctionE2ETest {
         String jarFilePathUrl = String.format("http://127.0.0.1:%d/pulsar-functions-api-examples.jar",
                 fileServer.getAddress().getPort());
         testE2EPulsarFunction(jarFilePathUrl);
+    }
+
+    @Test(timeOut = 30000)
+    public void testReadCompactedFunction() throws Exception {
+        final String namespacePortion = "io";
+        final String replNamespace = tenant + "/" + namespacePortion;
+        final String sourceTopic = "persistent://" + replNamespace + "/my-topic1";
+        final String sinkTopic = "persistent://" + replNamespace + "/output";
+        final String functionName = "PulsarFunction-test";
+        final String subscriptionName = "test-sub";
+        admin.namespaces().createNamespace(replNamespace);
+        Set<String> clusters = Sets.newHashSet(Lists.newArrayList("use"));
+        admin.namespaces().setNamespaceReplicationClusters(replNamespace, clusters);
+        final int messageNum = 20;
+        final int maxKeys = 10;
+        // 1 Setup producer
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(sourceTopic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+        pulsarClient.newConsumer().topic(sourceTopic).subscriptionName(subscriptionName).readCompacted(true).subscribe().close();
+        // 2 Send messages and record the expected values after compaction
+        Map<String, String> expected = new HashMap<>();
+        for (int j = 0; j < messageNum; j++) {
+            String key = "key" + j % maxKeys;
+            String value = "my-message-" + key + j;
+            producer.newMessage().key(key).value(value).send();
+            //Duplicate keys will exist, the value of the new key will be retained
+            expected.put(key, value);
+        }
+        // 3 Trigger compaction
+        ScheduledExecutorService compactionScheduler = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("compactor").setDaemon(true).build());
+        TwoPhaseCompactor twoPhaseCompactor = new TwoPhaseCompactor(config,
+                pulsarClient, pulsar.getBookKeeperClient(), compactionScheduler);
+        twoPhaseCompactor.compact(sourceTopic).get();
+
+        // 4 Setup function
+        FunctionConfig functionConfig = createFunctionConfig(tenant, namespacePortion, functionName,
+                sourceTopic, sinkTopic, subscriptionName);
+        Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+        consumerConfig.setReadCompacted(true);
+        inputSpecs.put(sourceTopic, consumerConfig);
+        functionConfig.setInputSpecs(inputSpecs);
+        String jarFilePathUrl = Utils.FILE + ":" + getClass().getClassLoader().getResource("pulsar-functions-api-examples.jar").getFile();
+        admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
+
+        // 5 Function should only read compacted value，so we will only receive compacted messages
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(sinkTopic).subscriptionName("sink-sub").subscribe();
+        int count = 0;
+        while (true) {
+            Message<String> message = consumer.receive(10, TimeUnit.SECONDS);
+            if (message == null) {
+                break;
+            }
+            consumer.acknowledge(message);
+            count++;
+            Assert.assertEquals(expected.remove(message.getKey()) + "!", message.getValue());
+        }
+        Assert.assertEquals(count, maxKeys);
+        Assert.assertTrue(expected.isEmpty());
+
+        compactionScheduler.shutdownNow();
+        consumer.close();
+        producer.close();
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptions;
@@ -233,7 +234,7 @@ public class CmdFunctions extends CmdBase {
         protected String customSerdeInputString;
         @Parameter(names = "--custom-schema-inputs", description = "The map of input topics to Schema class names (as a JSON string)")
         protected String customSchemaInputString;
-        @Parameter(names = "--input-specs", description = "Custom config for each topic (as a JSON string)")
+        @Parameter(names = "--input-specs", description = "The map of inputs to custom configuration (as a JSON string)")
         protected String inputSpecs;
         // for backwards compatibility purposes
         @Parameter(names = "--outputSerdeClassName", description = "The SerDe class to be used for messages output by the function", hidden = true)
@@ -371,7 +372,7 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setCustomSchemaInputs(customschemaInputMap);
             }
             if (null != inputSpecs) {
-                Type type = new TypeToken<Map<String, String>>() {}.getType();
+                Type type = new TypeToken<Map<String, ConsumerConfig>>() {}.getType();
                 functionConfig.setInputSpecs(new Gson().fromJson(inputSpecs, type));
             }
             if (null != topicsPattern) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -233,6 +233,8 @@ public class CmdFunctions extends CmdBase {
         protected String customSerdeInputString;
         @Parameter(names = "--custom-schema-inputs", description = "The map of input topics to Schema class names (as a JSON string)")
         protected String customSchemaInputString;
+        @Parameter(names = "--input-specs", description = "Custom config for each topic (as a JSON string)")
+        protected String inputSpecs;
         // for backwards compatibility purposes
         @Parameter(names = "--outputSerdeClassName", description = "The SerDe class to be used for messages output by the function", hidden = true)
         protected String DEPRECATED_outputSerdeClassName;
@@ -367,6 +369,10 @@ public class CmdFunctions extends CmdBase {
                 Type type = new TypeToken<Map<String, String>>() {}.getType();
                 Map<String, String> customschemaInputMap = new Gson().fromJson(customSchemaInputString, type);
                 functionConfig.setCustomSchemaInputs(customschemaInputMap);
+            }
+            if (null != inputSpecs) {
+                Type type = new TypeToken<Map<String, String>>() {}.getType();
+                functionConfig.setInputSpecs(new Gson().fromJson(inputSpecs, type));
             }
             if (null != topicsPattern) {
                 functionConfig.setTopicsPattern(topicsPattern);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptions;
@@ -276,6 +277,9 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--custom-schema-inputs", description = "The map of input topics to Schema types or class names (as a JSON string)")
         protected String customSchemaInputString;
 
+        @Parameter(names = "--input-specs", description = "The map of inputs to custom configuration (as a JSON string)")
+        protected String inputSpecs;
+
         @Parameter(names = "--max-redeliver-count", description = "Maximum number of times that a message will be redelivered before being sent to the dead letter queue")
         protected Integer maxMessageRetries;
         @Parameter(names = "--dead-letter-topic", description = "Name of the dead topic where the failing messages will be sent.")
@@ -384,6 +388,11 @@ public class CmdSinks extends CmdBase {
                 Type type = new TypeToken<Map<String, String>>(){}.getType();
                 Map<String, String> customSchemaInputMap = new Gson().fromJson(customSchemaInputString, type);
                 sinkConfig.setTopicToSchemaType(customSchemaInputMap);
+            }
+
+            if(null != inputSpecs){
+                Type type = new TypeToken<Map<String, ConsumerConfig>>(){}.getType();
+                sinkConfig.setInputSpecs(new Gson().fromJson(inputSpecs, type));
             }
 
             sinkConfig.setMaxMessageRetries(maxMessageRetries);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -42,6 +42,8 @@ public class ConsumerConfig {
     private boolean isRegexPattern;
     @Builder.Default
     private Map<String, String> schemaProperties = new HashMap<>();
+    @Builder.Default
+    private Map<String, String> consumerProperties = new HashMap<>();
     private Integer receiverQueueSize;
 
     public ConsumerConfig(String schemaType) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -37,4 +37,5 @@ public class ConsumerConfig {
     private String serdeClassName;
     private boolean isRegexPattern;
     private Integer receiverQueueSize;
+    private boolean readCompacted;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -683,10 +683,10 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     consumerConfig.setSerdeClassName(conf.getSerdeClassName());
                 }
                 consumerConfig.setSchemaProperties(conf.getSchemaPropertiesMap());
+                consumerConfig.setConsumerProperties(conf.getConsumerPropertiesMap());
                 if (conf.hasReceiverQueueSize()) {
                     consumerConfig.setReceiverQueueSize(conf.getReceiverQueueSize().getValue());
                 }
-                consumerConfig.setReadCompacted(conf.getReadCompacted());
                 pulsarSourceConfig.getTopicSchema().put(topic, consumerConfig);
             });
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -685,6 +685,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 if (conf.hasReceiverQueueSize()) {
                     consumerConfig.setReceiverQueueSize(conf.getReceiverQueueSize().getValue());
                 }
+                consumerConfig.setReadCompacted(conf.getReadCompacted());
                 pulsarSourceConfig.getTopicSchema().put(topic, consumerConfig);
             });
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -86,6 +86,9 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             if (conf.getReceiverQueueSize() != null) {
                 cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
             }
+            if (conf.readCompacted) {
+                cb = cb.readCompacted(true);
+            }
             cb = cb.properties(properties);
             if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
                     && pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() > 0) {
@@ -94,7 +97,6 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             if (pulsarSourceConfig.getTimeoutMs() != null) {
                 cb = cb.ackTimeout(pulsarSourceConfig.getTimeoutMs(), TimeUnit.MILLISECONDS);
             }
-
             if (pulsarSourceConfig.getMaxMessageRetries() != null && pulsarSourceConfig.getMaxMessageRetries() >= 0) {
                 DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicyBuilder = DeadLetterPolicy.builder();
                 deadLetterPolicyBuilder.maxRedeliverCount(pulsarSourceConfig.getMaxMessageRetries());
@@ -169,7 +171,11 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                 schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf.getSchemaType(), true);
             }
             configs.put(topic,
-                    ConsumerConfig.<T> builder().schema(schema).isRegexPattern(conf.isRegexPattern()).receiverQueueSize(conf.getReceiverQueueSize()).build());
+                    ConsumerConfig.<T> builder().
+                            schema(schema).
+                            isRegexPattern(conf.isRegexPattern()).
+                            receiverQueueSize(conf.getReceiverQueueSize()).
+                            readCompacted(conf.isReadCompacted()).build());
         });
 
         return configs;
@@ -189,6 +195,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
         private Schema<T> schema;
         private boolean isRegexPattern;
         private Integer receiverQueueSize;
+        private boolean readCompacted;
     }
 
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -86,9 +86,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             if (conf.getReceiverQueueSize() != null) {
                 cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
             }
-            if (conf.readCompacted) {
-                cb = cb.readCompacted(true);
-            }
+            cb = cb.readCompacted(conf.readCompacted);
             cb = cb.properties(properties);
             if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
                     && pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() > 0) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -86,7 +86,9 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             if (conf.getReceiverQueueSize() != null) {
                 cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
             }
-            cb = cb.readCompacted(conf.readCompacted);
+            if(conf.readCompacted){
+                cb = cb.readCompacted(conf.readCompacted);
+            }
             cb = cb.properties(properties);
             if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
                     && pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() > 0) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -75,10 +75,13 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                     .cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
                     .subscriptionName(pulsarSourceConfig.getSubscriptionName())
                     .subscriptionInitialPosition(pulsarSourceConfig.getSubscriptionPosition())
-                    .subscriptionType(pulsarSourceConfig.getSubscriptionType())
-                    .loadConf(new HashMap<>(conf.getConsumerProperties()))
-                    //messageListener is annotated with @JsonIgnore,so setting messageListener should be put behind loadConf
-                    .messageListener(this);
+                    .subscriptionType(pulsarSourceConfig.getSubscriptionType());
+
+            if (conf.getConsumerProperties() != null && !conf.getConsumerProperties().isEmpty()) {
+                cb.loadConf(new HashMap<>(conf.getConsumerProperties()));
+            }
+            //messageListener is annotated with @JsonIgnore,so setting messageListener should be put behind loadConf
+            cb.messageListener(this);
 
             if (conf.isRegexPattern) {
                 cb = cb.topicsPattern(topic);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -76,6 +76,8 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                     .subscriptionName(pulsarSourceConfig.getSubscriptionName())
                     .subscriptionInitialPosition(pulsarSourceConfig.getSubscriptionPosition())
                     .subscriptionType(pulsarSourceConfig.getSubscriptionType())
+                    .loadConf(new HashMap<>(conf.getConsumerProperties()))
+                    //messageListener is annotated with @JsonIgnore,so setting messageListener should be put behind loadConf
                     .messageListener(this);
 
             if (conf.isRegexPattern) {
@@ -85,9 +87,6 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             }
             if (conf.getReceiverQueueSize() != null) {
                 cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
-            }
-            if(conf.readCompacted){
-                cb = cb.readCompacted(conf.readCompacted);
             }
             cb = cb.properties(properties);
             if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
@@ -175,7 +174,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                             schema(schema).
                             isRegexPattern(conf.isRegexPattern()).
                             receiverQueueSize(conf.getReceiverQueueSize()).
-                            readCompacted(conf.isReadCompacted()).build());
+                            consumerProperties(conf.getConsumerProperties()).build());
         });
 
         return configs;
@@ -195,7 +194,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
         private Schema<T> schema;
         private boolean isRegexPattern;
         private Integer receiverQueueSize;
-        private boolean readCompacted;
+        private Map<String, String> consumerProperties;
     }
 
 }

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -95,6 +95,7 @@ message ConsumerSpec {
     }
     ReceiverQueueSize receiverQueueSize = 4;
     map<string, string> schemaProperties = 5;
+    map<string, string> consumerProperties = 6;
 }
 
 message SourceSpec {
@@ -149,6 +150,8 @@ message SinkSpec {
     bool forwardSourceMessageProperty = 8;
 
     map<string, string> schemaProperties = 9;
+
+    map<string, string> consumerProperties = 10;
 }
 
 message PackageLocationMetaData {

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -94,6 +94,7 @@ message ConsumerSpec {
         int32 value = 1;
     }
     ReceiverQueueSize receiverQueueSize = 4;
+    bool readCompacted = 5;
 }
 
 message SourceSpec {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -118,6 +118,7 @@ public class FunctionConfigUtils {
                     bldr.setReceiverQueueSize(Function.ConsumerSpec.ReceiverQueueSize.newBuilder()
                             .setValue(consumerConf.getReceiverQueueSize()).build());
                 }
+                bldr.setReadCompacted(consumerConf.isReadCompacted());
                 sourceSpecBuilder.putInputSpecs(topicName, bldr.build());
             });
         }
@@ -278,6 +279,7 @@ public class FunctionConfigUtils {
             if (input.getValue().hasReceiverQueueSize()) {
                 consumerConfig.setReceiverQueueSize(input.getValue().getReceiverQueueSize().getValue());
             }
+            consumerConfig.setReadCompacted(input.getValue().getReadCompacted());
             consumerConfig.setRegexPattern(input.getValue().getIsRegexPattern());
             consumerConfigMap.put(input.getKey(), consumerConfig);
         }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -109,6 +109,7 @@ public class FunctionConfigUtils {
                             Function.ConsumerSpec.newBuilder()
                                     .setSchemaType(consumerConfig.getSchemaType())
                                     .putAllSchemaProperties(consumerConfig.getSchemaProperties())
+                                    .putAllConsumerProperties(consumerConfig.getConsumerProperties())
                                     .setIsRegexPattern(false)
                                     .build());
                 } catch (JsonProcessingException e) {
@@ -132,6 +133,7 @@ public class FunctionConfigUtils {
                 if (consumerConf.getSchemaProperties() != null) {
                     bldr.putAllSchemaProperties(consumerConf.getSchemaProperties());
                 }
+                bldr.putAllConsumerProperties(consumerConf.getConsumerProperties());
                 sourceSpecBuilder.putInputSpecs(topicName, bldr.build());
             });
         }
@@ -180,6 +182,7 @@ public class FunctionConfigUtils {
                 if (StringUtils.isNotEmpty(conf)) {
                     ConsumerConfig consumerConfig = OBJECT_MAPPER.readValue(conf, ConsumerConfig.class);
                     sinkSpecBuilder.putAllSchemaProperties(consumerConfig.getSchemaProperties());
+                    sinkSpecBuilder.putAllConsumerProperties(consumerConfig.getConsumerProperties());
                 }
             } catch (JsonProcessingException e) {
                 throw new IllegalArgumentException(String.format("Incorrect custom schema outputs ,Topic %s ", functionConfig.getOutput()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -143,6 +143,7 @@ public class SinkConfigUtils {
                     bldr.setReceiverQueueSize(Function.ConsumerSpec.ReceiverQueueSize.newBuilder()
                             .setValue(spec.getReceiverQueueSize()).build());
                 }
+                bldr.setReadCompacted(spec.isReadCompacted());
                 sourceSpecBuilder.putInputSpecs(topic, bldr.build());
             });
         }
@@ -259,6 +260,7 @@ public class SinkConfigUtils {
                 consumerConfig.setReceiverQueueSize(input.getValue().getReceiverQueueSize().getValue());
             }
             consumerConfig.setRegexPattern(input.getValue().getIsRegexPattern());
+            consumerConfig.setReadCompacted(input.getValue().getReadCompacted());
             consumerConfigMap.put(input.getKey(), consumerConfig);
         }
         sinkConfig.setInputSpecs(consumerConfigMap);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -143,7 +143,7 @@ public class SinkConfigUtils {
                     bldr.setReceiverQueueSize(Function.ConsumerSpec.ReceiverQueueSize.newBuilder()
                             .setValue(spec.getReceiverQueueSize()).build());
                 }
-                bldr.setReadCompacted(spec.isReadCompacted());
+                bldr.putAllConsumerProperties(spec.getConsumerProperties());
                 sourceSpecBuilder.putInputSpecs(topic, bldr.build());
             });
         }
@@ -260,7 +260,7 @@ public class SinkConfigUtils {
                 consumerConfig.setReceiverQueueSize(input.getValue().getReceiverQueueSize().getValue());
             }
             consumerConfig.setRegexPattern(input.getValue().getIsRegexPattern());
-            consumerConfig.setReadCompacted(input.getValue().getReadCompacted());
+            consumerConfig.setConsumerProperties(input.getValue().getConsumerPropertiesMap());
             consumerConfigMap.put(input.getKey(), consumerConfig);
         }
         sinkConfig.setInputSpecs(consumerConfigMap);


### PR DESCRIPTION


Fixes #5538

### Motivation



### Modifications
In function mode and sink mode, PulsarSource can read compacted topic。
By `inputSpecs` parameter, each topic can independently decide whether to read compacted

### Verifying this change
unit test:
org.apache.pulsar.io.PulsarFunctionE2ETest#testReadCompactedFunction
org.apache.pulsar.io.PulsarFunctionE2ETest#testReadCompactedSink


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
