### PR TITLE
Change "policies not found" log event to warning level.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -695,7 +695,7 @@ public abstract class PulsarWebResource {
                 }
             } else {
                 String msg = String.format("Policies not found for %s namespace", namespace.toString());
-                log.error(msg);
+                log.warn(msg);
                 validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND, msg));
             }
         }).exceptionally(ex -> {


### PR DESCRIPTION
### Motivation

This event is happening when trying to use a non-existing namespace. We shouldn't treat that as a system-error event.