### PR TITLE
[Issue 6518][docs] Refine monitor and Pulsar metrics content

### DIFF
--- a/site2/docs/deploy-monitoring.md
+++ b/site2/docs/deploy-monitoring.md
@@ -1,10 +1,10 @@
 ---
 id: deploy-monitoring
-title: Monitoring
-sidebar_label: Monitoring
+title: Monitor
+sidebar_label: Monitor
 ---
 
-You can use different ways to monitor a Pulsar cluster, exposing both metrics that relate to the usage of topics and the overall health of the individual components of the cluster.
+You can use different ways to monitor a Pulsar cluster, exposing both metrics related to the usage of topics and the overall health of the individual components of the cluster.
 
 ## Collect metrics
 
@@ -20,13 +20,13 @@ You can collect Pulsar broker metrics from brokers and export the metrics in JSO
   bin/pulsar-admin broker-stats destinations
   ```
 
-* Broker metrics, which contain the broker information and topics stats aggregated at namespace level. You can fetch the broker metrics using the command below:
+* Broker metrics, which contain the broker information and topics stats aggregated at namespace level. You can fetch the broker metrics by using the following command:
 
   ```shell
   bin/pulsar-admin broker-stats monitoring-metrics
   ```
 
-All the message rates are updated every 1min.
+All the message rates are updated every minute.
 
 The aggregated broker metrics are also exposed in the [Prometheus](https://prometheus.io) format at:
 
@@ -36,47 +36,44 @@ http://$BROKER_ADDRESS:8080/metrics
 
 ### ZooKeeper stats
 
-The local Zookeeper and configuration store server and clients that are shipped with Pulsar have been instrumented to expose detailed stats through Prometheus as well.
+The local ZooKeeper, configuration store server and clients that are shipped with Pulsar can expose detailed stats through Prometheus.
 
 ```shell
 http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local Zookeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
 
 ### BookKeeper stats
 
-For BookKeeper you can configure the stats frameworks by changing the `statsProviderClass` in
-`conf/bookkeeper.conf`.
+You can configure the stats frameworks for BookKeeper by modifying the `statsProviderClass` in the `conf/bookkeeper.conf` file.
 
-The default BookKeeper configuration, which is included with Pulsar distribution, enables the Prometheus exporter.
+The default BookKeeper configuration enables the Prometheus exporter. The configuration is included with Pulsar distribution.
 
 ```shell
 http://$BOOKIE_ADDRESS:8000/metrics
 ```
 
-The default port for bookie is `8000` (instead of `8080`). You can change the port by configuring `prometheusStatsHttpPort` in `conf/bookkeeper.conf`.
+The default port for bookie is `8000`. You can change the port by configuring `prometheusStatsHttpPort` in the `conf/bookkeeper.conf` file.
 
 ## Configure Prometheus
 
-You can use Prometheus to collect and store the metrics data. For details, refer to [Prometheus guide](https://prometheus.io/docs/introduction/getting_started/).
+You can use Prometheus to collect all the metrics exposed for Pulsar components and set up [Grafana](https://grafana.com/) dashboards to display the metrics and monitor your Pulsar cluster. For details, refer to [Prometheus guide](https://prometheus.io/docs/introduction/getting_started/).
 
-When you run Pulsar on bare metal, you can provide the list of nodes that needs to be probed. When you deploy Pulsar in a Kubernetes cluster, the monitoring is automatically setup with the [provided](deploy-kubernetes.md) instructions.
+When you run Pulsar on bare metal, you can provide the list of nodes to be probed. When you deploy Pulsar in a Kubernetes cluster, the monitoring is setup automatically. For details, refer to [Kubernetes instructions](kubernetes-helm.md). 
 
 ## Dashboards
 
-When you collect time series statistics, the major problem is to make sure the number of dimensions attached to the data does not explode.
-
-For that reason you only need to collect time series of metrics aggregated at the namespace level.
+When you collect time series statistics, the major problem is to make sure the number of dimensions attached to the data does not explode. Thus you only need to collect time series of metrics aggregated at the namespace level.
 
 ### Pulsar per-topic dashboard
 
-The per-topic dashboard instructions are available at [Dashboard](administration-dashboard.md).
+The per-topic dashboard instructions are available at [Pulsar manager](administration-pulsar-manager.md).
 
 ### Grafana
 
-You can use grafana to easily create dashboard driven by the data that is stored in Prometheus.
+You can use grafana to create dashboard driven by the data that is stored in Prometheus.
 
 When you deploy Pulsar on Kubernetes, a `pulsar-grafana` Docker image is enabled by default. You can use the docker image with the principal dashboards.
 
@@ -87,3 +84,11 @@ docker run -p3000:3000 \
         -e PROMETHEUS_URL=http://$PROMETHEUS_HOST:9090/ \
         apachepulsar/pulsar-grafana:latest
 ```
+
+The following are some Grafana dashboards examples:
+
+- [pulsar-grafana](http://pulsar.apache.org/docs/en/deploy-monitoring/#grafana): a Grafana dashboard that displays metrics collected in Prometheus for Pulsar clusters running on Kubernetes.
+- [apache-pulsar-grafana-dashboard](https://github.com/streamnative/apache-pulsar-grafana-dashboard): a collection of Grafana dashboard templates for different Pulsar components running on both Kubernetes and on-premise machines.
+
+ ## Alerting rules
+ You can set alerting rules according to your Pulsar environment. To configure alerting rules for Apache Pulsar, you can refer to [StreamNative platform](https://streamnative.io/docs/latest/configure/control-center/alertmanager) examples or [Alert Manager](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) alerting rules.

--- a/site2/docs/helm-overview.md
+++ b/site2/docs/helm-overview.md
@@ -22,7 +22,6 @@ This chart includes all the components for a complete experience, but each part 
     - Pulsar Manager
     - Prometheus
     - Grafana
-    - Alert Manager
 
 It includes support for:
 

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -401,13 +401,3 @@ All the proxy metrics are labelled with the following labels:
 | split_record_deserialize_time | Summary | Time spent on deserializing message to record. For example, Avro, JSON, and so on. |
 | split_record_deserialize_time_per_query | Summary | Time spent on deserializing message to record per query. |
 | split_total_execution_time | Summary | Total execution time . |
-
-## Monitor
-
-You can [set up a Prometheus instance](https://prometheus.io/) to collect all the metrics exposed for Pulsar components and set up
-[Grafana](https://grafana.com/) dashboards to display the metrics and monitor your Pulsar cluster.
-
-The following are some Grafana dashboards examples:
-
-- [pulsar-grafana](http://pulsar.apache.org/docs/en/deploy-monitoring/#grafana): a Grafana dashboard that displays metrics collected in Prometheus for Pulsar clusters running on Kubernetes.
-- [apache-pulsar-grafana-dashboard](https://github.com/streamnative/apache-pulsar-grafana-dashboard): a collection of Grafana dashboard templates for different Pulsar components running on both Kubernetes and on-premise machines.


### PR DESCRIPTION
Fixes #6518 

### Motivation
1. Pulsar metrics provide some reference info, we can move the "monitoring info" into "Monitor" chapter, and keep information easy to find and use.
2. Fix #6518 and add alerting rules related info.

### Modifications
1. Remove "monitoring" content in Pulsar metrics;
2. Add alerting rule info in "Monitor" section;
3. Update "Dashboard" into "Pulsar Manager" (in line 72 of the `deploy-monitoring.md ` file );
4. Remove "Alert manager" from Pulsar control center in Helm overview.
