### PR TITLE
[Doc] --Add a note about --state-storage-service-url in localrun command of Function

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -450,7 +450,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally. ||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.3.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.3.0/reference-pulsar-admin.md
@@ -425,7 +425,7 @@ Options
 |`--schema-type`|Schema Type to be used for storing output messages||
 |`--sliding-interval-count`|Number of messages after which the window ends||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The service URL for the function’s state storage (if the function uses a storage system different from the Apache BookKeeper cluster used by Pulsar)||
+|`--state-storage-service-url`|The service URL for the function’s state storage (if the function uses a storage system different from the Apache BookKeeper cluster used by Pulsar). This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern||
 |`--user-config`|A user-supplied config value, set as a key/value pair. You can set multiple user config values.||

--- a/site2/website/versioned_docs/version-2.3.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.3.1/reference-pulsar-admin.md
@@ -425,7 +425,7 @@ Options
 |`--schema-type`|Schema Type to be used for storing output messages||
 |`--sliding-interval-count`|Number of messages after which the window ends||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The service URL for the function’s state storage (if the function uses a storage system different from the Apache BookKeeper cluster used by Pulsar)||
+|`--state-storage-service-url`|The service URL for the function’s state storage (if the function uses a storage system different from the Apache BookKeeper cluster used by Pulsar). This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern||
 |`--user-config`|A user-supplied config value, set as a key/value pair. You can set multiple user config values.||

--- a/site2/website/versioned_docs/version-2.3.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.3.2/reference-pulsar-admin.md
@@ -430,7 +430,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.4.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.4.0/reference-pulsar-admin.md
@@ -430,7 +430,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.4.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.4.1/reference-pulsar-admin.md
@@ -434,7 +434,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.4.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.4.2/reference-pulsar-admin.md
@@ -434,7 +434,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.5.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.5.0/reference-pulsar-admin.md
@@ -451,7 +451,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.5.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.5.1/reference-pulsar-admin.md
@@ -451,7 +451,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||

--- a/site2/website/versioned_docs/version-2.5.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.5.2/reference-pulsar-admin.md
@@ -451,7 +451,7 @@ Options
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
-|`--state-storage-service-url`|The URL for the state storage service (by default Apache BookKeeper)||
+|`--state-storage-service-url`|The URL for the state storage service. By default, it it set to the service URL of the Apache BookKeeper. This service URL must be added manually when the Pulsar Function runs locally.||
 |`--tenant`|The function’s tenant||
 |`--topics-pattern`|The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)||
 |`--user-config`|User-defined config key/values||


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/6215


### Motivation

Function localrun deployment cannot store state because the --state_storage_serviceurl should be manually set when Function runs locally.


### Modifications

Add a note in the flag --state_storage_serviceurl  of the localrun deployment of Function.

Updated releases: master, releases 2.5.2--2.3.0.


