### PR TITLE
[C++] Fix partition index error in close callback

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -90,6 +90,8 @@ class ProducerImpl : public HandlerBase,
 
     uint64_t getProducerId() const;
 
+    int32_t partition() const noexcept { return partition_; }
+
     virtual void start();
 
     virtual void shutdown();


### PR DESCRIPTION
### Motivation

In partitioned producer/consumer's close callback, the partition index is always 0.

### Modifications

- Pass `ProducerImpl`/`ConsumerImpl`'s internal partition index field to `PartitionedProducerImpl`/`PartitionedConsumerImpl`'s close callback.
- Change two debug level logs to error level.