### PR TITLE
Add support for partitioned tables

### DIFF
--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
@@ -98,7 +98,7 @@ public class JdbcUtils {
      */
     public static TableId getTableId(Connection connection, String tableName) throws Exception {
         DatabaseMetaData metadata = connection.getMetaData();
-        try (ResultSet rs = metadata.getTables(null, null, tableName, new String[]{"TABLE"})) {
+        try (ResultSet rs = metadata.getTables(null, null, tableName, new String[]{"TABLE","PARTITIONED TABLE"})) {
             if (rs.next()) {
                 String catalogName = rs.getString(1);
                 String schemaName = rs.getString(2);


### PR DESCRIPTION
### Motivation
Databases like PostgreSQL support table partitioning which will
cause the table not to be found in getTableId for jdbc sink/sources.

### Modifications

Adding "PARTITIONED TABLE" to the types passed to getTables fixes this.

### Verifying this change

Unfortunately the test suite doesn't pass for me even before this change,
but I ran the following after re-building the connector and no longer get
the table not found message.

```bin/pulsar-admin sinks create --tenant mytenant--namespace mynamespace --name mysink --archive ./connectors/pulsar-io-jdbc-postgres-2.6.0.nar --inputs mytopic --sink-config-file ./connectors/postgres.yaml --processingGuarantees EFFECTIVELY_ONCE --parallelism 1```

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
Supporting partitioned tables shouldn't have to be specifically mentioned in documentation
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
