### PR TITLE
[broker] Prevent redirection of lookup requests from looping

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
@@ -34,28 +34,35 @@ public class LookupResult {
 
     private final Type type;
     private final LookupData lookupData;
+    private final boolean authoritativeRedirect;
 
     public LookupResult(NamespaceEphemeralData namespaceEphemeralData) {
         this.type = Type.BrokerUrl;
+        this.authoritativeRedirect = false;
         this.lookupData = new LookupData(namespaceEphemeralData.getNativeUrl(),
                 namespaceEphemeralData.getNativeUrlTls(), namespaceEphemeralData.getHttpUrl(),
                 namespaceEphemeralData.getHttpUrlTls());
     }
 
-    public LookupResult(String httpUrl, String httpUrlTls, String brokerServiceUrl, String brokerServiceUrlTls) {
+    public LookupResult(String httpUrl, String httpUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
+            boolean authoritativeRedirect) {
         this.type = Type.RedirectUrl; // type = redirect => as current broker is
                                       // not owner and prepares LookupResult
                                       // with other broker's urls
+        this.authoritativeRedirect = authoritativeRedirect;
         this.lookupData = new LookupData(brokerServiceUrl, brokerServiceUrlTls, httpUrl, httpUrlTls);
     }
 
-    public LookupResult(String httpUrl, String httpUrlTls, String nativeUrl, String nativeUrlTls, Type type) {
+    public LookupResult(String httpUrl, String httpUrlTls, String nativeUrl, String nativeUrlTls, Type type,
+            boolean authoritativeRedirect) {
         this.type = type;
+        this.authoritativeRedirect = authoritativeRedirect;
         this.lookupData = new LookupData(nativeUrl, nativeUrlTls, httpUrl, httpUrlTls);
     }
 
     public LookupResult(NamespaceEphemeralData namespaceEphemeralData, String nativeUrl, String nativeUrlTls) {
         this.type = Type.BrokerUrl;
+        this.authoritativeRedirect = false;
         this.lookupData = new LookupData(nativeUrl, nativeUrlTls, namespaceEphemeralData.getHttpUrl(),
                 namespaceEphemeralData.getHttpUrlTls());
     }
@@ -66,6 +73,10 @@ public class LookupResult {
 
     public boolean isRedirect() {
         return type == Type.RedirectUrl;
+    }
+
+    public boolean isAuthoritativeRedirect() {
+        return authoritativeRedirect;
     }
 
     public LookupData getLookupData() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -92,7 +92,7 @@ public class TopicLookupBase extends PulsarWebResource {
             LookupResult result = optionalResult.get();
             // We have found either a broker that owns the topic, or a broker to which we should redirect the client to
             if (result.isRedirect()) {
-                boolean newAuthoritative = this.isLeaderBroker();
+                boolean newAuthoritative = result.isAuthoritativeRedirect();
                 URI redirect;
                 try {
                     String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
@@ -266,7 +266,7 @@ public class TopicLookupBase extends PulsarWebResource {
 
                             LookupData lookupData = lookupResult.get().getLookupData();
                             if (lookupResult.get().isRedirect()) {
-                                boolean newAuthoritative = isLeaderBroker(pulsarService);
+                                boolean newAuthoritative = lookupResult.get().isAuthoritativeRedirect();
                                 lookupfuture.complete(
                                         newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),
                                                 newAuthoritative, LookupType.Redirect, requestId, false));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -358,13 +358,13 @@ public class NamespaceServiceTest extends BrokerTestBase {
         ZkUtils.createFullPathOptimistic(pulsar.getZkClient(), path2,
                 ObjectMapperFactory.getThreadLocal().writeValueAsBytes(ld), ZooDefs.Ids.OPEN_ACL_UNSAFE,
                 CreateMode.EPHEMERAL);
-        LookupResult result1 = pulsar.getNamespaceService().createLookupResult(candidateBroker1).get();
+        LookupResult result1 = pulsar.getNamespaceService().createLookupResult(candidateBroker1, false).get();
 
         // update to new load manager
         LoadManager oldLoadManager = pulsar.getLoadManager()
                 .getAndSet(new ModularLoadManagerWrapper(new ModularLoadManagerImpl()));
         oldLoadManager.stop();
-        LookupResult result2 = pulsar.getNamespaceService().createLookupResult(candidateBroker2).get();
+        LookupResult result2 = pulsar.getNamespaceService().createLookupResult(candidateBroker2, false).get();
         Assert.assertEquals(result1.getLookupData().getBrokerUrl(), candidateBroker1);
         Assert.assertEquals(result2.getLookupData().getBrokerUrl(), candidateBroker2);
         System.out.println(result2);


### PR DESCRIPTION
Master Issue: #7041

### Motivation

Usually, the leader broker determines which broker owns which namespace bundle. The leader picks a broker to assign the bundle to based on each broker's load and redirects the lookup request with the "authoritative" flag set to true. The follower broker that receives the lookup request with the "authoritative" flag set to true will attempt to take ownership of the bundle.

However, if the leader is not active, other brokers will also redirect lookup requests to the broker they consider to be the least loaded. In this case, the "authoritative" flag is false, so the broker being redirected may not try to take ownership of the bundle. The broker takes ownership of the bundle only if it considers itself the least loaded.

This can cause a redirection loop if each broker considers a different broker is the least loaded. This redirection loop ends when a new leader is elected, but a large number of loops will cause `StackOverflowError` on the client side (see #7096).

https://github.com/apache/pulsar/blob/6826040d32961e3e44f70622bcb89a116935ab68/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L441-L461

### Modifications

If the leader is not active, follower brokers that receive a lookup request will redirect it with the "authoritative" flag set to true. A broker that receives a request with the "authoritative" flag set to true will always try to take ownership of that bundle. This avoids the redirection loop.