### PR TITLE
Use consistent command in CI disk clean task

### DIFF
--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-broker.yml
+++ b/.github/workflows/ci-unit-broker-broker.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-client.yml
+++ b/.github/workflows/ci-unit-broker-client.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-flaky.yml
+++ b/.github/workflows/ci-unit-broker-flaky.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-long-time.yml
+++ b/.github/workflows/ci-unit-broker-long-time.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-others.yml
+++ b/.github/workflows/ci-unit-broker-others.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-publish-throttle.yml
+++ b/.github/workflows/ci-unit-broker-publish-throttle.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker-transaction.yml
+++ b/.github/workflows/ci-unit-broker-transaction.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit-broker.yml
+++ b/.github/workflows/ci-unit-broker.yml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'
         run: |
-          sudo swapoff /swapfile
+          sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
           docker rmi $(docker images -q) -f


### PR DESCRIPTION
### Motivation

In the github actions we have 2 different sets of commands to clean the disks at the beginning of the job: 

 `sudo swapoff /swapfile` and `sudo swapoff -a`

The ones with  `sudo swapoff /swapfile` are failing, so changing it to use the other form.

 * https://github.com/apache/pulsar/pull/7356/checks?check_run_id=806117815

```
Run sudo swapoff /swapfile
  sudo swapoff /swapfile
  sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
  sudo apt clean
  docker rmi $(docker images -q) -f
  df -h
  shell: /bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/jdk/8.0.252/x64
    JAVA_HOME_8.0.252_x64: /opt/hostedtoolcache/jdk/8.0.252/x64
swapoff: /swapfile: swapoff failed: No such file or directory
##[error]Process completed with exit code 255.
```
