### PR TITLE
[broker] Consumer is registered on dispatcher even if hash range conflicts on Key_Shared subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -155,8 +155,6 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
             throw new ConsumerBusyException("Subscription reached max consumers limit");
         }
 
-        consumers.add(consumer);
-
         if (subscriptionType == SubType.Exclusive
                 && consumer.getKeySharedMeta() != null
                 && consumer.getKeySharedMeta().getHashRangesList() != null
@@ -167,6 +165,8 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         } else {
             isKeyHashRangeFiltered = false;
         }
+
+        consumers.add(consumer);
 
         if (!pickAndScheduleActiveConsumer()) {
             // the active consumer is not changed

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
@@ -47,7 +47,13 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
     @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
         super.addConsumer(consumer);
-        selector.addConsumer(consumer);
+        try {
+            selector.addConsumer(consumer);
+        } catch (BrokerServiceException e) {
+            consumerSet.removeAll(consumer);
+            consumerList.remove(consumer);
+            throw e;
+        }
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -93,7 +93,13 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
         super.addConsumer(consumer);
-        selector.addConsumer(consumer);
+        try {
+            selector.addConsumer(consumer);
+        } catch (BrokerServiceException e) {
+            consumerSet.removeAll(consumer);
+            consumerList.remove(consumer);
+            throw e;
+        }
 
         // If this was the 1st consumer, or if all the messages are already acked, then we
         // don't need to do anything special

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -658,7 +658,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     @Test
     public void testHashRangeConflict() throws PulsarClientException {
         this.conf.setSubscriptionKeySharedEnable(true);
-        final String topic = "testHashRangeConflict-" + UUID.randomUUID().toString();
+        final String topic = "persistent://public/default/testHashRangeConflict-" + UUID.randomUUID().toString();
         final String sub = "test";
 
         Consumer<String> consumer1 = createFixedHashRangesConsumer(topic, sub, Range.of(0,99), Range.of(400, 65535));
@@ -666,6 +666,10 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         Consumer<String> consumer2 = createFixedHashRangesConsumer(topic, sub, Range.of(100,399));
         Assert.assertTrue(consumer2.isConnected());
+
+        PersistentStickyKeyDispatcherMultipleConsumers dispatcher = (PersistentStickyKeyDispatcherMultipleConsumers) pulsar
+                .getBrokerService().getTopicReference(topic).get().getSubscription(sub).getDispatcher();
+        Assert.assertEquals(dispatcher.getConsumers().size(), 2);
 
         try {
             createFixedHashRangesConsumer(topic, sub, Range.of(0, 65535));
@@ -679,7 +683,9 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         } catch (PulsarClientException.ConsumerAssignException ignore) {
         }
 
+        Assert.assertEquals(dispatcher.getConsumers().size(), 2);
         consumer1.close();
+        Assert.assertEquals(dispatcher.getConsumers().size(), 1);
 
         try {
             createFixedHashRangesConsumer(topic, sub, Range.of(0, 65535));
@@ -705,9 +711,11 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Consumer<String> consumer4 = createFixedHashRangesConsumer(topic, sub, Range.of(50,99));
         Assert.assertTrue(consumer4.isConnected());
 
+        Assert.assertEquals(dispatcher.getConsumers().size(), 3);
         consumer2.close();
         consumer3.close();
         consumer4.close();
+        Assert.assertFalse(dispatcher.isConsumerConnected());
     }
 
     private Consumer<String> createFixedHashRangesConsumer(String topic, String subscription, Range... ranges) throws PulsarClientException {


### PR DESCRIPTION
### Motivation

If hash ranges specified by multiple consumers conflict on a Key_Shared subscription, the consumer that connects later will fail to subscribe. When this happens, the consumer that should have failed to subscribe is added to the topic stats. These "non-existent" consumers will not disappear until the broker server is restarted.

When the hash ranges conflict, an exception is thrown from `HashRangeExclusiveStickyKeyConsumerSelector#addConsumer()`. However, at that time, the addition of the consumer to `consumerList` and `consumerSet` of the dispatcher has already been completed, and it will not be removed.
https://github.com/apache/pulsar/blob/1bdfc0dedfba5507dad57af56a3dc56737195383/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L94-L96

### Modifications

If an exception is thrown from `HashRangeExclusiveStickyKeyConsumerSelector#addConsumer()`, remove the consumer added to `consumerList` and `consumerSet`.