### PR TITLE
Fix topic getting recreated immediately after deletion

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
@@ -79,7 +80,7 @@ public class TopicLookupBase extends PulsarWebResource {
         }
 
         CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                .getBrokerServiceUrlAsync(topicName, authoritative);
+                .getBrokerServiceUrlAsync(topicName, LookupOptions.builder().authoritative(authoritative).loadTopicsInBundle(false).build());
 
         lookupFuture.thenAccept(optionalResult -> {
             if (optionalResult == null || !optionalResult.isPresent()) {
@@ -251,7 +252,12 @@ public class TopicLookupBase extends PulsarWebResource {
             if (validationFailureResponse != null) {
                 lookupfuture.complete(validationFailureResponse);
             } else {
-                pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topicName, authoritative, advertisedListenerName)
+                LookupOptions options = LookupOptions.builder()
+                        .authoritative(authoritative)
+                        .advertisedListenerName(advertisedListenerName)
+                        .loadTopicsInBundle(true)
+                        .build();
+                pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topicName, options)
                         .thenAccept(lookupResult -> {
 
                             if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/LookupOptions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/LookupOptions.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import lombok.Builder;
+import lombok.Data;
+
+import org.apache.commons.lang3.StringUtils;
+
+@Data
+@Builder
+public class LookupOptions {
+    /**
+     * If authoritative, it means the lookup had already been redirected here by a different broker
+     */
+    private final boolean authoritative;
+
+    /**
+     * If read-only, do not attempt to acquire ownership
+     */
+    private final boolean readOnly;
+
+    /**
+     * After acquiring the ownership, load all the topics
+     */
+    private final boolean loadTopicsInBundle;
+
+    /**
+     * The lookup request was made through HTTPs
+     */
+    private final boolean requestHttps;
+
+    private final String advertisedListenerName;
+
+    public boolean hasAdvertisedListenerName() {
+        return StringUtils.isNotBlank(advertisedListenerName);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -172,15 +172,9 @@ public class NamespaceService {
         }
     }
 
-    public CompletableFuture<Optional<LookupResult>> getBrokerServiceUrlAsync(TopicName topic,
-            boolean authoritative) {
-        return getBrokerServiceUrlAsync(topic, authoritative, null);
-    }
-
-    public CompletableFuture<Optional<LookupResult>> getBrokerServiceUrlAsync(TopicName topic, boolean authoritative,
-                                                                              final String advertisedListenerName) {
+    public CompletableFuture<Optional<LookupResult>> getBrokerServiceUrlAsync(TopicName topic, LookupOptions options) {
         return getBundleAsync(topic)
-                .thenCompose(bundle -> findBrokerServiceUrl(bundle, authoritative, false /* read-only */, advertisedListenerName));
+                .thenCompose(bundle -> findBrokerServiceUrl(bundle, options));
     }
 
     public CompletableFuture<NamespaceBundle> getBundleAsync(TopicName topic) {
@@ -210,38 +204,36 @@ public class NamespaceService {
      *
      * If the service unit is not owned, return an empty optional
      */
-    public Optional<URL> getWebServiceUrl(ServiceUnitId suName, boolean authoritative, boolean isRequestHttps,
-            boolean readOnly) throws Exception {
+    public Optional<URL> getWebServiceUrl(ServiceUnitId suName, LookupOptions options) throws Exception {
         if (suName instanceof TopicName) {
             TopicName name = (TopicName) suName;
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Getting web service URL of topic: {} - auth: {}", name, authoritative);
+                LOG.debug("Getting web service URL of topic: {} - options: {}", name, options);
             }
-            return this.internalGetWebServiceUrl(getBundle(name), authoritative, isRequestHttps, readOnly)
+            return this.internalGetWebServiceUrl(getBundle(name), options)
                     .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
         }
 
         if (suName instanceof NamespaceName) {
-            return this.internalGetWebServiceUrl(getFullBundle((NamespaceName) suName), authoritative, isRequestHttps,
-                    readOnly).get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+            return this.internalGetWebServiceUrl(getFullBundle((NamespaceName) suName), options)
+                    .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
         }
 
         if (suName instanceof NamespaceBundle) {
-            return this.internalGetWebServiceUrl((NamespaceBundle) suName, authoritative, isRequestHttps, readOnly)
+            return this.internalGetWebServiceUrl((NamespaceBundle) suName, options)
                     .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
         }
 
         throw new IllegalArgumentException("Unrecognized class of NamespaceBundle: " + suName.getClass().getName());
     }
 
-    private CompletableFuture<Optional<URL>> internalGetWebServiceUrl(NamespaceBundle bundle, boolean authoritative,
-            boolean isRequestHttps, boolean readOnly) {
+    private CompletableFuture<Optional<URL>> internalGetWebServiceUrl(NamespaceBundle bundle, LookupOptions options) {
 
-        return findBrokerServiceUrl(bundle, authoritative, readOnly).thenApply(lookupResult -> {
+        return findBrokerServiceUrl(bundle, options).thenApply(lookupResult -> {
             if (lookupResult.isPresent()) {
                 try {
                     LookupData lookupData = lookupResult.get().getLookupData();
-                    final String redirectUrl = isRequestHttps ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
+                    final String redirectUrl = options.isRequestHttps() ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
                     return Optional.of(new URL(redirectUrl));
                 } catch (Exception e) {
                     // just log the exception, nothing else to do
@@ -329,19 +321,6 @@ public class NamespaceService {
         = new ConcurrentOpenHashMap<>();
 
     /**
-     * Main internal method to lookup and setup ownership of service unit to a broker.
-     *
-     * @param bundle
-     * @param authoritative
-     * @param readOnly
-     * @return
-     */
-    private CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(NamespaceBundle bundle, boolean authoritative,
-                                                                           boolean readOnly) {
-        return findBrokerServiceUrl(bundle, authoritative, readOnly, null);
-    }
-
-    /**
      * Main internal method to lookup and setup ownership of service unit to a broker
      *
      * @param bundle
@@ -351,14 +330,13 @@ public class NamespaceService {
      * @return
      * @throws PulsarServerException
      */
-    private CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(NamespaceBundle bundle, boolean authoritative,
-            boolean readOnly, final String advertisedListenerName) {
+    private CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(NamespaceBundle bundle, LookupOptions options) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("findBrokerServiceUrl: {} - read-only: {}", bundle, readOnly);
+            LOG.debug("findBrokerServiceUrl: {} - options: {}", bundle, options);
         }
 
         ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
-        if (authoritative) {
+        if (options.isAuthoritative()) {
             targetMap = findingBundlesAuthoritative;
         } else {
             targetMap = findingBundlesNotAuthoritative;
@@ -372,13 +350,13 @@ public class NamespaceService {
                 if (!nsData.isPresent()) {
                     // No one owns this bundle
 
-                    if (readOnly) {
+                    if (options.isReadOnly()) {
                         // Do not attempt to acquire ownership
                         future.complete(Optional.empty());
                     } else {
                         // Now, no one owns the namespace yet. Hence, we will try to dynamically assign it
                         pulsar.getExecutor().execute(() -> {
-                            searchForCandidateBroker(bundle, future, authoritative, advertisedListenerName);
+                            searchForCandidateBroker(bundle, future, options);
                         });
                     }
                 } else if (nsData.get().isDisabled()) {
@@ -389,11 +367,11 @@ public class NamespaceService {
                         LOG.debug("Namespace bundle {} already owned by {} ", bundle, nsData);
                     }
                     // find the target
-                    if (StringUtils.isNotBlank(advertisedListenerName)) {
-                        AdvertisedListener listener = nsData.get().getAdvertisedListeners().get(advertisedListenerName);
+                    if (options.hasAdvertisedListenerName()) {
+                        AdvertisedListener listener = nsData.get().getAdvertisedListeners().get(options.getAdvertisedListenerName());
                         if (listener == null) {
                             future.completeExceptionally(
-                                    new PulsarServerException("the broker do not have " + advertisedListenerName + " listener"));
+                                    new PulsarServerException("the broker do not have " + options.getAdvertisedListenerName() + " listener"));
                         } else {
                             future.complete(Optional.of(new LookupResult(nsData.get(),
                                     listener.getBrokerServiceUrl().toString(), listener.getBrokerServiceUrlTls().toString())));
@@ -418,13 +396,8 @@ public class NamespaceService {
     }
 
     private void searchForCandidateBroker(NamespaceBundle bundle,
-            CompletableFuture<Optional<LookupResult>> lookupFuture, boolean authoritative) {
-        searchForCandidateBroker(bundle, lookupFuture, authoritative, null);
-    }
-
-    private void searchForCandidateBroker(NamespaceBundle bundle,
-                                          CompletableFuture<Optional<LookupResult>> lookupFuture, boolean authoritative,
-                                          final String advertisedListenerName) {
+                                          CompletableFuture<Optional<LookupResult>> lookupFuture,
+                                          LookupOptions options) {
         String candidateBroker = null;
         boolean authoritativeRedirect = pulsar.getLeaderElectionService().isLeader();
 
@@ -440,7 +413,7 @@ public class NamespaceService {
             }
 
             if (candidateBroker == null) {
-                if (authoritative) {
+                if (options.isAuthoritative()) {
                     // leader broker already assigned the current broker as owner
                     candidateBroker = pulsar.getSafeWebServiceAddress();
                 } else if (!this.loadManager.get().isCentralized()
@@ -486,14 +459,16 @@ public class NamespaceService {
                     } else {
                         // Found owner for the namespace bundle
 
-                        // Schedule the task to pre-load topics
-                        pulsar.loadNamespaceTopics(bundle);
+                        if (options.isLoadTopicsInBundle()) {
+                            // Schedule the task to pre-load topics
+                            pulsar.loadNamespaceTopics(bundle);
+                        }
                         // find the target
-                        if (StringUtils.isNotBlank(advertisedListenerName)) {
-                            AdvertisedListener listener = ownerInfo.getAdvertisedListeners().get(advertisedListenerName);
+                        if (options.hasAdvertisedListenerName()) {
+                            AdvertisedListener listener = ownerInfo.getAdvertisedListeners().get(options.getAdvertisedListenerName());
                             if (listener == null) {
                                 lookupFuture.completeExceptionally(
-                                        new PulsarServerException("the broker do not have " + advertisedListenerName + " listener"));
+                                        new PulsarServerException("the broker do not have " + options.getAdvertisedListenerName() + " listener"));
                                 return;
                             } else {
                                 lookupFuture.complete(Optional.of(new LookupResult(ownerInfo, listener.getBrokerServiceUrl().toString(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTests.java
@@ -62,13 +62,13 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
         final AtomicBoolean onLoad = new AtomicBoolean(false);
         final AtomicBoolean unLoad = new AtomicBoolean(false);
 
-        final String namespace = "prop/ns-test-1";
+        final String namespace = "prop/" + UUID.randomUUID().toString();
 
         pulsar.getNamespaceService().addNamespaceBundleOwnershipListener(new NamespaceBundleOwnershipListener() {
 
             @Override
             public boolean test(NamespaceBundle namespaceBundle) {
-                return namespaceBundle.getNamespaceObject().getLocalName().equals("ns-test-1");
+                return namespaceBundle.getNamespaceObject().toString().equals(namespace);
             }
 
             @Override
@@ -95,7 +95,7 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
 
         producer.close();
 
-        admin.namespaces().unload("prop/ns-test-1");
+        admin.namespaces().unload(namespace);
 
         countDownLatch.await();
 


### PR DESCRIPTION
### Motivation

There is a bug in the delete topic procedure that can trigger the topic re-creation immediately after it gets deleted.

This can happen when the topic is not currently open. eg: 
 1. Request to delete the topic
 2. Namespace bundle is not owned
 3. Take ownership of bundle
 4. Start background loading of topics for the bundle
 5. Delete the topic

If (5) finishes before (4), then the the can recreate a new topic with the old name.

This bug is causing random failure on some of the tests like `NamespaceOwnershipListenerTests` where the namespace delete operation fails because "namespace is not empty" even though we just had deleted the only topic.

### Modifications

 * Pass a flag to avoid background topic loading for operations that just require to prove the ownership
 * Instead of passing N boolean flags, consolidated the args into a `LookupOptions` data class.
