### PR TITLE
[Issue 7669][pulsar-client] fix producer stats recorder time unit error

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -59,7 +59,7 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
 
     private volatile double sendMsgsRate;
     private volatile double sendBytesRate;
-    private volatile double[] latencyPctValues;
+    private volatile double[] latencyPctValues = new double[PERCENTILES.length];
 
     private static final double[] PERCENTILES = { 0.5, 0.75, 0.95, 0.99, 0.999, 1.0 };
 
@@ -148,9 +148,9 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
                             producer.getProducerName(), producer.getPendingQueueSize(),
                             THROUGHPUT_FORMAT.format(sendMsgsRate),
                             THROUGHPUT_FORMAT.format(sendBytesRate / 1024 / 1024 * 8),
-                            DEC.format(latencyPctValues[0] / 1000.0), DEC.format(latencyPctValues[2] / 1000.0),
-                            DEC.format(latencyPctValues[3] / 1000.0), DEC.format(latencyPctValues[4] / 1000.0),
-                            DEC.format(latencyPctValues[5] / 1000.0),
+                            DEC.format(latencyPctValues[0]), DEC.format(latencyPctValues[2]),
+                            DEC.format(latencyPctValues[3]), DEC.format(latencyPctValues[4]),
+                            DEC.format(latencyPctValues[5]),
                             THROUGHPUT_FORMAT.format(currentNumAcksReceived / elapsed), currentNumSendFailedMsgs);
                 }
 


### PR DESCRIPTION
Fixes #<7669>

### Motivation

A useless time unit convert was made by mistake when printing producer throughput and latency stats to log

### Modifications

Remove useless time unit convert to milliseconds and init latencyPctValues array to prevent NullPointerException

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no )
  - The public API: ( no )
  - The schema: ( no )
  - The default values of configurations: ( no )
  - The wire protocol: ( no )
  - The rest endpoints: ( no )
  - The admin cli options: (no )
  - Anything that affects deployment: ( no )

### Documentation

  - Does this pull request introduce a new feature? ( no )
