### PR TITLE
Fix backward compatibility issues with batch index acknowledgment.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -67,7 +67,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
             .subscriptionName("sub")
             .receiverQueueSize(100)
             .subscriptionType(SubscriptionType.Shared)
-            .batchIndexAcknowledgmentEnabled(true)
+            .enableBatchIndexAcknowledgment(true)
             .negativeAckRedeliveryDelay(2, TimeUnit.SECONDS)
             .subscribe();
 
@@ -126,7 +126,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
             .topic(topic)
             .subscriptionName("sub")
             .receiverQueueSize(100)
-            .batchIndexAcknowledgmentEnabled(true)
+            .enableBatchIndexAcknowledgment(true)
             .subscribe();
 
         @Cleanup
@@ -196,7 +196,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .acknowledgmentGroupTime(1, TimeUnit.MILLISECONDS)
                 .topic(topic)
-                .batchIndexAcknowledgmentEnabled(true)
+                .enableBatchIndexAcknowledgment(true)
                 .subscriptionName("test")
                 .subscribe();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -67,6 +67,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
             .subscriptionName("sub")
             .receiverQueueSize(100)
             .subscriptionType(SubscriptionType.Shared)
+            .batchIndexAcknowledgmentEnabled(true)
             .negativeAckRedeliveryDelay(2, TimeUnit.SECONDS)
             .subscribe();
 
@@ -125,6 +126,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
             .topic(topic)
             .subscriptionName("sub")
             .receiverQueueSize(100)
+            .batchIndexAcknowledgmentEnabled(true)
             .subscribe();
 
         @Cleanup
@@ -194,6 +196,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .acknowledgmentGroupTime(1, TimeUnit.MILLISECONDS)
                 .topic(topic)
+                .batchIndexAcknowledgmentEnabled(true)
                 .subscriptionName("test")
                 .subscribe();
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -613,7 +613,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Enable or disable the batch index acknowledgment. To enable this feature must ensure batch index acknowledgment
      * feature is enabled at the broker side.
      */
