### PR TITLE
[Issue 2688]Support set retention on topic level.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -47,6 +47,7 @@ import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.PulsarApi;
@@ -517,6 +518,9 @@ public abstract class AdminResource extends PulsarWebResource {
             return Optional.ofNullable(pulsar().getTopicPoliciesService().getTopicPolicies(topicName));
         } catch (RestException re) {
             throw re;
+        } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e){
+            log.error("Topic {} policies cache have not init.", topicName);
+            throw new RestException(e);
         } catch (Exception e) {
             log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);
             throw new RestException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2197,9 +2197,10 @@ public class PersistentTopicsBase extends AdminResource {
             log.warn(
                     "[{}] Failed to update retention quota configuration for topic {}: conflicts with retention quota",
                     clientAppId(), topicName);
-            throw new RestException(Status.PRECONDITION_FAILED,
+            asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
                     "Retention Quota must exceed configured backlog quota for topic. " +
-                            "Please increase retention quota and retry");
+                            "Please increase retention quota and retry"));
+            return;
         }
         topicPolicies.setRetentionPolicies(retention);
         pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1006,7 +1006,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/backlogQuota")
-    @ApiOperation(value = " Set a backlog quota for a topic.")
+    @ApiOperation(value = "Set a backlog quota for a topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 409, message = "Concurrent modification"),
@@ -1082,7 +1082,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @GET
     @Path("/{tenant}/{namespace}/{topic}/retention")
-    @ApiOperation(value = "Get retention config on a topic.")
+    @ApiOperation(value = "Get retention configuration for specified topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
@@ -1103,7 +1103,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/retention")
-    @ApiOperation(value = "Set retention configuration on a topic.")
+    @ApiOperation(value = "Set retention configuration for specified topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
@@ -1126,7 +1126,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @DELETE
     @Path("/{tenant}/{namespace}/{topic}/retention")
-    @ApiOperation(value = "Remove retention configuration on a topic.")
+    @ApiOperation(value = "Remove retention configuration for specified topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1103,7 +1103,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/retention")
-    @ApiOperation(value = " Set retention configuration on a topic.")
+    @ApiOperation(value = "Set retention configuration on a topic.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Topic does not exist"),
             @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
@@ -1117,6 +1117,28 @@ public class PersistentTopics extends PersistentTopicsBase {
         validateTopicName(tenant, namespace, encodedTopic);
         try {
             internalSetRetention(asyncResponse, retention);
+        } catch (RestException e) {
+            asyncResponse.resume(e);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/{topic}/retention")
+    @ApiOperation(value = "Remove retention configuration on a topic.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist"),
+            @ApiResponse(code = 405, message = "Topic level policy is disabled, to enable the topic level policy and retry"),
+            @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 412, message = "Retention Quota must exceed backlog quota") })
+    public void removeRetention(@Suspended final AsyncResponse asyncResponse,
+                             @PathParam("tenant") String tenant,
+                             @PathParam("namespace") String namespace,
+                             @PathParam("topic") @Encoded String encodedTopic) {
+        validateTopicName(tenant, namespace, encodedTopic);
+        try {
+            internalRemoveRetention(asyncResponse);
         } catch (RestException e) {
             asyncResponse.resume(e);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1760,9 +1760,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         TopicName name = TopicName.get(topic);
         RetentionPolicies retentionPolicies = null;
         try {
-            retentionPolicies = getTopicPolicies(name)
+            retentionPolicies = Optional.ofNullable(getTopicPolicies(name))
                     .map(TopicPolicies::getRetentionPolicies)
-                    .orElse( null);
+                    .orElse(null);
             if (retentionPolicies == null){
                 retentionPolicies = brokerService.pulsar().getConfigurationCache().policiesCache()
                         .get(AdminResource.path(POLICIES, name.getNamespace()))
@@ -1787,19 +1787,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         // Negative retention time means the topic should be retained indefinitely,
         // because its own data has to be retained
         return retentionTime < 0 || (System.nanoTime() - lastActive) < retentionTime;
-    }
-
-    private Optional<TopicPolicies> getTopicPolicies(TopicName topicName){
-        if (!brokerService.pulsar().getConfiguration().isTopicLevelPoliciesEnabled()) {
-            return Optional.empty();
-        }
-        try {
-            TopicPoliciesService topicPoliciesService = brokerService.pulsar().getTopicPoliciesService();
-            return Optional.ofNullable(topicPoliciesService.getTopicPolicies(topicName));
-        } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.warn("Topic {} policies cache have not init.", topicName);
-            return Optional.empty();
-        }
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -87,6 +87,7 @@ import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.StreamingStats;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.TopicPoliciesService;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
@@ -1757,27 +1758,47 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     private boolean shouldTopicBeRetained() {
         TopicName name = TopicName.get(topic);
+        RetentionPolicies retentionPolicies = null;
         try {
-            Optional<Policies> policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path(POLICIES, name.getNamespace()));
-            // If no policies, the default is to have no retention and delete the inactive topic
-            RetentionPolicies retentionPolicies = policies.map(p -> p.retention_policies).orElseGet(
-                    () -> new RetentionPolicies(
-                            brokerService.pulsar().getConfiguration().getDefaultRetentionTimeInMinutes(),
-                            brokerService.pulsar().getConfiguration().getDefaultRetentionSizeInMB())
-            );
-            long retentionTime = TimeUnit.MINUTES.toNanos(retentionPolicies.getRetentionTimeInMinutes());
-
-            // Negative retention time means the topic should be retained indefinitely,
-            // because its own data has to be retained
-            return retentionTime < 0 || (System.nanoTime() - lastActive) < retentionTime;
+            retentionPolicies = getTopicPolicies(name)
+                    .map(TopicPolicies::getRetentionPolicies)
+                    .orElse( null);
+            if (retentionPolicies == null){
+                retentionPolicies = brokerService.pulsar().getConfigurationCache().policiesCache()
+                        .get(AdminResource.path(POLICIES, name.getNamespace()))
+                        .map(p -> p.retention_policies)
+                        .orElse(null);
+            }
+            if (retentionPolicies == null){
+                // If no policies, the default is to have no retention and delete the inactive topic
+                retentionPolicies = new RetentionPolicies(
+                        brokerService.pulsar().getConfiguration().getDefaultRetentionTimeInMinutes(),
+                        brokerService.pulsar().getConfiguration().getDefaultRetentionSizeInMB());
+            }
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Error getting policies", topic);
             }
-
             // Don't delete in case we cannot get the policies
             return true;
+        }
+
+        long retentionTime = TimeUnit.MINUTES.toNanos(retentionPolicies.getRetentionTimeInMinutes());
+        // Negative retention time means the topic should be retained indefinitely,
+        // because its own data has to be retained
+        return retentionTime < 0 || (System.nanoTime() - lastActive) < retentionTime;
+    }
+
+    private Optional<TopicPolicies> getTopicPolicies(TopicName topicName){
+        if (!brokerService.pulsar().getConfiguration().isTopicLevelPoliciesEnabled()) {
+            return Optional.empty();
+        }
+        try {
+            TopicPoliciesService topicPoliciesService = brokerService.pulsar().getTopicPoliciesService();
+            return Optional.ofNullable(topicPoliciesService.getTopicPolicies(topicName));
+        } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
+            log.warn("Topic {} policies cache have not init.", topicName);
+            return Optional.empty();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -39,8 +39,6 @@ import org.testng.annotations.Test;
 @Slf4j
 public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TopicBacklogQuotaTest.class);
-
     private final String testTenant = "my-tenant";
 
     private final String testNamespace = "my-namespace";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -124,7 +124,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testCheckBlcklogQuota() throws Exception {
+    public void testCheckBacklogQuota() throws Exception {
         RetentionPolicies retentionPolicies = new RetentionPolicies(10, 10);
         String namespace = TopicName.get(testTopic).getNamespace();
         admin.namespaces().setRetention(namespace, retentionPolicies);
@@ -166,9 +166,6 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testCheckRetention() throws Exception {
         BacklogQuota backlogQuota =
                 new BacklogQuota(10 * 1024 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        RetentionPolicies retentionPolicies = new RetentionPolicies(10, 11);
-        String namespace = TopicName.get(testTopic).getNamespace();
-        admin.namespaces().setRetention(namespace, retentionPolicies);
         admin.topics().setBacklogQuota(testTopic, backlogQuota);
         Thread.sleep(3000);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
-public class TopicTopicPoliciesQuotaTest extends MockedPulsarServiceBaseTest {
+public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
     private final String testTenant = "my-tenant";
 
@@ -57,7 +57,7 @@ public class TopicTopicPoliciesQuotaTest extends MockedPulsarServiceBaseTest {
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Sets.newHashSet("test"));
         admin.topics().createPartitionedTopic(testTopic, 2);
-        Producer producer = pulsarClient.newProducer().topic(testTenant + "/" + testNamespace + "/" + "lookup-topic").create();
+        Producer producer = pulsarClient.newProducer().topic(testTopic).create();
         producer.close();
         Thread.sleep(3000);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicTopicPoliciesQuotaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicTopicPoliciesQuotaTest.java
@@ -204,17 +204,39 @@ public class TopicTopicPoliciesQuotaTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testSetRetention() throws Exception {
+        RetentionPolicies retention = new RetentionPolicies(60, 1024);
+        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
 
-        RetentionPolicies retentionPolicies = new RetentionPolicies();
-        log.info("Retention: {} will set to the topic: {}", retentionPolicies, testTopic);
-
-        admin.topics().setRetention(testTopic, retentionPolicies);
+        admin.topics().setRetention(testTopic, retention);
         log.info("Retention set success on topic: {}", testTopic);
 
         Thread.sleep(3000);
         RetentionPolicies getRetention = admin.topics().getRetention(testTopic);
         log.info("Retention {} get on topic: {}", getRetention, testTopic);
-        Assert.assertEquals(getRetention, retentionPolicies);
+        Assert.assertEquals(getRetention, retention);
+
+        admin.topics().deletePartitionedTopic(testTopic, true);
+    }
+
+    @Test
+    public void testRemoveRetention() throws Exception {
+
+        RetentionPolicies retention = new RetentionPolicies(60, 1024);
+        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
+
+        admin.topics().setRetention(testTopic, retention);
+        log.info("Retention set success on topic: {}", testTopic);
+
+        Thread.sleep(3000);
+        RetentionPolicies getRetention = admin.topics().getRetention(testTopic);
+        log.info("Retention {} get on topic: {}", getRetention, testTopic);
+        Assert.assertEquals(getRetention, retention);
+
+        admin.topics().removeRetention(testTopic);
+        Thread.sleep(3000);
+        log.info("Retention {} get on topic: {} after remove", getRetention, testTopic);
+        getRetention = admin.topics().getRetention(testTopic);
+        Assert.assertNull(getRetention);
 
         admin.topics().deletePartitionedTopic(testTopic, true);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicTopicPoliciesQuotaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicTopicPoliciesQuotaTest.java
@@ -29,17 +29,13 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
-public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TopicBacklogQuotaTest.class);
+public class TopicTopicPoliciesQuotaTest extends MockedPulsarServiceBaseTest {
 
     private final String testTenant = "my-tenant";
 
@@ -47,18 +43,7 @@ public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
 
     private final String myNamespace = testTenant + "/" + testNamespace;
 
-    private final String backlogQuotaTopic = "persistent://" + myNamespace + "/test-set-backlog-quota";
-
-    public void disableTopicLevelPolicies() throws Exception {
-        this.conf.setSystemTopicEnabled(true);
-        this.conf.setTopicLevelPoliciesEnabled(false);
-        super.internalSetup();
-
-        admin.clusters().createCluster("test", new ClusterData(pulsar.getWebServiceAddress()));
-        TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
-        admin.tenants().createTenant(this.testTenant, tenantInfo);
-        admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Sets.newHashSet("test"));
-    }
+    private final String testTopic = "persistent://" + myNamespace + "/test-set-backlog-quota";
 
     @BeforeMethod
     @Override
@@ -71,7 +56,7 @@ public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
         TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Sets.newHashSet("test"));
-        admin.topics().createPartitionedTopic(backlogQuotaTopic, 2);
+        admin.topics().createPartitionedTopic(testTopic, 2);
         Producer producer = pulsarClient.newProducer().topic(testTenant + "/" + testNamespace + "/" + "lookup-topic").create();
         producer.close();
         Thread.sleep(3000);
@@ -87,68 +72,68 @@ public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
     public void testSetBacklogQuota() throws Exception {
 
         BacklogQuota backlogQuota = new BacklogQuota(1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
 
-        admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
-        log.info("Backlog quota set success on topic: {}", backlogQuotaTopic);
+        admin.topics().setBacklogQuota(testTopic, backlogQuota);
+        log.info("Backlog quota set success on topic: {}", testTopic);
 
         Thread.sleep(3000);
-        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(backlogQuotaTopic)
+        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(testTopic)
                 .get(BacklogQuota.BacklogQuotaType.destination_storage);
-        log.info("Backlog quota {} get on topic: {}", getBacklogQuota, backlogQuotaTopic);
+        log.info("Backlog quota {} get on topic: {}", getBacklogQuota, testTopic);
         Assert.assertEquals(getBacklogQuota, backlogQuota);
 
         BacklogQuotaManager backlogQuotaManager = pulsar.getBrokerService().getBacklogQuotaManager();
-        BacklogQuota backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(backlogQuotaTopic));
-        log.info("Backlog quota {} in backlog quota manager on topic: {}", backlogQuotaInManager, backlogQuotaTopic);
+        BacklogQuota backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(testTopic));
+        log.info("Backlog quota {} in backlog quota manager on topic: {}", backlogQuotaInManager, testTopic);
         Assert.assertEquals(backlogQuotaInManager, backlogQuota);
 
-        admin.topics().deletePartitionedTopic(backlogQuotaTopic, true);
+        admin.topics().deletePartitionedTopic(testTopic, true);
     }
 
     @Test
     public void testRemoveBacklogQuota() throws Exception {
         BacklogQuota backlogQuota = new BacklogQuota(1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
-        admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
-        log.info("Backlog quota set success on topic: {}", backlogQuotaTopic);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
+        admin.topics().setBacklogQuota(testTopic, backlogQuota);
+        log.info("Backlog quota set success on topic: {}", testTopic);
 
         Thread.sleep(3000);
-        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(backlogQuotaTopic)
+        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(testTopic)
                 .get(BacklogQuota.BacklogQuotaType.destination_storage);
-        log.info("Backlog quota {} get on topic: {}", getBacklogQuota, backlogQuotaTopic);
+        log.info("Backlog quota {} get on topic: {}", getBacklogQuota, testTopic);
         Assert.assertEquals(backlogQuota, getBacklogQuota);
 
         BacklogQuotaManager backlogQuotaManager = pulsar.getBrokerService().getBacklogQuotaManager();
-        BacklogQuota backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(backlogQuotaTopic));
-        log.info("Backlog quota {} in backlog quota manager on topic: {}", backlogQuotaInManager, backlogQuotaTopic);
+        BacklogQuota backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(testTopic));
+        log.info("Backlog quota {} in backlog quota manager on topic: {}", backlogQuotaInManager, testTopic);
         Assert.assertEquals(backlogQuota, backlogQuotaInManager);
 
-        admin.topics().removeBacklogQuota(backlogQuotaTopic);
-        getBacklogQuota = admin.topics().getBacklogQuotaMap(backlogQuotaTopic)
+        admin.topics().removeBacklogQuota(testTopic);
+        getBacklogQuota = admin.topics().getBacklogQuotaMap(testTopic)
                 .get(BacklogQuota.BacklogQuotaType.destination_storage);
-        log.info("Backlog quota {} get on topic: {} after remove", getBacklogQuota, backlogQuotaTopic);
+        log.info("Backlog quota {} get on topic: {} after remove", getBacklogQuota, testTopic);
         Assert.assertNull(getBacklogQuota);
 
-        backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(backlogQuotaTopic));
+        backlogQuotaInManager = backlogQuotaManager.getBacklogQuota(TopicName.get(testTopic));
         log.info("Backlog quota {} in backlog quota manager on topic: {} after remove", backlogQuotaInManager,
-                backlogQuotaTopic);
+                testTopic);
         Assert.assertEquals(backlogQuotaManager.getDefaultQuota(), backlogQuotaInManager);
 
-        admin.topics().deletePartitionedTopic(backlogQuotaTopic, true);
+        admin.topics().deletePartitionedTopic(testTopic, true);
     }
 
     @Test
-    public void testCheckQuota() throws Exception {
+    public void testCheckBlcklogQuota() throws Exception {
         RetentionPolicies retentionPolicies = new RetentionPolicies(10, 10);
-        String namespace = TopicName.get(backlogQuotaTopic).getNamespace();
+        String namespace = TopicName.get(testTopic).getNamespace();
         admin.namespaces().setRetention(namespace, retentionPolicies);
 
         BacklogQuota backlogQuota =
                 new BacklogQuota(10 * 1024 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
         try {
-            admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
+            admin.topics().setBacklogQuota(testTopic, backlogQuota);
             Assert.fail();
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 412);
@@ -156,9 +141,9 @@ public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(3000);
         backlogQuota =
                 new BacklogQuota(10 * 1024 * 1024 + 1, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
         try {
-            admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
+            admin.topics().setBacklogQuota(testTopic, backlogQuota);
             Assert.fail();
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 412);
@@ -166,44 +151,71 @@ public class TopicBacklogQuotaTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(3000);
         backlogQuota =
                 new BacklogQuota(10 * 1024 * 1024 - 1, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
-        admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
+        admin.topics().setBacklogQuota(testTopic, backlogQuota);
         Thread.sleep(3000);
-        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(backlogQuotaTopic)
+        BacklogQuota getBacklogQuota = admin.topics().getBacklogQuotaMap(testTopic)
                 .get(BacklogQuota.BacklogQuotaType.destination_storage);
-        log.info("Backlog quota {} get on topic: {} after remove", getBacklogQuota, backlogQuotaTopic);
+        log.info("Backlog quota {} get on topic: {} after remove", getBacklogQuota, testTopic);
         Assert.assertEquals(getBacklogQuota, backlogQuota);
 
-        admin.topics().deletePartitionedTopic(backlogQuotaTopic, true);
+        admin.topics().deletePartitionedTopic(testTopic, true);
     }
 
     @Test
-    public void testBacklogQuotaDisabled() throws Exception {
-        disableTopicLevelPolicies();
-        admin.topics().createPartitionedTopic(backlogQuotaTopic, 2);
+    public void testCheckRetention() throws Exception {
+        BacklogQuota backlogQuota =
+                new BacklogQuota(10 * 1024 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
+        RetentionPolicies retentionPolicies = new RetentionPolicies(10, 11);
+        String namespace = TopicName.get(testTopic).getNamespace();
+        admin.namespaces().setRetention(namespace, retentionPolicies);
+        admin.topics().setBacklogQuota(testTopic, backlogQuota);
+        Thread.sleep(3000);
 
-        BacklogQuota backlogQuota = new BacklogQuota(1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
-        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, backlogQuotaTopic);
-
+        RetentionPolicies retention = new RetentionPolicies(10, 10);
+        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
         try {
-            admin.topics().setBacklogQuota(backlogQuotaTopic, backlogQuota);
+            admin.topics().setRetention(testTopic, retention);
             Assert.fail();
         } catch (PulsarAdminException e) {
-            Assert.assertEquals(e.getStatusCode(), 405);
+            Assert.assertEquals(e.getStatusCode(), 412);
         }
 
+        retention = new RetentionPolicies(10, 9);
+        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
         try {
-            admin.topics().removeBacklogQuota(backlogQuotaTopic);
+            admin.topics().setRetention(testTopic, retention);
             Assert.fail();
         } catch (PulsarAdminException e) {
-            Assert.assertEquals(e.getStatusCode(), 405);
+            Assert.assertEquals(e.getStatusCode(), 412);
         }
 
-        try {
-            admin.topics().getBacklogQuotaMap(backlogQuotaTopic);
-            Assert.fail();
-        } catch (PulsarAdminException e) {
-            Assert.assertEquals(e.getStatusCode(), 405);
-        }
+        Thread.sleep(3000);
+        retention = new RetentionPolicies(10, 12);
+        log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
+        admin.topics().setRetention(testTopic, retention);
+        Thread.sleep(3000);
+        RetentionPolicies getRetention = admin.topics().getRetention(testTopic);
+        log.info("Backlog quota {} get on topic: {}", getRetention, testTopic);
+        Assert.assertEquals(getRetention, retention);
+
+        admin.topics().deletePartitionedTopic(testTopic, true);
+    }
+
+    @Test
+    public void testSetRetention() throws Exception {
+
+        RetentionPolicies retentionPolicies = new RetentionPolicies();
+        log.info("Retention: {} will set to the topic: {}", retentionPolicies, testTopic);
+
+        admin.topics().setRetention(testTopic, retentionPolicies);
+        log.info("Retention set success on topic: {}", testTopic);
+
+        Thread.sleep(3000);
+        RetentionPolicies getRetention = admin.topics().getRetention(testTopic);
+        log.info("Retention {} get on topic: {}", getRetention, testTopic);
+        Assert.assertEquals(getRetention, retentionPolicies);
+
+        admin.topics().deletePartitionedTopic(testTopic, true);
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1566,7 +1566,40 @@ public interface Topics {
      * <p/>
      * Get the retention configuration for a topic.
      * <p/>
-     * Response example:
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<RetentionPolicies> getRetentionAsync(String topic);
+
+    /**
+     * Remove the retention configuration for all the topics on a topic.
+     * <p/>
+     * Remove the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeRetention(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the retention configuration for all the topics on a topic asynchronously.
+     * <p/>
+     * Remove the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
      * <p/>
      *
      * <pre>
@@ -1581,6 +1614,5 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
-    CompletableFuture<RetentionPolicies> getRetentionAsync(String topic);
-
+    CompletableFuture<Void> removeRetentionAsync(String topic);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1479,7 +1479,7 @@ public interface Topics {
     void removeMessageTTL(String topic) throws PulsarAdminException;
 
     /**
-     * Set the retention configuration for all the topics on a topic.
+     * Set the retention configuration on a topic.
      * <p/>
      * Set the retention configuration on a topic. This operation requires Pulsar super-user access.
      * <p/>

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 
 /**
@@ -1476,4 +1477,110 @@ public interface Topics {
      *             Unexpected error
      */
     void removeMessageTTL(String topic) throws PulsarAdminException;
+
+    /**
+     * Set the retention configuration for all the topics on a topic.
+     * <p/>
+     * Set the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException;
+
+    /**
+     * Set the retention configuration for all the topics on a topic asynchronously.
+     * <p/>
+     * Set the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> setRetentionAsync(String topic, RetentionPolicies retention);
+
+    /**
+     * Get the retention configuration for a topic.
+     * <p/>
+     * Get the retention configuration for a topic.
+     * <p/>
+     * Response example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    RetentionPolicies getRetention(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the retention configuration for a topic asynchronously.
+     * <p/>
+     * Get the retention configuration for a topic.
+     * <p/>
+     * Response example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<RetentionPolicies> getRetentionAsync(String topic);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1519,5 +1519,26 @@ public class TopicsImpl extends BaseResource implements Topics {
         return future;
     }
 
+    @Override
+    public void removeRetention(String topic) throws PulsarAdminException {
+        try {
+            removeRetentionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeRetentionAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        return asyncDeleteRequest(path);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(TopicsImpl.class);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -76,6 +76,7 @@ import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.Codec;
@@ -1461,6 +1462,61 @@ public class TopicsImpl extends BaseResource implements Topics {
         } catch (Exception e) {
             throw getApiException(e);
         }
+    }
+
+    @Override
+    public void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException {
+        try {
+            setRetentionAsync(topic, retention).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setRetentionAsync(String topic, RetentionPolicies retention) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        return asyncPostRequest(path, Entity.entity(retention, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public RetentionPolicies getRetention(String topic) throws PulsarAdminException {
+        try {
+            return getRetentionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<RetentionPolicies> getRetentionAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        final CompletableFuture<RetentionPolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<RetentionPolicies>() {
+                    @Override
+                    public void completed(RetentionPolicies retentionPolicies) {
+                        future.complete(retentionPolicies);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
     }
 
     private static final Logger log = LoggerFactory.getLogger(TopicsImpl.class);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
 @Parameters(commandDescription = "Operations on persistent topics")
@@ -107,6 +108,8 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("get-message-ttl", new GetMessageTTL());
         jcommander.addCommand("set-message-ttl", new SetMessageTTL());
         jcommander.addCommand("remove-message-ttl", new RemoveMessageTTL());
+        jcommander.addCommand("get-retention", new GetRetention());
+        jcommander.addCommand("set-retention", new SetRetention());
     }
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
@@ -925,6 +928,55 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             admin.topics().removeMessageTTL(persistentTopic);
+        }
+    }
+
+    @Parameters(commandDescription = "Get the retention policy for a topic")
+    private class GetRetention extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            print(admin.topics().getRetention(persistentTopic));
+        }
+    }
+
+    @Parameters(commandDescription = "Set the retention policy for a topic")
+    private class SetRetention extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "--time",
+                "-t" }, description = "Retention time in minutes (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w). "
+                + "0 means no retention and -1 means infinite time retention", required = true)
+        private String retentionTimeStr;
+
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit (eg: 10M, 16G, 3T). "
+                + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
+        private String limitStr;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            long sizeLimit = validateSizeString(limitStr);
+            long retentionTimeInSec = RelativeTimeUtil.parseRelativeTimeInSeconds(retentionTimeStr);
+
+            final int retentionTimeInMin;
+            if (retentionTimeInSec != -1) {
+                retentionTimeInMin = (int) TimeUnit.SECONDS.toMinutes(retentionTimeInSec);
+            } else {
+                retentionTimeInMin = -1;
+            }
+
+            final int retentionSizeInMB;
+            if (sizeLimit != -1) {
+                retentionSizeInMB = (int) (sizeLimit / (1024 * 1024));
+            } else {
+                retentionSizeInMB = -1;
+            }
+            admin.topics().setRetention(persistentTopic, new RetentionPolicies(retentionTimeInMin, retentionSizeInMB));
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -110,6 +110,7 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("remove-message-ttl", new RemoveMessageTTL());
         jcommander.addCommand("get-retention", new GetRetention());
         jcommander.addCommand("set-retention", new SetRetention());
+        jcommander.addCommand("remove-retention", new RemoveRetention());
     }
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
@@ -977,6 +978,18 @@ public class CmdTopics extends CmdBase {
                 retentionSizeInMB = -1;
             }
             admin.topics().setRetention(persistentTopic, new RetentionPolicies(retentionTimeInMin, retentionSizeInMB));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove the retention policy for a topic")
+    private class RemoveRetention extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            admin.topics().removeRetention(persistentTopic);
         }
     }
 }


### PR DESCRIPTION
### Motivation
Support set retention quota on topic level.
Based on the system topic function.
### Modifications
Support get-retention on topic level.
Support set-retention on topic level.
Support remove-retention on topic level.

### Verifying this change
This change added tests and can be verified as follows:

  - *test set topic retention*
  - *test remove topic retention*
  - *test get topic retention*
  - *test disabled topic retention*
  - *test topic retention parameters are valid*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (`yes`)
  - Anything that affects deployment: (no)
### Documentation

  - *Does this pull request introduce a new feature? (`yes`)*
  - *If yes, how is the feature documented? (`docs` / `JavaDocs`)*
