### PR TITLE
[pulsar-proxy] Handle NPE while updating proxy stats

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -143,7 +143,10 @@ public class ProxyService implements Closeable {
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("proxy-stats-executor"));
         statsExecutor.schedule(()->{
             this.clientCnxs.forEach(cnx -> {
-                cnx.getDirectProxyHandler().getInboundChannelRequestsRate().calculateRate();
+                if (cnx.getDirectProxyHandler() != null
+                        && cnx.getDirectProxyHandler().getInboundChannelRequestsRate() != null) {
+                    cnx.getDirectProxyHandler().getInboundChannelRequestsRate().calculateRate();
+                }
             });
             this.topicStats.forEach((topic, stats) -> {
                 stats.calculate();


### PR DESCRIPTION
### Motivation
Handle NPE while updating proxy-stats
```
java.lang.NullPointerException
	at org.apache.pulsar.proxy.server.ProxyService.lambda$1(ProxyService.java:161)
	at java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4649)
	at java.util.Collections$SetFromMap.forEach(Collections.java:5476)
	at org.apache.pulsar.proxy.server.ProxyService.lambda$0(ProxyService.java:159)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:745)
```