-    ConsumerBuilder<T> batchIndexAcknowledgmentEnabled(boolean batchIndexAcknowledgmentEnabled);
+    ConsumerBuilder<T> enableBatchIndexAcknowledgment(boolean batchIndexAcknowledgmentEnabled);
 
     /**
      * Consumer buffers chunk messages into memory until it receives all the chunks of the original message. While

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -610,6 +610,12 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> enableRetry(boolean retryEnable);
 
     /**
+     * Enable or disable the batch index acknowledgment. To enable this feature must ensure batch index acknowledgment
+     * feature is enabled at the broker side.
+     */
+    ConsumerBuilder<T> batchIndexAcknowledgmentEnabled(boolean batchIndexAcknowledgmentEnabled);
+
+    /**
      * Consumer buffers chunk messages into memory until it receives all the chunks of the original message. While
      * consuming chunk-messages, chunks from same message might not be contiguous in the stream and they might be mixed
      * with other messages' chunks. so, consumer has to maintain multiple buffers to manage chunks coming from different

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -416,7 +416,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> batchIndexAcknowledgmentEnabled(boolean batchIndexAcknowledgmentEnabled) {
+    public ConsumerBuilder<T> enableBatchIndexAcknowledgment(boolean batchIndexAcknowledgmentEnabled) {
         conf.setBatchIndexAckEnabled(batchIndexAcknowledgmentEnabled);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -416,6 +416,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+    public ConsumerBuilder<T> batchIndexAcknowledgmentEnabled(boolean batchIndexAcknowledgmentEnabled) {
+        conf.setBatchIndexAckEnabled(batchIndexAcknowledgmentEnabled);
+        return this;
+    }
+
+    @Override
     public ConsumerBuilder<T> expireTimeOfIncompleteChunkedMessage(long duration, TimeUnit unit) {
         conf.setExpireTimeOfIncompleteChunkedMessageMillis(unit.toMillis(duration));
         return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -547,9 +547,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             ackType);
                 }
             } else {
-                BatchMessageIdImpl batchMessageId = (BatchMessageIdImpl) messageId;
-                acknowledgmentsGroupingTracker.addBatchIndexAcknowledgment(batchMessageId, batchMessageId.getBatchIndex(),
-                    batchMessageId.getBatchSize(), ackType, properties);
+                if (conf.isBatchIndexAckEnabled()) {
+                    BatchMessageIdImpl batchMessageId = (BatchMessageIdImpl) messageId;
+                    acknowledgmentsGroupingTracker.addBatchIndexAcknowledgment(batchMessageId, batchMessageId.getBatchIndex(),
+                            batchMessageId.getBatchSize(), ackType, properties);
+                }
                 // other messages in batch are still pending ack.
                 return CompletableFuture.completedFuture(null);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -125,6 +125,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private KeySharedPolicy keySharedPolicy;
 
+    private boolean batchIndexAckEnabled = false;
+
     @JsonIgnore
     public String getSingleTopic() {
         checkArgument(topicNames.size() == 1);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
@@ -16,25 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.pulsar.tests.integration.backwardscompatibility;
 
-import org.testng.annotations.Test;
+import org.apache.pulsar.tests.integration.containers.PulsarContainer;
+import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
+import org.testng.ITest;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
 
-public class SmokeTest2_2 extends PulsarStandaloneTestSuite2_2 {
+public class PulsarStandaloneTestSuite2_5 extends PulsarStandaloneTestBase implements ITest {
 
-    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
-    public void testPublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {
-        super.testPublishAndConsume(serviceUrl, isPersistent);
+    @BeforeSuite
+    public void setUpCluster() throws Exception {
+        super.startCluster(PulsarContainer.PULSAR_2_5_IMAGE_NAME);
     }
 
-    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
-    public void testBatchMessagePublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {
-        super.testBatchMessagePublishAndConsume(serviceUrl, isPersistent);
+    @AfterSuite
+    public void tearDownCluster() throws Exception {
+        super.stopCluster();
     }
-
-    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
-    public void testBatchIndexAckDisabled(String serviceUrl, boolean isPersistent) throws Exception {
-        super.testBatchIndexAckDisabled(serviceUrl);
+    @Override
+    public String getTestName() {
+        return "pulsar-standalone-suite";
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_3.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_3.java
@@ -33,4 +33,8 @@ public class SmokeTest2_3 extends PulsarStandaloneTestSuite2_3 {
         super.testBatchMessagePublishAndConsume(serviceUrl, isPersistent);
     }
 
+    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
+    public void testBatchIndexAckDisabled(String serviceUrl, boolean isPersistent) throws Exception {
+        super.testBatchIndexAckDisabled(serviceUrl);
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_4.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_4.java
@@ -33,4 +33,8 @@ public class SmokeTest2_4 extends PulsarStandaloneTestSuite2_4 {
         super.testBatchMessagePublishAndConsume(serviceUrl, isPersistent);
     }
 
+    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
+    public void testBatchIndexAckDisabled(String serviceUrl, boolean isPersistent) throws Exception {
+        super.testBatchIndexAckDisabled(serviceUrl);
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_5.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_5.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 import org.testng.annotations.Test;
 
-public class SmokeTest2_2 extends PulsarStandaloneTestSuite2_2 {
+public class SmokeTest2_5 extends PulsarStandaloneTestSuite2_5 {
 
     @Test(dataProvider = "StandaloneServiceUrlAndTopics")
     public void testPublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -41,6 +41,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
     public static final int BROKER_HTTP_PORT = 8080;
 
     public static final String DEFAULT_IMAGE_NAME = "apachepulsar/pulsar-test-latest-version:latest";
+    public static final String PULSAR_2_5_IMAGE_NAME = "apachepulsar/pulsar:2.5.0";
     public static final String PULSAR_2_4_IMAGE_NAME = "apachepulsar/pulsar:2.4.0";
     public static final String PULSAR_2_3_IMAGE_NAME = "apachepulsar/pulsar:2.3.0";
     public static final String PULSAR_2_2_IMAGE_NAME = "apachepulsar/pulsar:2.2.0";

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
@@ -24,13 +24,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.junit.Assert;
 
 public class PulsarTestBase {
 
@@ -126,6 +130,48 @@ public class PulsarTestBase {
                     Message<String> m = consumer.receive();
                     assertEquals("smoke-message-" + i, m.getValue());
                 }
+            }
+        }
+    }
+
+    public void testBatchIndexAckDisabled(String serviceUrl) throws Exception {
+        String topicName = generateTopicName("test-batch-index-ack-disabled", true);
+        final int numMessages = 100;
+        try (PulsarClient client = PulsarClient.builder()
+                .serviceUrl(serviceUrl)
+                .build()) {
+
+            try (Consumer<Integer> consumer = client.newConsumer(Schema.INT32)
+                    .topic(topicName)
+                    .subscriptionName("sub")
+                    .receiverQueueSize(100)
+                    .subscriptionType(SubscriptionType.Shared)
+                    .batchIndexAcknowledgmentEnabled(false)
+                    .ackTimeout(3, TimeUnit.SECONDS)
+                    .subscribe();) {
+
+                try (Producer<Integer> producer = client.newProducer(Schema.INT32)
+                        .topic(topicName)
+                        .batchingMaxPublishDelay(50, TimeUnit.MILLISECONDS)
+                        .create()) {
+
+                    List<CompletableFuture<MessageId>> futures = new ArrayList<>();
+                    for (int i = 0; i < numMessages; i++) {
+                        futures.add(producer.sendAsync(i));
+                    }
+                    // Wait for all messages are publish succeed.
+                    FutureUtil.waitForAll(futures).get();
+                }
+
+                for (int i = 0; i < numMessages; i++) {
+                    Message<Integer> m = consumer.receive();
+                    if (i % 2 == 0) {
+                        consumer.acknowledge(m);
+                    }
+                }
+
+                Message<Integer> redelivery = consumer.receive(3, TimeUnit.SECONDS);
+                Assert.assertNotNull(redelivery);
             }
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
@@ -146,8 +146,8 @@ public class PulsarTestBase {
                     .subscriptionName("sub")
                     .receiverQueueSize(100)
                     .subscriptionType(SubscriptionType.Shared)
-                    .batchIndexAcknowledgmentEnabled(false)
-                    .ackTimeout(3, TimeUnit.SECONDS)
+                    .enableBatchIndexAcknowledgment(false)
+                    .ackTimeout(1, TimeUnit.SECONDS)
                     .subscribe();) {
 
                 try (Producer<Integer> producer = client.newProducer(Schema.INT32)


### PR DESCRIPTION
Fixes #7460

### Motivation

Fix backward compatibility issues with batch index acknowledgment.

### Modifications

Disable batch index acknowledgment by default at the consumer side.

### Verifying this change

Integration tests added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: ( no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
