### PR TITLE
[Doc] Add a note about sink-type and source-type value of the built-in connector.

### DIFF
--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -100,7 +100,7 @@ $ pulsar-admin sources update options
 | `-st`, `--schema-type` | The schema type.<br> Either a builtin schema (for example, AVRO and JSON) or custom schema class name to be used to encode messages emitted from source.
 | `--source-config` | Source config key/values.
 | `--source-config-file` | The path to a YAML config file specifying the source's configuration.
-| `-t`, `--source-type` | The source's connector provider.
+| `-t`, `--source-type` | The source's connector provider. The `source-type` parameter of the currently built-in connectors is determined by the setting of the `name` parameter specified in the pulsar-io.yaml file.
 | `--tenant` | The source's tenant.
 | `--update-auth-data` | Whether or not to update the auth data.<br>**Default value: false.**
 
@@ -359,7 +359,7 @@ $ pulsar-admin sinks create options
 | `--retain-ordering` | Sink consumes and sinks messages in order.
 | `--sink-config` | sink config key/values.
 | `--sink-config-file` | The path to a YAML config file specifying the sink's configuration.
-| `-t`, `--sink-type` | The sink's connector provider.
+| `-t`, `--sink-type` | The sink's connector provider. The `sink-type` parameter of the currently built-in connectors is determined by the setting of the `name` parameter specified in the pulsar-io.yaml file.
 | `--subs-name` | Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer.
 | `--tenant` | The sink's tenant.
 | `--timeout-ms` | The message timeout in milliseconds.

--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -202,6 +202,9 @@ to create a sink connector and perform other operations on them.
 
 Run the following command to create a Cassandra sink connector with sink type _cassandra_ and the config file _examples/cassandra-sink.yml_ created previously.
 
+#### Note
+> The `sink-type` parameter of the currently built-in connectors is determined by the setting of the `name` parameter specified in the pulsar-io.yaml file.
+
 ```bash
 bin/pulsar-admin sinks create \
     --tenant public \


### PR DESCRIPTION
Fixes #6109

### Motivation
Tell user the available values of "--sink-type" "--source-type" parameter of the Cassandra built-in connector.

### Modifications
Update the following docs:

- Pulsar IO > get started
- Connector Admin CLI

Currently, only docs in master is updated. After the PR is approved, versioned docs will be updated also. So, do not immediately merge the PR when it is approved.
