### PR TITLE
[C++] Show bytes throughput for performance tests

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -343,6 +343,8 @@ add_custom_target(format python ${BUILD_SUPPORT_DIR}/run_clang_format.py
         0
         ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
         ${CMAKE_SOURCE_DIR}/lib
+        ${CMAKE_SOURCE_DIR}/perf
+        ${CMAKE_SOURCE_DIR}/examples
         ${CMAKE_SOURCE_DIR}/tests
         ${CMAKE_SOURCE_DIR}/include)
 
@@ -352,5 +354,7 @@ add_custom_target(check-format python ${BUILD_SUPPORT_DIR}/run_clang_format.py
         1
         ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
         ${CMAKE_SOURCE_DIR}/lib
+        ${CMAKE_SOURCE_DIR}/perf
+        ${CMAKE_SOURCE_DIR}/examples
         ${CMAKE_SOURCE_DIR}/tests
         ${CMAKE_SOURCE_DIR}/include)

--- a/pulsar-client-cpp/examples/SampleConsumer.cc
+++ b/pulsar-client-cpp/examples/SampleConsumer.cc
@@ -27,7 +27,6 @@ DECLARE_LOG_OBJECT()
 using namespace pulsar;
 
 int main() {
-
     Client client("pulsar://localhost:6650");
 
     Consumer consumer;

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -359,6 +359,9 @@ int main(int argc, char** argv) {
         producerConf.setCryptoKeyReader(keyReader);
     }
 
+    // Enable round robin message routing if it is a partitioned topic
+    producerConf.setPartitionsRoutingMode(ProducerConfiguration::RoundRobinDistribution);
+
     pulsar::ClientConfiguration conf;
     conf.setUseTls(args.isUseTls);
     conf.setTlsAllowInsecureConnection(args.isTlsAllowInsecureConnection);

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -69,22 +69,20 @@ struct Arguments {
 
 namespace pulsar {
 class PulsarFriend {
- public:
-    static Client getClient(const std::string& url, const ClientConfiguration conf,
-                            bool poolConnections) {
+   public:
+    static Client getClient(const std::string& url, const ClientConfiguration conf, bool poolConnections) {
         return Client(url, conf, poolConnections);
     }
 };
-}
+}  // namespace pulsar
 
 unsigned long messagesProduced;
 unsigned long bytesProduced;
 using namespace boost::accumulators;
 using namespace pulsar;
 
-class EncKeyReader: public CryptoKeyReader {
-
-  private:
+class EncKeyReader : public CryptoKeyReader {
+   private:
     std::string pubKeyContents;
 
     void readFile(std::string fileName, std::string& fileContents) const {
@@ -94,8 +92,7 @@ class EncKeyReader: public CryptoKeyReader {
         fileContents = fileStream.str();
     }
 
-  public:
-
+   public:
     EncKeyReader(std::string keyFile) {
         if (keyFile.empty()) {
             return;
@@ -103,12 +100,14 @@ class EncKeyReader: public CryptoKeyReader {
         readFile(keyFile, pubKeyContents);
     }
 
-    Result getPublicKey(const std::string &keyName, std::map<std::string, std::string>& metadata, EncryptionKeyInfo& encKeyInfo) const {
+    Result getPublicKey(const std::string& keyName, std::map<std::string, std::string>& metadata,
+                        EncryptionKeyInfo& encKeyInfo) const {
         encKeyInfo.setKey(pubKeyContents);
         return ResultOk;
     }
 
-    Result getPrivateKey(const std::string &keyName, std::map<std::string, std::string>& metadata, EncryptionKeyInfo& encKeyInfo) const {
+    Result getPrivateKey(const std::string& keyName, std::map<std::string, std::string>& metadata,
+                         EncryptionKeyInfo& encKeyInfo) const {
         return ResultInvalidConfiguration;
     }
 };
@@ -127,7 +126,8 @@ typedef std::chrono::high_resolution_clock Clock;
 void sendCallback(pulsar::Result result, const pulsar::MessageId& msgId, Clock::time_point& publishTime) {
     LOG_DEBUG("result = " << result);
     assert(result == pulsar::ResultOk);
-    uint64_t latencyUsec = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - publishTime).count();
+    uint64_t latencyUsec =
+        std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - publishTime).count();
     Lock lock(mutex);
     ++messagesProduced;
     // FIXME: Please fix me in here.
@@ -136,9 +136,8 @@ void sendCallback(pulsar::Result result, const pulsar::MessageId& msgId, Clock::
 }
 
 // Start a pulsar producer on a topic and keep producing messages
-void runProducer(const Arguments& args, std::string topicName, int threadIndex,
-                 RateLimiterPtr limiter, pulsar::Producer& producer,
-                 const std::atomic<bool>& exitCondition) {
+void runProducer(const Arguments& args, std::string topicName, int threadIndex, RateLimiterPtr limiter,
+                 pulsar::Producer& producer, const std::atomic<bool>& exitCondition) {
     LOG_INFO("Producing messages for topic = " << topicName << ", threadIndex = " << threadIndex);
 
     std::unique_ptr<char[]> payload(new char[args.msgSize]);
@@ -151,7 +150,8 @@ void runProducer(const Arguments& args, std::string topicName, int threadIndex,
         }
         pulsar::Message msg = builder.create().setAllocatedContent(payload.get(), args.msgSize).build();
 
-        producer.sendAsync(msg, std::bind(sendCallback, std::placeholders::_1, std::placeholders::_2, Clock::now()));
+        producer.sendAsync(
+            msg, std::bind(sendCallback, std::placeholders::_1, std::placeholders::_2, Clock::now()));
         if (exitCondition) {
             LOG_INFO("Thread interrupted. Exiting producer thread.");
             break;
@@ -159,8 +159,8 @@ void runProducer(const Arguments& args, std::string topicName, int threadIndex,
     }
 }
 
-void startPerfProducer(const Arguments& args, pulsar::ProducerConfiguration &producerConf, pulsar::Client &client,
-        const std::atomic<bool>& exitCondition) {
+void startPerfProducer(const Arguments& args, pulsar::ProducerConfiguration& producerConf,
+                       pulsar::Client& client, const std::atomic<bool>& exitCondition) {
     RateLimiterPtr limiter;
     if (args.rate != -1) {
         limiter = std::make_shared<pulsar::RateLimiter>(args.rate);
@@ -168,24 +168,23 @@ void startPerfProducer(const Arguments& args, pulsar::ProducerConfiguration &pro
 
     producerList.resize(args.numTopics * args.numProducers);
     for (int i = 0; i < args.numTopics; i++) {
-        std::string topic =
-                (args.numTopics == 1) ?
-                        args.topic : args.topic + "-" + std::to_string(i);
+        std::string topic = (args.numTopics == 1) ? args.topic : args.topic + "-" + std::to_string(i);
         LOG_INFO("Adding " << args.numProducers << " producers on topic " << topic);
 
         for (int j = 0; j < args.numProducers; j++) {
-            pulsar::Result result = client.createProducer(topic, producerConf, producerList[i*args.numProducers + j]);
+            pulsar::Result result =
+                client.createProducer(topic, producerConf, producerList[i * args.numProducers + j]);
             if (result != pulsar::ResultOk) {
                 LOG_ERROR("Couldn't create producer: " << result);
                 exit(-1);
             } else {
-                LOG_DEBUG("Created Producer at index " << i*args.numProducers + j);
+                LOG_DEBUG("Created Producer at index " << i * args.numProducers + j);
             }
 
             for (int k = 0; k < args.numOfThreadsPerProducer; k++) {
-                threadList.push_back(std::thread(
-                        std::bind(runProducer, args, topic, k, limiter, producerList[i * args.numProducers + j],
-                                    std::cref(exitCondition))));
+                threadList.push_back(std::thread(std::bind(runProducer, args, topic, k, limiter,
+                                                           producerList[i * args.numProducers + j],
+                                                           std::cref(exitCondition))));
             }
         }
     }
@@ -202,7 +201,7 @@ int main(int argc, char** argv) {
         po::variables_map vm;
         po::options_description confFileDesc;
         confFileDesc.add_options()  //
-        ("serviceURL", po::value<std::string>()->default_value("pulsar://localhost:6650"));
+            ("serviceURL", po::value<std::string>()->default_value("pulsar://localhost:6650"));
 
         po::store(po::parse_config_file<char>(file, confFileDesc, true), vm);
         po::notify(vm);
@@ -217,65 +216,73 @@ int main(int argc, char** argv) {
     positional.add("topic", 1);
 
     po::options_description desc("Allowed options");
-    desc.add_options()  //
-    ("help,h", "Print this help message")  //
+    desc.add_options()                         //
+        ("help,h", "Print this help message")  //
 
-    ("auth-params,v", po::value<std::string>(&args.authParams)->default_value(""), "Authentication parameters, e.g., \"key1:val1,key2:val2\"") //
+        ("auth-params,v", po::value<std::string>(&args.authParams)->default_value(""),
+         "Authentication parameters, e.g., \"key1:val1,key2:val2\"")  //
 
-    ("auth-plugin,a", po::value<std::string>(&args.authPlugin)->default_value(""), "Authentication plugin class library path") //
+        ("auth-plugin,a", po::value<std::string>(&args.authPlugin)->default_value(""),
+         "Authentication plugin class library path")  //
 
-    ("use-tls,b", po::value<bool>(&args.isUseTls)->default_value(false), "Whether tls connection is used")  //
+        ("use-tls,b", po::value<bool>(&args.isUseTls)->default_value(false),
+         "Whether tls connection is used")  //
 
-    ("allow-insecure,d", po::value<bool>(&args.isTlsAllowInsecureConnection)->default_value(true), "Whether insecure tls connection is allowed")  //
+        ("allow-insecure,d", po::value<bool>(&args.isTlsAllowInsecureConnection)->default_value(true),
+         "Whether insecure tls connection is allowed")  //
 
-    ("trust-cert-file,c", po::value<std::string>(&args.tlsTrustCertsFilePath)->default_value(""), "TLS trust certification file path")  //
+        ("trust-cert-file,c", po::value<std::string>(&args.tlsTrustCertsFilePath)->default_value(""),
+         "TLS trust certification file path")  //
 
-    ("rate,r", po::value<double>(&args.rate)->default_value(100.0),
-     "Publish rate msg/s across topics")  //
-    ("size,s", po::value<int>(&args.msgSize)->default_value(1024), "Message size")  //
+        ("rate,r", po::value<double>(&args.rate)->default_value(100.0),
+         "Publish rate msg/s across topics")                                            //
+        ("size,s", po::value<int>(&args.msgSize)->default_value(1024), "Message size")  //
 
-    ("num-topics,t", po::value<int>(&args.numTopics)->default_value(1), "Number of topics")  //
+        ("num-topics,t", po::value<int>(&args.numTopics)->default_value(1), "Number of topics")  //
 
-    ("num-producers,n", po::value<int>(&args.numProducers)->default_value(1),
-     "Number of producers (per topic)")  //
+        ("num-producers,n", po::value<int>(&args.numProducers)->default_value(1),
+         "Number of producers (per topic)")  //
 
-    ("num-threads-per-producers", po::value<int>(&args.numOfThreadsPerProducer)->default_value(1),
-     "Number of threads (per producer)") //
+        ("num-threads-per-producers", po::value<int>(&args.numOfThreadsPerProducer)->default_value(1),
+         "Number of threads (per producer)")  //
 
-    ("service-url,u", po::value<std::string>(&args.serviceURL)->default_value(defaultServiceUrl),
-     "Pulsar Service URL")  //
+        ("service-url,u", po::value<std::string>(&args.serviceURL)->default_value(defaultServiceUrl),
+         "Pulsar Service URL")  //
 
-    ("producer-queue-size,p", po::value<int>(&args.producerQueueSize)->default_value(1000),
-     "Max size of producer pending messages queue")  //
+        ("producer-queue-size,p", po::value<int>(&args.producerQueueSize)->default_value(1000),
+         "Max size of producer pending messages queue")  //
 
-    ("io-threads,i", po::value<int>(&args.ioThreads)->default_value(1),
-     "Number of IO threads to use")  //
+        ("io-threads,i", po::value<int>(&args.ioThreads)->default_value(1),
+         "Number of IO threads to use")  //
 
-    ("listener-threads,l", po::value<int>(&args.listenerThreads)->default_value(1),
-     "Number of listener threads") //
+        ("listener-threads,l", po::value<int>(&args.listenerThreads)->default_value(1),
+         "Number of listener threads")  //
 
-    ("sampling-period", po::value<long>(&args.samplingPeriod)->default_value(20),
-     "Time elapsed in seconds before reading are aggregated. Default: 20 sec") //
+        ("sampling-period", po::value<long>(&args.samplingPeriod)->default_value(20),
+         "Time elapsed in seconds before reading are aggregated. Default: 20 sec")  //
 
-    ("num-of-samples", po::value<long>(&args.numberOfSamples)->default_value(0),
-     "Number of samples to take. Default: 0 (run forever)") //
+        ("num-of-samples", po::value<long>(&args.numberOfSamples)->default_value(0),
+         "Number of samples to take. Default: 0 (run forever)")  //
 
-    ("batch-size", po::value<unsigned int>(&args.batchingMaxMessages)->default_value(1),
-            "If batch size == 1 then batching is disabled. Default batch size == 1") //
+        ("batch-size", po::value<unsigned int>(&args.batchingMaxMessages)->default_value(1),
+         "If batch size == 1 then batching is disabled. Default batch size == 1")  //
 
-    ("compression", po::value<std::string>(&args.compression)->default_value(""),
-             "Compression can be either 'zlib' or 'lz4'. Default is no compression") //
+        ("compression", po::value<std::string>(&args.compression)->default_value(""),
+         "Compression can be either 'zlib' or 'lz4'. Default is no compression")  //
 
-    ("max-batch-size-in-bytes", po::value<long>(&args.batchingMaxAllowedSizeInBytes)->default_value(128 * 1024),
-            "Use only is batch-size > 1, Default is 128 KB") //
+        ("max-batch-size-in-bytes",
+         po::value<long>(&args.batchingMaxAllowedSizeInBytes)->default_value(128 * 1024),
+         "Use only is batch-size > 1, Default is 128 KB")  //
 
-    ("max-batch-publish-delay-in-ms", po::value<long>(&args.batchingMaxPublishDelayMs)->default_value(3000),
-            "Use only is batch-size > 1, Default is 3 seconds") //
+        ("max-batch-publish-delay-in-ms",
+         po::value<long>(&args.batchingMaxPublishDelayMs)->default_value(3000),
+         "Use only is batch-size > 1, Default is 3 seconds")  //
 
-    ("encryption-key-name,k", po::value<std::string>(&args.encKeyName)->default_value(""), "The public key name to encrypt payload") //
+        ("encryption-key-name,k", po::value<std::string>(&args.encKeyName)->default_value(""),
+         "The public key name to encrypt payload")  //
 
-    ("encryption-key-value-file,f", po::value<std::string>(&args.encKeyValueFile)->default_value(""),
-            "The file which contains the public key to encrypt payload"); //
+        ("encryption-key-value-file,f", po::value<std::string>(&args.encKeyValueFile)->default_value(""),
+         "The file which contains the public key to encrypt payload");  //
 
     po::options_description hidden;
     hidden.add_options()("topic", po::value<std::string>(&args.topic), "Topic name");
@@ -285,9 +292,7 @@ int main(int argc, char** argv) {
 
     po::variables_map map;
     try {
-        po::store(
-                po::command_line_parser(argc, argv).options(allOptions).positional(positional).run(),
-                map);
+        po::store(po::command_line_parser(argc, argv).options(allOptions).positional(positional).run(), map);
         po::notify(map);
     } catch (const std::exception& e) {
         std::cerr << "Error parsing parameters -- " << e.what() << std::endl << std::endl;
@@ -301,8 +306,8 @@ int main(int argc, char** argv) {
     }
 
     if (map.count("topic") != 1) {
-        std::cerr << "Need to specify a topic name. eg: persistent://prop/cluster/ns/my-topic"
-                  << std::endl << std::endl;
+        std::cerr << "Need to specify a topic name. eg: persistent://prop/cluster/ns/my-topic" << std::endl
+                  << std::endl;
         std::cerr << desc << std::endl;
         return -1;
     }
@@ -322,7 +327,8 @@ int main(int argc, char** argv) {
         } else if (it->second.value().type() == typeid(unsigned int)) {
             LOG_INFO(it->first << ": " << it->second.as<unsigned int>());
         } else {
-            LOG_INFO(it->first << ": " << "new data type used, please create an else condition in the code");
+            LOG_INFO(it->first << ": "
+                               << "new data type used, please create an else condition in the code");
         }
     }
 
@@ -362,7 +368,7 @@ int main(int argc, char** argv) {
     }
     conf.setIOThreads(args.ioThreads);
     conf.setMessageListenerThreads(args.listenerThreads);
-    if(!args.authPlugin.empty()) {
+    if (!args.authPlugin.empty()) {
         pulsar::AuthenticationPtr auth = pulsar::AuthFactory::create(args.authPlugin, args.authParams);
         conf.setAuth(auth);
     }
@@ -394,7 +400,8 @@ int main(int argc, char** argv) {
         lock.unlock();
 
         LOG_INFO("Throughput produced: " << rate << "  msg/s --- " << throughput << " Mbit/s --- "  //
-               << "Lat avg: " << latencyAvgMs << " ms -- Lat 99pct: " << latency99pctMs << " ms");
+                                         << "Lat avg: " << latencyAvgMs
+                                         << " ms -- Lat 99pct: " << latency99pctMs << " ms");
         oldTime = now;
     }
     LOG_INFO("Total messagesProduced = " << totalMessagesProduced + messagesProduced);

--- a/pulsar-client-cpp/perf/RateLimiter.h
+++ b/pulsar-client-cpp/perf/RateLimiter.h
@@ -26,14 +26,14 @@
 namespace pulsar {
 
 class RateLimiter {
- public:
+   public:
     RateLimiter(double rate);
 
     void acquire();
 
     void acquire(int permits);
 
- private:
+   private:
     RateLimiter(const RateLimiter&);
     RateLimiter& operator=(const RateLimiter&);
     typedef std::chrono::high_resolution_clock Clock;
@@ -47,16 +47,14 @@ class RateLimiter {
 };
 
 RateLimiter::RateLimiter(double rate)
-        : interval_(std::chrono::microseconds((long)(1e6 / rate))),
-          storedPermits_(0.0),
-          maxPermits_(rate),
-          nextFree_(Clock::now()) {
+    : interval_(std::chrono::microseconds((long)(1e6 / rate))),
+      storedPermits_(0.0),
+      maxPermits_(rate),
+      nextFree_(Clock::now()) {
     assert(rate < 1e6 && "Exceeded maximum rate");
 }
 
-void RateLimiter::acquire() {
-    acquire(1);
-}
+void RateLimiter::acquire() { acquire(1); }
 
 void RateLimiter::acquire(int permits) {
     Clock::time_point now = Clock::now();
@@ -64,8 +62,7 @@ void RateLimiter::acquire(int permits) {
     Lock lock(mutex_);
 
     if (now > nextFree_) {
-        storedPermits_ = std::min<long>(maxPermits_,
-                                        storedPermits_ + (now - nextFree_) / interval_);
+        storedPermits_ = std::min<long>(maxPermits_, storedPermits_ + (now - nextFree_) / interval_);
         nextFree_ = now;
     }
 
@@ -88,6 +85,6 @@ void RateLimiter::acquire(int permits) {
     }
 }
 
-}  // pulsar
+}  // namespace pulsar
 
 #endif /* PERF_RATELIMITER_H_ */


### PR DESCRIPTION
### Motivation

The send callback changed after #4811 but message size cannot be retrieved from `MessageId`, so the statistics of message bytes were lost.

### Modifications

- Format code in `examples` and `perf` directories;
- Add a parameter to send callback to record each message's bytes count;
- Enable round robin routing for partitioned topics.