### PR TITLE
Fix batch ackset recycled multiple times.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -183,7 +183,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
     }
 
     @Test
-    public void testSafeAckSetRecycle() throws Exception  {
+    public void testDoNotRecycleAckSetMultipleTimes() throws Exception  {
         final String topic = "persistent://my-property/my-ns/testSafeAckSetRecycle";
 
         Producer<byte[]> producer = pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -181,4 +181,35 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
         // broker also need to handle the available permits.
         Assert.assertEquals(received.size(), 100);
     }
+
+    @Test
+    public void testSafeAckSetRecycle() throws Exception  {
+        final String topic = "persistent://my-property/my-ns/testSafeAckSetRecycle";
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .batchingMaxMessages(10)
+                .blockIfQueueFull(true).topic(topic)
+                .create();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .acknowledgmentGroupTime(1, TimeUnit.MILLISECONDS)
+                .topic(topic)
+                .subscriptionName("test")
+                .subscribe();
+
+        final int messages = 100;
+        for (int i = 0; i < messages; i++) {
+            producer.sendAsync("Hello Pulsar".getBytes());
+        }
+
+        // Should not throw an exception.
+        for (int i = 0; i < messages; i++) {
+            consumer.acknowledgeCumulative(consumer.receive());
+            // make sure the group ack flushed.
+            Thread.sleep(2);
+        }
+
+        producer.close();
+        consumer.close();
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -205,6 +205,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         }
 
         final ByteBuf cmd = Commands.newAck(consumer.consumerId, msgId.ledgerId, msgId.entryId, bitSet, ackType, null, properties);
+        bitSet.recycle();
         cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
         return true;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -961,9 +961,6 @@ public class Commands {
 
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.ACK).setAck(ack));
         ack.recycle();
-        if (ackSet != null) {
-            ackSet.recycle();
-        }
         ackBuilder.recycle();
         messageIdDataBuilder.recycle();
         messageIdData.recycle();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
@@ -27,7 +27,6 @@ import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This this copy of {@link BitSet}.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
@@ -1184,7 +1184,6 @@ public class BitSetRecyclable implements Cloneable, java.io.Serializable {
         return this;
     }
 
-    private final AtomicBoolean recycled = new AtomicBoolean(false);
     private Handle<BitSetRecyclable> recyclerHandle = null;
 
     private static final Recycler<BitSetRecyclable> RECYCLER = new Recycler<BitSetRecyclable>() {
@@ -1199,13 +1198,11 @@ public class BitSetRecyclable implements Cloneable, java.io.Serializable {
     }
 
     public static BitSetRecyclable create() {
-        BitSetRecyclable instance = RECYCLER.get();
-        instance.recycled.set(false);
-        return instance;
+        return RECYCLER.get();
     }
 
     public void recycle() {
-        if (recyclerHandle != null && recycled.compareAndSet(false, true)) {
+        if (recyclerHandle != null) {
             this.clear();
             recyclerHandle.recycle(this);
         }


### PR DESCRIPTION

Fixes #7384

### Motivation

Fix batch ackset recycled multiple times. The root cause is a race condition in group ack flush and cumulative Ack. So add recycled state check for the ackset.

### Verifying this change

New unit test added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
