### PR TITLE
[Doc]--[python client] negative acks

### DIFF
--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -86,6 +86,33 @@ while True:
 client.close()
 ```
 
+This example shows how to configure negative acknowledgement.
+
+```python
+from pulsar import Client, schema
+client = Client('pulsar://localhost:6650')
+consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
+producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+for i in range(10):
+    print('send msg "hello-%d"' % i)
+    producer.send_async('hello-%d' % i, callback=None)
+producer.flush()
+for i in range(10):
+    msg = consumer.receive()
+    consumer.negative_acknowledge(msg)
+    print('receive and nack msg "%s"' % msg.data())
+for i in range(10):
+    msg = consumer.receive()
+    consumer.acknowledge(msg)
+    print('receive and ack msg "%s"' % msg.data())
+try:
+    # No more messages expected
+    msg = consumer.receive(100)
+except:
+    print("no more msg")
+    pass
+```
+
 ### Reader interface example
 
 You can use the Pulsar Python API to use the Pulsar [reader interface](concepts-clients.md#reader-interface). Here's an example:

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
@@ -1,21 +1,17 @@
 ---
-id: version-2.5.2-client-libraries-python
-title: Pulsar Python client
+id: version-2.4.0-client-libraries-python
+title: The Pulsar Python client
 sidebar_label: Python
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
 
-All the methods in producer, consumer, and reader of a Python client are thread-safe.
-
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
-
-## Install
+## Installation
 
 You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from source.
 
-### Install using pip
+### Installation using pip
 
 To install the `pulsar-client` library as a pre-built package using the [pip](https://pip.pypa.io/en/stable/) package manager:
 
@@ -27,12 +23,12 @@ Installation via PyPi is available for the following Python versions:
 
 Platform | Supported Python versions
 :--------|:-------------------------
-MacOS <br />  10.13 (High Sierra), 10.14 (Mojave) <br /> | 2.7, 3.7
-Linux | 2.7, 3.4, 3.5, 3.6, 3.7
+| MacOS<br /> 10.11 (El Capitan) — 10.12 (Sierra) — 10.13 (High Sierra) — 10.14 (Mojave)<br />| 2.7, 3.7
+|Linux | 2.7, 3.4, 3.5, 3.6, 3.7
 
-### Install from source
+### Installing from source
 
-To install the `pulsar-client` library by building from source, follow [instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That builds the Python binding for the library.
+To install the `pulsar-client` library by building from source, follow [these instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That also builds the Python binding for the library.
 
 To install the built Python bindings:
 
@@ -48,11 +44,11 @@ The complete Python API reference is available at [api/python](/api/python).
 
 ## Examples
 
-You can find a variety of Python code examples for the `pulsar-client` library.
+You can find a variety of Python code examples for the `pulsar-client` library as below.
 
 ### Producer example
 
-The following example creates a Python producer for the `my-topic` topic and sends 10 messages on that topic:
+This creates a Python producer for the `my-topic` topic and send 10 messages on that topic:
 
 ```python
 import pulsar
@@ -69,7 +65,7 @@ client.close()
 
 ### Consumer example
 
-The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
+This example creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listens for incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker:
 
 ```python
 consumer = client.subscribe('my-topic', 'my-subscription')
@@ -91,21 +87,28 @@ This example shows how to configure negative acknowledgement.
 
 ```python
 from pulsar import Client, schema
+
 client = Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
 producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+
 for i in range(10):
     print('send msg "hello-%d"' % i)
     producer.send_async('hello-%d' % i, callback=None)
+
 producer.flush()
+
 for i in range(10):
     msg = consumer.receive()
     consumer.negative_acknowledge(msg)
     print('receive and nack msg "%s"' % msg.data())
+
 for i in range(10):
     msg = consumer.receive()
     consumer.acknowledge(msg)
     print('receive and ack msg "%s"' % msg.data())
+
 try:
     # No more messages expected
     msg = consumer.receive(100)
