### PR TITLE
[doc] Add doc for Pulsar SQL support in tiered storage

### DIFF
--- a/site2/docs/cookbooks-tiered-storage.md
+++ b/site2/docs/cookbooks-tiered-storage.md
@@ -33,6 +33,8 @@ Pulsar uses multi-part objects to upload the segment data. It is possible that a
 We recommend you add a life cycle rule your bucket to expire incomplete multi-part upload after a day or two to avoid
 getting charged for incomplete uploads.
 
+When ledgers are offloaded to long term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+
 ## Configuring the offload driver
 
 Offloading is configured in ```broker.conf```.

--- a/site2/website/versioned_docs/version-2.4.0/cookbooks-tiered-storage.md
+++ b/site2/website/versioned_docs/version-2.4.0/cookbooks-tiered-storage.md
@@ -31,6 +31,8 @@ Pulsar uses multi-part objects to upload the segment data. It is possible that a
 We recommend you add a life cycle rule your bucket to expire incomplete multi-part upload after a day or two to avoid
 getting charged for incomplete uploads.
 
+When ledgers are offloaded to long term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+
 ## Configuring the offload driver
 
 Offloading is configured in ```broker.conf```.

--- a/site2/website/versioned_docs/version-2.5.0/cookbooks-tiered-storage.md
+++ b/site2/website/versioned_docs/version-2.5.0/cookbooks-tiered-storage.md
@@ -34,6 +34,8 @@ Pulsar uses multi-part objects to upload the segment data. It is possible that a
 We recommend you add a life cycle rule your bucket to expire incomplete multi-part upload after a day or two to avoid
 getting charged for incomplete uploads.
 
+When ledgers are offloaded to long term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+
 ## Configuring the offload driver
 
 Offloading is configured in ```broker.conf```.


### PR DESCRIPTION
Master Issue: #4045

### Motivation
Pulsar SQL is enabled to query data in offloaded ledger, yet the doc content is not added.

### Modifications

Add doc content in master, 2.4 and 2.5 versioned docs.