### PR TITLE
[pulsar-broker] Broker handle back-pressure with max-pending message across topics to avoid OOM

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -305,6 +305,9 @@ maxConcurrentTopicLoadRequest=5000
 # Max concurrent non-persistent message can be processed per connection
 maxConcurrentNonPersistentMessagePerConnection=1000
 
+# Max number of concurrent pending published messages to control back-pressure across all topics on broker ((0 to disable it)
+maxConcurrentPendingPublishMessages=0
+
 # Number of worker threads to serve non-persistent topic
 numWorkerThreadsForNonPersistentTopic=8
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -208,6 +208,9 @@ maxConcurrentTopicLoadRequest=5000
 # Max concurrent non-persistent message can be processed per connection
 maxConcurrentNonPersistentMessagePerConnection=1000
 
+# Max number of concurrent pending published messages to control back-pressure across all topics on broker ((0 to disable it)
+maxConcurrentPendingPublishMessages=0
+
 # Number of worker threads to serve non-persistent topic
 numWorkerThreadsForNonPersistentTopic=8
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -602,6 +602,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Max concurrent non-persistent message can be processed per connection")
     private int maxConcurrentNonPersistentMessagePerConnection = 1000;
     @FieldContext(
+        dynamic = true,
+        category = CATEGORY_SERVER,
+        doc = "Max number of concurrent pending published messages to control backpressure across "
+                + "all topics on broker ((0 to disable it)"
+    )
+    private int maxConcurrentPendingPublishMessages = 0;
+    @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Number of worker threads to serve non-persistent topic")
     private int numWorkerThreadsForNonPersistentTopic = Runtime.getRuntime().availableProcessors();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -192,7 +192,7 @@ public abstract class MockedPulsarServiceBaseTest {
                 admin = null;
             }
             if (pulsarClient != null) {
-                pulsarClient.close();
+                pulsarClient.shutdown();
                 pulsarClient = null;
             }
             if (pulsar != null) {


### PR DESCRIPTION
### Motivation

We have seen multiple different scenarios when broker suddenly sees huge spike in heap-memory usage and consumes all allocated heap-memory and eventually it crashes with OOM. One of the scenarios for broker crashing with OOM is broker can't handle the back-pressure from bookie add-entry timeout. 
Broker limits max-pending messages per topic but it doesn't limit total number of pending messages across all topics. if broker is serving many topics with high publish rate and due to some reasons if broker started seeing add-entry timeout from bk-client then it allocates large number of non-recyclable objects which starts causing high GC and eventually it crashes with OOM. We saw many brokers crashed same time due to bk n/w partitioning/bk add-entry high add-latency. It can be easily reproducible by simulating bookie behavior which can cause`Bookie operation timeout` error at broker , and publish with 30K-40K rate with 1K topics.
Therefore, we need a mechanism to handle bookie back-pressure at broker by limiting number of pending messages across all topics in the broker.

Broker-Error: Add-entry timing out at bk-client
```
org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [prop/cluster/ns/persistent/t1] Created new ledger 123456
13:25:04.468 [BookKeeperClientWorker-OrderedExecutor-20-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (123456, 1): Bookie operation timeout
13:25:04.469 [BookKeeperClientWorker-OrderedExecutor-20-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (123456, 2): Bookie operation timeout
13:25:04.469 [BookKeeperClientWorker-OrderedExecutor-20-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (123456, 3): Bookie operation timeout
13:25:04.469 [BookKeeperClientWorker-OrderedExecutor-20-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (123456, 4): Bookie operation timeout
```
Broker sees sudden spike in heap memory usage and crashes
![Snip20200709_56](https://user-images.githubusercontent.com/2898254/87123893-7d0c3600-c23c-11ea-9172-55ccd78f8d64.png)

### Modification
- add configuration to restrict total pending publish messages across all topics in a broker: `maxConcurrentPendingPublishMessages`
- by default this feature will be disable with value =0 and will not change any existing behavior