### PR TITLE
[doc] add cpp client document for oauth2 authentication

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -795,7 +795,7 @@ The following schema formats are currently available for Java:
 
 ## Authentication
 
-Pulsar currently supports three authentication schemes: [TLS](security-tls-authentication.md), [Athenz](security-athenz.md), and [Oauth2](security-oauth.md). You can use the Pulsar Java client with all of them.
+Pulsar currently supports three authentication schemes: [TLS](security-tls-authentication.md), [Athenz](security-athenz.md), and [Oauth2](security-oauth2.md). You can use the Pulsar Java client with all of them.
 
 ### TLS Authentication
 
@@ -857,7 +857,7 @@ PulsarClient client = PulsarClient.builder()
 
 ### Oauth2
 
-The following example shows how to use [Oauth2](security-oauth.md) as an authentication provider for the Pulsar Java client.
+The following example shows how to use [Oauth2](security-oauth2.md) as an authentication provider for the Pulsar Java client.
 
 You can use the factory method to configure authentication for Pulsar Java client.
 

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -1,5 +1,5 @@
 ---
-id: security-oauth
+id: security-oauth2
 title: Client authentication using OAuth 2.0 access tokens
 sidebar_label: Authentication using OAuth 2.0 access tokens
 ---
@@ -74,10 +74,14 @@ You can use the Oauth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com/oauth/token";
+String credentialsUrl = "file:///path/to/KeyFile.json";
+String audience = "https://dev-kt-aa9ne.us.auth0.com/api/v2/";
+
 PulsarClient client = PulsarClient.builder()
     .serviceUrl("pulsar://broker.example.com:6650/")
     .authentication(
-        AuthenticationFactoryOAuth2.clientCredentials(this.issuerUrl, this.credentialsUrl, this.audience))
+        AuthenticationFactoryOAuth2.clientCredentials(issuerUrl, credentialsUrl, audience))
     .build();
 ```
 
@@ -85,9 +89,27 @@ In addition, you can also use the encoded parameters to configure authentication
 
 ```java
 Authentication auth = AuthenticationFactory
-    .create(AuthenticationOAuth2.class.getName(), "{"type":"client_credentials","privateKey":"...","issuerUrl":"...","audience":"..."}");
+    .create(AuthenticationOAuth2.class.getName(), "{"type":"client_credentials","privateKey":"./key/path/..","issuerUrl":"...","audience":"..."}");
 PulsarClient client = PulsarClient.builder()
     .serviceUrl("pulsar://broker.example.com:6650/")
     .authentication(auth)
     .build();
+```
+
+### CPP
+
+Cpp client is similar to java client. user need to provide parameters of issuerUrl, private_key(which is the credentials file path), and audience.
+
+```c++
+#include <pulsar/Client.h>
+
+pulsar::ClientConfiguration config;
+std::string params = R"({
+    "issuer_url": "https://dev-kt-aa9ne.us.auth0.com/oauth/token",
+    "private_key": "../../pulsar-broker/src/test/resources/authentication/token/cpp_credentials_file.json",
+    "audience": "https://dev-kt-aa9ne.us.auth0.com/api/v2/"})";
+    
+config.setAuth(pulsar::AuthOauth2::create(params));
+
+pulsar::Client client("pulsar://broker.example.com:6650/", config);
 ```

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -98,7 +98,7 @@ PulsarClient client = PulsarClient.builder()
 
 ### C++ client
 
-Cpp client is similar to java client. user need to provide parameters of issuerUrl, private_key(which is the credentials file path), and audience.
+The C++ client is similar to the Java client. You need to provide parameters of `issuerUrl`, `private_key` (the credentials file path), and the audience.
 
 ```c++
 #include <pulsar/Client.h>

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -96,7 +96,7 @@ PulsarClient client = PulsarClient.builder()
     .build();
 ```
 
-### CPP
+### C++ client
 
 Cpp client is similar to java client. user need to provide parameters of issuerUrl, private_key(which is the credentials file path), and audience.
 

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -88,7 +88,7 @@
       "security-jwt",
       "security-athenz",
       "security-kerberos",
-      "security-oauth",
+      "security-oauth2",
       "security-authorization",
       "security-encryption",
       "security-extending",


### PR DESCRIPTION

### Motivation
Related with #7606, which add oauth2 authentication in cpp.
This PR is to add cpp client document for oauth2 authentication.

### Modifications

- Add documentation.
- rename file name "security-oauth" to "security-oauth2"

