### PR TITLE
catch throwable when start pulsar

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -347,8 +347,8 @@ public class PulsarBrokerStarter {
 
         try {
             starter.start();
-        } catch (Exception e) {
-            log.error("Failed to start pulsar service.", e);
+        } catch (Throwable t) {
+            log.error("Failed to start pulsar service.", t);
             Runtime.getRuntime().halt(1);
         } finally {
             starter.join();


### PR DESCRIPTION
### Motivation
Currently, pulsar only catch exception when `BrokerStarter.start()` https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java#L350 failed,  some error such as NoSuchMethodError or NoClassDefFoundError can not be caught, and pulsar will in abnormal status but no error log will found in the log file. 
### Modification
modify exception to throwable
