### PR TITLE
Added ability to delete and update records in ElasticSearch sink connector

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -69,7 +69,7 @@ public class ElasticSearchSink implements Sink<byte[]> {
     private CredentialsProvider credentialsProvider;
     private ElasticSearchConfig elasticSearchConfig;
 
-    protected static final String ACTION = "ACTION";
+    protected static final String ELASTICSEARCH_ACTION = "ACTION";
     protected static final String UPSERT = "UPSERT";
     protected static final String DELETE = "DELETE";
     protected static final String ID = "ID";
@@ -89,7 +89,7 @@ public class ElasticSearchSink implements Sink<byte[]> {
     @Override
     public void write(Record<byte[]> record) {
         KeyValue<String, byte[]> keyValue = extractKeyValue(record);
-        String action = record.getProperties().get(ACTION);
+        String action = record.getProperties().get(ELASTICSEARCH_ACTION);
 
         if (action == null) {
             action = UPSERT;


### PR DESCRIPTION
### Motivation
I need to use ElasticSearch via Pulsar as a database but not as a dump of logs that’s why I implemented the possibility to update and delete records, as well as to set id when creating a record

### Modifications
Record processing
  - added "*ACTION*" [Record] property which can be "*UPSERT*" or "*DELETE*", default value is "*UPSERT*"
  - added "*ID*" [Record] property which provides record id (required for "*DELETE*")

Tests
  -  added *updateSingleRecordTest*
  -  added *deleteSingleRecordTest*
  -  renamed *singleRecordTest-> insertSingleRecordTest*

### Verifying this change
This change added tests and can be verified as follows:
  - *Extended unit tests (ElasticSearchSinkTests) for update and delete requests*

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: don't know

### Documentation

  - Does this pull request introduce a new feature: yes 
  - Is the feature documented: not documented
> I didn't find a documentation section for sink [Record] interface
