### PR TITLE
Fix: function BC issue introduced in 2.6

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -51,7 +51,7 @@ public class FunctionWorkerStarter {
 
         if (workerArguments.help) {
             commander.usage();
-            System.exit(-1);
+            System.exit(1);
             return;
         }
 
@@ -68,7 +68,7 @@ public class FunctionWorkerStarter {
         } catch (Throwable th) {
             log.error("Encountered error in function worker.", th);
             worker.stop();
-            System.exit(-1);
+            Runtime.getRuntime().halt(1);
         }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("Stopping function worker service...");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -63,18 +63,16 @@ public class FunctionWorkerStarter {
         }
 
         final Worker worker = new Worker(workerConfig);
-        
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            log.info("Stopping function worker service ..");
-            worker.stop();
-        }));
-
         try {
             worker.start();
         } catch (Throwable th) {
-            log.error("Encountered error in function worker", th);
+            log.error("Encountered error in function worker.", th);
             worker.stop();
             System.exit(-1);
         }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Stopping function worker service...");
+            worker.stop();
+        }));
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -63,15 +63,18 @@ public class FunctionWorkerStarter {
         }
 
         final Worker worker = new Worker(workerConfig);
-        try {
-            worker.start();
-        } catch (Throwable th) {
-            worker.stop();
-            System.exit(-1);
-        }
+        
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("Stopping function worker service ..");
             worker.stop();
         }));
+
+        try {
+            worker.start();
+        } catch (Throwable th) {
+            log.error("Encountered error in function worker", th);
+            worker.stop();
+            System.exit(-1);
+        }
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -157,9 +157,17 @@ public final class WorkerUtils {
 
     public static URI initializeDlogNamespace(InternalConfigurationData internalConf) throws IOException {
         String zookeeperServers = internalConf.getZookeeperServers();
-        URI metadataServiceUri = URI.create(internalConf.getBookkeeperMetadataServiceUri());
-        String ledgersStoreServers = metadataServiceUri.getAuthority().replace(";", ",");
-        String ledgersRootPath = metadataServiceUri.getPath();
+        String ledgersRootPath;
+        String ledgersStoreServers;
+        // for BC purposes
+        if (internalConf.getBookkeeperMetadataServiceUri() == null) {
+            ledgersRootPath = internalConf.getLedgersRootPath();
+            ledgersStoreServers = zookeeperServers;
+        } else {
+            URI metadataServiceUri = URI.create(internalConf.getBookkeeperMetadataServiceUri());
+            ledgersStoreServers = metadataServiceUri.getAuthority().replace(";", ",");
+            ledgersRootPath = metadataServiceUri.getPath();
+        }
         BKDLConfig dlConfig = new BKDLConfig(ledgersStoreServers, ledgersRootPath);
         DLMetadata dlMetadata = DLMetadata.create(dlConfig);
         URI dlogUri = URI.create(String.format("distributedlog://%s/pulsar/functions", zookeeperServers));


### PR DESCRIPTION

### Motivation

There was a backwards compatibility breakage introduced in:

https://github.com/apache/pulsar/pull/5985

If running function workers separately from brokers, updating workers and brokers independently from 2.5 to 2.6 will cause the following error:

`java.lang.NullPointerException: null\n\tat java.net.URI$Parser.parse(URI.java:3104) ~[?:?]\n\tat java.net.URI.<init>(URI.java:600) ~[?:?]\n\tat java.net.URI.create(URI.java:881) ~[?:?]\n\tat org.apache.pulsar.functions.worker.WorkerUtils.initializeDlogNamespace(WorkerUtils.java:160) ~[org.apache.pulsar-pulsar-functions-worker-2.7.0-SNAPSHOT.jar:2.7.0-SNAPSHOT]\n\tat org.apache.pulsar.functions.worker.Worker.initialize(Worker.java:155) ~[org.apache.pulsar-pulsar-functions-worker-2.7.0-SNAPSHOT.jar:2.7.0-SNAPSHOT]\n\tat org.apache.pulsar.functions.worker.Worker.start(Worker.java:69) ~[org.apache.pulsar-pulsar-functions-worker-2.7.0-SNAPSHOT.jar:2.7.0-SNAPSHOT]\n\tat org.apache.pulsar.functions.worker.FunctionWorkerStarter.main(FunctionWorkerStarter.java:67) [org.apache.pulsar-pulsar-functions-worker-2.7.0-SNAPSHOT.jar:2.7.0-SNAPSHOT]\n`

This is because a 2.5 broker will response will have "bookkeeperMetadataServiceUri" and the admin client will return the field as null:

`InternalConfigurationData{zookeeperServers=zookeeper-dev-0.zookeeper-dev:2181,zookeeper-dev-1.zookeeper-dev:2181,zookeeper-dev-2.zookeeper-dev:2181, configurationStoreServers=zookeeper-dev-0.zookeeper-dev:2181,zookeeper-dev-1.zookeeper-dev:2181,zookeeper-dev-2.zookeeper-dev:2181, ledgersRootPath=/ledgers, bookkeeperMetadataServiceUri=null, stateStorageServiceUrl=null}`

Thus causing the NPE.

Will also need a fix on the broker side for if broker was updated to 2.6 before the worker is.
