### PR TITLE
 [Doc]--Set partition key for message when using function publish

### DIFF
--- a/site2/website/versioned_docs/version-2.4.0/functions-api.md
+++ b/site2/website/versioned_docs/version-2.4.0/functions-api.md
@@ -110,6 +110,7 @@ Both the [Java](#java-sdk-functions) and [Python](#python-sdk-functions) SDKs pr
 
 * The name and ID of the Pulsar Function
 * The message ID of each message. Each Pulsar message is automatically assigned an ID.
+* The key, event time, properties and partition key of each message
 * The name of the topic on which the message was sent
 * The names of all input topics as well as the output topic associated with the function
 * The name of the class used for [SerDe](#serialization-and-deserialization-serde)
@@ -120,6 +121,8 @@ Both the [Java](#java-sdk-functions) and [Python](#python-sdk-functions) SDKs pr
 * Access to arbitrary [user config](#user-config) values supplied via the CLI
 * An interface for recording [metrics](functions-metrics.md)
 * An interface for storing and retrieving state in [state storage](functions-overview.md#state-storage)
+* A function to publish new messages onto arbitrary topics.
+* A function to acknowledge the message being processed (if auto-acknowledgement is disabled).
 
 ### User config
 
@@ -573,6 +576,9 @@ The [`Context`](https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/p
 Method | What it provides
 :------|:----------------
 `get_message_id` | The message ID of the message being processed
+`get_message_key` | The key of the message being processed
+`get_message_eventtime` | The event time of the message being processed
+`get_message_properties` | The properties of the message being processed
 `get_current_message_topic_name` | The topic of the message being currently being processed
 `get_function_tenant` | The tenant under which the current Pulsar Function runs under
 `get_function_namespace` | The namespace under which the current Pulsar Function runs under
@@ -583,10 +589,17 @@ Method | What it provides
 `get_logger` | A logger object that can be used for [logging](#python-logging)
 `get_user_config_value` | Returns the value of a [user-defined config](#python-user-config) (or `None` if the config doesn't exist)
 `get_user_config_map` | Returns the entire user-defined config as a dict
+`get_secret` | The secret value associated with the name
+`get_partition_key` | The partition key of the input message
 `record_metric` | Records a per-key [metric](#python-metrics)
 `publish` | Publishes a message to the specified Pulsar topic
 `get_output_serde_class_name` | The name of the output [SerDe](#python-serde) class
 `ack` | [Acks](reference-terminology.md#acknowledgment-ack) the message being processed to Pulsar
+`incr_counter` | Increase the counter of a given key in the managed state
+`get_counter` | Get the counter of a given key in the managed state
+`del_counter` | Delete the counter of a given key in the managed state
+`put_state` | Update the value of a given key in the managed state
+`get_state` | Get the value of a given key in the managed state
 
 ### Python SerDe
 


### PR DESCRIPTION
### Motivation

Pulsar release 2.4.0 supports setting partition key for messages when using function publish, as described in this PR: https://github.com/apache/pulsar/pull/4005

The code is updated but the doc is not updated accordingly.


### Modifications

1: Update the doc based on the code updated.
2: also add some legacy missing methods in the context class of the python functions according to the code.
3: This update is only for Pulsar 2.4.0 release. No need to update docs in 2.4.1 and later releases as these docs have been updated.

