### PR TITLE
fix return an explicit error to tell the application that the namespa…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1942,7 +1942,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     public CompletableFuture<PartitionedTopicMetadata> fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(TopicName topicName) {
         if(pulsar.getNamespaceService() == null){
-            return FutureUtil.failedFuture(new NullPointerException("namespaceService is null"));
+            return FutureUtil.failedFuture(new NamingException("namespace service is not ready"));
         }
         return pulsar.getNamespaceService().checkTopicExists(topicName)
                 .thenCompose(topicExists -> {


### PR DESCRIPTION
Master Issue: #7163
## Motivation

Sometimes get partitioned metadata will throws NullPointerException, because the NamespaceService not initialized yet , so needed a judgment .

## Modifications
BrokerService
```java
        if(pulsar.getNamespaceService() == null){
            return FutureUtil.failedFuture(new NamingException("namespace service is not ready."));
        }
```
