### PR TITLE
[pulsar-client-cpp] Add MessageId to send Message

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -104,6 +104,12 @@ class PULSAR_PUBLIC Message {
     const MessageId& getMessageId() const;
 
     /**
+     * Set the unique message ID.
+     *
+     */
+    void setMessageId(const MessageId& messageID) const;
+
+    /**
      * Get the partition key for this message
      * @return key string that is hashed to determine message's topic partition
      */

--- a/pulsar-client-cpp/lib/Message.cc
+++ b/pulsar-client-cpp/lib/Message.cc
@@ -96,6 +96,13 @@ const MessageId& Message::getMessageId() const {
     }
 }
 
+void Message::setMessageId(const MessageId& messageID) const {
+    if (impl_) {
+        impl_->messageId = messageID;
+    }
+    return;
+}
+
 bool Message::hasPartitionKey() const {
     if (impl_) {
         return impl_->hasPartitionKey();

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -44,6 +44,8 @@ Result Producer::send(const Message& msg) {
 
     MessageId mi;
     Result result = promise.getFuture().get(mi);
+    msg.setMessageId(mi);
+
     return result;
 }
 

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -268,8 +268,10 @@ TEST(BasicEndToEndTest, testProduceConsume) {
     // Send synchronously
     std::string content = "msg-1-content";
     Message msg = MessageBuilder().setContent(content).build();
+    ASSERT_EQ(MessageId(-1, -1, -1, -1), msg.getMessageId());
     result = producer.send(msg);
     ASSERT_EQ(ResultOk, result);
+    ASSERT_NE(MessageId(-1, -1, -1, -1), msg.getMessageId());
 
     Message receivedMsg;
     consumer.receive(receivedMsg);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-node/issues/94

### Motivation
We want to return MessageId at Producer.send in pulsar-client-node. It use Producer::send internally but send method can't return MessageId(sendAsync was already implemented in https://github.com/apache/pulsar/pull/4811).

### Modifications
Add MessageId to Message instance of Producer::send argument.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Check MessageId at E2E test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