@@ -129,32 +132,13 @@ while True:
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```
-### Multi-topic subscriptions
 
-In addition to subscribing a consumer to a single Pulsar topic, you can also subscribe to multiple topics simultaneously. To use multi-topic subscriptions, you can supply a regular expression (regex) or a `List` of topics. If you select topics via regex, all topics must be within the same Pulsar namespace.
-
-The following is an example. 
-
-```python
-import re
-consumer = client.subscribe(re.compile('persistent://public/default/topic-*'), 'my-subscription')
-while True:
-    msg = consumer.receive()
-    try:
-        print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
-        # Acknowledge successful processing of the message
-        consumer.acknowledge(msg)
-    except:
-        # Message failed to be processed
-        consumer.negative_acknowledge(msg)
-client.close()
-```
 
 ## Schema
 
-### Declare and validate schema
+### Declaring and validating schema
 
-You can declare a schema by passing a class that inherits
+A schema can be declared by passing a class that inherits
 from `pulsar.schema.Record` and defines the fields as
 class variables. For example:
 
@@ -167,7 +151,8 @@ class Example(Record):
     c = Boolean()
 ```
 
-With this simple schema definition, you can create producers, consumers and readers instances that refer to that.
+With this simple schema definition we can then create producers,
+consumers and readers instances that will be referring to that.
 
 ```python
 producer = client.create_producer(
@@ -177,15 +162,19 @@ producer = client.create_producer(
 producer.send(Example(a='Hello', b=1))
 ```
 
-After creating the producer, the Pulsar broker validates that the existing topic schema is indeed of "Avro" type and that the format is compatible with the schema definition of the `Example` class.
+When the producer is created, the Pulsar broker validates that
+the existing topic schema is indeed of "Avro" type and that the
+format is compatible with the schema definition of the `Example`
+class.
 
-If there is a mismatch, an exception occurs in the producer creation.
+If there is a mismatch, the producer creation raises an
+exception.
 
 Once a producer is created with a certain schema definition,
-it will only accept objects that are instances of the declared
+it only accepts objects that are instances of the declared
 schema class.
 
-Similarly, for a consumer/reader, the consumer will return an
+Similarly, for a consumer/reader, the consumer returns an
 object, instance of the schema record class, rather than the raw
 bytes:
 
@@ -209,7 +198,8 @@ while True:
 
 ### Supported schema types
 
-You can use different builtin schema types in Pulsar. All the definitions are in the `pulsar.schema` package.
+There are different builtin schema types that can be used in Pulsar.
+All the definitions are in the `pulsar.schema` package.
 
 | Schema | Notes |
 | ------ | ----- |
@@ -220,11 +210,12 @@ You can use different builtin schema types in Pulsar. All the definitions are in
 
 ### Schema definition reference
 
-The schema definition is done through a class that inherits from `pulsar.schema.Record`.
+The schema definition is done through a class that inherits from
+`pulsar.schema.Record`.
 
-This class has a number of fields which can be of either
-`pulsar.schema.Field` type or another nested `Record`. All the
-fields are specified in the `pulsar.schema` package. The fields
+This class can have a number of fields which can be of either
+`pulsar.schema.Field` type or even another nested `Record`. All the
+fields are also specified in the `pulsar.schema` package. The fields
 are matching the AVRO fields types.
 
 | Field Type | Python Type | Notes |
@@ -236,19 +227,20 @@ are matching the AVRO fields types.
 | `Double`   | `float`     |       |
 | `Bytes`    | `bytes`     |       |
 | `String`   | `str`       |       |
-| `Array`    | `list`      | Need to specify record type for items. |
-| `Map`      | `dict`      | Key is always `String`. Need to specify value type. |
+| `Array`    | `list`      | Need to specify record type for items |
+| `Map`      | `dict`      | Key is always `String`. Need to specify value type |
 
-Additionally, any Python `Enum` type can be used as a valid field type.
+Additionally, any Python `Enum` type can be used as a valid field
+type
 
 #### Fields parameters
 
-When adding a field, you can use these parameters in the constructor.
+When adding a field these parameters can be used in the constructor:
 
 | Argument   | Default | Notes |
 | ---------- | --------| ----- |
 | `default`  | `None`  | Set a default value for the field. Eg: `a = Integer(default=5)` |
-| `required` | `False` | Mark the field as "required". It is set in the schema accordingly. |
+| `required` | `False` | Mark the field as "required". This will set it in the schema accordingly. |
 
 #### Schema definition examples
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
@@ -1,21 +1,17 @@
 ---
