### PR TITLE
[Issue 7492][pulsar-broker] Cleanup configuration process when using PulsarStandaloneBuilder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
@@ -108,25 +108,28 @@ public final class PulsarStandaloneBuilder {
         return this;
     }
 
-    public PulsarStandalone build()
-    {
-        // Change IOException and ConfigurationException into a RuntimeException, because if the
-        // config file isn't readable, there is nothing a caller can do, so don't bother with
-        // a checked exception that needs to be catched
-        try {
-            // By reading the configuration file here, the user can modify the configurations before
-            // calling PulsarStandalone.start()
-            ServerConfiguration bkServerConf = new ServerConfiguration();
-            bkServerConf.loadConf(new File(pulsarStandalone.getConfigFile()).toURI().toURL());
-            pulsarStandalone.setBkServerConfig(bkServerConf);
+    public PulsarStandalone build() {
+        // Don't break existing code which does not have the config file set
+        if (pulsarStandalone.getConfigFile() != null) {
+            // Change IOException and ConfigurationException into a RuntimeException, because if the
+            // config file isn't readable, there is nothing a caller can do, so don't bother with
+            // a checked exception that needs to be catched
+            try {
+                // By reading the configuration file here, the user can modify the configurations before
+                // calling PulsarStandalone.start()
+                ServerConfiguration bkServerConf = new ServerConfiguration();
+                bkServerConf.loadConf(new File(pulsarStandalone.getConfigFile()).toURI().toURL());
+                pulsarStandalone.setBkServerConfig(bkServerConf);
 
-            pulsarStandalone.setConfig(PulsarConfigurationLoader.create(
-                    new FileInputStream(pulsarStandalone.getConfigFile()), ServiceConfiguration.class));
-        }
-        catch (IOException | ConfigurationException e) {
-            // IllegalArgumentException seems appropriate here as the config file was used as an "argument"
-            // by using #withConfigFile
-            throw new IllegalArgumentException("Config file could not be read: " + pulsarStandalone.getConfigFile(), e);
+                pulsarStandalone.setConfig(PulsarConfigurationLoader.create(
+                        new FileInputStream(pulsarStandalone.getConfigFile()), ServiceConfiguration.class));
+            } catch (IOException | ConfigurationException e) {
+                // IllegalArgumentException seems appropriate here as the config file was used as an "argument"
+                // by using #withConfigFile
+                throw new IllegalArgumentException("Config file could not be read: " + pulsarStandalone.getConfigFile(), e);
+            }
+        } else {
+            pulsarStandalone.setConfig(new ServiceConfiguration());
         }
 
         if (pulsarStandalone.getConfig().getClusterName() == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar;
 
 import java.io.File;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
@@ -36,7 +36,7 @@ public class PulsarStandaloneBuilderTest {
         if (testConfigFile.exists()) {
             testConfigFile.delete();
         }
-        PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
+        PrintWriter printWriter = new PrintWriter(testConfigFile);
         printWriter.println("managedLedgerDefaultEnsembleSize=1");
         printWriter.println("managedLedgerDefaultWriteQuorum=1");
         printWriter.println("managedLedgerDefaultAckQuorum=1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
@@ -1,0 +1,44 @@
+package org.apache.pulsar;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class PulsarStandaloneBuilderTest {
+    @Test
+    public void testBuildCreatesConfigObjects() throws FileNotFoundException {
+        File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
+        printWriter.println("managedLedgerDefaultEnsembleSize=1");
+        printWriter.println("managedLedgerDefaultWriteQuorum=1");
+        printWriter.println("managedLedgerDefaultAckQuorum=1");
+        printWriter.println("journalMaxSizeMB=1024");
+        printWriter.println("journalPreAllocSizeMB=8");
+        printWriter.println("journalWriteBufferSizeKB=32");
+        printWriter.close();
+        testConfigFile.deleteOnExit();
+
+        final PulsarStandalone pulsarStandalone = PulsarStandaloneBuilder.instance()
+                .withConfigFile(testConfigFile.getAbsolutePath())
+                .build();
+
+        assertNotNull(pulsarStandalone.getConfig(), "ServiceConfiguration must not be null");
+        assertNotNull(pulsarStandalone.getBkServerConfig(), "ServerConfiguration must not be null");
+        assertEquals(pulsarStandalone.getConfig().getManagedLedgerDefaultEnsembleSize(), 1);
+        assertEquals(pulsarStandalone.getConfig().getManagedLedgerDefaultWriteQuorum(), 1);
+        assertEquals(pulsarStandalone.getConfig().getManagedLedgerDefaultAckQuorum(), 1);
+        assertEquals(pulsarStandalone.getBkServerConfig().getMaxJournalSizeMB(), 1024);
+        assertEquals(pulsarStandalone.getBkServerConfig().getJournalPreAllocSizeMB(), 8);
+        assertEquals(pulsarStandalone.getBkServerConfig().getJournalWriteBufferSizeKB(), 32);
+    }
+}


### PR DESCRIPTION

Fixes #7492 

### Motivation

`PulsarStandaloneBuilder.withConfig()` does effectively nothing because provided config will be overwritten in `PulsarStandaloneBuilder.build()`. Any values set on a configuration object set by `withConfig()` will be lost.
Additionally unlike in `PulsarStandaloneStarter` the `PulsarStandaloneBuilder` does not evaluate the configuration file for the `ServiceConfiguration`, so only options for `LocalBookkeeperEnsemble` (via the `ServerConfiguration` class evaluation in `PulsarStandalone.start()`) will be read from the configuration file, all other (e.g. `managedLedgerDefaultEnsembleSize`) will be ignored.
And options for `LocalBookkeeperEnsemble` are only read from config file and can't be changed by code.


### Modifications

This change drops `PulsarStandaloneBuilder.withConfig()` in favour of a new `withConfigFile` method. The provided configuration file will be read in `PulsarStandaloneBuilder.build()` and allows using it for `ServiceConfiguration`. Changes to the configuration can be made after calling `PulsarStandaloneBuilder.build()` and before `PulsarStandalone.start()`, making it clear to the user that such changes overwrite values set in the configuration file.
This change also introduces a `bkServerConfig` property into `PulsarStandalone`. This allows to create a `ServerConfiguration` from the configuration file in `PulsarStandaloneBuilder.build()` and changing the configuration afterwards by code. If provided `PulsarStandalone` uses the `bkServerConfig` property for the `LocalBookkeeperEnsemble` or creates a new `ServerConfiguration` from the configuration file, if the property is not set, to maintain compatibility with existing code.


### Verifying this change

This change added tests and can be verified as follows:
  - Added a test for `PulsarStandaloneBuilder` to check, if configuration objects are created and filled from configuration file

### Does this pull request potentially affect one of the following parts:

  - The public API: *yes* (`PulsarStandaloneBuilder`)

### Documentation

  - Does this pull request introduce a new feature? yes (`PulsarStandaloneBuilder.withConfigFile`)
  - If yes, how is the feature documented? (Java comments, self-explanatory)
