### PR TITLE
[pulsar-websocket] Fails to start in a separate deployment

### DIFF
--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>


### PR DESCRIPTION
### Motivation
We create a websocket proxy bundle as separate deployment without depending on broker or any other components. Right now, websocket proxy fails at startup with below error:
This is failing because websocket requires `jersey-hk2` into classpath to start webserver but it's not failing with `./bin/pulsar websocket` because it keeps broker's dependent jars into the classpath and it already has required `jersey-hk2` in the classpath.
```
20:09:09.698 [main] INFO o.a.p.w.s.WebSocketServiceStarter - Loading configuration from /home/y/conf/cloud_messaging_websocket_proxy/websocket-proxy.conf
20:09:09.852 [main] INFO org.eclipse.jetty.util.log - Logging initialized @899ms to org.eclipse.jetty.util.log.Slf4jLog
20:09:10.317 [main] INFO o.a.p.websocket.service.ProxyServer - Starting web socket proxy at port 8080
20:09:10.343 [main] INFO org.eclipse.jetty.server.Server - jetty-9.4.12.v20180830; built: 2018-08-30T13:59:14.071Z; git: 27208684755d94a92186989f695db2d7b21ebc51; jvm 1.8.0_121-b34
20:09:10.429 [main] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
20:09:10.430 [main] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
20:09:10.432 [main] INFO org.eclipse.jetty.server.session - node0 Scavenging every 600000ms
20:09:10.474 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@42a48628

{/ws/producer,null,AVAILABLE}
20:09:10.477 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@293a5bf6

{/ws/consumer,null,AVAILABLE}
20:09:10.479 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@6aeb35e6

{/ws/reader,null,AVAILABLE}
20:09:10.480 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@1283bb96

{/ws/v2/producer,null,AVAILABLE}
20:09:10.481 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@74f0ea28

{/ws/v2/consumer,null,AVAILABLE}
20:09:10.483 [main] INFO o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@f6efaab

{/ws/v2/reader,null,AVAILABLE}
20:09:10.562 [main] WARN o.e.j.s.handler.ContextHandler.admin - unavailable
java.lang.IllegalStateException: InjectionManagerFactory not found.
at org.glassfish.jersey.internal.inject.Injections.lambda$lookupInjectionManagerFactory$0(Injections.java:98)
at java.util.Optional.orElseThrow(Optional.java:290)
at org.glassfish.jersey.internal.inject.Injections.lookupInjectionManagerFactory(Injections.java:98)
at org.glassfish.jersey.internal.inject.Injections.createInjectionManager(Injections.java:93)
at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:282)
at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:335)
at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:178)
at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:370)
at javax.servlet.GenericServlet.init(GenericServlet.java:244)
at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:670)
at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:427)
at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:760)
```

### Modification
Add `jersey-hk2` into websocket proxy classpath.