### PR TITLE
Avoid NPEs at ledger creation when DNS failures happen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ docker.debug-info
 examples/flink/src/main/java/org/apache/flink/avro/generated
 pulsar-flink/src/test/java/org/apache/flink/avro/generated
 pulsar-client/src/test/java/org/apache/pulsar/client/avro/generated
+/build/

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2284,77 +2284,72 @@ public class ManagedCursorImpl implements ManagedCursor {
     void createNewMetadataLedger(final VoidCallback callback) {
         ledger.mbean.startCursorLedgerCreateOp();
 
-        try {
-            ledger.asyncCreateLedger(bookkeeper, config, digestType, (rc, lh, ctx) -> {
+        ledger.asyncCreateLedger(bookkeeper, config, digestType, (rc, lh, ctx) -> {
 
-                if (ledger.checkAndCompleteLedgerOpTask(rc, lh, ctx)) {
+            if (ledger.checkAndCompleteLedgerOpTask(rc, lh, ctx)) {
+                return;
+            }
+
+            ledger.getExecutor().execute(safeRun(() -> {
+                ledger.mbean.endCursorLedgerCreateOp();
+                if (rc != BKException.Code.OK) {
+                    log.warn("[{}] Error creating ledger for cursor {}: {}", ledger.getName(), name,
+                            BKException.getMessage(rc));
+                    callback.operationFailed(new ManagedLedgerException(BKException.getMessage(rc)));
                     return;
                 }
 
-                ledger.getExecutor().execute(safeRun(() -> {
-                    ledger.mbean.endCursorLedgerCreateOp();
-                    if (rc != BKException.Code.OK) {
-                        log.warn("[{}] Error creating ledger for cursor {}: {}", ledger.getName(), name,
-                                BKException.getMessage(rc));
-                        callback.operationFailed(new ManagedLedgerException(BKException.getMessage(rc)));
-                        return;
-                    }
-
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Created ledger {} for cursor {}", ledger.getName(), lh.getId(), name);
-                    }
-                    // Created the ledger, now write the last position
-                    // content
-                    MarkDeleteEntry mdEntry = lastMarkDeleteEntry;
-                    persistPositionToLedger(lh, mdEntry, new VoidCallback() {
-                        @Override
-                        public void operationComplete() {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Persisted position {} for cursor {}", ledger.getName(),
-                                        mdEntry.newPosition, name);
-                            }
-                            switchToNewLedger(lh, new VoidCallback() {
-                                @Override
-                                public void operationComplete() {
-                                    callback.operationComplete();
-                                }
-
-                                @Override
-                                public void operationFailed(ManagedLedgerException exception) {
-                                    // it means it failed to switch the newly created ledger so, it should be
-                                    // deleted to prevent leak
-                                    bookkeeper.asyncDeleteLedger(lh.getId(), (int rc, Object ctx) -> {
-                                        if (rc != BKException.Code.OK) {
-                                            log.warn("[{}] Failed to delete orphan ledger {}", ledger.getName(),
-                                                    lh.getId());
-                                        }
-                                    }, null);
-                                    callback.operationFailed(exception);
-                                }
-                            });
-                        }
-
-                        @Override
-                        public void operationFailed(ManagedLedgerException exception) {
-                            log.warn("[{}] Failed to persist position {} for cursor {}", ledger.getName(),
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Created ledger {} for cursor {}", ledger.getName(), lh.getId(), name);
+                }
+                // Created the ledger, now write the last position
+                // content
+                MarkDeleteEntry mdEntry = lastMarkDeleteEntry;
+                persistPositionToLedger(lh, mdEntry, new VoidCallback() {
+                    @Override
+                    public void operationComplete() {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Persisted position {} for cursor {}", ledger.getName(),
                                     mdEntry.newPosition, name);
-
-                            ledger.mbean.startCursorLedgerDeleteOp();
-                            bookkeeper.asyncDeleteLedger(lh.getId(), new DeleteCallback() {
-                                @Override
-                                public void deleteComplete(int rc, Object ctx) {
-                                    ledger.mbean.endCursorLedgerDeleteOp();
-                                }
-                            }, null);
-                            callback.operationFailed(exception);
                         }
-                    });
-                }));
-            }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name));
-        } catch (Throwable t) {
-            log.error("[{}] Encountered unexpected error when creating cursor ledger", name, t);
-            callback.operationFailed(new ManagedLedgerException(t));
-        }
+                        switchToNewLedger(lh, new VoidCallback() {
+                            @Override
+                            public void operationComplete() {
+                                callback.operationComplete();
+                            }
+
+                            @Override
+                            public void operationFailed(ManagedLedgerException exception) {
+                                // it means it failed to switch the newly created ledger so, it should be
+                                // deleted to prevent leak
+                                bookkeeper.asyncDeleteLedger(lh.getId(), (int rc, Object ctx) -> {
+                                    if (rc != BKException.Code.OK) {
+                                        log.warn("[{}] Failed to delete orphan ledger {}", ledger.getName(),
+                                                lh.getId());
+                                    }
+                                }, null);
+                                callback.operationFailed(exception);
+                            }
+                        });
+                    }
+
+                    @Override
+                    public void operationFailed(ManagedLedgerException exception) {
+                        log.warn("[{}] Failed to persist position {} for cursor {}", ledger.getName(),
+                                mdEntry.newPosition, name);
+
+                        ledger.mbean.startCursorLedgerDeleteOp();
+                        bookkeeper.asyncDeleteLedger(lh.getId(), new DeleteCallback() {
+                            @Override
+                            public void deleteComplete(int rc, Object ctx) {
+                                ledger.mbean.endCursorLedgerDeleteOp();
+                            }
+                        }, null);
+                        callback.operationFailed(exception);
+                    }
+                });
+            }));
+        }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name));
     }
 
     private List<LongProperty> buildPropertiesMap(Map<String, Long> properties) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -53,6 +53,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.protocol.schema.SchemaStorage;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.LongSchemaVersion;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.protocol.schema.StoredSchema;
 import org.apache.pulsar.zookeeper.ZooKeeperCache;
 import org.apache.zookeeper.CreateMode;
