### PR TITLE
Update Jackson to 2.11.1 and ensure all dependencies are pinned

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,14 +312,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.48.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.7.3.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.10.1.jar
-     - com.fasterxml.jackson.core-jackson-core-2.10.1.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.10.1.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.10.1.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.10.1.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.10.1.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.10.1.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.10.1.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.11.1.jar
+     - com.fasterxml.jackson.core-jackson-core-2.11.1.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.11.1.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.11.1.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.11.1.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.11.1.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.11.1.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.11.1.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
  * Gson -- com.google.code.gson-gson-2.8.2.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -431,7 +431,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-common-9.4.29.v20200521.jar
     - org.eclipse.jetty.websocket-websocket-server-9.4.29.v20200521.jar
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.29.v20200521.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.24.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * HttpClient
     - org.apache.httpcomponents-httpclient-4.5.5.jar

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -28,32 +28,14 @@
     <version>2.7.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.pulsar.examples</groupId>
   <artifactId>spark</artifactId>
   <name>Pulsar Examples :: Spark</name>
-
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <jaskson.version>2.6.5</jaskson.version>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jaskson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jaskson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jaskson.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.10.1</jackson.version>
-    <jackson.databind.version>2.10.1</jackson.databind.version>
+    <jackson.version>2.11.1</jackson.version>
+    <jackson.databind.version>2.11.1</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.5.21</swagger.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
@@ -745,6 +745,30 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.10</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.11</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-paranamer</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-parameter-names</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson.version}</version>
       </dependency>
