### PR TITLE
Add server bind address to proxy webserver

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -133,6 +133,12 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
+        doc = "Hostname or IP address the service binds on"
+    )
+    private String bindAddress = "0.0.0.0";
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
         doc = "Hostname or IP address the service advertises to the outside world."
             + " If not set, the value of `InetAddress.getLocalHost().getCanonicalHostName()` is used."
     )

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -91,6 +91,7 @@ public class WebServer {
         if (config.getWebServicePort().isPresent()) {
             this.externalServicePort = config.getWebServicePort().get();
             connector = new ServerConnector(server, 1, 1, new HttpConnectionFactory(http_config));
+            connector.setHost(config.getBindAddress());
             connector.setPort(externalServicePort);
             connectors.add(connector);
         }
@@ -122,6 +123,7 @@ public class WebServer {
                 }
                 connectorTls = new ServerConnector(server, 1, 1, sslCtxFactory);
                 connectorTls.setPort(config.getWebServicePortTls().get());
+                connectorTls.setHost(config.getBindAddress());
                 connectors.add(connectorTls);
             } catch (Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Proxy webserver does not always bind to right network interface.
This provides a a parameter to configure it and assign "0.0.0.0" as default.