### PR TITLE
make orderedExecutor threads number configurable

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -58,7 +58,8 @@ advertisedAddress=
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 
-# Number of threads to use for orderedExecutor. Default is 8
+# Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
+# such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
 numOrderedExecutorThreads=
 
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -60,7 +60,7 @@ numIOThreads=
 
 # Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
 # such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
-numOrderedExecutorThreads=
+numOrderedExecutorThreads=8
 
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -58,6 +58,9 @@ advertisedAddress=
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 
+# Number of threads to use for orderedExecutor. Default is 8
+numOrderedExecutorThreads=
+
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -39,7 +39,8 @@ advertisedAddress=
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 
-# Number of threads to use for orderedExecutor. Default is 8
+# Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
+# such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
 numOrderedExecutorThreads=
 
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -39,6 +39,9 @@ advertisedAddress=
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 
+# Number of threads to use for orderedExecutor. Default is 8
+numOrderedExecutorThreads=
+
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -41,7 +41,7 @@ numIOThreads=
 
 # Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
 # such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
-numOrderedExecutorThreads=
+numOrderedExecutorThreads=8
 
 # Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -171,6 +171,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int numIOThreads = 2 * Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "Number of threads to use for orderedExecutor."
+            + " Default is 8"
+    )
+    private int numOrderedExecutorThreads = 8;
+
+    @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Number of threads to use for HTTP requests processing"
                 + " Default is set to `2 * Runtime.getRuntime().availableProcessors()`"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -173,7 +173,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Number of threads to use for orderedExecutor."
-            + " Default is 8"
+            + " The ordered executor is used to operate with zookeeper, such as init zookeeper client,"
+            + " get namespace policies from zookeeper etc. It also used to split bundle. Default is 8"
     )
     private int numOrderedExecutorThreads = 8;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -417,7 +417,9 @@ public class PulsarService implements AutoCloseable {
                 throw new IllegalArgumentException("brokerServicePort/brokerServicePortTls must be present");
             }
 
-            orderedExecutor = OrderedExecutor.newBuilder().numThreads(8).name("pulsar-ordered")
+            orderedExecutor = OrderedExecutor.newBuilder()
+                    .numThreads(config.getNumOrderedExecutorThreads())
+                    .name("pulsar-ordered")
                     .build();
 
             // Initialize the message protocol handlers


### PR DESCRIPTION
### Motivation
The orderedExecutor number is hard code to 8 when pulsar service start, it should be configurable in broker.conf.
```
orderedExecutor = OrderedExecutor.newBuilder().numThreads(8).name("pulsar-ordered")
```
### Changes
make the orderedExecutor threads number configurable in broker.conf