### PR TITLE
#683 - Replace internal proprietary sun.reflect.ReflectionFactory API with Objenesis API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@ flexible messaging model and an intuitive client API.</description>
     <failsafe.version>2.3.1</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <confluent.version>5.2.2</confluent.version>
+    <objenesis.version>3.1</objenesis.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -1078,31 +1079,37 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>opencensus-api</artifactId>
         <version>${opencensus.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-grpc-metrics</artifactId>
         <version>${opencensus.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-high-level-client</artifactId>
         <version>${elasticsearch.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${joda.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${javassist.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>net.jcip</groupId>
         <artifactId>jcip-annotations</artifactId>
         <version>${jcip.version}</version>
       </dependency>
+      
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
@@ -1114,6 +1121,13 @@ flexible messaging model and an intuitive client API.</description>
           </exclusion>
         </exclusions>
       </dependency>
+      
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>${objenesis.version}</version>
+      </dependency>
+    
     </dependencies>
   </dependencyManagement>
 

--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -1,25 +1,16 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+  license agreements. See the NOTICE file distributed with this work for additional 
+  information regarding copyright ownership. The ASF licenses this file to 
+  you under the Apache License, Version 2.0 (the "License"); you may not use 
+  this file except in compliance with the License. You may obtain a copy of 
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+  by applicable law or agreed to in writing, software distributed under the 
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+  OF ANY KIND, either express or implied. See the License for the specific 
+  language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -52,6 +43,11 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
     </dependency>
   </dependencies>
 

--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -1,16 +1,25 @@
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-  license agreements. See the NOTICE file distributed with this work for additional 
-  information regarding copyright ownership. The ASF licenses this file to 
-  you under the Apache License, Version 2.0 (the "License"); you may not use 
-  this file except in compliance with the License. You may obtain a copy of 
-  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-  by applicable law or agreed to in writing, software distributed under the 
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-  OF ANY KIND, either express or implied. See the License for the specific 
-  language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -69,7 +69,7 @@ public class MockZooKeeper extends ZooKeeper {
     
     //see details of Objenesis caching - http://objenesis.org/details.html
     //see supported jvms - https://github.com/easymock/objenesis/blob/master/SupportedJVMs.md
-    private static Objenesis objenesis = new ObjenesisStd();
+    private static final Objenesis objenesis = new ObjenesisStd();
 
     public enum Op {
         CREATE, GET, SET, GET_CHILDREN, DELETE, EXISTS, SYNC,

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -18,7 +18,13 @@
  */
 package org.apache.zookeeper;
 
-import java.lang.reflect.Constructor;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -30,7 +36,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.zookeeper.AsyncCallback.Children2Callback;
 import org.apache.zookeeper.AsyncCallback.ChildrenCallback;
@@ -48,16 +53,6 @@ import org.objenesis.instantiator.ObjectInstantiator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
-
-import io.netty.util.concurrent.DefaultThreadFactory;
-
-@SuppressWarnings({ "deprecation", "restriction", "rawtypes" })
 public class MockZooKeeper extends ZooKeeper {
     private TreeMap<String, Pair<byte[], Integer>> tree;
     private SetMultimap<String, Watcher> watchers;
@@ -100,7 +95,7 @@ public class MockZooKeeper extends ZooKeeper {
 
     public static MockZooKeeper newInstance(ExecutorService executor, int readOpDelayMs) {
         try {
-            ObjectInstantiator mockZooKeeperInstantiator = objenesis.getInstantiatorOf(MockZooKeeper.class);
+            ObjectInstantiator<MockZooKeeper> mockZooKeeperInstantiator = objenesis.getInstantiatorOf(MockZooKeeper.class);
             MockZooKeeper zk = (MockZooKeeper) mockZooKeeperInstantiator.newInstance();
             zk.init(executor);
             zk.readOpDelayMs = readOpDelayMs;

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -290,7 +290,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(failure.get().intValue(), path, ctx, null, null);
                 return;
             } else if (stopped) {
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null, null);
                 return;
             }
 
@@ -303,7 +303,7 @@ public class MockZooKeeper extends ZooKeeper {
             }
 
             if (value == null) {
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null, null);
             } else {
                 Stat stat = new Stat();
                 stat.setVersion(value.getRight());
@@ -356,13 +356,13 @@ public class MockZooKeeper extends ZooKeeper {
                 return;
             } else if (stopped) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
                 return;
             }
 
             if (!tree.containsKey(path)) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
                 return;
             }
 
@@ -475,11 +475,11 @@ public class MockZooKeeper extends ZooKeeper {
                 return;
             } else if (stopped) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null, null);
                 return;
             } else if (!tree.containsKey(path)) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null, null);
                 return;
             }
 
@@ -567,7 +567,7 @@ public class MockZooKeeper extends ZooKeeper {
                 return;
             } else if (stopped) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
                 return;
             }
 
@@ -576,7 +576,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(0, path, ctx, new Stat());
             } else {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
             }
         });
     }
