### PR TITLE
ISSUE-7497: fix the command for starting bookies in the foreground

### DIFF
--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -285,7 +285,7 @@ $ bin/pulsar-daemon start bookie
 To start the bookie in the foreground:
 
 ```bash
-$ bin/bookkeeper bookie
+$ bin/pulsar bookie
 ```
 
 You can verify that a bookie works properly by running the `bookiesanity` command on the [BookKeeper shell](reference-cli-tools.md#shell):


### PR DESCRIPTION
Master Issue: #<7497>

Fix the command for starting bookies in the foreground.