@@ -768,8 +792,38 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-csv</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-cbor</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-smile</artifactId>
         <version>${jackson.version}</version>
       </dependency>
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.util.EnumResolver;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -56,6 +58,8 @@ public final class FieldParser {
 
     private static final Map<String, Method> CONVERTERS = new HashMap<>();
     private static final Map<Class<?>, Class<?>> WRAPPER_TYPES = new HashMap<>();
+
+    private static final AnnotationIntrospector ANNOTATION_INTROSPECTOR = new JacksonAnnotationIntrospector();
 
     static {
         // Preload converters and wrapperTypes.
@@ -97,7 +101,7 @@ public final class FieldParser {
 
         if (to.isEnum()) {
             // Converting string to enum
-            EnumResolver r = EnumResolver.constructUsingToString((Class<Enum<?>>) to, null);
+            EnumResolver r = EnumResolver.constructUsingToString((Class<Enum<?>>) to, ANNOTATION_INTROSPECTOR);
             T value = (T) r.findEnum((String) from);
             if (value == null) {
                 throw new RuntimeException("Invalid value '" + from + "' for enum " + to);

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -35,7 +35,7 @@
         <jackson.version>2.8.11</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.4</jackson.databind.version>
+        <jackson.databind.version>2.8.11.6</jackson.databind.version>
     </properties>
 
     <modules>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -31,13 +31,6 @@
     <artifactId>pulsar-sql</artifactId>
     <name>Pulsar SQL :: Parent</name>
 
-    <properties>
-        <jackson.version>2.8.11</jackson.version>
-        <!--fix Security Vulnerabilities-->
-        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.6</jackson.databind.version>
-    </properties>
-
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -210,14 +210,20 @@ The Apache Software License, Version 2.0
     - jackson-annotations-2.8.11.jar
     - jackson-core-2.8.11.jar
     - jackson-databind-2.8.11.6.jar
-    - jackson-dataformat-smile-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar
-    - jackson-datatype-guava-2.8.11.jar
-    - jackson-datatype-jdk8-2.8.11.jar
     - jackson-datatype-jdk8-2.8.11.jar
     - jackson-datatype-joda-2.8.11.jar
     - jackson-datatype-jsr310-2.8.11.jar
     - jackson-dataformat-yaml-2.8.11.jar
+    - jackson-annotations-2.11.1.jar
+    - jackson-core-2.11.1.jar
+    - jackson-databind-2.11.1.6.jar
+    - jackson-dataformat-smile-2.11.1.jar
+    - jackson-datatype-guava-2.11.1.jar
+    - jackson-datatype-jdk8-2.11.1.jar
+    - jackson-datatype-joda-2.11.1.jar
+    - jackson-datatype-jsr310-2.11.1.jar
+    - jackson-dataformat-yaml-2.11.1.jar
  * Guava
     - guava-25.1-jre.jar
  * Google Guice
@@ -394,6 +400,7 @@ The Apache Software License, Version 2.0
     - rocksdbjni-5.13.3.jar
   * SnakeYAML
     - snakeyaml-1.17.jar
+    - snakeyaml-1.26.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -209,7 +209,7 @@ The Apache Software License, Version 2.0
   * Jackson
     - jackson-annotations-2.8.11.jar
     - jackson-core-2.8.11.jar
-    - jackson-databind-2.8.11.4.jar
+    - jackson-databind-2.8.11.6.jar
     - jackson-dataformat-smile-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar
     - jackson-datatype-guava-2.8.11.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,23 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.8.11.jar
-    - jackson-core-2.8.11.jar
-    - jackson-databind-2.8.11.6.jar
-    - jackson-datatype-guava-2.8.11.jar
-    - jackson-datatype-jdk8-2.8.11.jar
-    - jackson-datatype-joda-2.8.11.jar
-    - jackson-datatype-jsr310-2.8.11.jar
-    - jackson-dataformat-yaml-2.8.11.jar
     - jackson-annotations-2.11.1.jar
     - jackson-core-2.11.1.jar
-    - jackson-databind-2.11.1.6.jar
+    - jackson-databind-2.11.1.jar
     - jackson-dataformat-smile-2.11.1.jar
     - jackson-datatype-guava-2.11.1.jar
     - jackson-datatype-jdk8-2.11.1.jar
     - jackson-datatype-joda-2.11.1.jar
     - jackson-datatype-jsr310-2.11.1.jar
     - jackson-dataformat-yaml-2.11.1.jar
+    - jackson-jaxrs-base-2.11.1.jar
+    - jackson-jaxrs-json-provider-2.11.1.jar
+    - jackson-module-jaxb-annotations-2.11.1.jar
+    - jackson-module-jsonSchema-2.11.1.jar
  * Guava
     - guava-25.1-jre.jar
  * Google Guice
@@ -399,7 +395,6 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-5.13.3.jar
   * SnakeYAML
-    - snakeyaml-1.17.jar
     - snakeyaml-1.26.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
@@ -442,10 +437,6 @@ The Apache Software License, Version 2.0
   * GSON
     - gson-2.8.2.jar
   * Jackson
-    - jackson-jaxrs-base-2.8.11.jar
-    - jackson-jaxrs-json-provider-2.8.11.jar
-    - jackson-module-jaxb-annotations-2.8.11.jar
-    - jackson-module-jsonSchema-2.8.11.jar
     - jackson-module-parameter-names-2.10.0.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
@@ -522,6 +513,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - javax.annotation-api-1.3.2.jar
    - javax.activation-1.2.0.jar
    - javax.activation-api-1.2.0.jar
+   - jakarta.activation-api-1.2.1.jar
  * HK2 - Dependency Injection Kernel
    - hk2-api-2.5.0-b42.jar
    - hk2-locator-2.5.0-b42.jar
@@ -555,6 +547,8 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - logback-core-1.2.3.jar
   * MIME Streaming Extension
     - mimepull-1.9.6.jar
+  * XML Bind API
+    - jakarta.xml.bind-api-2.3.2.jar
 
 Public Domain (CC0) -- licenses/LICENSE-CC0.txt
  * HdrHistogram

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -42,10 +42,10 @@
         <!-- Launcher properties -->
         <main-class>io.prestosql.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.11.1</jackson.version>
         <!--fix Security Vulnerabilities-->
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.8.11.4</jackson.databind.version>
+        <jackson.databind.version>2.11.1</jackson.databind.version>
         <com.ning.async.http.client.version>1.9.40</com.ning.async.http.client.version>
         <maven.version>3.0.5</maven.version>
         <guava.version>25.1-jre</guava.version>


### PR DESCRIPTION
### Motivation

There are several CVEs opened on earlier versions of Jackson, updating to latest stable.

Additionally, we are not pinning the version on all the transitive dependencies and thus picking older versions for them.