@@ -592,7 +592,7 @@ public class MockZooKeeper extends ZooKeeper {
                 return;
             } else if (stopped) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
                 return;
             }
 
@@ -605,7 +605,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(0, path, ctx, new Stat());
             } else {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
             }
         });
     }
@@ -618,7 +618,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(failure.get().intValue(), path, ctx);
                 return;
             } else if (stopped) {
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx);
                 return;
             }
 
@@ -675,7 +675,7 @@ public class MockZooKeeper extends ZooKeeper {
     @Override
     public void setData(final String path, final byte[] data, int version, final StatCallback cb, final Object ctx) {
         if (stopped) {
-            cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null);
+            cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
             return;
         }
 
@@ -691,13 +691,13 @@ public class MockZooKeeper extends ZooKeeper {
                 return;
             } else if (stopped) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.ConnectionLoss, path, ctx, null);
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
                 return;
             }
 
             if (!tree.containsKey(path)) {
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.NoNode, path, ctx, null);
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
                 return;
             }
 
@@ -707,7 +707,7 @@ public class MockZooKeeper extends ZooKeeper {
             if (version != -1 && version != currentVersion) {
                 log.debug("[{}] Current version: {} -- Expected: {}", path, currentVersion, version);
                 mutex.unlock();
-                cb.processResult(KeeperException.Code.BadVersion, path, ctx, null);
+                cb.processResult(KeeperException.Code.BADVERSION.intValue(), path, ctx, null);
                 return;
             }
 


### PR DESCRIPTION
Fixes #683
"[Objenesis](http://objenesis.org/index.html) is a small Java library that serves one purpose: To instantiate a new object of a particular class."

Used by Spring, EasyMock, Mockito, Kryo etc
[List of supported JVMs](https://github.com/easymock/objenesis/blob/master/SupportedJVMs.md#list-of-currently-supported-jvms)

### Motivation

- We need to instantiate a Zookeeper client instance without invoking the constructor in the MockZookeeper.
- sun.reflect.ReflectionFactory is internal API and might not exists on all JVM variants.
- Compiler warnings are produced during maven builds

### Modifications

- Added Objenesis in root pom dependencyManagement section
- Replaced ReflectionFactory API for Objenesis API in org.apache.zookeeper.MockZooKeeper
- Removed @SuppressWarnings annotation on org.apache.zookeeper.MockZooKeeper
- Replaced deprecated org.apache.zookeeper.KeeperException.Code constants with recommended enums

### Verifying this change

- [X] Make sure that the change passes the CI checks.
- [X] This change is already covered by existing tests, such as 
      - org.apache.pulsar.zookeeper.ZookeeperCacheTest
      - org.apache.pulsar.discovery.service.BaseDiscoveryTestSetup
      - org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest
      - org.apache.pulsar.discovery.service.BaseDiscoveryTestSetup
      - org.apache.pulsar.discovery.service.web.BaseZKStarterTest
      - org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloaderTest
      - org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloaderTest

