### PR TITLE
[pulsar-broker] Keep max-concurrent http web-request configurable

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -76,6 +76,9 @@ numExecutorThreadPoolSize=
 # Default is 10
 numCacheExecutorThreadPoolSize=10
 
+# Max concurrent web requests
+maxConcurrentHttpRequests=1024
+
 # Flag to control features that are meant to be used when running in standalone mode
 isRunningStandalone=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -57,6 +57,9 @@ numExecutorThreadPoolSize=
 # Default is 10
 numCacheExecutorThreadPoolSize=10
 
+# Max concurrent web requests
+maxConcurrentHttpRequests=1024
+
 # Name of the cluster to which this broker belongs to
 clusterName=standalone
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -205,6 +205,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int numCacheExecutorThreadPoolSize = 10;
 
+    @FieldContext(category = CATEGORY_SERVER, doc = "Max concurrent web requests")
+    private int maxConcurrentHttpRequests = 1024;
+
     @FieldContext(category = CATEGORY_SERVER, doc = "Whether to enable the delayed delivery for messages.")
     private boolean delayedDeliveryEnabled = true;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -63,12 +63,12 @@ public class WebService implements AutoCloseable {
 
     public static final String ATTRIBUTE_PULSAR_NAME = "pulsar";
     public static final String HANDLER_CACHE_CONTROL = "max-age=3600";
-    public static final int MAX_CONCURRENT_REQUESTS = 1024; // make it configurable?
 
     private final PulsarService pulsar;
     private final Server server;
     private final List<Handler> handlers;
     private final WebExecutorThreadPool webServiceExecutor;
+    public final int maxConcurrentRequests;
 
     private final ServerConnector httpConnector;
     private final ServerConnector httpsConnector;
@@ -80,6 +80,7 @@ public class WebService implements AutoCloseable {
                 pulsar.getConfiguration().getNumHttpServerThreads(),
                 "pulsar-web");
         this.server = new Server(webServiceExecutor);
+        this.maxConcurrentRequests = pulsar.getConfiguration().getMaxConcurrentHttpRequests();
         List<ServerConnector> connectors = new ArrayList<>();
 
         Optional<Integer> port = pulsar.getConfiguration().getWebServicePort();
@@ -131,7 +132,7 @@ public class WebService implements AutoCloseable {
         }
 
         // Limit number of concurrent HTTP connections to avoid getting out of file descriptors
-        connectors.forEach(c -> c.setAcceptQueueSize(WebService.MAX_CONCURRENT_REQUESTS / connectors.size()));
+        connectors.forEach(c -> c.setAcceptQueueSize(maxConcurrentRequests / connectors.size()));
         server.setConnectors(connectors.toArray(new ServerConnector[connectors.size()]));
     }
 


### PR DESCRIPTION
### Motivation
Sometime based on broker lower-spec, we want to tune number of max concurrent http requests. 

### Modification
Add config to configure max concurrent web requests.