### PR TITLE
fix website build for format error in sidebars.json

### DIFF
--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -88,7 +88,7 @@
       "security-jwt",
       "security-athenz",
       "security-kerberos",
-      "security-oauth"
+      "security-oauth",
       "security-authorization",
       "security-encryption",
       "security-extending",


### PR DESCRIPTION


Fixes #7536 

### Motivation

website build error happens: https://builds.apache.org/job/pulsar-website-build/1070/console
```
$ docusaurus-write-translations
internal/modules/cjs/loader.js:800
    throw err;
    ^

SyntaxError: /pulsar/site2/website/sidebars.json: Unexpected string in JSON at position 2167
    at JSON.parse (<anonymous>)
    at Object.Module._extensions..json (internal/modules/cjs/loader.js:797:27)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/pulsar/site2/website/node_modules/docusaurus/lib/server/readMetadata.js:44:17)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Module._compile (/pulsar/site2/website/node_modules/pirates/lib/index.js:99:24)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

this is caused by the format error in sidebars.json brings in #7462 

### Modifications

Fix the error. 
