### PR TITLE
Fix typo in replicationPolicyCheckDurationSeconds config var

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -937,7 +937,7 @@ replicatorPrefix=pulsar.repl
 
 # Duration to check replication policy to avoid replicator inconsistency
 # due to missing ZooKeeper watch (disable with value 0)
-replicatioPolicyCheckDurationSeconds=600
+replicationPolicyCheckDurationSeconds=600
 
 # Default message retention time
 defaultRetentionTimeInMinutes=0

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -684,7 +684,7 @@ replicationProducerQueueSize=1000
 
 # Duration to check replication policy to avoid replicator inconsistency
 # due to missing ZooKeeper watch (disable with value 0)
-replicatioPolicyCheckDurationSeconds=600
+replicationPolicyCheckDurationSeconds=600
 
 # Default message retention time
 defaultRetentionTimeInMinutes=0

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -552,7 +552,7 @@ The [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool can be used
 |replicationMetricsEnabled|   |true|
 |replicationConnectionsPerBroker|   |16|
 |replicationProducerQueueSize|    |1000|
-| replicatioPolicyCheckDurationSeconds | Duration to check replication policy to avoid replicator inconsistency due to missing ZooKeeper watch. When the value is set to 0, disable checking replication policy. | 600 |
+| replicationPolicyCheckDurationSeconds | Duration to check replication policy to avoid replicator inconsistency due to missing ZooKeeper watch. When the value is set to 0, disable checking replication policy. | 600 |
 |defaultRetentionTimeInMinutes|   |0|
 |defaultRetentionSizeInMB|    |0|
 |keepAliveIntervalSeconds|    |30|


### PR DESCRIPTION
### Motivation

To fix typo in default configuration.

### Modifications

Change "replicatioPolicyCheckDurationSeconds" to "replicatio**n**PolicyCheckDurationSeconds."