### PR TITLE
[C++] Wait for all seek operations completed

### DIFF
--- a/pulsar-client-cpp/lib/MultiResultCallback.h
+++ b/pulsar-client-cpp/lib/MultiResultCallback.h
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/ConsumerConfiguration.h>  // for ResultCallback
+
+#include <atomic>
+#include <memory>
+
+namespace pulsar {
+
+class MultiResultCallback {
+   public:
+    MultiResultCallback(ResultCallback callback, int numToComplete)
+        : callback_(callback),
+          numToComplete_(numToComplete),
+          numCompletedPtr_(std::make_shared<std::atomic_int>(0)) {}
+
+    void operator()(Result result) {
+        if (result == ResultOk) {
+            if (++(*numCompletedPtr_) == numToComplete_) {
+                callback_(result);
+            }
+        } else {
+            callback_(result);
+        }
+    }
+
+   private:
+    ResultCallback callback_;
+    const int numToComplete_;
+    const std::shared_ptr<std::atomic_int> numCompletedPtr_;
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -553,10 +553,13 @@ void PartitionedConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callb
         callback(ResultAlreadyClosed);
         return;
     }
+
+    // consumers_ could only be modified when state_ is Ready, so we needn't lock consumersMutex_ here
+    ConsumerList consumerList = consumers_;
     stateLock.unlock();
 
     MultiResultCallback multiResultCallback(callback, consumers_.size());
-    for (ConsumerList::const_iterator i = consumers_.begin(); i != consumers_.end(); i++) {
+    for (ConsumerList::const_iterator i = consumerList.begin(); i != consumerList.end(); i++) {
         (*i)->seekAsync(timestamp, multiResultCallback);
     }
 }

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include "PartitionedConsumerImpl.h"
+#include "MultiResultCallback.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -553,8 +554,10 @@ void PartitionedConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callb
         return;
     }
     stateLock.unlock();
+
+    MultiResultCallback multiResultCallback(callback, consumers_.size());
     for (ConsumerList::const_iterator i = consumers_.begin(); i != consumers_.end(); i++) {
-        (*i)->seekAsync(timestamp, callback);
+        (*i)->seekAsync(timestamp, multiResultCallback);
     }
 }
 


### PR DESCRIPTION
### Motivation

When a partitioned consumer calls `seek`, it waits for only one partition's seek operation completed  because each internal consumer calls `callback(result)` to complete the same `Promise`.

### Modifications

- Add a `MultiResultCallback` implementation, the callback completes only if all N events completes successfully or one of N events failed.
- Use `MultiResultCallback` to wrap `callback` from `PartitionedConsumerImpl::seekAsync`.