@@ -500,20 +501,24 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     private CompletableFuture<LedgerHandle> createLedger(String schemaId) {
         Map<String, byte[]> metadata = LedgerMetadataUtils.buildMetadataForSchema(schemaId);
         final CompletableFuture<LedgerHandle> future = new CompletableFuture<>();
-        bookKeeper.asyncCreateLedger(
-            config.getManagedLedgerDefaultEnsembleSize(),
-            config.getManagedLedgerDefaultWriteQuorum(),
-            config.getManagedLedgerDefaultAckQuorum(),
-            BookKeeper.DigestType.fromApiDigestType(config.getManagedLedgerDigestType()),
-            LedgerPassword,
-            (rc, handle, ctx) -> {
-                if (rc != BKException.Code.OK) {
-                    future.completeExceptionally(bkException("Failed to create ledger", rc, -1, -1));
-                } else {
-                    future.complete(handle);
-                }
-            }, null, metadata
-        );
+        try {
+            bookKeeper.asyncCreateLedger(
+                    config.getManagedLedgerDefaultEnsembleSize(),
+                    config.getManagedLedgerDefaultWriteQuorum(),
+                    config.getManagedLedgerDefaultAckQuorum(),
+                    BookKeeper.DigestType.fromApiDigestType(config.getManagedLedgerDigestType()),
+                    LedgerPassword,
+                    (rc, handle, ctx) -> {
+                        if (rc != BKException.Code.OK) {
+                            future.completeExceptionally(bkException("Failed to create ledger", rc, -1, -1));
+                        } else {
+                            future.complete(handle);
+                        }
+                    }, null, metadata);
+        } catch (Throwable t) {
+            log.error("[{}] Encountered unexpected error when creating schema ledger", schemaId, t);
+            return FutureUtil.failedFuture(t);
+        }
         return future;
     }
 


### PR DESCRIPTION
### Motivation

As a followup to the fix in #7401, also use try/catch in all places where we're creating new ledgers to cover against NPEs triggered by DNS errors.