### PR TITLE
Issue 7271 LocalRunner

### DIFF
--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -288,7 +288,7 @@ public class LocalRunner {
                             .getProtectionDomain().getCodeSource().getLocation().getFile();
                 }
 
-                String builtInSink = isBuiltInSource(userCodeFile);
+                String builtInSink = isBuiltInSink(userCodeFile);
                 if (builtInSink != null) {
                     sinkConfig.setArchive(builtInSink);
                 }


### PR DESCRIPTION
<!--
### Contribution Checklist
Fixes #7271

### Motivation

The logic block was checking if a given Sink was a builtin function, but the method call was to `isBuiltInSource` when it should be `isBuiltInSink` 

### Modifications

Replaced the call to `isBuiltInSource` with a call to  `isBuiltInSink` instead

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No

### Documentation

N/A