-id: version-2.5.2-client-libraries-python
-title: Pulsar Python client
+id: version-2.4.1-client-libraries-python
+title: The Pulsar Python client
 sidebar_label: Python
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
 
-All the methods in producer, consumer, and reader of a Python client are thread-safe.
-
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
-
-## Install
+## Installation
 
 You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from source.
 
-### Install using pip
+### Installation using pip
 
 To install the `pulsar-client` library as a pre-built package using the [pip](https://pip.pypa.io/en/stable/) package manager:
 
@@ -27,12 +23,12 @@ Installation via PyPi is available for the following Python versions:
 
 Platform | Supported Python versions
 :--------|:-------------------------
-MacOS <br />  10.13 (High Sierra), 10.14 (Mojave) <br /> | 2.7, 3.7
-Linux | 2.7, 3.4, 3.5, 3.6, 3.7
+| MacOS<br /> 10.11 (El Capitan) — 10.12 (Sierra) — 10.13 (High Sierra) — 10.14 (Mojave)<br />| 2.7, 3.7
+|Linux | 2.7, 3.4, 3.5, 3.6, 3.7
 
-### Install from source
+### Installing from source
 
-To install the `pulsar-client` library by building from source, follow [instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That builds the Python binding for the library.
+To install the `pulsar-client` library by building from source, follow [these instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That will also build the Python binding for the library.
 
 To install the built Python bindings:
 
@@ -48,11 +44,11 @@ The complete Python API reference is available at [api/python](/api/python).
 
 ## Examples
 
-You can find a variety of Python code examples for the `pulsar-client` library.
+Below you'll find a variety of Python code examples for the `pulsar-client` library.
 
 ### Producer example
 
-The following example creates a Python producer for the `my-topic` topic and sends 10 messages on that topic:
+This creates a Python producer for the `my-topic` topic and send 10 messages on that topic:
 
 ```python
 import pulsar
@@ -69,7 +65,7 @@ client.close()
 
 ### Consumer example
 
-The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
+This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
 consumer = client.subscribe('my-topic', 'my-subscription')
@@ -91,21 +87,28 @@ This example shows how to configure negative acknowledgement.
 
 ```python
 from pulsar import Client, schema
+
 client = Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
 producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+
 for i in range(10):
     print('send msg "hello-%d"' % i)
     producer.send_async('hello-%d' % i, callback=None)
+
 producer.flush()
+
 for i in range(10):
     msg = consumer.receive()
     consumer.negative_acknowledge(msg)
     print('receive and nack msg "%s"' % msg.data())
+
 for i in range(10):
     msg = consumer.receive()
     consumer.acknowledge(msg)
     print('receive and ack msg "%s"' % msg.data())
+
 try:
     # No more messages expected
     msg = consumer.receive(100)
@@ -129,32 +132,13 @@ while True:
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```
-### Multi-topic subscriptions
 
-In addition to subscribing a consumer to a single Pulsar topic, you can also subscribe to multiple topics simultaneously. To use multi-topic subscriptions, you can supply a regular expression (regex) or a `List` of topics. If you select topics via regex, all topics must be within the same Pulsar namespace.
-
-The following is an example. 
-
-```python
-import re
-consumer = client.subscribe(re.compile('persistent://public/default/topic-*'), 'my-subscription')
-while True:
-    msg = consumer.receive()
-    try:
-        print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
-        # Acknowledge successful processing of the message
-        consumer.acknowledge(msg)
-    except:
-        # Message failed to be processed
-        consumer.negative_acknowledge(msg)
-client.close()
-```
 
 ## Schema
 
-### Declare and validate schema
+### Declaring and validating schema
 
-You can declare a schema by passing a class that inherits
+A schema can be declared by passing a class that inherits
 from `pulsar.schema.Record` and defines the fields as
 class variables. For example:
 
@@ -167,7 +151,8 @@ class Example(Record):
     c = Boolean()
 ```
 
-With this simple schema definition, you can create producers, consumers and readers instances that refer to that.
+With this simple schema definition we can then create producers,
+consumers and readers instances that will be referring to that.
 
 ```python
 producer = client.create_producer(
@@ -177,9 +162,13 @@ producer = client.create_producer(
 producer.send(Example(a='Hello', b=1))
 ```
 
-After creating the producer, the Pulsar broker validates that the existing topic schema is indeed of "Avro" type and that the format is compatible with the schema definition of the `Example` class.
+When the producer is created, the Pulsar broker will validate that
+the existing topic schema is indeed of "Avro" type and that the
+format is compatible with the schema definition of the `Example`
+class.
 
-If there is a mismatch, an exception occurs in the producer creation.
+If there is a mismatch, the producer creation will raise an
+exception.
 
 Once a producer is created with a certain schema definition,
 it will only accept objects that are instances of the declared
@@ -209,7 +198,8 @@ while True:
 
 ### Supported schema types
 
-You can use different builtin schema types in Pulsar. All the definitions are in the `pulsar.schema` package.
+There are different builtin schema types that can be used in Pulsar.
+All the definitions are in the `pulsar.schema` package.
 
 | Schema | Notes |
 | ------ | ----- |
@@ -220,11 +210,12 @@ You can use different builtin schema types in Pulsar. All the definitions are in
 
 ### Schema definition reference
 
-The schema definition is done through a class that inherits from `pulsar.schema.Record`.
+The schema definition is done through a class that inherits from
+`pulsar.schema.Record`.
 
-This class has a number of fields which can be of either
-`pulsar.schema.Field` type or another nested `Record`. All the
-fields are specified in the `pulsar.schema` package. The fields
+This class can have a number of fields which can be of either
+`pulsar.schema.Field` type or even another nested `Record`. All the
+fields are also specified in the `pulsar.schema` package. The fields
 are matching the AVRO fields types.
 
 | Field Type | Python Type | Notes |
@@ -236,19 +227,20 @@ are matching the AVRO fields types.
 | `Double`   | `float`     |       |
 | `Bytes`    | `bytes`     |       |
 | `String`   | `str`       |       |
-| `Array`    | `list`      | Need to specify record type for items. |
-| `Map`      | `dict`      | Key is always `String`. Need to specify value type. |
+| `Array`    | `list`      | Need to specify record type for items |
+| `Map`      | `dict`      | Key is always `String`. Need to specify value type |
 
-Additionally, any Python `Enum` type can be used as a valid field type.
+Additionally, any Python `Enum` type can be used as a valid field
+type
 
 #### Fields parameters
 
-When adding a field, you can use these parameters in the constructor.
+When adding a field these parameters can be used in the constructor:
 
 | Argument   | Default | Notes |
 | ---------- | --------| ----- |
 | `default`  | `None`  | Set a default value for the field. Eg: `a = Integer(default=5)` |
-| `required` | `False` | Mark the field as "required". It is set in the schema accordingly. |
+| `required` | `False` | Mark the field as "required". This will set it in the schema accordingly. |
 
 #### Schema definition examples
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
@@ -1,21 +1,17 @@
 ---
-id: version-2.5.2-client-libraries-python
-title: Pulsar Python client
+id: version-2.4.2-client-libraries-python
+title: The Pulsar Python client
 sidebar_label: Python
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
 
-All the methods in producer, consumer, and reader of a Python client are thread-safe.
-
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
-
-## Install
+## Installation
 
 You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from source.
 
-### Install using pip
+### Installation using pip
 
 To install the `pulsar-client` library as a pre-built package using the [pip](https://pip.pypa.io/en/stable/) package manager:
 
@@ -27,12 +23,12 @@ Installation via PyPi is available for the following Python versions:
 
 Platform | Supported Python versions
 :--------|:-------------------------
-MacOS <br />  10.13 (High Sierra), 10.14 (Mojave) <br /> | 2.7, 3.7
-Linux | 2.7, 3.4, 3.5, 3.6, 3.7
+| MacOS<br /> 10.11 (El Capitan) — 10.12 (Sierra) — 10.13 (High Sierra) — 10.14 (Mojave)<br />| 2.7, 3.7
+|Linux | 2.7, 3.4, 3.5, 3.6, 3.7
 
-### Install from source
+### Installing from source
 
-To install the `pulsar-client` library by building from source, follow [instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That builds the Python binding for the library.
+To install the `pulsar-client` library by building from source, follow [these instructions](client-libraries-cpp.md#compilation) and compile the Pulsar C++ client library. That will also build the Python binding for the library.
 
 To install the built Python bindings:
 
@@ -48,11 +44,11 @@ The complete Python API reference is available at [api/python](/api/python).
 
 ## Examples
 
-You can find a variety of Python code examples for the `pulsar-client` library.
+Below you'll find a variety of Python code examples for the `pulsar-client` library.
 
 ### Producer example
 
-The following example creates a Python producer for the `my-topic` topic and sends 10 messages on that topic:
+This creates a Python producer for the `my-topic` topic and send 10 messages on that topic:
 
 ```python
 import pulsar
@@ -69,7 +65,7 @@ client.close()
 
 ### Consumer example
 
-The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
+This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
 consumer = client.subscribe('my-topic', 'my-subscription')
@@ -91,21 +87,28 @@ This example shows how to configure negative acknowledgement.
 
 ```python
 from pulsar import Client, schema
+
 client = Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
 producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+
 for i in range(10):
     print('send msg "hello-%d"' % i)
     producer.send_async('hello-%d' % i, callback=None)
+
 producer.flush()
+
 for i in range(10):
     msg = consumer.receive()
     consumer.negative_acknowledge(msg)
     print('receive and nack msg "%s"' % msg.data())
+
 for i in range(10):
     msg = consumer.receive()
     consumer.acknowledge(msg)
     print('receive and ack msg "%s"' % msg.data())
+
 try:
     # No more messages expected
     msg = consumer.receive(100)
@@ -129,32 +132,13 @@ while True:
     print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
     # No acknowledgment
 ```
-### Multi-topic subscriptions
 
-In addition to subscribing a consumer to a single Pulsar topic, you can also subscribe to multiple topics simultaneously. To use multi-topic subscriptions, you can supply a regular expression (regex) or a `List` of topics. If you select topics via regex, all topics must be within the same Pulsar namespace.
-
-The following is an example. 
-
-```python
-import re
-consumer = client.subscribe(re.compile('persistent://public/default/topic-*'), 'my-subscription')
-while True:
-    msg = consumer.receive()
-    try:
-        print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
-        # Acknowledge successful processing of the message
-        consumer.acknowledge(msg)
-    except:
-        # Message failed to be processed
-        consumer.negative_acknowledge(msg)
-client.close()
-```
 
 ## Schema
 
-### Declare and validate schema
+### Declaring and validating schema
 
-You can declare a schema by passing a class that inherits
+A schema can be declared by passing a class that inherits
 from `pulsar.schema.Record` and defines the fields as
 class variables. For example:
 
@@ -167,7 +151,8 @@ class Example(Record):
     c = Boolean()
 ```
 
-With this simple schema definition, you can create producers, consumers and readers instances that refer to that.
+With this simple schema definition we can then create producers,
+consumers and readers instances that will be referring to that.
 
 ```python
 producer = client.create_producer(
@@ -177,9 +162,13 @@ producer = client.create_producer(
 producer.send(Example(a='Hello', b=1))
 ```
 
-After creating the producer, the Pulsar broker validates that the existing topic schema is indeed of "Avro" type and that the format is compatible with the schema definition of the `Example` class.
+When the producer is created, the Pulsar broker will validate that
+the existing topic schema is indeed of "Avro" type and that the
+format is compatible with the schema definition of the `Example`
+class.
 
-If there is a mismatch, an exception occurs in the producer creation.
+If there is a mismatch, the producer creation will raise an
+exception.
 
 Once a producer is created with a certain schema definition,
 it will only accept objects that are instances of the declared
@@ -209,7 +198,8 @@ while True:
 
 ### Supported schema types
 
-You can use different builtin schema types in Pulsar. All the definitions are in the `pulsar.schema` package.
+There are different builtin schema types that can be used in Pulsar.
+All the definitions are in the `pulsar.schema` package.
 
 | Schema | Notes |
 | ------ | ----- |
@@ -220,11 +210,12 @@ You can use different builtin schema types in Pulsar. All the definitions are in
 
 ### Schema definition reference
 
-The schema definition is done through a class that inherits from `pulsar.schema.Record`.
+The schema definition is done through a class that inherits from
+`pulsar.schema.Record`.
 
-This class has a number of fields which can be of either
-`pulsar.schema.Field` type or another nested `Record`. All the
-fields are specified in the `pulsar.schema` package. The fields
+This class can have a number of fields which can be of either
+`pulsar.schema.Field` type or even another nested `Record`. All the
+fields are also specified in the `pulsar.schema` package. The fields
 are matching the AVRO fields types.
 
 | Field Type | Python Type | Notes |
@@ -236,19 +227,20 @@ are matching the AVRO fields types.
 | `Double`   | `float`     |       |
 | `Bytes`    | `bytes`     |       |
 | `String`   | `str`       |       |
-| `Array`    | `list`      | Need to specify record type for items. |
-| `Map`      | `dict`      | Key is always `String`. Need to specify value type. |
+| `Array`    | `list`      | Need to specify record type for items |
+| `Map`      | `dict`      | Key is always `String`. Need to specify value type |
 
-Additionally, any Python `Enum` type can be used as a valid field type.
+Additionally, any Python `Enum` type can be used as a valid field
+type
 
 #### Fields parameters
 
-When adding a field, you can use these parameters in the constructor.
+When adding a field these parameters can be used in the constructor:
 
 | Argument   | Default | Notes |
 | ---------- | --------| ----- |
 | `default`  | `None`  | Set a default value for the field. Eg: `a = Integer(default=5)` |
-| `required` | `False` | Mark the field as "required". It is set in the schema accordingly. |
+| `required` | `False` | Mark the field as "required". This will set it in the schema accordingly. |
 
 #### Schema definition examples
 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
@@ -83,6 +83,33 @@ while True:
 client.close()
 ```
 
+This example shows how to configure negative acknowledgement.
+
+```python
+from pulsar import Client, schema
+client = Client('pulsar://localhost:6650')
+consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
+producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+for i in range(10):
+    print('send msg "hello-%d"' % i)
+    producer.send_async('hello-%d' % i, callback=None)
+producer.flush()
+for i in range(10):
+    msg = consumer.receive()
+    consumer.negative_acknowledge(msg)
+    print('receive and nack msg "%s"' % msg.data())
+for i in range(10):
+    msg = consumer.receive()
+    consumer.acknowledge(msg)
+    print('receive and ack msg "%s"' % msg.data())
+try:
+    # No more messages expected
+    msg = consumer.receive(100)
+except:
+    print("no more msg")
+    pass
+```
+
 ### Reader interface example
 
 You can use the Pulsar Python API to use the Pulsar [reader interface](concepts-clients.md#reader-interface). Here's an example:

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
@@ -87,6 +87,33 @@ while True:
 client.close()
 ```
 
+This example shows how to configure negative acknowledgement.
+
+```python
+from pulsar import Client, schema
+client = Client('pulsar://localhost:6650')
+consumer = client.subscribe('negative_acks','test',schema=schema.StringSchema())
+producer = client.create_producer('negative_acks',schema=schema.StringSchema())
+for i in range(10):
+    print('send msg "hello-%d"' % i)
+    producer.send_async('hello-%d' % i, callback=None)
+producer.flush()
+for i in range(10):
+    msg = consumer.receive()
+    consumer.negative_acknowledge(msg)
+    print('receive and nack msg "%s"' % msg.data())
+for i in range(10):
+    msg = consumer.receive()
+    consumer.acknowledge(msg)
+    print('receive and ack msg "%s"' % msg.data())
+try:
+    # No more messages expected
+    msg = consumer.receive(100)
+except:
+    print("no more msg")
+    pass
+```
+
 ### Reader interface example
 
 You can use the Pulsar Python API to use the Pulsar [reader interface](concepts-clients.md#reader-interface). Here's an example:


### PR DESCRIPTION

### Motivation

In Pulsar 2.4.0, negative acknowledgement is supported in Python client. But the doc has no such code example. 

So this PR is for adding negative ack code example for releases: master--2.4.0.

The doc update is approved in PR: https://github.com/apache/pulsar/pull/7148. But the PR fails CI test. So i close that PR and re-create a new PR.



### Modifications

Add negative ack code example to python client doc for releases master--2.4.0.
