### PR TITLE
[Issue 7032][Doc] Update connector admin CLI for suporting DLQ for sink/source.

### DIFF
--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -557,7 +557,9 @@ $ pulsar-admin sinks localrun options
 | `--client-auth-plugin` | Client authentication plugin using which function-process can connect to broker.
 |`--cpu`|The CPU (in cores) that needs to be allocated per sink instance (applicable only to the Docker runtime).
 | `--custom-schema-inputs` | The map of input topics to Schema types or class names (as a JSON string).
-| `--custom-serde-inputs` | The map of input topics to SerDe class names (as a JSON string).
+| `--max-redeliver-count` | Maximum number of times that a message is redelivered before being sent to the dead letter queue.
+| --dead-letter-topic | Name of the dead letter topic where the failing messages are sent.
+|| `--custom-serde-inputs` | The map of input topics to SerDe class names (as a JSON string).
 |`--disk`|The disk (in bytes) that needs to be allocated per sink instance (applicable only to the Docker runtime).|
 |`--hostname-verification-enabled`|Enable hostname verification.<br>**Default value: false**.
 | `-i`, `--inputs` | The sink's input topic or topics (multiple topics can be specified as a comma-separated list).
@@ -573,6 +575,7 @@ $ pulsar-admin sinks localrun options
 |`--subs-name` | Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer.
 |`--tenant`|The sink’s tenant.
 | `--timeout-ms` | The message timeout in milliseconds.
+| --negative-ack-redelivery-delay-ms | The negatively-acknowledged message redelivery delay in milliseconds. |
 |`--tls-allow-insecure`|Allow insecure tls connection.<br>**Default value: false**.
 |`--tls-trust-cert-path`|The tls trust cert file path.
 | `--topics-pattern` | TopicsPattern to consume from list of topics under a namespace that match the pattern. <br>`--input` and `--topics-Pattern` are mutually exclusive. <br>Add SerDe class name for a pattern in `--customSerdeInputs` (supported for java fun only).

--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -575,7 +575,7 @@ $ pulsar-admin sinks localrun options
 |`--subs-name` | Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer.
 |`--tenant`|The sink’s tenant.
 | `--timeout-ms` | The message timeout in milliseconds.
-| --negative-ack-redelivery-delay-ms | The negatively-acknowledged message redelivery delay in milliseconds. |
+| `--negative-ack-rede` livery-delay-ms | The negatively-acknowledged message redelivery delay in milliseconds. |
 |`--tls-allow-insecure`|Allow insecure tls connection.<br>**Default value: false**.
 |`--tls-trust-cert-path`|The tls trust cert file path.
 | `--topics-pattern` | TopicsPattern to consume from list of topics under a namespace that match the pattern. <br>`--input` and `--topics-Pattern` are mutually exclusive. <br>Add SerDe class name for a pattern in `--customSerdeInputs` (supported for java fun only).

--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -575,7 +575,7 @@ $ pulsar-admin sinks localrun options
 |`--subs-name` | Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer.
 |`--tenant`|The sink’s tenant.
 | `--timeout-ms` | The message timeout in milliseconds.
-| `--negative-ack-rede` livery-delay-ms | The negatively-acknowledged message redelivery delay in milliseconds. |
+| `--negative-ack-redelivery-delay-ms` | The negatively-acknowledged message redelivery delay in milliseconds. |
 |`--tls-allow-insecure`|Allow insecure tls connection.<br>**Default value: false**.
 |`--tls-trust-cert-path`|The tls trust cert file path.
 | `--topics-pattern` | TopicsPattern to consume from list of topics under a namespace that match the pattern. <br>`--input` and `--topics-Pattern` are mutually exclusive. <br>Add SerDe class name for a pattern in `--customSerdeInputs` (supported for java fun only).

--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -558,8 +558,8 @@ $ pulsar-admin sinks localrun options
 |`--cpu`|The CPU (in cores) that needs to be allocated per sink instance (applicable only to the Docker runtime).
 | `--custom-schema-inputs` | The map of input topics to Schema types or class names (as a JSON string).
 | `--max-redeliver-count` | Maximum number of times that a message is redelivered before being sent to the dead letter queue.
-| --dead-letter-topic | Name of the dead letter topic where the failing messages are sent.
-|| `--custom-serde-inputs` | The map of input topics to SerDe class names (as a JSON string).
+| `--dead-letter-topic` | Name of the dead letter topic where the failing messages are sent.
+| `--custom-serde-inputs` | The map of input topics to SerDe class names (as a JSON string).
 |`--disk`|The disk (in bytes) that needs to be allocated per sink instance (applicable only to the Docker runtime).|
 |`--hostname-verification-enabled`|Enable hostname verification.<br>**Default value: false**.
 | `-i`, `--inputs` | The sink's input topic or topics (multiple topics can be specified as a comma-separated list).

--- a/site2/docs/io-use.md
+++ b/site2/docs/io-use.md
@@ -118,7 +118,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sources reload
 ```
 
-For more information, see [`here`](io-cli#reload).
+For more information, see [`here`](io-cli.md#reload).
 
 #### Sink
 
@@ -128,7 +128,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sinks reload
 ```
 
-For more information, see [`here`](io-cli#reload-1).
+For more information, see [`here`](io-cli.md#reload-1).
 
 ### `available`
 

--- a/site2/website/versioned_docs/version-2.5.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-use.md
@@ -120,7 +120,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sources reload
 ```
 
-For more information, see [`here`](io-cli#reload).
+For more information, see [`here`](io-cli.md#reload).
 
 #### Sink
 
@@ -130,7 +130,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sinks reload
 ```
 
-For more information, see [`here`](io-cli#reload-1).
+For more information, see [`here`](io-cli.md#reload-1).
 
 ### `available`
 

--- a/site2/website/versioned_docs/version-2.6.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-use.md
@@ -1,4 +1,5 @@
----
+-
+--
 id: version-2.6.0-io-use
 title: How to use Pulsar connectors
 sidebar_label: Use
@@ -119,7 +120,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sources reload
 ```
 
-For more information, see [`here`](io-cli#reload).
+For more information, see [`here`](io-cli.md#reload).
 
 #### Sink
 
@@ -129,7 +130,7 @@ Use the `reload` subcommand.
 $ pulsar-admin sinks reload
 ```
 
-For more information, see [`here`](io-cli#reload-1).
+For more information, see [`here`](io-cli.md#reload-1).
 
 ### `available`
 


### PR DESCRIPTION
Fix #7032 

Update doc for issue #7032 based on the PR #7094 

### Motivation

1. Update doc for issue #7032 for supporting DLQ for sink/source.

2: fix legacy link error for `reload` command in "How to use Pulsar connectors" document


### Modifications

1: add options in localrun for sink connector in connector admin CLI.

2: fix legacy link error for `reload` command in "How to use Pulsar connectors" document

