### PR TITLE
[Issue 7033] Remove redundant ledger dir creation when necessary

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -20,14 +20,18 @@ package org.apache.pulsar.broker.zookeeper;
 
 import org.apache.pulsar.PulsarClusterMetadataSetup;
 import org.apache.pulsar.broker.zookeeper.ZooKeeperClientAspectJTest.ZookeeperServerTest;
+import org.apache.zookeeper.ZooKeeper;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
 public class ClusterMetadataSetupTest {
     private ZookeeperServerTest localZkS;
 
-    // test SetupClusterMetadata several times, all should be suc
+    // test SetupClusterMetadata several times, all should be successful
     @Test
     public void testReSetupClusterMetadata() throws Exception {
         String[] args = {
@@ -42,6 +46,42 @@ public class ClusterMetadataSetupTest {
         PulsarClusterMetadataSetup.main(args);
         PulsarClusterMetadataSetup.main(args);
         PulsarClusterMetadataSetup.main(args);
+    }
+
+    @Test
+    public void testSetupWithBkMetadataServiceUri() throws Exception {
+        String zkConnection = "127.0.0.1:" + localZkS.getZookeeperPort();
+        String[] args = {
+                "--cluster", "testReSetupClusterMetadata-cluster",
+                "--zookeeper", zkConnection,
+                "--configuration-store", zkConnection,
+                "--bookkeeper-metadata-service-uri", "zk+null://" + zkConnection + "/chroot/ledgers",
+                "--web-service-url", "http://127.0.0.1:8080",
+                "--web-service-url-tls", "https://127.0.0.1:8443",
+                "--broker-service-url", "pulsar://127.0.0.1:6650",
+                "--broker-service-url-tls","pulsar+ssl://127.0.0.1:6651"
+        };
+
+        PulsarClusterMetadataSetup.main(args);
+
+        ZooKeeper localZk = PulsarClusterMetadataSetup.initZk(zkConnection, 30000);
+        // expected not exist
+        assertNull(localZk.exists("/ledgers", false));
+
+        String[] args1 = {
+                "--cluster", "testReSetupClusterMetadata-cluster",
+                "--zookeeper", zkConnection,
+                "--configuration-store", zkConnection,
+                "--web-service-url", "http://127.0.0.1:8080",
+                "--web-service-url-tls", "https://127.0.0.1:8443",
+                "--broker-service-url", "pulsar://127.0.0.1:6650",
+                "--broker-service-url-tls","pulsar+ssl://127.0.0.1:6651"
+        };
+
+        PulsarClusterMetadataSetup.main(args1);
+
+        // expected exist
+        assertNotNull(localZk.exists("/ledgers", false));
     }
 
     @BeforeMethod


### PR DESCRIPTION
### Motivation

Fixes #7033

### Modifications

Add the logic to handle the creation of ledger dir when using an existing bookkeeper cluster and a test for this.