### PR TITLE
Revert "#7678 - changed root pom to use jetty bom (#7630)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,13 +402,35 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>rocksdbjni</artifactId>
         <version>${rocksdb.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-bom</artifactId>
+        <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlets</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-proxy</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
This reverts commit e2368b80f4fda274cc57a44abb1f33067a979198. (#7630)

### Motivation

There's an issue with this change that makes tests fail in `tiered-storage/file-system`

```
[INFO] Running org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloaderTest
[INFO] Running org.apache.bookkeeper.mledger.offload.filesystem.FileStoreTestBase
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.257 s - in org.apache.bookkeeper.mledger.offload.filesystem.FileStoreTestBase
[ERROR] Tests run: 6, Failures: 1, Errors: 0, Skipped: 5, Time elapsed: 1.558 s <<< FAILURE! - in org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloaderTest
[ERROR] start(org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloaderTest)  Time elapsed: 1.499 s  <<< FAILURE!
java.lang.NoClassDefFoundError: org/eclipse/jetty/util/ClassVisibilityChecker
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
```

I suspect that there could be a jetty module that is being picked up in the new version, while the plugin was trying to pin to an older version.


@vcottagiri Reverting for now to clear master CI (which is also already broker for Github env issues...), until we can sort it out.

I think the main problem, is that CI only ran the "license check" build since it was a modification of `pom.xml`, instead of running all the tests. Since the pom changes the deps, we should always run full tests in these cases.
