### PR TITLE
[pulsar-client-cpp] Some clarification of docs for partition and ordering key

### DIFF
--- a/pulsar-client-cpp/include/pulsar/MessageBuilder.h
+++ b/pulsar-client-cpp/include/pulsar/MessageBuilder.h
@@ -64,13 +64,13 @@ class PULSAR_PUBLIC MessageBuilder {
     MessageBuilder& setProperties(const StringMap& properties);
 
     /**
-     * set partition key for the message routing
+     * set partition key for message routing and topic compaction
      * @param hash of this key is used to determine message's topic partition
      */
     MessageBuilder& setPartitionKey(const std::string& partitionKey);
 
     /**
-     * set ordering key for the message routing
+     * set ordering key used for key_shared subscriptions
      * @param the ordering key for the message
      */
     MessageBuilder& setOrderingKey(const std::string& orderingKey);


### PR DESCRIPTION
### Motivation

As a Pulsar newbie, the role of "partition key" and "ordering key" aren't entirely clear from the Doxygen comments.  These names are not used in the public Pulsar documentation that I saw, so expanding the comments felt useful to me and may help other users.

### Modifications

Expanded doc strings for `MessageBuilder.setPartitionKey` and `setOrderingKey`

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

This change improves the C++ Doxygen output.