### PR TITLE
[Doc]--Introduce GenericRecordBuilder and the Avro implementation

### DIFF
--- a/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
@@ -79,6 +79,28 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
+The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+
+**Example** 
+
+1. Use the `RecordSchemaBuilder` to build a schema.
+
+    ```java
+    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("schemaName");
+    recordSchemaBuilder.field("intField").type(SchemaType.INT32);
+    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+
+    Producer<GenericRecord> producer = client.newProducer(Schema.generic(schemaInfo)).create();
+    ```
+
+2. Use `RecordBuilder` to build the generic records.
+
+    ```java
+    producer.newMessage().value(schema.newRecordBuilder()
+                .set("intField", 32)
+                .build()).send();
+    ```
+
 ## Managing Schemas
 
 You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
@@ -79,7 +79,7 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
-The following example shows how to define an Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
 
 **Example** 
 

--- a/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
@@ -79,7 +79,7 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
-The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+The following example shows how to define an Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
 
 **Example** 
 

--- a/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
@@ -79,6 +79,28 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
+The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+
+**Example** 
+
+1. Use the `RecordSchemaBuilder` to build a schema.
+
+    ```java
+    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("schemaName");
+    recordSchemaBuilder.field("intField").type(SchemaType.INT32);
+    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+
+    Producer<GenericRecord> producer = client.newProducer(Schema.generic(schemaInfo)).create();
+    ```
+
+2. Use `RecordBuilder` to build the generic records.
+
+    ```java
+    producer.newMessage().value(schema.newRecordBuilder()
+                .set("intField", 32)
+                .build()).send();
+    ```
+
 ## Managing Schemas
 
 You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
@@ -79,7 +79,7 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
-The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+The following example shows how to define an Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
 
 **Example** 
 

--- a/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
@@ -79,6 +79,28 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
+The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+
+**Example** 
+
+1. Use the `RecordSchemaBuilder` to build a schema.
+
+    ```java
+    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("schemaName");
+    recordSchemaBuilder.field("intField").type(SchemaType.INT32);
+    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+
+    Producer<GenericRecord> producer = client.newProducer(Schema.generic(schemaInfo)).create();
+    ```
+
+2. Use `RecordBuilder` to build the generic records.
+
+    ```java
+    producer.newMessage().value(schema.newRecordBuilder()
+                .set("intField", 32)
+                .build()).send();
+    ```
+
 ## Managing Schemas
 
 You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
@@ -79,7 +79,7 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
-The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+The following example shows how to define an Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
 
 **Example** 
 

--- a/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
@@ -79,6 +79,28 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
+The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+
+**Example** 
+
+1. Use the `RecordSchemaBuilder` to build a schema.
+
+    ```java
+    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("schemaName");
+    recordSchemaBuilder.field("intField").type(SchemaType.INT32);
+    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+
+    Producer<GenericRecord> producer = client.newProducer(Schema.generic(schemaInfo)).create();
+    ```
+
+2. Use `RecordBuilder` to build the generic records.
+
+    ```java
+    producer.newMessage().value(schema.newRecordBuilder()
+                .set("intField", 32)
+                .build()).send();
+    ```
+
 ## Managing Schemas
 
 You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.

--- a/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
@@ -79,7 +79,7 @@ For usage instructions, see the documentation for your preferred client library:
 
 > Support for other schema formats will be added in future releases of Pulsar.
 
-The following example shows how to define a Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
+The following example shows how to define an Avro schema using the `GenericSchemaBuilder`, generate a generic Avro schema using `GenericRecordBuilder`, and consume messages into `GenericRecord`.
 
 **Example** 
 


### PR DESCRIPTION
### Motivation

Release 2.4.0 introduces the generic record builder and provides a AVRO generic record implementation. here is the PR link: https://github.com/apache/pulsar/pull/3690. But the document is not updated accordingly.

Therefore, the PR is created to updated the document. docs in the following releases are updated:
releases 2.4.0/2.4.1/2.4.2/2.5.0

Docs in releases 2.5.1 and later releases have been re-structured and updated.

### Modifications

Add an example in Schema registry to describe how to use the GenericRecordBuilder to define the schema and access data.




