### PR TITLE
Allow topic compaction to be disabled in Pulsar Functions

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
@@ -189,7 +189,9 @@ public class SchedulerManager implements AutoCloseable {
                     new LinkedBlockingQueue<>(5));
             executorService.setThreadFactory(new ThreadFactoryBuilder().setNameFormat("worker-scheduler-%d").build());
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("worker-assignment-topic-compactor"));
-            scheduleCompaction(this.scheduledExecutorService, workerConfig.getTopicCompactionFrequencySec());
+            if (workerConfig.getTopicCompactionFrequencySec() > 0) {
+                scheduleCompaction(this.scheduledExecutorService, workerConfig.getTopicCompactionFrequencySec());
+            }
 
             isRunning = true;
             lastMessageProduced = null;


### PR DESCRIPTION
### Motivation

For Pulsar Functions, allow topic compaction for metadata and assignments topics to be disabled by specifying a negative frequency

