### PR TITLE
Support multi versions of Go for testing go functions

### DIFF
--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -30,6 +30,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.11, 1.12, 1.13, 1.14]
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -43,11 +46,11 @@ jobs:
         with:
           args: site2 .github deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up Go 1.12
+      - name: Set up Go
         uses: actions/setup-go@v1
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          go-version: 1.12
+          go-version: ${{ matrix.go-version }}
         id: go
 
       - name: InstallTool

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -28,9 +28,12 @@ on:
 
 jobs:
 
-  cpp-tests:
+  go-functions-tests:
     name:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.11, 1.12, 1.13, 1.14]
     timeout-minutes: 120
 
     steps:
@@ -46,15 +49,15 @@ jobs:
         with:
           args: site2 .github deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up Go 1.12
+      - name: Set up Go
         uses: actions/setup-go@v1
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          go-version: 1.12
+          go-version: ${{ matrix.go-version }}
         id: go
 
       - name: run tests
         if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
-          go test -v $(go list ./... | grep -v examples)
+          go test -v $(go list ./... | grep -v examples) ${{ matrix.go-version }}


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

Currently, the Pulsar Go Functions is only tested against Go version 1.12. We need to verify multiple versions.

### Modifications

*Describe the modifications you've done.*

I've modified the two GitHub Action workflows that are a part of this repo with
a [matrix](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) such that we test against multiple versions of Go.