### PR TITLE
[website] Update helm documentation to use the published helm chart

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -52,6 +52,16 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 ## Step 1: Install Pulsar Helm chart
 
+0. Add Pulsar charts repo.
+
+    ```bash
+    helm repo add apache https://pulsar.apache.org/charts
+    ```
+
+    ```bash
+    helm repo update
+    ```
+
 1. Clone the Pulsar Helm chart repository.
 
     ```bash
@@ -73,7 +83,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
-        pulsar-mini charts/pulsar
+        pulsar-mini apache/pulsar
     ```
 
 4. Check the status of all pods.

--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -344,9 +344,9 @@ Once you have finished the following three things, you can install a Helm releas
 In this example, we name our Helm release `pulsar`.
 
 ```bash
-git clone https://github.com/apache/pulsar-helm-chart
-cd pulsar-helm-chart
-helm upgrade --install pulsar charts/pulsar \
+helm repo add apache https://pulsar.apache.org/charts
+helm repo update
+helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```

--- a/site2/docs/helm-overview.md
+++ b/site2/docs/helm-overview.md
@@ -73,10 +73,10 @@ If you deploy a PoC for testing, we strongly suggest you follow our [Quick Start
 Once the Pulsar Helm chart is installed, use the `helm upgrade` to complete configuration changes and chart updates.
 
 ```bash
-git clone https://github.com/apache/pulsar-helm-chart
-cd pulsar-helm-chart
+helm repo add apache https://pulsar.apache.org/charts
+helm repo update
 helm get values <pulsar-release-name> > pulsar.yaml
-helm upgrade <pulsar-release-name> charts/pulsar -f pulsar.yaml
+helm upgrade <pulsar-release-name> apache/pulsar -f pulsar.yaml
 ```
 
 For more detailed information, see [Upgrading](helm-upgrade.md).

--- a/site2/docs/helm-upgrade.md
+++ b/site2/docs/helm-upgrade.md
@@ -11,7 +11,7 @@ We also recommend that you need to provide all values using the `helm upgrade --
 > #### Note
 >
 > You can retrieve your previous `--set` arguments cleanly, with `helm get values <release-name>`. If you direct this into a file (`helm get values <release-name> > pulsar.yml`), you can safely
-pass this file through `-f`. Thus `helm upgrade <release-name> charts/pulsar -f pulsar.yaml`. This safely replaces the behavior of `--reuse-values`.
+pass this file through `-f`. Thus `helm upgrade <release-name> apache/pulsar -f pulsar.yaml`. This safely replaces the behavior of `--reuse-values`.
 
 ## Steps
 
@@ -26,7 +26,7 @@ To upgrade Apache Pulsar to a newer version, follow these steps:
 4. Decide all the values you need to set.
 5. Perform the upgrade, with all `--set` arguments extracted in step 4.
     ```bash
-    helm upgrade <release-name> charts/pulsar \
+    helm upgrade <release-name> apache/pulsar \
         --version <new version> \
         -f pulsar.yaml \
         --set ...

--- a/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
@@ -53,6 +53,16 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 ## Step 1: Install Pulsar Helm chart
 
+0. Add Pulsar charts repo.
+
+    ```bash
+    helm repo add apache https://pulsar.apache.org/charts
+    ```
+
+    ```bash
+    helm repo update
+    ```
+
 1. Clone the Pulsar Helm chart repository.
 
     ```bash
@@ -74,7 +84,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
-        pulsar-mini charts/pulsar
+        pulsar-mini apache/pulsar
     ```
 
 4. Check the status of all pods.

--- a/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
@@ -345,9 +345,9 @@ Once you have finished the following three things, you can install a Helm releas
 In this example, we name our Helm release `pulsar`.
 
 ```bash
-git clone https://github.com/apache/pulsar-helm-chart
-cd pulsar-helm-chart
-helm upgrade --install pulsar charts/pulsar \
+helm repo add apache https://pulsar.apache.org/charts
+helm repo update
+helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```

--- a/site2/website/versioned_docs/version-2.6.0/helm-overview.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-overview.md
@@ -75,10 +75,10 @@ If you deploy a PoC for testing, we strongly suggest you follow our [Quick Start
 Once the Pulsar Helm chart is installed, use the `helm upgrade` to complete configuration changes and chart updates.
 
 ```bash
-git clone https://github.com/apache/pulsar-helm-chart
-cd pulsar-helm-chart
+helm repo add apache https://pulsar.apache.org/charts
+helm repo update
 helm get values <pulsar-release-name> > pulsar.yaml
-helm upgrade <pulsar-release-name> charts/pulsar -f pulsar.yaml
+helm upgrade <pulsar-release-name> apache/pulsar -f pulsar.yaml
 ```
 
 For more detailed information, see [Upgrading](helm-upgrade.md).

--- a/site2/website/versioned_docs/version-2.6.0/helm-upgrade.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-upgrade.md
@@ -12,7 +12,7 @@ We also recommend that you need to provide all values using the `helm upgrade --
 > #### Note
 >
 > You can retrieve your previous `--set` arguments cleanly, with `helm get values <release-name>`. If you direct this into a file (`helm get values <release-name> > pulsar.yml`), you can safely
-pass this file through `-f`. Thus `helm upgrade <release-name> charts/pulsar -f pulsar.yaml`. This safely replaces the behavior of `--reuse-values`.
+pass this file through `-f`. Thus `helm upgrade <release-name> apache/pulsar -f pulsar.yaml`. This safely replaces the behavior of `--reuse-values`.
 
 ## Steps
 
@@ -27,7 +27,7 @@ To upgrade Apache Pulsar to a newer version, follow these steps:
 4. Decide all the values you need to set.
 5. Perform the upgrade, with all `--set` arguments extracted in step 4.
     ```bash
-    helm upgrade <release-name> charts/pulsar \
+    helm upgrade <release-name> apache/pulsar \
         --version <new version> \
         -f pulsar.yaml \
         --set ...


### PR DESCRIPTION
*Motivation*

We have published the helm chart to https://pulsar.apache.org/charts. Change the documentation to use the officially published charts.

