### PR TITLE
Update documentation on prepare_helm_release.sh

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -65,8 +65,6 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ./scripts/pulsar/prepare_helm_release.sh \
         -n pulsar \
         -k pulsar-mini \
-        --control-center-admin pulsar \
-        --control-center-password pulsar \
         -c
     ```
 

--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -328,7 +328,6 @@ cd pulsar-helm-chart
 The `prepare_helm_release` creates the following resources:
 
 - A Kubernetes namespace for installing the Pulsar release
-- A secret for storing the username and password of the control center administrator. The username and password can be passed to `prepare_helm_release.sh` through flags `--control-center-admin` and `--control-center-password`. The username and password is used for logging into the Grafana dashboard and Pulsar Manager.
 - JWT secret keys and tokens for three super users: `broker-admin`, `proxy-admin`, and `admin`. By default, it generates an asymmetric pubic/private key pair. You can choose to generate a symmetric secret key by specifying `--symmetric`.
     - `proxy-admin` role is used for proxies to communicate to brokers.
     - `broker-admin` role is used for inter-broker communications.

--- a/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
@@ -66,8 +66,6 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ./scripts/pulsar/prepare_helm_release.sh \
         -n pulsar \
         -k pulsar-mini \
-        --control-center-admin pulsar \
-        --control-center-password pulsar \
         -c
     ```
 

--- a/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
@@ -329,7 +329,6 @@ cd pulsar-helm-chart
 The `prepare_helm_release` creates the following resources:
 
 - A Kubernetes namespace for installing the Pulsar release
-- A secret for storing the username and password of the control center administrator. The username and password can be passed to `prepare_helm_release.sh` through flags `--control-center-admin` and `--control-center-password`. The username and password is used for logging into the Grafana dashboard and Pulsar Manager.
 - JWT secret keys and tokens for three super users: `broker-admin`, `proxy-admin`, and `admin`. By default, it generates an asymmetric pubic/private key pair. You can choose to generate a symmetric secret key by specifying `--symmetric`.
     - `proxy-admin` role is used for proxies to communicate to brokers.
     - `broker-admin` role is used for inter-broker communications.


### PR DESCRIPTION
Fixes apache/pulsar-helm-chart#23

*Motivation*

    `control-center-admin` and `control-center-password` have already been removed from 2.6.0 helm chart.