### PR TITLE
[pulsar-admin] Fix tenant admin should be able to get tenant-info

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -72,7 +72,7 @@ public class TenantsBase extends AdminResource {
     public TenantInfo getTenantAdmin(
         @ApiParam(value = "The tenant name")
         @PathParam("tenant") String tenant) {
-        validateSuperUserAccess();
+        validateAdminAccessForTenant(tenant);
 
         try {
             return tenantsCache().get(path(POLICIES, tenant))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -142,6 +142,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         doReturn(mockZooKeeper).when(properties).globalZk();
         doReturn(configurationCache.propertiesCache()).when(properties).tenantsCache();
         doReturn("test").when(properties).clientAppId();
+        doReturn(null).when(properties).originalPrincipal();
+        doReturn(null).when(properties).clientAuthData();
         doNothing().when(properties).validateSuperUserAccess();
 
         namespaces = spy(new Namespaces());
@@ -420,18 +422,18 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         verify(properties, times(3)).validateSuperUserAccess();
 
         assertEquals(properties.getTenantAdmin("test-property"), tenantInfo);
-        verify(properties, times(4)).validateSuperUserAccess();
+        verify(properties, times(3)).validateSuperUserAccess();
 
         TenantInfo newPropertyAdmin = new TenantInfo(Sets.newHashSet("role1", "other-role"), allowedClusters);
         properties.updateTenant("test-property", newPropertyAdmin);
-        verify(properties, times(5)).validateSuperUserAccess();
+        verify(properties, times(4)).validateSuperUserAccess();
 
         // Wait for updateTenant to take effect
         Thread.sleep(100);
 
         assertEquals(properties.getTenantAdmin("test-property"), newPropertyAdmin);
         assertNotSame(properties.getTenantAdmin("test-property"), tenantInfo);
-        verify(properties, times(7)).validateSuperUserAccess();
+        verify(properties, times(4)).validateSuperUserAccess();
 
         // Check creating existing property
         try {


### PR DESCRIPTION
### Motivation
Right now, Tenant admin is not able to get tenant-info to validate certain tenant info such as: `allowedClusters` for the tenant.

### Modification
Allow tenant-admin to see tenant information.