### PR TITLE
Fix the nondurable consumer can not specify the initial position

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -193,6 +193,7 @@ public interface ManagedLedger {
      */
     ManagedCursor newNonDurableCursor(Position startCursorPosition) throws ManagedLedgerException;
     ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName) throws ManagedLedgerException;
+    ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName, InitialPosition initialPosition) throws ManagedLedgerException;
 
     /**
      * Delete a ManagedCursor asynchronously.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -856,7 +856,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     @Override
-    public ManagedCursor newNonDurableCursor(Position startCursorPosition, String cursorName)
+    public ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName) throws ManagedLedgerException {
+        return newNonDurableCursor(startPosition, subscriptionName, InitialPosition.Latest);
+    }
+
+    @Override
+    public ManagedCursor newNonDurableCursor(Position startCursorPosition, String cursorName, InitialPosition initialPosition)
             throws ManagedLedgerException {
         Objects.requireNonNull(cursorName, "cursor name can't be null");
         checkManagedLedgerIsOpen();
@@ -871,7 +876,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, config, this, cursorName,
-                (PositionImpl) startCursorPosition);
+                (PositionImpl) startCursorPosition, initialPosition);
         cursor.setActive();
 
         log.info("[{}] Opened new cursor: {}", name, cursor);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -45,8 +45,10 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
             switch (initialPosition) {
                 case Latest:
                     initializeCursorPosition(ledger.getLastPositionAndCounter());
+                    break;
                 case Earliest:
                     initializeCursorPosition(ledger.getFirstPositionAndCounter());
+                    break;
             }
         } else if (startCursorPosition.getLedgerId() == PositionImpl.earliest.getLedgerId()) {
             // Start from invalid ledger to read from first available entry

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -27,13 +27,14 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NonDurableCursorImpl extends ManagedCursorImpl {
 
     NonDurableCursorImpl(BookKeeper bookkeeper, ManagedLedgerConfig config, ManagedLedgerImpl ledger, String cursorName,
-            PositionImpl startCursorPosition) {
+                         PositionImpl startCursorPosition, PulsarApi.CommandSubscribe.InitialPosition initialPosition) {
         super(bookkeeper, config, ledger, cursorName);
 
         // Compare with "latest" position marker by using only the ledger id. Since the C++ client is using 48bits to
@@ -41,7 +42,12 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
         // both ledgerId and entryId to be Long.max()
         if (startCursorPosition == null || startCursorPosition.getLedgerId() == PositionImpl.latest.getLedgerId()) {
             // Start from last entry
-            initializeCursorPosition(ledger.getLastPositionAndCounter());
+            switch (initialPosition) {
+                case Latest:
+                    initializeCursorPosition(ledger.getLastPositionAndCounter());
+                case Earliest:
+                    initializeCursorPosition(ledger.getFirstPositionAndCounter());
+            }
         } else if (startCursorPosition.getLedgerId() == PositionImpl.earliest.getLedgerId()) {
             // Start from invalid ledger to read from first available entry
             recoverCursor(ledger.getPreviousPosition(ledger.getFirstPosition()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -590,7 +590,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         CompletableFuture<? extends Subscription> subscriptionFuture = isDurable ? //
                 getDurableSubscription(subscriptionName, initialPosition, startMessageRollbackDurationSec, replicatedSubscriptionState) //
-                : getNonDurableSubscription(subscriptionName, startMessageId, startMessageRollbackDurationSec);
+                : getNonDurableSubscription(subscriptionName, startMessageId, initialPosition, startMessageRollbackDurationSec);
 
         int maxUnackedMessages = isDurable
                 ? maxUnackedMessagesOnConsumer
@@ -693,7 +693,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName,
-            MessageId startMessageId, long startMessageRollbackDurationSec) {
+            MessageId startMessageId, InitialPosition initialPosition, long startMessageRollbackDurationSec) {
         log.info("[{}][{}] Creating non-durable subscription at msg id {}", topic, subscriptionName, startMessageId);
 
         synchronized (ledger) {
@@ -719,7 +719,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 Position startPosition = new PositionImpl(ledgerId, entryId);
                 ManagedCursor cursor = null;
                 try {
-                    cursor = ledger.newNonDurableCursor(startPosition, subscriptionName);
+                    cursor = ledger.newNonDurableCursor(startPosition, subscriptionName, initialPosition);
                 } catch (ManagedLedgerException e) {
                     return FutureUtil.failedFuture(e);
                 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -269,4 +269,9 @@ public class ConsumerBuilderImplTest {
         consumerBuilderImpl.patternAutoDiscoveryPeriod(1, TimeUnit.SECONDS);
     }
 
+    @Test
+    public void testConsumerMode() {
+        consumerBuilderImpl.subscriptionMode(SubscriptionMode.NonDurable)
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/NonDurableConsumerMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/NonDurableConsumerMessagingTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.tests.integration.messaging;
 
 import lombok.Cleanup;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/NonDurableConsumerMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/NonDurableConsumerMessagingTest.java
@@ -1,0 +1,56 @@
+package org.apache.pulsar.tests.integration.messaging;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.testng.annotations.Test;
+
+import java.util.stream.IntStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class NonDurableConsumerMessagingTest extends MessagingBase {
+
+    @Test(dataProvider = "ServiceUrls")
+    public void testNonDurableConsumer(String serviceUrls) throws Exception {
+        final String topicName = getNonPartitionedTopic("test-non-durable-consumer", false);
+        @Cleanup
+        final PulsarClient client = PulsarClient.builder().serviceUrl(serviceUrls).build();
+
+        int numMessages = 20;
+
+        try (final Producer<byte[]> producer = client.newProducer()
+            .topic(topicName)
+            .create()) {
+
+            IntStream.range(0, numMessages).forEach(i -> {
+                String payload = "message-" + i;
+                producer.sendAsync(payload.getBytes(UTF_8));
+            });
+            // flush the producer to make sure all messages are persisted
+            producer.flush();
+
+            try (final Consumer<byte[]> consumer = client.newConsumer()
+                .topic(topicName)
+                .subscriptionName("non-durable-consumer")
+                .subscriptionMode(SubscriptionMode.NonDurable)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe()) {
+
+                for (int i = 0; i < numMessages; i++) {
+                    Message<byte[]> msg = consumer.receive();
+                    assertEquals(
+                        "message-" + i,
+                        new String(msg.getValue(), UTF_8)
+                    );
+                }
+            }
+        }
+
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
@@ -439,4 +439,5 @@ public class TopicMessagingBase extends MessagingBase {
         closeConsumers(consumerList);
         log.info("-- Exiting {} test --", methodName);
     }
+
 }


### PR DESCRIPTION
---

Fixes #7619

*Motivation*

When using nondurable consumer to consumer message and specify the initial position
from earliest, the consumer can not start consume from the earliest message.
