### PR TITLE
Use fully qualified hostname as default to advertise worker.

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -493,7 +493,8 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     public static String unsafeLocalhostResolve() {
         try {
-            return InetAddress.getLocalHost().getHostName();
+            // Get the fully qualified hostname
+            return InetAddress.getLocalHost().getCanonicalHostName();
         } catch (UnknownHostException ex) {
             throw new IllegalStateException("Failed to resolve localhost name.", ex);
         }


### PR DESCRIPTION
### Motivation

Similar to #6235, we need to ensure to always use the fully qualified  hostname