### PR TITLE
[Issue 7445][Pulsar client] Avoid NPE on null payload

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -166,7 +166,9 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     public void updateNumMsgsReceived(Message<?> message) {
         if (message != null) {
             numMsgsReceived.increment();
-            numBytesReceived.add(message.getData().length);
+            if(message.getData()!=null) {
+                numBytesReceived.add(message.getData().length);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #7445

### Motivation

https://github.com/apache/pulsar/commit/d55bc00f34a2fa763a3756fa0adbb1366ae319bd introduced the capacity to have a null payload to msg, but the ConsumerStatsRecorderImpl wasn't adapted so an NPE occurs when the payload is null.

### Modifications

ConsumerStatsRecorderImpl was modified to escape the case of null payload.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API:  no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no 

### Documentation

  - Does this pull request introduce a new feature? no
 