### PR TITLE
When a function worker becomes the leader, start producer to assignment topic first before stopping the assignment tailer

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
@@ -95,14 +95,15 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
                 functionMetaDataManager.getIsInitialized().get();
                 functionRuntimeManager.getIsInitialized().get();
 
+                // make sure scheduler is initialized because this worker
+                // is the leader and may need to start computing and writing assignments
+                // also creates exclusive producer for assignment topic
+                schedulerManager.initialize();
+
                 // trigger read to the end of the topic and exit
                 // Since the leader can just update its in memory assignments cache directly
                 functionAssignmentTailer.triggerReadToTheEndAndExit().get();
                 functionAssignmentTailer.close();
-
-                // make sure scheduler is initialized because this worker
-                // is the leader and may need to start computing and writing assignments
-                schedulerManager.initialize();
 
                 // need to move function meta data manager into leader mode
                 functionMetaDataManager.acquireLeadership();


### PR DESCRIPTION

### Motivation

In the future after the exclusive producer feature is implemented, the function worker, when it becomes the leader, should start its exclusive producer to the assignment topic before it stops its assignment tailer.  This way we make sure no one else is producing to the assignment topic when trigger the assignment tailer to read to the end topic (get latest state) of the topic and exit.

