### PR TITLE
[docs] Add double dash to kubectl exec commands

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -137,7 +137,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.

--- a/site2/website/versioned_docs/version-2.5.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.5.0/getting-started-helm.md
@@ -131,7 +131,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.

--- a/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
@@ -138,7 +138,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.

--- a/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
@@ -130,7 +130,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.


### PR DESCRIPTION
### Motivation

kubectl 1.18.6 warns that not using the double dashes is deprecated. Adding the double dashes to the kubectl exec commands in the docs will remove this warning and future-proof the commands if kubectl drops support for running a command without the double dashes.

### Modifications

Documentation update

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
