### PR TITLE
[Issue-5924] [Doc]--Update geo-replication doc.

### DIFF
--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -35,8 +35,7 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-> #### Subscriptions are local to a cluster
-> While producers and consumers can publish to and consume from any cluster in a Pulsar instance, subscriptions are local to the clusters in which the subscriptions are created and cannot be transferred between clusters. If you do need to transfer a subscription, you need to create a new subscription in the desired cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after replicated subscription is enabled. Once replicated subscription is enabled, you can keep subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 


### PR DESCRIPTION

Fixes #5924 

### Motivation
Since PIP-33, we can configure a subscription to be replicated. hence it supports both local subscription and replicated subscription.

### Modifications
Update the pulsar doc: administration > geo-replication:

remove the original note, which emphasize supporting local subscription only.

This update is only for master. Once it is approved and merged, these updates will be updated to releases 2.5.2--2.4.0.


