### PR TITLE
The test should wait until the worker leader is ready, otherwise the request to create function will fail

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -293,6 +293,10 @@ public class PulsarFunctionE2ETest {
         });
         fileServerThread.start();
         latch.await(1, TimeUnit.SECONDS);
+
+        functionsWorkerService.getLeaderService().waitLeaderInit();
+
+
     }
 
     @AfterMethod
@@ -1493,8 +1497,6 @@ public class PulsarFunctionE2ETest {
 
     @Test(dataProvider = "validRoleName")
     public void testAuthorization(boolean validRoleName) throws Exception {
-        functionsWorkerService.getLeaderService().waitLeaderInit();
-
         final String namespacePortion = "io";
         final String replNamespace = tenant + "/" + namespacePortion;
         final String sinkTopic = "persistent://" + replNamespace + "/output";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -1493,6 +1493,7 @@ public class PulsarFunctionE2ETest {
 
     @Test(dataProvider = "validRoleName")
     public void testAuthorization(boolean validRoleName) throws Exception {
+        functionsWorkerService.getLeaderService().waitLeaderInit();
 
         final String namespacePortion = "io";
         final String replNamespace = tenant + "/" + namespacePortion;


### PR DESCRIPTION
### Motivation

The function test is failing if the request is being made while the leader is still initializing.