### PR TITLE
[Issue 7202] Upgrade commons-lang3 version to 3.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -344,7 +344,7 @@ The Apache Software License, Version 2.0
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.1.jar
     - org.apache.commons-commons-compress-1.19.jar
-    - org.apache.commons-commons-lang3-3.4.jar
+    - org.apache.commons-commons-lang3-3.6.jar
  * Netty
     - io.netty-netty-buffer-4.1.48.Final.jar
     - io.netty-netty-codec-4.1.48.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.4</version>
+        <version>3.6</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -228,7 +228,7 @@ The Apache Software License, Version 2.0
     - commons-beanutils-core-1.8.3.jar
     - commons-compress-1.19.jar
     - commons-lang3-3.3.2.jar
-    - commons-lang3-3.4.jar
+    - commons-lang3-3.6.jar
  * Netty
     - netty-3.10.6.Final.jar
     - netty-buffer-4.1.48.Final.jar


### PR DESCRIPTION
### Motivation

Fixes #7202

### Modifications

Upgrade commons-lang3 version to 3.6 in the root pom.xml to be consistent with BookKeeper.
Update the package name in LICENSE.