### PR TITLE
[pulsar-broker] Dispatch batch messages according consumer permits

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
@@ -66,40 +66,4 @@ public interface Entry {
      * of data reached to 0).
      */
     boolean release();
-
-    /**
-     * Get number of batch messages into the entry.
-     * @return
-     */
-    int getNumberOfBatchMessages();
-
-    /**
-     * Set number of batch messages into the entry.
-     * @param numberOfBatchMessages
-     */
-    void setNumberOfBatchMessages(int numberOfBatchMessages);
-
-    /**
-     * Set data size of the entry.
-     * @param totalSizeInBytes
-     */
-    void setTotalSizeInBytes(int totalSizeInBytes);
-
-    /**
-     * Set total number of chunked messages in entry.
-     * @param totalChunkedMessages
-     */
-    void setTotalChunkedMessages(int totalChunkedMessages);
-
-    /**
-     * Get total data size of the entry.
-     * @return
-     */
-    int getTotalSizeInBytes();
-
-    /**
-     * Get total number of chuncked messages.
-     * @return
-     */
-    int getTotalChunkedMessages();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
@@ -67,4 +67,39 @@ public interface Entry {
      */
     boolean release();
 
+    /**
+     * Get number of batch messages into the entry.
+     * @return
+     */
+    int getNumberOfBatchMessages();
+
+    /**
+     * Set number of batch messages into the entry.
+     * @param numberOfBatchMessages
+     */
+    void setNumberOfBatchMessages(int numberOfBatchMessages);
+
+    /**
+     * Set data size of the entry.
+     * @param totalSizeInBytes
+     */
+    void setTotalSizeInBytes(int totalSizeInBytes);
+
+    /**
+     * Set total number of chunked messages in entry.
+     * @param totalChunkedMessages
+     */
+    void setTotalChunkedMessages(int totalChunkedMessages);
+
+    /**
+     * Get total data size of the entry.
+     * @return
+     */
+    int getTotalSizeInBytes();
+
+    /**
+     * Get total number of chuncked messages.
+     * @return
+     */
+    int getTotalChunkedMessages();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -45,9 +45,6 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
     private long ledgerId;
     private long entryId;
     ByteBuf data;
-    private int numberOfBatchMessages;
-    private int totalSizeInBytes;
-    private int totalChunkedMessages;
 
     public static EntryImpl create(LedgerEntry ledgerEntry) {
         EntryImpl entry = RECYCLER.get();
@@ -162,36 +159,6 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
     }
 
     @Override
-    public int getNumberOfBatchMessages() {
-        return numberOfBatchMessages;
-    }
-
-    @Override
-    public void setNumberOfBatchMessages(int numberOfBatchMessages) {
-        this.numberOfBatchMessages = numberOfBatchMessages;
-    }
-
-    @Override
-    public int getTotalSizeInBytes() {
-        return totalSizeInBytes;
-    }
-
-    @Override
-    public void setTotalSizeInBytes(int totalSizeInBytes) {
-        this.totalSizeInBytes = totalSizeInBytes;
-    }
-
-    @Override
-    public int getTotalChunkedMessages() {
-        return totalChunkedMessages;
-    }
-
-    @Override
-    public void setTotalChunkedMessages(int totalChunkedMessages) {
-        this.totalChunkedMessages = totalChunkedMessages;
-    }
-
-    @Override
     protected void deallocate() {
         // This method is called whenever the ref-count of the EntryImpl reaches 0, so that now we can recycle it
         data.release();
@@ -199,9 +166,6 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
         timestamp = -1;
         ledgerId = -1;
         entryId = -1;
-        numberOfBatchMessages = -1;
-        totalSizeInBytes = -1;
-        totalChunkedMessages = -1;
         recyclerHandle.recycle(this);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -45,6 +45,9 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
     private long ledgerId;
     private long entryId;
     ByteBuf data;
+    private int numberOfBatchMessages;
+    private int totalSizeInBytes;
+    private int totalChunkedMessages;
 
     public static EntryImpl create(LedgerEntry ledgerEntry) {
         EntryImpl entry = RECYCLER.get();
@@ -159,6 +162,36 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
     }
 
     @Override
+    public int getNumberOfBatchMessages() {
+        return numberOfBatchMessages;
+    }
+
+    @Override
+    public void setNumberOfBatchMessages(int numberOfBatchMessages) {
+        this.numberOfBatchMessages = numberOfBatchMessages;
+    }
+
+    @Override
+    public int getTotalSizeInBytes() {
+        return totalSizeInBytes;
+    }
+
+    @Override
+    public void setTotalSizeInBytes(int totalSizeInBytes) {
+        this.totalSizeInBytes = totalSizeInBytes;
+    }
+
+    @Override
+    public int getTotalChunkedMessages() {
+        return totalChunkedMessages;
+    }
+
+    @Override
+    public void setTotalChunkedMessages(int totalChunkedMessages) {
+        this.totalChunkedMessages = totalChunkedMessages;
+    }
+
+    @Override
     protected void deallocate() {
         // This method is called whenever the ref-count of the EntryImpl reaches 0, so that now we can recycle it
         data.release();
@@ -166,6 +199,9 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
         timestamp = -1;
         ledgerId = -1;
         entryId = -1;
+        numberOfBatchMessages = -1;
+        totalSizeInBytes = -1;
+        totalChunkedMessages = -1;
         recyclerHandle.recycle(this);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -52,6 +52,30 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     }
 
     /**
+     * Update Entries with the metadata of each entry.
+     *
+     * @param entries
+     * @return
+     */
+    protected int updateEntryWrapperWithMetadata(EntryWrapper[] entryWrappers, List<Entry> entries) {
+        int totalMessages = 0;
+        for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {
+            Entry entry = entries.get(i);
+            if (entry == null) {
+                continue;
+            }
+
+            ByteBuf metadataAndPayload = entry.getDataBuffer();
+            MessageMetadata msgMetadata = Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1);
+            EntryWrapper entryWrapper = EntryWrapper.get(entry, msgMetadata);
+            entryWrappers[i] = entryWrapper;
+            int batchSize = msgMetadata.getNumMessagesInBatch();
+            totalMessages += batchSize;
+        }
+        return totalMessages;
+    }
+
+    /**
      * Filter messages that are being sent to a consumers.
      * <p>
      * Messages can be filtered out for multiple reasons:
@@ -74,6 +98,13 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     public void filterEntriesForConsumer(List<Entry> entries, EntryBatchSizes batchSizes,
             SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
             ManagedCursor cursor, boolean isReplayRead) {
+        filterEntriesForConsumer(Optional.empty(), entries, batchSizes, sendMessageInfo, indexesAcks, cursor,
+                isReplayRead);
+    }
+
+    public void filterEntriesForConsumer(Optional<EntryWrapper[]> entryWrapper, List<Entry> entries,
+            EntryBatchSizes batchSizes, SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
+            ManagedCursor cursor, boolean isReplayRead) {
         int totalMessages = 0;
         long totalBytes = 0;
         int totalChunkedMessages = 0;
@@ -82,19 +113,21 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
             if (entry == null) {
                 continue;
             }
-
             ByteBuf metadataAndPayload = entry.getDataBuffer();
-
-            MessageMetadata msgMetadata = Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1);
-
-            if (!isReplayRead && msgMetadata != null
-                    && msgMetadata.hasTxnidMostBits() && msgMetadata.hasTxnidLeastBits()) {
+            MessageMetadata msgMetadata = entryWrapper.isPresent() && entryWrapper.get()[i] != null
+                    ? entryWrapper.get()[i].getMetadata()
+                    : null;
+            msgMetadata = msgMetadata == null
+                    ? Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1)
+                    : msgMetadata;
+            if (!isReplayRead && msgMetadata != null && msgMetadata.hasTxnidMostBits()
+                    && msgMetadata.hasTxnidLeastBits()) {
                 if (Markers.isTxnMarker(msgMetadata)) {
                     entries.set(i, null);
                     entry.release();
                     continue;
-                } else if (((PersistentTopic) subscription.getTopic()).isTxnAborted(
-                        new TxnID(msgMetadata.getTxnidMostBits(), msgMetadata.getTxnidLeastBits()))) {
+                } else if (((PersistentTopic) subscription.getTopic())
+                        .isTxnAborted(new TxnID(msgMetadata.getTxnidMostBits(), msgMetadata.getTxnidLeastBits()))) {
                     subscription.acknowledgeMessage(Collections.singletonList(entry.getPosition()), AckType.Individual,
                             Collections.emptyMap());
                     entries.set(i, null);
@@ -129,8 +162,8 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
             batchSizes.setBatchSize(i, batchSize);
             long[] ackSet = null;
             if (indexesAcks != null && cursor != null) {
-                ackSet = cursor.getDeletedBatchIndexesAsLongArray(
-                        PositionImpl.get(entry.getLedgerId(), entry.getEntryId()));
+                ackSet = cursor
+                        .getDeletedBatchIndexesAsLongArray(PositionImpl.get(entry.getLedgerId(), entry.getEntryId()));
                 if (ackSet != null) {
                     indexesAcks.setIndexesAcks(i, Pair.of(batchSize, ackSet));
                 } else {
@@ -140,15 +173,9 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
 
             BrokerInterceptor interceptor = subscription.interceptor();
             if (null != interceptor) {
-                interceptor.beforeSendMessage(
-                    subscription,
-                    entry,
-                    ackSet,
-                    msgMetadata
-                );
+                interceptor.beforeSendMessage(subscription, entry, ackSet, msgMetadata);
             }
         }
-
         sendMessageInfo.setTotalMessages(totalMessages);
         sendMessageInfo.setTotalBytes(totalBytes);
         sendMessageInfo.setTotalChunkedMessages(totalChunkedMessages);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -72,8 +72,8 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
      *            an object where the total size in messages and bytes will be returned back to the caller
      */
     public void filterEntriesForConsumer(List<Entry> entries, EntryBatchSizes batchSizes,
-                                         SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
-                                         ManagedCursor cursor, boolean isReplayRead) {
+            SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
+            ManagedCursor cursor, boolean isReplayRead) {
         int totalMessages = 0;
         long totalBytes = 0;
         int totalChunkedMessages = 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.util.Recycler;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+
+public class EntryWrapper {
+    private Entry entry = null;
+    private MessageMetadata metadata = new MessageMetadata();
+    private boolean hasMetadata = false;
+
+    public static EntryWrapper get(Entry entry, MessageMetadata metadata) {
+        EntryWrapper entryWrapper = RECYCLER.get();
+        entryWrapper.entry = entry;
+        if (metadata != null) {
+            entryWrapper.hasMetadata = true;
+            entryWrapper.metadata.copyFrom(metadata);
+        }
+        entryWrapper.metadata.copyFrom(metadata);
+        return entryWrapper;
+    }
+
+    private EntryWrapper(Recycler.Handle<EntryWrapper> handle) {
+        this.handle = handle;
+    }
+
+    public Entry getEntry() {
+        return entry;
+    }
+
+    public MessageMetadata getMetadata() {
+        return hasMetadata ? metadata : null;
+    }
+
+    private final Recycler.Handle<EntryWrapper> handle;
+    private static final Recycler<EntryWrapper> RECYCLER = new Recycler<EntryWrapper>() {
+        @Override
+        protected EntryWrapper newObject(Handle<EntryWrapper> handle) {
+            return new EntryWrapper(handle);
+        }
+    };
+
+    public void recycle() {
+        entry = null;
+        hasMetadata = false;
+        metadata.clear();
+        handle.recycle(this);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -480,6 +480,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         int start = 0;
         long totalMessagesSent = 0;
         long totalBytesSent = 0;
+        int totalMessages = updateEntriesWithMetadata(entries);
+        int avgBatchSizePerMsg = totalMessages > 0 ? Math.max(totalMessages / entries.size(), 1) : 1;
 
         int firstAvailableConsumerPermits, currentTotalAvailablePermits;
         boolean dispatchMessage;
@@ -506,9 +508,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                                 + "availablePermits are {}", topic.getName(), name,
                         c, c.getAvailablePermits());
             }
-            int messagesForC = Math.min(
-                    Math.min(entriesToDispatch, availablePermits),
+
+            int messagesForC = Math.min(Math.min(entriesToDispatch, availablePermits),
                     serviceConfig.getDispatcherMaxRoundRobinBatchSize());
+            messagesForC = Math.max(messagesForC / avgBatchSizePerMsg, 1);
 
             if (messagesForC > 0) {
 


### PR DESCRIPTION
### Motivation
Right now, dispatching of batch messages is not predictable for a shared-subscription. Dispatcher doesn't consider number of batch messages in an entry which can cause higher number of message delivery than consumer receiver-queue.
For example:
If a topic has message-entries with 100 batched message in an entry.
If consumer has receiver queue=40 and has available-permits=20. then broker dispatches 20 entries with total 2000 (20*100) messages in it. because of that consumer's will high number of messages than expected and we can see available-permits in negative.

### Modification
- Find out average number of batch messages in an entry
- Dispatch messages considering total batch-messages in an entry

### Result
It will avoid dispatching higher number of messages than consumer's available-permit and will fix -ve available-permits.