### PR TITLE
[Issue 6437][broker] Prevent marker messages from accumulating in backlog of replicated subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -235,6 +235,25 @@ public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDi
         return -1;
     }
 
+    /**
+     * returns true only if {@link consumerList} has atleast one unblocked consumer and have available permits
+     *
+     * @return
+     */
+    @Override
+    public boolean isAtleastOneConsumerAvailable() {
+        if (consumerList.isEmpty() || IS_CLOSED_UPDATER.get(this) == TRUE) {
+            // abort read if no consumers are connected or if disconnect is initiated
+            return false;
+        }
+        for(Consumer consumer : consumerList) {
+            if (isConsumerAvailable(consumer)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -277,6 +277,14 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         return consumers;
     }
 
+    @Override
+    public boolean isAtleastOneConsumerAvailable() {
+        Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+        return (IS_CLOSED_UPDATER.get(this) == FALSE && isConsumerAvailable(currentConsumer));
+    }
+
+    public abstract boolean isConsumerAvailable(Consumer consumer);
+
     public boolean isConsumerConnected() {
         return ACTIVE_CONSUMER_UPDATER.get(this) != null;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -88,6 +88,8 @@ public interface Dispatcher {
 
     RedeliveryTracker getRedeliveryTracker();
 
+    boolean isAtleastOneConsumerAvailable();
+
     default Optional<DispatchRateLimiter> getRateLimiter() {
         return Optional.empty();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -59,7 +59,7 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     @Override
     public void sendMessages(List<Entry> entries) {
         Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
-        if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0 && currentConsumer.isWritable()) {
+        if (isConsumerAvailable(currentConsumer)) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             filterEntriesForConsumer(entries, batchSizes, sendMessageInfo, null, null);
@@ -153,5 +153,10 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     @Override
     protected void cancelPendingRead() {
         // No-op
+    }
+
+    @Override
+    public boolean isConsumerAvailable(Consumer consumer) {
+        return consumer != null && consumer.getAvailablePermits() > 0 && consumer.isWritable();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -629,24 +629,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         }
     }
 
-    /**
-     * returns true only if {@link consumerList} has atleast one unblocked consumer and have available permits
-     *
-     * @return
-     */
-    protected boolean isAtleastOneConsumerAvailable() {
-        if (consumerList.isEmpty() || IS_CLOSED_UPDATER.get(this) == TRUE) {
-            // abort read if no consumers are connected or if disconnect is initiated
-            return false;
-        }
-        for(Consumer consumer : consumerList) {
-            if (isConsumerAvailable(consumer)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private boolean isConsumerWritable() {
         for (Consumer consumer : consumerList) {
             if (consumer.isWritable()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -548,6 +548,11 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
     }
 
     @Override
+    public boolean isConsumerAvailable(Consumer consumer) {
+        return consumer != null && consumer.getAvailablePermits() > 0;
+    }
+
+    @Override
     public CompletableFuture<Void> close() {
         IS_CLOSED_UPDATER.set(this, TRUE);
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
@@ -171,6 +171,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
 
         // 2. validate basic dispatcher state
         assertTrue(subRef.getDispatcher().isConsumerConnected());
+        assertTrue(subRef.getDispatcher().isAtleastOneConsumerAvailable());
         assertEquals(subRef.getDispatcher().getType(), SubType.Failover);
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -102,6 +102,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
         // 2. validate basic dispatcher state
         assertTrue(subRef.getDispatcher().isConsumerConnected());
+        assertTrue(subRef.getDispatcher().isAtleastOneConsumerAvailable());
         assertEquals(subRef.getDispatcher().getType(), SubType.Shared);
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs * 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -149,6 +149,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertNotNull(topicRef);
         assertNotNull(subRef);
         assertTrue(subRef.getDispatcher().isConsumerConnected());
+        assertTrue(subRef.getDispatcher().isAtleastOneConsumerAvailable());
 
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertEquals(getAvailablePermits(subRef), 1000 /* default */);
@@ -164,6 +165,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         }
 
         assertTrue(subRef.getDispatcher().isConsumerConnected());
+        assertTrue(subRef.getDispatcher().isAtleastOneConsumerAvailable());
         rolloverPerIntervalStats();
         assertEquals(subRef.getNumberOfEntriesInBacklog(false), numMsgs * 2);
 
@@ -259,6 +261,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         consumer.close();
         assertFalse(subRef.getDispatcher().isConsumerConnected());
+        assertFalse(subRef.getDispatcher().isAtleastOneConsumerAvailable());
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilderTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ClusterMessageId;
@@ -42,7 +43,9 @@ import org.apache.pulsar.common.api.proto.PulsarMarkers.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshot;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshotRequest;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshotResponse;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ReplicatedSubscriptionsSnapshotBuilderTest {
@@ -51,8 +54,22 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
     private long currentTime = 0;
     private Clock clock;
     private ServiceConfiguration conf;
+    private PersistentSubscription sub;
     private ReplicatedSubscriptionsController controller;
     private List<ByteBuf> markers;
+    private List<ByteBuf> snapshots;
+    private List<ReplicatedSubscriptionsSnapshot> snapshotsProcessedByBuilder;
+
+    @DataProvider(name = "MockedDispatchers")
+    public static Object[][] mockedDispatchers() {
+        Dispatcher dispatcherWithConsumerAvailable = mock(Dispatcher.class);
+        when(dispatcherWithConsumerAvailable.isAtleastOneConsumerAvailable()).thenReturn(true);
+
+        Dispatcher dispatcherWithNoConsumerAvailable = mock(Dispatcher.class);
+        when(dispatcherWithNoConsumerAvailable.isAtleastOneConsumerAvailable()).thenReturn(false);
+
+        return new Object[][] { { dispatcherWithConsumerAvailable }, { dispatcherWithNoConsumerAvailable }, { null } };
+    }
 
     @BeforeMethod
     public void setup() {
@@ -63,9 +80,26 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
         conf.setReplicatedSubscriptionsSnapshotTimeoutSeconds(3);
 
         markers = new ArrayList<>();
+        snapshots = new ArrayList<>();
+        snapshotsProcessedByBuilder = new ArrayList<>();
+
+        sub = mock(PersistentSubscription.class);
+        doAnswer(invocation -> {
+            ReplicatedSubscriptionsSnapshot snapshot = invocation.getArgument(0, ReplicatedSubscriptionsSnapshot.class);
+            snapshotsProcessedByBuilder.add(snapshot);
+            return null;
+        }).when(sub).processReplicatedSubscriptionSnapshot(any(ReplicatedSubscriptionsSnapshot.class));
+
+        ConcurrentOpenHashMap<String, PersistentSubscription> subs = new ConcurrentOpenHashMap<>();
+        subs.put("sub1", sub);
+
+        PersistentTopic topic = mock(PersistentTopic.class);
+        when(topic.getName()).thenReturn("persistent://my-tenant/ms-ns/my-topic");
+        when(topic.getSubscriptions()).thenReturn(subs);
 
         controller = mock(ReplicatedSubscriptionsController.class);
         when(controller.localCluster()).thenReturn(localCluster);
+        when(controller.topic()).thenReturn(topic);
         doAnswer(invocation -> {
             ByteBuf marker = invocation.getArgument(0, ByteBuf.class);
             Commands.skipMessageMetadata(marker);
@@ -73,10 +107,18 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
             return null;
         }).when(controller)
                 .writeMarker(any(ByteBuf.class));
+        doAnswer(invocation -> {
+            ByteBuf snapshot = invocation.getArgument(0, ByteBuf.class);
+            Commands.skipMessageMetadata(snapshot);
+            snapshots.add(snapshot);
+            return null;
+        }).when(controller)
+                .writeSnapshot(any(ByteBuf.class));
     }
 
-    @Test
-    public void testBuildSnapshotWith2Clusters() throws Exception {
+    @Test(dataProvider = "MockedDispatchers")
+    public void testBuildSnapshotWith2Clusters(Dispatcher dispatcher) throws Exception {
+        when(sub.getDispatcher()).thenReturn(dispatcher);
         List<String> remoteClusters = Arrays.asList("b");
 
         ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(controller,
@@ -105,8 +147,8 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
                         .build());
 
         // At this point the snapshot should be created
-        assertEquals(markers.size(), 1);
-        ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(markers.remove(0));
+        assertEquals(snapshots.size(), 1);
+        ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(snapshots.remove(0));
         assertEquals(snapshot.getClustersCount(), 1);
         assertEquals(snapshot.getClusters(0).getCluster(), "b");
         assertEquals(snapshot.getClusters(0).getMessageId().getLedgerId(), 11);
@@ -114,10 +156,26 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         assertEquals(snapshot.getLocalMessageId().getLedgerId(), 1);
         assertEquals(snapshot.getLocalMessageId().getEntryId(), 1);
+
+        if (dispatcher != null && dispatcher.isAtleastOneConsumerAvailable()) {
+            assertTrue(snapshotsProcessedByBuilder.isEmpty());
+        } else {
+            assertEquals(snapshotsProcessedByBuilder.size(), 1);
+            ReplicatedSubscriptionsSnapshot snapshot2 = snapshotsProcessedByBuilder.remove(0);
+            assertEquals(snapshot2.getClustersCount(), 1);
+
+            assertEquals(snapshot2.getClusters(0).getCluster(), "b");
+            assertEquals(snapshot2.getClusters(0).getMessageId().getLedgerId(), 11);
+            assertEquals(snapshot2.getClusters(0).getMessageId().getEntryId(), 11);
+
+            assertEquals(snapshot2.getLocalMessageId().getLedgerId(), 1);
+            assertEquals(snapshot2.getLocalMessageId().getEntryId(), 1);
+        }
     }
 
-    @Test
-    public void testBuildSnapshotWith3Clusters() throws Exception {
+    @Test(dataProvider = "MockedDispatchers")
+    public void testBuildSnapshotWith3Clusters(Dispatcher dispatcher) throws Exception {
+        when(sub.getDispatcher()).thenReturn(dispatcher);
         List<String> remoteClusters = Arrays.asList("b", "c");
 
         ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(controller,
@@ -147,6 +205,8 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // No markers should be sent out
         assertTrue(markers.isEmpty());
+        assertTrue(snapshots.isEmpty());
+        assertTrue(snapshotsProcessedByBuilder.isEmpty());
 
         builder.receivedSnapshotResponse(new PositionImpl(2, 2),
                 ReplicatedSubscriptionsSnapshotResponse.newBuilder()
@@ -163,6 +223,8 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
         assertEquals(markers.size(), 1);
         request = Markers.parseReplicatedSubscriptionsSnapshotRequest(markers.remove(0));
         assertEquals(request.getSourceCluster(), localCluster);
+        assertTrue(snapshots.isEmpty());
+        assertTrue(snapshotsProcessedByBuilder.isEmpty());
 
         // Responses coming back
         builder.receivedSnapshotResponse(new PositionImpl(3, 3),
@@ -178,6 +240,8 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // No markers should be sent out
         assertTrue(markers.isEmpty());
+        assertTrue(snapshots.isEmpty());
+        assertTrue(snapshotsProcessedByBuilder.isEmpty());
 
         builder.receivedSnapshotResponse(new PositionImpl(4, 4),
                 ReplicatedSubscriptionsSnapshotResponse.newBuilder()
@@ -191,8 +255,8 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
                         .build());
 
         // At this point the snapshot should be created
-        assertEquals(markers.size(), 1);
-        ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(markers.remove(0));
+        assertEquals(snapshots.size(), 1);
+        ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(snapshots.remove(0));
         assertEquals(snapshot.getClustersCount(), 2);
         assertEquals(snapshot.getClusters(0).getCluster(), "b");
         assertEquals(snapshot.getClusters(0).getMessageId().getLedgerId(), 11);
@@ -204,6 +268,25 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         assertEquals(snapshot.getLocalMessageId().getLedgerId(), 4);
         assertEquals(snapshot.getLocalMessageId().getEntryId(), 4);
+
+        if (dispatcher != null && dispatcher.isAtleastOneConsumerAvailable()) {
+            assertTrue(snapshotsProcessedByBuilder.isEmpty());
+        } else {
+            assertEquals(snapshotsProcessedByBuilder.size(), 1);
+            ReplicatedSubscriptionsSnapshot snapshot2 = snapshotsProcessedByBuilder.remove(0);
+            assertEquals(snapshot2.getClustersCount(), 2);
+
+            assertEquals(snapshot2.getClusters(0).getCluster(), "b");
+            assertEquals(snapshot2.getClusters(0).getMessageId().getLedgerId(), 11);
+            assertEquals(snapshot2.getClusters(0).getMessageId().getEntryId(), 11);
+
+            assertEquals(snapshot2.getClusters(1).getCluster(), "c");
+            assertEquals(snapshot2.getClusters(1).getMessageId().getLedgerId(), 22);
+            assertEquals(snapshot2.getClusters(1).getMessageId().getEntryId(), 22);
+
+            assertEquals(snapshot2.getLocalMessageId().getLedgerId(), 4);
+            assertEquals(snapshot2.getLocalMessageId().getEntryId(), 4);
+        }
     }
 
     @Test


### PR DESCRIPTION
This is a further modification of the previously closed PR #6592.

Fixes #6437

### Motivation

In a replicated subscription with no consumers connected, the number of marker messages in the backlog will continue to increase. If at least one active consumer is connected, the marker messages will be acknowledged and deleted by the dispatcher.
https://github.com/apache/pulsar/blob/2d2c63e4d7fc4ce90068edf15f39de82ef738e33/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L88-L100
On the other hand, if no consumers are connected, or if they are connected but cannot receive any messages, the dispatcher does not exist or has stopped reading entries. As a result, the marker messages accumulate in the backlog without being acknoledged by anyone.


### Modifications

There are four types of marker messages:

- ReplicatedSubscriptionsSnapshotRequest
- ReplicatedSubscriptionsSnapshotResponse
- ReplicatedSubscriptionsSnapshot
- ReplicatedSubscriptionsUpdate

Of these, three messages, except `ReplicatedSubscriptionsSnapshot`, are not used in the local cluster. They are published to local topics for sending to remote clusters. So, modified the `ReplicatedSubscriptionsController` class to acknowledge these marker messages on all subscriptions immediately after publishing the messages to a local topic.

On the other hand, `ReplicatedSubscriptionsSnapshot` is only used by dispatchers in the local cluster and does not need to be sent to remote clusters. So, `ReplicatedSubscriptionsController` only acknowledges those messages on behalf of dispatcher if dispatcher has not been initialized or if there are no available consumers.

In addition, marker messages sent from remote clusters are now acknowledged by the replicator on all subscriptions.

With these changes, marker messages no longer continue to accumulate in the replicated subscription backlog.