### PR TITLE
Fix the regression in isSupperUser

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -47,17 +47,6 @@ public interface AuthorizationProvider extends Closeable {
     /**
      * Check if specified role is a super user
      * @param role the role to check
-     * @return a CompletableFuture containing a boolean in which true means the role is a super user
-     * and false if it is not
-     */
-    default CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
-        Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
-        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
-    }
-
-    /**
-     * Check if specified role is a super user
-     * @param role the role to check
      * @param authenticationData authentication data related to the role
      * @return a CompletableFuture containing a boolean in which true means the role is a super user
      * and false if it is not
@@ -65,7 +54,20 @@ public interface AuthorizationProvider extends Closeable {
     default CompletableFuture<Boolean> isSuperUser(String role,
                                                    AuthenticationDataSource authenticationData,
                                                    ServiceConfiguration serviceConfiguration) {
-        return isSuperUser(role, serviceConfiguration);
+        Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
+        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
+    }
+
+    /**
+     * @deprecated Use method {@link #isSuperUser(String, AuthenticationDataSource, ServiceConfiguration)}
+     * Check if specified role is a super user
+     * @param role the role to check
+     * @return a CompletableFuture containing a boolean in which true means the role is a super user
+     * and false if it is not
+     */
+    default CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+        Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
+        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
     }
 
     /**

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -322,7 +322,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             String role, String authDataJson) {
         return updateSubscriptionPermissionAsync(namespace, subscriptionName, Collections.singleton(role), true);
     }
-    
+
     private CompletableFuture<Void> updateSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName, Set<String> roles,
             boolean remove) {
         CompletableFuture<Void> result = new CompletableFuture<>();
@@ -549,7 +549,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                     new IllegalStateException("TopicOperation is not supported."));
         }
 
-        CompletableFuture<Boolean> isSuperUserFuture = isSuperUser(role, conf);
+        CompletableFuture<Boolean> isSuperUserFuture = isSuperUser(role, authData, conf);
 
         return isSuperUserFuture
                 .thenCombine(isAuthorizedFuture, (isSuperUser, isAuthorized) -> isSuperUser || isAuthorized);
@@ -573,14 +573,14 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
 
             if (role != null && conf.getProxyRoles().contains(role)) {
                 // role check
-                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, conf);
+                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, authData, conf);
                 CompletableFuture<Boolean> isRoleTenantAdminFuture = isTenantAdmin(tenantName, role, tenantInfo, authData);
                 CompletableFuture<Boolean> isRoleAuthorizedFuture = isRoleSuperUserFuture
                         .thenCombine(isRoleTenantAdminFuture, (isRoleSuperUser, isRoleTenantAdmin) ->
                                 isRoleSuperUser || isRoleTenantAdmin);
 
                 // originalRole check
-                CompletableFuture<Boolean> isOriginalRoleSuperUserFuture = isSuperUser(originalRole, conf);
+                CompletableFuture<Boolean> isOriginalRoleSuperUserFuture = isSuperUser(originalRole, authData, conf);
                 CompletableFuture<Boolean> isOriginalRoleTenantAdminFuture = isTenantAdmin(tenantName, originalRole,
                         tenantInfo, authData);
                 CompletableFuture<Boolean> isOriginalRoleAuthorizedFuture = isOriginalRoleSuperUserFuture
@@ -593,7 +593,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                 isRoleAuthorized && isOriginalRoleAuthorized);
             } else {
                 // role check
-                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, conf);
+                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, authData, conf);
                 CompletableFuture<Boolean> isRoleTenantAdminFuture = isTenantAdmin(tenantName, role, tenantInfo, authData);
                 return isRoleSuperUserFuture
                         .thenCombine(isRoleTenantAdminFuture, (isRoleSuperUser, isRoleTenantAdmin) ->


### PR DESCRIPTION
### Motivation
In #6708, we change to use `isSuperUser(String, AuthenticationDataSource, ServiceConfiguration)` for the dynamic check of superuser using AuthenticationDataSource. And #6428 is using old method  `isSuperUser(String, ServiceConfiguration)`,
This change tries to change it back.

### Modifications

switch `isSuperUser(String, ServiceConfiguration)` to `isSuperUser(String, AuthenticationDataSource, ServiceConfiguration)`
