### PR TITLE
[pulsar-io-hdfs2] Add config to create subdirectory from current time

### DIFF
--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import lombok.Data;
@@ -95,16 +97,24 @@ public class HdfsSinkConfig extends AbstractHdfsConfig implements Serializable {
     public void validate() {
         super.validate();
         if ((StringUtils.isEmpty(fileExtension) && getCompression() == null)
-            || StringUtils.isEmpty(filenamePrefix)) {
-           throw new IllegalArgumentException("Required property not set.");
+                || StringUtils.isEmpty(filenamePrefix)) {
+            throw new IllegalArgumentException("Required property not set.");
         }
 
         if (syncInterval < 0) {
-          throw new IllegalArgumentException("Sync Interval cannot be negative");
+            throw new IllegalArgumentException("Sync Interval cannot be negative");
         }
 
         if (maxPendingRecords < 1) {
-          throw new IllegalArgumentException("Max Pending Records must be a positive integer");
+            throw new IllegalArgumentException("Max Pending Records must be a positive integer");
+        }
+
+        if (subdirectoryPattern != null) {
+            try {
+                LocalDateTime.of(2020, 1, 1, 12, 0).format(DateTimeFormatter.ofPattern(subdirectoryPattern));
+            } catch (Exception e) {
+                throw new IllegalArgumentException(subdirectoryPattern + " is not a valid pattern: " + e.getMessage());
+            }
         }
     }
 }

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
@@ -73,6 +73,14 @@ public class HdfsSinkConfig extends AbstractHdfsConfig implements Serializable {
      */
     private int maxPendingRecords = Integer.MAX_VALUE;
 
+    /**
+     * A subdirectory associated with the created time of the sink.
+     * The pattern is the formatted pattern of {@link AbstractHdfsConfig#getDirectory()}'s subdirectory.
+     *
+     * @see java.time.format.DateTimeFormatter for pattern's syntax
+     */
+    private String subdirectoryPattern;
+
     public static HdfsSinkConfig load(String yamlFile) throws IOException {
        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
        return mapper.readValue(new File(yamlFile), HdfsSinkConfig.class);

--- a/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfigTests.java
+++ b/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfigTests.java
@@ -44,6 +44,7 @@ public class HdfsSinkConfigTests {
 		assertEquals("/foo/bar", config.getDirectory());
 		assertEquals("prefix", config.getFilenamePrefix());
 		assertEquals(Compression.SNAPPY, config.getCompression());
+		assertEquals("yyyy-MM-dd", config.getSubdirectoryPattern());
 	}
 	
 	@Test
@@ -53,6 +54,7 @@ public class HdfsSinkConfigTests {
 		map.put("directory", "/foo/bar");
 		map.put("filenamePrefix", "prefix");
 		map.put("compression", "SNAPPY");
+		map.put("subdirectoryPattern", "yy-MM-dd");
 		
 		HdfsSinkConfig config = HdfsSinkConfig.load(map);
 		assertNotNull(config);
@@ -60,6 +62,7 @@ public class HdfsSinkConfigTests {
 		assertEquals("/foo/bar", config.getDirectory());
 		assertEquals("prefix", config.getFilenamePrefix());
 		assertEquals(Compression.SNAPPY, config.getCompression());
+		assertEquals("yy-MM-dd", config.getSubdirectoryPattern());
 	}
 	
 	@Test

--- a/pulsar-io/hdfs2/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/hdfs2/src/test/resources/sinkConfig.yaml
@@ -21,5 +21,6 @@
 "hdfsConfigResources": "core-site.xml",
 "directory": "/foo/bar",
 "filenamePrefix": "prefix",
-"compression": "SNAPPY"
+"compression": "SNAPPY",
+"subdirectoryPattern": "yyyy-MM-dd"
 }

--- a/site2/docs/io-hdfs2-sink.md
+++ b/site2/docs/io-hdfs2-sink.md
@@ -26,6 +26,7 @@ The configuration of the HDFS2 sink connector has the following properties.
 | `separator` | char|false |None |The character used to separate records in a text file. <br/><br/>If no value is provided, the contents from all records are concatenated together in one continuous byte array. |
 | `syncInterval` | long| false |0| The interval between calls to flush data to HDFS disk in milliseconds. |
 | `maxPendingRecords` |int| false|Integer.MAX_VALUE |  The maximum number of records that hold in memory before acking. <br/><br/>Setting this property to 1 makes every record send to disk before the record is acked.<br/><br/>Setting this property to a higher value allows buffering records before flushing them to disk. 
+| `subdirectoryPattern` | String | false | None | A subdirectory associated with the created time of the sink.<br/>The pattern is the formatted pattern of `directory`'s subdirectory.<br/><br/>See [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) for pattern's syntax. |
 
 ### Example
 
@@ -39,7 +40,8 @@ Before using the HDFS2 sink connector, you need to create a configuration file t
         "directory": "/foo/bar",
         "filenamePrefix": "prefix",
         "fileExtension": ".log",
-        "compression": "SNAPPY"
+        "compression": "SNAPPY",
+        "subdirectoryPattern": "yyyy-MM-dd"
     }
     ```
 
@@ -52,4 +54,5 @@ Before using the HDFS2 sink connector, you need to create a configuration file t
         filenamePrefix: "prefix"
         fileExtension: ".log"
         compression: "SNAPPY"
+        subdirectoryPattern: "yyyy-MM-dd"
     ```


### PR DESCRIPTION
### Motivation

Adding a subdirectory associated with current time willmake it easier to process HDFS files in batch.

For example, user can create multiple running sink instances with `yyyy-MM-dd-hh` pattern. Then stop all instances at next hour. Eventually, files of the subdirectory will contain all messages consumed during this hour.

### Modifications

- Add a `subdirectoryPattern` field to `HdfsSinkConfig`
- Update some simple tests for `HdfsSinkConfig`
- Update the doc of HDFS2 sink

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)