### PR TITLE
fix bookieMetadataServiceUri acquisition method

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1161,7 +1161,7 @@ public class PulsarService implements AutoCloseable {
         // init bookkeeper metadata service uri
         String metadataServiceUri = null;
         try {
-            String zkServers = config.getZookeeperServers();
+            String zkServers = config.getConfigurationStoreServers();
             bkConf.setZkServers(zkServers);
             metadataServiceUri = bkConf.getMetadataServiceUri();
         } catch (ConfigurationException e) {


### PR DESCRIPTION
Master Issue: #7457
## Motivation

when zookeeperServers and configurationStoreServers is different , the bookieMetadataServiceUri is incorrectly obtained 

## Modifications
BrokerService
```java
    public static String bookieMetadataServiceUri(ServiceConfiguration config) {
        ClientConfiguration bkConf = new ClientConfiguration();
        // init bookkeeper metadata service uri
        String metadataServiceUri = null;
        try {
            String zkServers = config.getConfigurationStoreServers();
            bkConf.setZkServers(zkServers);
            metadataServiceUri = bkConf.getMetadataServiceUri();
        } catch (ConfigurationException e) {
            LOG.error("Failed to get bookkeeper metadata service uri", e);
        }
        return metadataServiceUri;
    }
```
