### PR TITLE
[Issue 7313] Update information about the JDBC connectors for the download page

### DIFF
--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -90,10 +90,28 @@ module.exports = [
         link: 'https://www.influxdata.com/'
     },
     {
-        name: 'jdbc',
-        longName: 'JDBC sink',
+        name: 'jdbc-clickhouse',
+        longName: 'JDBC ClickHouse sink',
         type: 'Sink',
-        link: 'https://github.com/apache/pulsar/tree/master/pulsar-io/jdbc'
+        link: 'https://clickhouse.tech/'
+    },
+    {
+        name: 'jdbc-mariadb',
+        longName: 'JDBC MariaDB sink',
+        type: 'Sink',
+        link: 'https://mariadb.org/'
+    },
+    {
+        name: 'jdbc-postgres',
+        longName: 'JDBC PostgresSQL sink',
+        type: 'Sink',
+        link: 'https://www.postgresql.org/'
+    },
+    {
+        name: 'jdbc-sqlite',
+        longName: 'JDBC SQLite sink',
+        type: 'Sink',
+        link: 'https://www.sqlite.org/'
     },
     {
         name: 'kafka-connect-adaptor',


### PR DESCRIPTION
Fixes #7313 

### Motivation

After dividing the old JDBC connector into multiple connectors for different databases, I forgot to modify the connectors.js file.

### Modifications

The connectors.js file was extended with the info about new JDBC connectors.

Please let me know if I need to do/modify anything else.