### PR TITLE
Add license header for readme file of oauth2

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/README.md
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/README.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 # Pulsar Client Authentication Plugin for OAuth 2.0
 
 Pulsar supports authenticating clients using OAuth 2.0 access tokens.


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Modifications

Run `mvn apache-rat:check` to verify the license headers in the `apache-pulsar-2.6.1-src.tar.gz` package, found that the `README.md` file in oauth2 lacks a license header


Add license header for readme file of oauth2.
