### PR TITLE
Fix race condition in which exitFuture in FunctionAssignmentTailer never gets completed even though the tailer thread has exited

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -123,9 +123,7 @@ public class FunctionAssignmentTailer implements AutoCloseable {
                 reader = null;
             }
 
-            exitFuture = null;
             exitOnEndOfTopic = false;
-            
         } catch (IOException e) {
             log.error("Failed to stop function assignment tailer", e);
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -80,7 +80,6 @@ public class FunctionAssignmentTailer implements AutoCloseable {
             if (tailerThread == null || !tailerThread.isAlive()) {
                 tailerThread = getTailerThread();
             }
-            exitFuture = new CompletableFuture<>();
             tailerThread.start();
         }
     }
@@ -113,6 +112,11 @@ public class FunctionAssignmentTailer implements AutoCloseable {
                     }
                 }
                 tailerThread = null;
+
+                // complete exit future to be safe
+                exitFuture.complete(null);
+                // reset the future
+                exitFuture = new CompletableFuture<>();
             }
             if (reader != null) {
                 reader.close();


### PR DESCRIPTION


### Motivation

Method "startFromMessage()" can be called after method "triggerReadToTheEndAndExit()". Method "startFromMessage()" will reset the future to a new future, thus when the tailer thread exits the new future will be completed and the future returned by method "triggerReadToTheEndAndExit()" will never be completed


### Modifications

Move the resetting the future in the close() method