### PR TITLE
Fix Log4cxx support

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ MESSAGE(STATUS "BUILD_PYTHON_WRAPPER:  " ${BUILD_PYTHON_WRAPPER})
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
-option(USE_LOG4CXX "Build with Log4cxx support" OFF)
+option(USE_LOG4CXX "Build with Log4cxx support" ON)
 MESSAGE(STATUS "USE_LOG4CXX:  " ${USE_LOG4CXX})
 
 IF (CMAKE_BUILD_TYPE STREQUAL "")

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ MESSAGE(STATUS "BUILD_PYTHON_WRAPPER:  " ${BUILD_PYTHON_WRAPPER})
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
-option(USE_LOG4CXX "Build with Log4cxx support" ON)
+option(USE_LOG4CXX "Build with Log4cxx support" OFF)
 MESSAGE(STATUS "USE_LOG4CXX:  " ${USE_LOG4CXX})
 
 IF (CMAKE_BUILD_TYPE STREQUAL "")

--- a/pulsar-client-cpp/lib/Log4CxxLogger.h
+++ b/pulsar-client-cpp/lib/Log4CxxLogger.h
@@ -28,8 +28,8 @@ namespace pulsar {
 
 class PULSAR_PUBLIC Log4CxxLoggerFactory : public LoggerFactory {
    public:
-    static LoggerFactoryPtr create();
-    static LoggerFactoryPtr create(const std::string& log4cxxConfFile);
+    static std::unique_ptr<LoggerFactory> create();
+    static std::unique_ptr<LoggerFactory> create(const std::string& log4cxxConfFile);
 
     Logger* getLogger(const std::string& fileName);
 };

--- a/pulsar-client-cpp/lib/Log4cxxLogger.cc
+++ b/pulsar-client-cpp/lib/Log4cxxLogger.cc
@@ -62,7 +62,7 @@ class Log4CxxLogger : public Logger {
     }
 };
 
-LoggerFactoryPtr Log4CxxLoggerFactory::create() {
+std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create() {
     if (!LogManager::getLoggerRepository()->isConfigured()) {
         LogManager::getLoggerRepository()->setConfigured(true);
         LoggerPtr root = log4cxx::Logger::getRootLogger();
@@ -73,10 +73,10 @@ LoggerFactoryPtr Log4CxxLoggerFactory::create() {
         root->addAppender(appender);
     }
 
-    return LoggerFactoryPtr(new Log4CxxLoggerFactory());
+    return std::unique_ptr<LoggerFactory>(new Log4CxxLoggerFactory());
 }
 
-LoggerFactoryPtr Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile) {
+std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile) {
     try {
         log4cxx::PropertyConfigurator::configure(log4cxxConfFile);
     } catch (const std::exception &e) {
@@ -87,7 +87,7 @@ LoggerFactoryPtr Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile
                   << std::endl;
     }
 
-    return LoggerFactoryPtr(new Log4CxxLoggerFactory());
+    return std::unique_ptr<LoggerFactory>(new Log4CxxLoggerFactory());
 }
 
 Logger *Log4CxxLoggerFactory::getLogger(const std::string &fileName) { return new Log4CxxLogger(fileName); }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Currently the log4cxx support is broken because of a recent refactor.


### Modifications

Fixed the Log4Cxx logger refactor.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
