### PR TITLE
Fixed io use docs metadata

### DIFF
--- a/site2/website/versioned_docs/version-2.6.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-use.md
@@ -1,4 +1,3 @@
--
 --
 id: version-2.6.0-io-use
 title: How to use Pulsar connectors


### PR DESCRIPTION

### Motivation

website docs build failed:
```
/pulsar/site2/website/node_modules/docusaurus/lib/server/versionFallback.js:67
    throw new Error("No 'original_id' field found in ".concat(file, ". Perhaps you forgot to add it when importing prior versions of your docs?"));
    ^

Error: No 'original_id' field found in /pulsar/site2/website/versioned_docs/version-2.6.0/io-use.md. Perhaps you forgot to add it when importing prior versions of your docs?
    at forEach (/pulsar/site2/website/node_modules/docusaurus/lib/server/versionFallback.js:64:11)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/pulsar/site2/website/node_modules/docusaurus/lib/server/versionFallback.js:52:7)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Module._compile (/pulsar/site2/website/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Object.newLoader [as .js] (/pulsar/site2/website/node_modules/pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```

### Modifications

* Fixed io-use docs metadata


### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
