### PR TITLE
Add default MessageRoutingMode to ProducerConfigurationData

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -62,7 +62,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     private boolean blockIfQueueFull = false;
     private int maxPendingMessages = DEFAULT_MAX_PENDING_MESSAGES;
     private int maxPendingMessagesAcrossPartitions = DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
-    private MessageRoutingMode messageRoutingMode = null;
+    private MessageRoutingMode messageRoutingMode = MessageRoutingMode.RoundRobinPartition;
     private HashingScheme hashingScheme = HashingScheme.JavaStringHash;
 
     private ProducerCryptoFailureAction cryptoFailureAction = ProducerCryptoFailureAction.FAIL;


### PR DESCRIPTION
* ProducerConfigurationData defaults messageRoutingMode to null, this will result in NPE when used with partitioned topics as is.
* We now default to MessageRoutingMode.RoundRobinPartition.