### PR TITLE
[Pulsar Admin] support config request timeout

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -875,6 +875,34 @@ public class PulsarAdminToolTest {
     }
 
     @Test
+    public void requestTimeout() throws Exception {
+        Properties properties = new Properties();
+        properties.put("webServiceUrl", "http://localhost:2181");
+        PulsarAdminTool tool = new PulsarAdminTool(properties);
+
+        try {
+            tool.run("--request-timeout 1".split(" "));
+        } catch (Exception e) {
+            //Ok
+        }
+
+        Field adminBuilderField = PulsarAdminTool.class.getDeclaredField("adminBuilder");
+        adminBuilderField.setAccessible(true);
+        PulsarAdminBuilderImpl builder = (PulsarAdminBuilderImpl) adminBuilderField.get(tool);
+        Field requestTimeoutField =
+                PulsarAdminBuilderImpl.class.getDeclaredField("requestTimeout");
+        requestTimeoutField.setAccessible(true);
+        int requestTimeout = (int) requestTimeoutField.get(builder);
+
+        Field requestTimeoutUnitField =
+                PulsarAdminBuilderImpl.class.getDeclaredField("requestTimeoutUnit");
+        requestTimeoutUnitField.setAccessible(true);
+        TimeUnit requestTimeoutUnit = (TimeUnit) requestTimeoutUnitField.get(builder);
+        assertEquals(1, requestTimeout);
+        assertEquals(TimeUnit.SECONDS, requestTimeoutUnit);
+    }
+
+    @Test
     public void testAuthTlsWithJsonParam() throws Exception {
 
         Properties properties = new Properties();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
@@ -43,6 +44,10 @@ public class PulsarAdminTool {
 
     @Parameter(names = { "--auth-plugin" }, description = "Authentication plugin class name.")
     String authPluginClassName = null;
+
+    @Parameter(names = { "--request-timeout" }, description = "Request time out in seconds for "
+            + "the pulsar admin client for any request")
+    int requestTimeout = PulsarAdmin.DEFAULT_REQUEST_TIMEOUT_SECONDS;
 
     @Parameter(
         names = { "--auth-params" },
@@ -143,6 +148,7 @@ public class PulsarAdminTool {
         try {
             adminBuilder.serviceHttpUrl(serviceUrl);
             adminBuilder.authentication(authPluginClassName, authParams);
+            adminBuilder.requestTimeout(requestTimeout, TimeUnit.SECONDS);
             PulsarAdmin admin = adminFactory.apply(adminBuilder);
             for (Map.Entry<String, Class<?>> c : commandMap.entrySet()) {
                 addCommand(c, admin);


### PR DESCRIPTION
### Motivation
 Currently, pulsar admin cli tool request timeout is 300 seconds, this pr is to make it configurable.

### Modifications
add option `request-timeout` to config pulsar admin cli tool request timeout, default is 300 seconds.
add unit test.