### PR TITLE
Schema check logging is too verbose

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -61,10 +61,10 @@ abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityC
             SchemaValidator schemaValidator = createSchemaValidator(strategy);
             schemaValidator.validate(toSchema, fromList);
         } catch (SchemaParseException e) {
-            log.error("Error during schema parsing: {}", e.getMessage(), e);
+            log.warn("Error during schema parsing: {}", e.getMessage());
             throw new IncompatibleSchemaException(e);
         } catch (SchemaValidationException e) {
-            log.error("Error during schema compatibility check: {}", e.getMessage(), e);
+            log.warn("Error during schema compatibility check: {}", e.getMessage());
             throw new IncompatibleSchemaException(e);
         }
     }


### PR DESCRIPTION
### Motivation

These were error level logs at the broker, which triggers alerts even
though there's nothing the operator can do, as the problem occurs when
the client sends invalid schema to the broker. Marking as warn.
