### PR TITLE
[Issue 7210][pulsar docker]make the conf and data writeable for a (non-root) user

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-VOLUME  ["/pulsar/conf", "/pulsar/data"]
+RUN chmod -R a+w /pulsar/{conf,data}
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 


### PR DESCRIPTION
Master Issue: #7210

### Motivation


Make it possible to run pulsar dockers in user space - for example on clusters where root user in container is not allowed to prevent privilege escalation in case of security breach

### Modifications

The `VOLUME` makes it impossible to modify access attributes of the existing files. Instead of freezing it the change is to make it more relaxed and susceptible for change in derived images.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.


### Documentation

n/a
