### PR TITLE
[Issue 7407] Support for tombstones (null value in messages) does not work

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -166,7 +166,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     public void updateNumMsgsReceived(Message<?> message) {
         if (message != null) {
             numMsgsReceived.increment();
-            numBytesReceived.add(message.getData().length);
+            numBytesReceived.add(message.getData() == null ? 0 : message.getData().length);
         }
     }
 


### PR DESCRIPTION
Added check to prevent NPE when a tombstone (null value) is produced.

Fixes #7407

### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Null value check

### Verifying this change

Tests are provided in #7407. Some similar tests should be integrated into Pulsar code when final solution is presented.

### Does this pull request potentially affect one of the following parts:

No

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? (null check)
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
