### PR TITLE
Fix: Race condition in updateFunctionOnLeader

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -208,6 +208,11 @@ public class WorkerService {
               functionMetaDataManager,
               errorNotifier);
 
+            // the metadata mananger needs to the leader service to make sure
+            // if worker is leader that it needs to be complete finished initializing to become leader
+            // before performing tasks like updateOnLeader
+            functionMetaDataManager.setLeaderService(leaderService);
+
             log.info("/** Start Leader Service **/");
             leaderService.start();
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1554,8 +1554,10 @@ public abstract class ComponentImpl {
             log.error(errorMsg, e);
             throw new RestException(e.getStatusCode(), e.getMessage());
         } catch (IllegalStateException e) {
+            log.error(errorMsg, e);
             throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
         } catch (IllegalArgumentException e) {
+            log.error(errorMsg, e);
             throw new RestException(Status.BAD_REQUEST, e.getMessage());
         }
     }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
@@ -118,17 +118,11 @@ public class FunctionMetaDataManagerTest {
                 new FunctionMetaDataManager(workerConfig,
                         mock(SchedulerManager.class),
                         mockPulsarClient(), ErrorNotifier.getDefaultImpl()));
+        functionMetaDataManager.setLeaderService(mock(LeaderService.class));
+
         Function.FunctionMetaData m1 = Function.FunctionMetaData.newBuilder()
                 .setVersion(1)
                 .setFunctionDetails(Function.FunctionDetails.newBuilder().setName("func-1")).build();
-
-        // update when you are not the leader
-        try {
-            functionMetaDataManager.updateFunctionOnLeader(m1, false);
-            Assert.assertTrue(false);
-        } catch (IllegalStateException e) {
-            Assert.assertEquals(e.getMessage(), "Not the leader");
-        }
 
         // become leader
         functionMetaDataManager.acquireLeadership();
@@ -176,18 +170,11 @@ public class FunctionMetaDataManagerTest {
                 new FunctionMetaDataManager(workerConfig,
                         mockedScheduler,
                         mockPulsarClient(), ErrorNotifier.getDefaultImpl()));
+        functionMetaDataManager.setLeaderService(mock(LeaderService.class));
         Function.FunctionMetaData m1 = Function.FunctionMetaData.newBuilder()
                 .setVersion(1)
                 .setFunctionDetails(Function.FunctionDetails.newBuilder().setName("func-1")
                         .setNamespace("namespace-1").setTenant("tenant-1")).build();
-
-        // Try deleting when you are not the leader
-        try {
-            functionMetaDataManager.updateFunctionOnLeader(m1, true);
-            Assert.assertTrue(false);
-        } catch (IllegalStateException e) {
-            Assert.assertEquals(e.getMessage(), "Not the leader");
-        }
 
         // become leader
         functionMetaDataManager.acquireLeadership();


### PR DESCRIPTION

### Motivation

Wait under worker is done with becoming leader routine before performing operations like updateFunctionOnLeader.

If we don't, a deadlock can happen :

Jetty - Create Request -> updateOnLeader (synchronized on FunctionMetadataManger) -> publish to metadata topic -> waitLeaderInit - > wait on tailer thread to close()

tailer thread -reads from metadata topic -> process update (synchronized on FunctionMetadataManger)


