### PR TITLE
fix #6834:  add pulsar-client-messagecrypto-bc into pulsar-client dependency to avoid method not found

### DIFF
--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>pulsar-client-original</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-messagecrypto-bc</artifactId>
+      <version>${project.parent.version}</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Fixes #6834

### Motivation

`MessageCryptoBc` implements the interface of `MessageCrypto`. while `pulsar-client` did a shade to`ByteBuf`, and caused the method parameter changed from `org.apache.pulsar.shade.io.netty.buffer.ByteBuf` to `io.netty.buffer.ByteBuf` and will cause error of:
```
Caused by: java.lang.NoSuchMethodError: 'org.apache.pulsar.shade.io.netty.buffer.ByteBuf org.apache.pulsar.client.api.MessageCrypto.encrypt(java.util.Set, org.apache.pulsar.client.api.CryptoKeyReader, java.util.function.Supplier, org.apache.pulsar.shade.io.netty.buffer.ByteBuf)
```

### Modifications

add pulsar-client-messagecrypto-bc into pulsar-client dependency to avoid method-not-found issue.

