### PR TITLE
[Issue 7517][pulsar-broker] Reestablish namespace bundle ownership from false negative releasing and false positive acquiring

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -912,6 +912,15 @@ public class NamespaceService {
         }
     }
 
+    public CompletableFuture<Boolean> checkTopicOwnership(TopicName topicName) {
+        try {
+            NamespaceBundle bundle = getBundle(topicName);
+            return ownershipCache.checkOwnership(bundle);
+        } catch (Exception ex) {
+            return FutureUtil.failedFuture(ex);
+        }
+    }
+
     public void removeOwnedServiceUnit(NamespaceName nsName) throws Exception {
         ownershipCache.removeOwnership(getFullBundle(nsName))
                 .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
@@ -125,7 +125,7 @@ public class OwnedBundle {
         LOG.info("Disabling ownership: {}", this.bundle);
 
         // close topics forcefully
-        CompletableFuture<Void> future = pulsar.getNamespaceService().getOwnershipCache()
+        return pulsar.getNamespaceService().getOwnershipCache()
                 .updateBundleState(this.bundle, false)
                 .thenCompose(v -> pulsar.getBrokerService().unloadServiceUnit(bundle, true, timeout, timeoutUnit))
                 .handle((numUnloadedTopics, ex) -> {
@@ -140,19 +140,12 @@ public class OwnedBundle {
                 .thenCompose(v -> {
                     // delete ownership node on zk
                     return pulsar.getNamespaceService().getOwnershipCache().removeOwnership(bundle);
-                }).thenAccept(v -> {
+                }).whenComplete((ignored, ex) -> {
                     double unloadBundleTime = TimeUnit.NANOSECONDS
                             .toMillis((System.nanoTime() - unloadBundleStartTime));
                     LOG.info("Unloading {} namespace-bundle with {} topics completed in {} ms", this.bundle,
-                            unloadedTopics, unloadBundleTime);
+                            unloadedTopics, unloadBundleTime, ex);
                 });
-
-        future.exceptionally(ex -> {
-            // Failed to remove ownership node: enable namespace-bundle again so, it can serve new topics
-            pulsar.getNamespaceService().getOwnershipCache().updateBundleState(this.bundle, true);
-            return null;
-        });
-        return future;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +110,7 @@ public class OwnershipCache {
     /**
      * The <code>NamespaceService</code> which using <code>OwnershipCache</code>
      */
-    private NamespaceService namespaceService;
+    private final NamespaceService namespaceService;
 
     private final PulsarService pulsar;
 
@@ -176,6 +177,44 @@ public class OwnershipCache {
         CacheMetricsCollector.CAFFEINE.addCache("owned-bundles", this.ownedBundlesCache);
     }
 
+    private CompletableFuture<Optional<Map.Entry<NamespaceEphemeralData, Stat>>> resolveOwnership(String path) {
+        return ownershipReadOnlyCache.getWithStatAsync(path).thenApply(optionalOwnerDataWithStat -> {
+            if (optionalOwnerDataWithStat.isPresent()) {
+                Map.Entry<NamespaceEphemeralData, Stat> ownerDataWithStat = optionalOwnerDataWithStat.get();
+                Stat stat = ownerDataWithStat.getValue();
+                if (stat.getEphemeralOwner() == localZkCache.getZooKeeper().getSessionId()) {
+                    LOG.info("Successfully reestablish ownership of {}", path);
+                    OwnedBundle ownedBundle = new OwnedBundle(ServiceUnitZkUtils.suBundleFromPath(path, bundleFactory));
+                    ownedBundlesCache.put(path, CompletableFuture.completedFuture(ownedBundle));
+                    ownershipReadOnlyCache.invalidate(path);
+                    namespaceService.onNamespaceBundleOwned(ownedBundle.getNamespaceBundle());
+                }
+            }
+            return optionalOwnerDataWithStat;
+        });
+    }
+
+    /**
+     * Check whether this broker owns given namespace bundle.
+     *
+     * @param bundle namespace bundle
+     * @return future that will complete with check result
+     */
+    public CompletableFuture<Boolean> checkOwnership(NamespaceBundle bundle) {
+        OwnedBundle ownedBundle = getOwnedBundle(bundle);
+        if (ownedBundle != null) {
+            return CompletableFuture.completedFuture(true);
+        }
+        String bundlePath = ServiceUnitZkUtils.path(bundle);
+        return resolveOwnership(bundlePath).thenApply(optionalOwnedDataWithStat -> {
+            if (!optionalOwnedDataWithStat.isPresent()) {
+                return false;
+            }
+            Stat stat = optionalOwnedDataWithStat.get().getValue();
+            return stat.getEphemeralOwner() == localZkCache.getZooKeeper().getSessionId();
+        });
+    }
+
     /**
      * Method to get the current owner of the <code>ServiceUnit</code>
      *
@@ -198,7 +237,7 @@ public class OwnershipCache {
         }
 
         // If we're not the owner, we need to check if anybody else is
-        return ownershipReadOnlyCache.getAsync(path);
+        return resolveOwnership(path).thenApply(optional -> optional.map(Map.Entry::getKey));
     }
 
     /**
@@ -225,26 +264,25 @@ public class OwnershipCache {
         // service unit
         ownedBundlesCache.get(path).thenAccept(namespaceBundle -> {
             LOG.info("Successfully acquired ownership of {}", path);
-            if (namespaceService != null) {
-                namespaceService.onNamespaceBundleOwned(bundle);
-            }
+            namespaceService.onNamespaceBundleOwned(bundle);
             future.complete(selfOwnerInfo);
         }).exceptionally(exception -> {
             // Failed to acquire ownership
             if (exception instanceof CompletionException
                     && exception.getCause() instanceof KeeperException.NodeExistsException) {
-                LOG.info("Failed to acquire ownership of {} -- Already owned by other broker", path);
-                // Other broker acquired ownership at the same time, let's try to read it from the read-only cache
-                ownershipReadOnlyCache.getAsync(path).thenAccept(ownerData -> {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Found owner for {} at {}", bundle, ownerData);
-                    }
-
-                    if (ownerData.isPresent()) {
-                        future.complete(ownerData.get());
+                resolveOwnership(path).thenAccept(optionalOwnerDataWithStat -> {
+                    if (optionalOwnerDataWithStat.isPresent()) {
+                        Map.Entry<NamespaceEphemeralData, Stat> ownerDataWithStat = optionalOwnerDataWithStat.get();
+                        NamespaceEphemeralData ownerData = ownerDataWithStat.getKey();
+                        Stat stat = ownerDataWithStat.getValue();
+                        if (stat.getEphemeralOwner() != localZkCache.getZooKeeper().getSessionId()) {
+                            LOG.info("Failed to acquire ownership of {} -- Already owned by broker {}", path, ownerData);
+                        }
+                        future.complete(ownerData);
                     } else {
                         // Strange scenario: we couldn't create a z-node because it was already existing, but when we
                         // try to read it, it's not there anymore
+                        LOG.info("Failed to acquire ownership of {} -- Already owned by unknown broker", path);
                         future.completeExceptionally(exception);
                     }
                 }).exceptionally(ex -> {
@@ -255,7 +293,6 @@ public class OwnershipCache {
             } else {
                 // Other ZK error, bailing out for now
                 LOG.warn("Failed to acquire ownership of {}: {}", bundle, exception.getMessage(), exception);
-                ownedBundlesCache.synchronous().invalidate(path);
                 future.completeExceptionally(exception);
             }
 
@@ -273,13 +310,12 @@ public class OwnershipCache {
         CompletableFuture<Void> result = new CompletableFuture<>();
         String key = ServiceUnitZkUtils.path(bundle);
         localZkCache.getZooKeeper().delete(key, -1, (rc, path, ctx) -> {
+            // Invalidate cache even in error since this operation may succeed in server side.
+            ownedBundlesCache.synchronous().invalidate(key);
+            ownershipReadOnlyCache.invalidate(key);
+            namespaceService.onNamespaceBundleUnload(bundle);
             if (rc == KeeperException.Code.OK.intValue() || rc == KeeperException.Code.NONODE.intValue()) {
                 LOG.info("[{}] Removed zk lock for service unit: {}", key, KeeperException.Code.get(rc));
-                ownedBundlesCache.synchronous().invalidate(key);
-                ownershipReadOnlyCache.invalidate(key);
-                if (namespaceService != null) {
-                    namespaceService.onNamespaceBundleUnload(bundle);
-                }
                 result.complete(null);
             } else {
                 LOG.warn("[{}] Failed to delete the namespace ephemeral node. key={}", key,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -951,7 +952,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      */
     protected CompletableFuture<Optional<Topic>> loadOrCreatePersistentTopic(final String topic,
             boolean createIfMissing) throws RuntimeException {
-        checkTopicNsOwnership(topic);
         final CompletableFuture<Optional<Topic>> topicFuture = futureWithDeadline(pulsar.getConfiguration().getTopicLoadTimeoutSeconds(),
                 TimeUnit.SECONDS, new TimeoutException("Failed to load topic within timeout"));
         if (!pulsar.getConfiguration().isEnablePersistentTopics()) {
@@ -962,22 +962,30 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             return topicFuture;
         }
 
-        final Semaphore topicLoadSemaphore = topicLoadRequestSemaphore.get();
-
-        if (topicLoadSemaphore.tryAcquire()) {
-            createPersistentTopic(topic, createIfMissing, topicFuture);
-            topicFuture.handle((persistentTopic, ex) -> {
-                // release permit and process pending topic
-                topicLoadSemaphore.release();
-                createPendingLoadTopic();
-                return null;
-            });
-        } else {
-            pendingTopicLoadingQueue.add(new ImmutablePair<String, CompletableFuture<Optional<Topic>>>(topic, topicFuture));
-            if (log.isDebugEnabled()) {
-                log.debug("topic-loading for {} added into pending queue", topic);
+        checkTopicNsOwnershipAsync(topic).whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                topicFuture.completeExceptionally(throwable);
+                return;
             }
-        }
+
+            final Semaphore topicLoadSemaphore = topicLoadRequestSemaphore.get();
+
+            if (topicLoadSemaphore.tryAcquire()) {
+                createPersistentTopic(topic, createIfMissing, topicFuture);
+                topicFuture.handle((persistentTopic, ex) -> {
+                    // release permit and process pending topic
+                    topicLoadSemaphore.release();
+                    createPendingLoadTopic();
+                    return null;
+                });
+            } else {
+                pendingTopicLoadingQueue.add(new ImmutablePair<String, CompletableFuture<Optional<Topic>>>(topic, topicFuture));
+                if (log.isDebugEnabled()) {
+                    log.debug("topic-loading for {} added into pending queue", topic);
+                }
+            }
+        });
+
         return topicFuture;
     }
 
@@ -1353,21 +1361,33 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return false;
     }
 
-    public void checkTopicNsOwnership(final String topic) throws RuntimeException {
+    public CompletableFuture<Void> checkTopicNsOwnershipAsync(final String topic) {
         TopicName topicName = TopicName.get(topic);
-        boolean ownedByThisInstance;
-        try {
-            ownedByThisInstance = pulsar.getNamespaceService().isServiceUnitOwned(topicName);
-        } catch (Exception e) {
-            log.debug("Failed to check the ownership of the topic: {}", topicName, e);
-            throw new RuntimeException(new ServerMetadataException(e));
-        }
+        CompletableFuture<Void> checkFuture = new CompletableFuture<>();
+        pulsar.getNamespaceService().checkTopicOwnership(topicName).whenComplete((ownedByThisInstance, throwable) -> {
+            if (throwable != null) {
+                log.debug("Failed to check the ownership of the topic: {}", topicName, throwable);
+                checkFuture.completeExceptionally(new ServerMetadataException(throwable));
+            } else if (!ownedByThisInstance) {
+                String msg = String.format("Namespace bundle for topic (%s) not served by this instance. "
+                        + "Please redo the lookup. Request is denied: namespace=%s", topic, topicName.getNamespace());
+                log.warn(msg);
+                checkFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
+            } else {
+                checkFuture.complete(null);
+            }
+        });
+        return checkFuture;
+    }
 
-        if (!ownedByThisInstance) {
-            String msg = String.format("Namespace bundle for topic (%s) not served by this instance. Please redo the lookup. "
-                    + "Request is denied: namespace=%s", topic, topicName.getNamespace());
-            log.warn(msg);
-            throw new RuntimeException(new ServiceUnitNotReadyException(msg));
+    public void checkTopicNsOwnership(final String topic) throws RuntimeException {
+        try {
+            checkTopicNsOwnershipAsync(topic).join();
+        } catch (CompletionException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
+            throw new RuntimeException(ex.getCause());
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -238,7 +238,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
     }
 
     @Test
-    public void testremoveOwnershipNamespaceBundle() throws Exception {
+    public void testRemoveOwnershipNamespaceBundle() throws Exception {
 
         OwnershipCache ownershipCache = spy(pulsar.getNamespaceService().getOwnershipCache());
 
@@ -255,7 +255,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
 
         NamespaceBundle bundle = bundles.getBundles().get(0);
-        assertNotNull(ownershipCache.tryAcquiringOwnership(bundle));
+        ownershipCache.tryAcquiringOwnership(bundle).get();
         assertNotNull(ownershipCache.getOwnedBundle(bundle));
         ownershipCache.removeOwnership(bundles).get();
         assertNull(ownershipCache.getOwnedBundle(bundle));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -187,6 +187,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         doReturn(nsSvc).when(pulsar).getNamespaceService();
         doReturn(true).when(nsSvc).isServiceUnitOwned(any(NamespaceBundle.class));
         doReturn(true).when(nsSvc).isServiceUnitActive(any(TopicName.class));
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any(TopicName.class));
 
         setupMLAsyncCallbackMocks();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertFalse;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
@@ -103,6 +104,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
         doReturn(nsSvc).when(pulsar).getNamespaceService();
         doReturn(true).when(nsSvc).isServiceUnitOwned(any(NamespaceBundle.class));
         doReturn(true).when(nsSvc).isServiceUnitActive(any(TopicName.class));
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any(TopicName.class));
 
         final List<Position> addedEntries = Lists.newArrayList();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -202,6 +202,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(nsSvc).when(pulsar).getNamespaceService();
         doReturn(true).when(nsSvc).isServiceUnitOwned(any());
         doReturn(true).when(nsSvc).isServiceUnitActive(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any());
 
         setupMLAsyncCallbackMocks();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -187,6 +187,7 @@ public class ServerCnxTest {
         doReturn(namespaceService).when(pulsar).getNamespaceService();
         doReturn(true).when(namespaceService).isServiceUnitOwned(any());
         doReturn(true).when(namespaceService).isServiceUnitActive(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(namespaceService).checkTopicOwnership(any());
 
         setupMLAsyncCallbackMocks();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -18,19 +18,48 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
 import com.google.common.collect.Sets;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.jute.Record;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.broker.namespace.LookupOptions;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.namespace.ServiceUnitZkUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.proto.CreateRequest;
+import org.apache.zookeeper.proto.DeleteRequest;
+import org.apache.zookeeper.proto.ReplyHeader;
+import org.apache.zookeeper.server.ByteBufferInputStream;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.mockito.stubbing.Answer;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -45,6 +74,8 @@ public class TopicOwnerTest {
     protected static final int BROKER_COUNT = 5;
     protected ServiceConfiguration[] configurations = new ServiceConfiguration[BROKER_COUNT];
     protected PulsarService[] pulsarServices = new PulsarService[BROKER_COUNT];
+    protected PulsarService leaderPulsar;
+    protected PulsarAdmin leaderAdmin;
 
     @BeforeMethod
     void setup() throws Exception {
@@ -68,11 +99,355 @@ public class TopicOwnerTest {
             pulsarServices[i] = new PulsarService(config);
             pulsarServices[i].start();
 
+            // Sleep until pulsarServices[0] becomes leader, this way we can spy namespace bundle assignment easily.
+            while (i == 0 && !pulsarServices[0].getLeaderElectionService().isLeader()) {
+                Thread.sleep(10);
+            }
+
             pulsarAdmins[i] = PulsarAdmin.builder()
                     .serviceHttpUrl(pulsarServices[i].getWebServiceAddress())
                     .build();
         }
+        leaderPulsar = pulsarServices[0];
+        leaderAdmin = pulsarAdmins[0];
         Thread.sleep(1000);
+    }
+
+    @AfterMethod
+    void tearDown() throws Exception {
+        for (int i = 0; i < BROKER_COUNT; i++) {
+            pulsarServices[i].close();
+            pulsarAdmins[i].close();
+        }
+        bkEnsemble.stop();
+    }
+
+    @SuppressWarnings("unchecked")
+    private MutableObject<PulsarService> spyLeaderNamespaceServiceForAuthorizedBroker() {
+        // Spy leader namespace service to inject authorized broker for namespace-bundle from leader,
+        // this is a safe operation since it is just an recommendation if namespace-bundle has no owner
+        // currently. Namespace-bundle ownership contention is an atomic operation through zookeeper.
+        NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
+        NamespaceService spyLeaderNamespaceService = spy(leaderNamespaceService);
+        final MutableObject<PulsarService> leaderAuthorizedBroker = new MutableObject<>();
+        Answer<CompletableFuture<Optional<LookupResult>>> answer = invocation -> {
+            PulsarService pulsarService = leaderAuthorizedBroker.getValue();
+            if (pulsarService == null) {
+                return (CompletableFuture<Optional<LookupResult>>) invocation.callRealMethod();
+            }
+            LookupResult lookupResult = new LookupResult(
+                    pulsarService.getWebServiceAddress(),
+                    pulsarService.getWebServiceAddressTls(),
+                    pulsarService.getBrokerServiceUrl(),
+                    pulsarService.getBrokerServiceUrlTls(),
+                    true);
+            return CompletableFuture.completedFuture(Optional.of(lookupResult));
+        };
+        doAnswer(answer).when(spyLeaderNamespaceService).getBrokerServiceUrlAsync(any(TopicName.class), any(LookupOptions.class));
+        Whitebox.setInternalState(leaderPulsar, "nsService", spyLeaderNamespaceService);
+        return leaderAuthorizedBroker;
+    }
+
+    private CompletableFuture<Void> watchZookeeperReconnect(ZooKeeper zooKeeper) throws Exception {
+        CompletableFuture<Void> reconnectedFuture = new CompletableFuture<>();
+        zooKeeper.exists("/", (WatchedEvent event) -> {
+            Watcher.Event.KeeperState state = event.getState();
+            if (state == Watcher.Event.KeeperState.SyncConnected) {
+                reconnectedFuture.complete(null);
+            }
+        });
+        return reconnectedFuture;
+    }
+
+    @FunctionalInterface
+    interface RequestMatcher {
+        boolean match(Request request) throws Exception;
+    }
+
+    private void spyZookeeperToDisconnectBeforePersist(ZooKeeper zooKeeper, RequestMatcher matcher) {
+        ZooKeeperServer zooKeeperServer = bkEnsemble.getZkServer();
+        ServerCnxn zkServerConnection = bkEnsemble.getZookeeperServerConnection(zooKeeper);
+        ZooKeeperServer spyZooKeeperServer = spy(zooKeeperServer);
+
+        // Spy zk server connection to close connection to cause connection loss after namespace-bundle
+        // deleted successfully. This mimics crash of connected zk server after committing requested operation.
+        Whitebox.setInternalState(zkServerConnection, "zkServer", spyZooKeeperServer);
+        doAnswer(invocation -> {
+            Request request = invocation.getArgument(0);
+            if (request.sessionId != zooKeeper.getSessionId()) {
+                return invocation.callRealMethod();
+            }
+            if (!matcher.match(request)) {
+                return invocation.callRealMethod();
+            }
+            Whitebox.setInternalState(zkServerConnection, "zkServer", zooKeeperServer);
+            bkEnsemble.disconnectZookeeper(zooKeeper);
+            return null;
+        }).when(spyZooKeeperServer).submitRequest(any(Request.class));
+    }
+
+    private void spyZookeeperToDisconnectAfterPersist(ZooKeeper zooKeeper, RequestMatcher matcher) {
+        ZooKeeperServer zooKeeperServer = bkEnsemble.getZkServer();
+        ServerCnxn zkServerConnection = bkEnsemble.getZookeeperServerConnection(zooKeeper);
+        ZooKeeperServer spyZooKeeperServer = spy(zooKeeperServer);
+
+        // Spy zk server connection to close connection to cause connection loss after namespace-bundle
+        // deleted successfully. This mimics crash of connected zk server after committing requested operation.
+        Whitebox.setInternalState(zkServerConnection, "zkServer", spyZooKeeperServer);
+        MutableBoolean disconnected = new MutableBoolean();
+        doAnswer(invocation -> {
+            Request request = invocation.getArgument(0);
+            if (request.sessionId != zooKeeper.getSessionId()) {
+                return invocation.callRealMethod();
+            }
+            if (!matcher.match(request)) {
+                return invocation.callRealMethod();
+            }
+
+            ServerCnxn spyZkServerConnection1 = spy(zkServerConnection);
+            doAnswer(responseInvocation -> {
+                synchronized (disconnected) {
+                    ReplyHeader replyHeader = responseInvocation.getArgument(0);
+                    if (replyHeader.getXid() == request.cxid && replyHeader.getErr() == 0) {
+                        Whitebox.setInternalState(zkServerConnection, "zkServer", zooKeeperServer);
+                        disconnected.setTrue();
+                        bkEnsemble.disconnectZookeeper(zooKeeper);
+                    } else if (disconnected.isFalse()) {
+                        return responseInvocation.callRealMethod();
+                    }
+                    return null;
+                }
+            }).when(spyZkServerConnection1).sendResponse(any(ReplyHeader.class), nullable(Record.class), any(String.class));
+            Whitebox.setInternalState(request, "cnxn", spyZkServerConnection1);
+            return invocation.callRealMethod();
+        }).when(spyZooKeeperServer).submitRequest(any(Request.class));
+    }
+
+    @Test
+    public void testAcquireOwnershipWithZookeeperDisconnectedBeforeOwnershipNodeCreated() throws Exception {
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
+        TenantInfo tenantInfo = new TenantInfo();
+        tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
+        pulsarAdmins[0].tenants().createTenant("my-tenant", tenantInfo);
+        pulsarAdmins[0].namespaces().createNamespace("my-tenant/my-ns", 16);
+
+        String topic1 = "persistent://my-tenant/my-ns/topic-1";
+        NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
+        NamespaceBundle namespaceBundle = leaderNamespaceService.getBundle(TopicName.get(topic1));
+
+        final MutableObject<PulsarService> leaderAuthorizedBroker = spyLeaderNamespaceServiceForAuthorizedBroker();
+
+        PulsarService pulsar1 = pulsarServices[1];
+        final ZooKeeper zooKeeper1 = pulsar1.getZkClient();
+
+        final CompletableFuture<Void> reconnectedFuture = watchZookeeperReconnect(zooKeeper1);
+
+        String namespaceBundlePath = ServiceUnitZkUtils.path(namespaceBundle);
+
+        spyZookeeperToDisconnectBeforePersist(zooKeeper1, request -> {
+            if (request.type != ZooDefs.OpCode.create) {
+                return false;
+            }
+
+            CreateRequest createRequest = new CreateRequest();
+            ByteBufferInputStream.byteBuffer2Record(request.request.duplicate(), createRequest);
+            return createRequest.getPath().contains(namespaceBundlePath);
+        });
+
+        leaderAuthorizedBroker.setValue(pulsar1);
+
+        try {
+            // Trigger ownership acquiring and zookeeper disconnecting before ownership node created.
+            //
+            // Ignore its execution result since whether it is fail or not depends on concrete implementation.
+            pulsarAdmins[1].lookups().lookupTopic(topic1);
+        } catch (Exception ex) {
+            // Ignored intentionally.
+        }
+
+        reconnectedFuture.join();
+
+        // We don't known whether previous lookup was successful or not, but now all lookups should succeed.
+        Assert.assertEquals(pulsarAdmins[0].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+
+        pulsar1.getBrokerService().getTopic(topic1, true).join();
+
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+    }
+
+    @Test
+    public void testAcquireOwnershipWithZookeeperDisconnectedAfterOwnershipNodeCreated() throws Exception {
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
+        TenantInfo tenantInfo = new TenantInfo();
+        tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
+        pulsarAdmins[0].tenants().createTenant("my-tenant", tenantInfo);
+        pulsarAdmins[0].namespaces().createNamespace("my-tenant/my-ns", 16);
+
+        String topic1 = "persistent://my-tenant/my-ns/topic-1";
+        NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
+        NamespaceBundle namespaceBundle = leaderNamespaceService.getBundle(TopicName.get(topic1));
+
+        final MutableObject<PulsarService> leaderAuthorizedBroker = spyLeaderNamespaceServiceForAuthorizedBroker();
+
+        PulsarService pulsar1 = pulsarServices[1];
+        final ZooKeeper zooKeeper1 = pulsar1.getZkClient();
+
+        final CompletableFuture<Void> reconnectedFuture = watchZookeeperReconnect(zooKeeper1);
+
+        String namespaceBundlePath = ServiceUnitZkUtils.path(namespaceBundle);
+
+        spyZookeeperToDisconnectAfterPersist(zooKeeper1, request -> {
+            if (request.type != ZooDefs.OpCode.create) {
+                return false;
+            }
+
+            CreateRequest createRequest = new CreateRequest();
+            ByteBufferInputStream.byteBuffer2Record(request.request.duplicate(), createRequest);
+            return createRequest.getPath().contains(namespaceBundlePath);
+        });
+
+        leaderAuthorizedBroker.setValue(pulsar1);
+
+        try {
+            // Trigger ownership acquiring and zookeeper disconnecting after ownership node created.
+            //
+            // Ignore its execution result since whether it is fail or not depends on concrete implementation.
+            pulsarAdmins[1].lookups().lookupTopic(topic1);
+        } catch (Exception ex) {
+            // Ignored intentionally.
+        }
+
+        reconnectedFuture.join();
+
+        Assert.assertEquals(pulsarAdmins[0].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+
+        pulsar1.getBrokerService().getTopic(topic1, true).join();
+
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+    }
+
+    @Test
+    public void testReleaseOwnershipWithZookeeperDisconnectedBeforeOwnershipNodeDeleted() throws Exception {
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
+        TenantInfo tenantInfo = new TenantInfo();
+        tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
+        pulsarAdmins[0].tenants().createTenant("my-tenant", tenantInfo);
+        pulsarAdmins[0].namespaces().createNamespace("my-tenant/my-ns", 16);
+
+        String topic1 = "persistent://my-tenant/my-ns/topic-1";
+        NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
+        NamespaceBundle namespaceBundle = leaderNamespaceService.getBundle(TopicName.get(topic1));
+
+        final MutableObject<PulsarService> leaderAuthorizedBroker = spyLeaderNamespaceServiceForAuthorizedBroker();
+
+        PulsarService pulsar1 = pulsarServices[1];
+        PulsarService pulsar2 = pulsarServices[2];
+
+        leaderAuthorizedBroker.setValue(pulsar1);
+        Assert.assertEquals(pulsarAdmins[0].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+
+        ZooKeeper zooKeeper1 = pulsar1.getZkClient();
+
+        CompletableFuture<Void> reconnectedFuture = watchZookeeperReconnect(zooKeeper1);
+
+        String namespaceBundlePath = ServiceUnitZkUtils.path(namespaceBundle);
+
+        spyZookeeperToDisconnectBeforePersist(zooKeeper1, request -> {
+            if (request.type != ZooDefs.OpCode.delete) {
+                return false;
+            }
+            DeleteRequest deleteRequest = new DeleteRequest();
+            ByteBufferInputStream.byteBuffer2Record(request.request.duplicate(), deleteRequest);
+            return deleteRequest.getPath().contains(namespaceBundlePath);
+        });
+
+        try {
+            pulsarAdmins[1].namespaces().unloadNamespaceBundle(namespaceBundle.getNamespaceObject().toString(), namespaceBundle.getBundleRange());
+        } catch (Exception ex) {
+            // Ignored since whether failing unloading when zk connection-loss is an implementation detail.
+        }
+
+        reconnectedFuture.join();
+
+        leaderAuthorizedBroker.setValue(pulsar2);
+
+        // We don't known whether previous unload was successful or not, but now all lookups should return same result.
+        final String currentBrokerServiceUrl = pulsarAdmins[0].lookups().lookupTopic(topic1);
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), currentBrokerServiceUrl);
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), currentBrokerServiceUrl);
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), currentBrokerServiceUrl);
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), currentBrokerServiceUrl);
+
+        pulsarAdmins[0].topics().createNonPartitionedTopic(topic1);
+    }
+
+    @Test
+    public void testReleaseOwnershipWithZookeeperDisconnectedAfterOwnershipNodeDeleted() throws Exception {
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
+        TenantInfo tenantInfo = new TenantInfo();
+        tenantInfo.setAllowedClusters(Sets.newHashSet("my-cluster"));
+        pulsarAdmins[0].tenants().createTenant("my-tenant", tenantInfo);
+        pulsarAdmins[0].namespaces().createNamespace("my-tenant/my-ns", 16);
+
+        String topic1 = "persistent://my-tenant/my-ns/topic-1";
+        NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
+        NamespaceBundle namespaceBundle = leaderNamespaceService.getBundle(TopicName.get(topic1));
+
+        final MutableObject<PulsarService> leaderAuthorizedBroker = spyLeaderNamespaceServiceForAuthorizedBroker();
+
+        PulsarService pulsar1 = pulsarServices[1];
+        PulsarService pulsar2 = pulsarServices[2];
+
+        leaderAuthorizedBroker.setValue(pulsar1);
+        Assert.assertEquals(pulsarAdmins[0].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), pulsar1.getBrokerServiceUrl());
+
+        ZooKeeper zooKeeper1 = pulsar1.getZkClient();
+
+        CompletableFuture<Void> reconnectedFuture = watchZookeeperReconnect(zooKeeper1);
+
+        String namespaceBundlePath = ServiceUnitZkUtils.path(namespaceBundle);
+
+        spyZookeeperToDisconnectAfterPersist(zooKeeper1, request -> {
+            if (request.type != ZooDefs.OpCode.delete) {
+                return false;
+            }
+            DeleteRequest deleteRequest = new DeleteRequest();
+            ByteBufferInputStream.byteBuffer2Record(request.request.duplicate(), deleteRequest);
+            return deleteRequest.getPath().contains(namespaceBundlePath);
+        });
+
+        try {
+            pulsarAdmins[1].namespaces().unloadNamespaceBundle(namespaceBundle.getNamespaceObject().toString(), namespaceBundle.getBundleRange());
+        } catch (Exception ex) {
+            // Ignored since whether failing unloading when zk connection-loss is an implementation detail.
+        }
+
+        reconnectedFuture.join();
+
+        leaderAuthorizedBroker.setValue(pulsar2);
+
+        Assert.assertEquals(pulsarAdmins[0].lookups().lookupTopic(topic1), pulsar2.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[3].lookups().lookupTopic(topic1), pulsar2.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[4].lookups().lookupTopic(topic1), pulsar2.getBrokerServiceUrl());
+
+        pulsar2.getBrokerService().getTopic(topic1, true).join();
+
+        Assert.assertEquals(pulsarAdmins[2].lookups().lookupTopic(topic1), pulsar2.getBrokerServiceUrl());
+        Assert.assertEquals(pulsarAdmins[1].lookups().lookupTopic(topic1), pulsar2.getBrokerServiceUrl());
     }
 
     @Test

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
@@ -40,10 +41,10 @@ import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 
 import org.apache.bookkeeper.bookie.BookieException.InvalidCookieException;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.clients.StorageClientBuilder;
 import org.apache.bookkeeper.clients.admin.StorageAdminClient;
 import org.apache.bookkeeper.clients.config.StorageClientSettings;
@@ -55,7 +56,6 @@ import org.apache.bookkeeper.common.util.Backoff;
 import org.apache.bookkeeper.common.util.Backoff.Jitter.Type;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
-import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stream.proto.NamespaceConfiguration;
@@ -73,6 +73,7 @@ import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -203,6 +204,23 @@ public class LocalBookkeeperEnsemble {
 
         LOG.info("ZooKeeper server up: {}", b);
         LOG.debug("Local ZK started (port: {}, data_directory: {})", zkPort, zkDataDir.getAbsolutePath());
+    }
+
+    public void disconnectZookeeper(ZooKeeper zooKeeper) {
+        ServerCnxn serverCnxn = getZookeeperServerConnection(zooKeeper);
+        try {
+            Method method = serverCnxn.getClass().getMethod("close");
+            method.invoke(serverCnxn);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public ServerCnxn getZookeeperServerConnection(ZooKeeper zooKeeper) {
+        return StreamSupport.stream(serverFactory.getConnections().spliterator(), false)
+            .filter((cnxn) -> cnxn.getSessionId() == zooKeeper.getSessionId())
+            .findFirst()
+            .orElse(null);
     }
 
     private void initializeZookeper() throws IOException {
@@ -409,6 +427,10 @@ public class LocalBookkeeperEnsemble {
         }
     }
 
+    public void stopBK(int i) {
+        bs[i].shutdown();
+    }
+
     public void stopBK() {
         LOG.debug("Local ZK/BK stopping ...");
         for (BookieServer bookie : bs) {
@@ -416,27 +438,30 @@ public class LocalBookkeeperEnsemble {
         }
     }
 
+    public void startBK(int i) throws Exception {
+        try {
+            bs[i] = new BookieServer(bsConfs[i], NullStatsLogger.INSTANCE);
+        } catch (InvalidCookieException e) {
+            // InvalidCookieException can happen if the machine IP has changed
+            // Since we are running here a local bookie that is always accessed
+            // from localhost, we can ignore the error
+            for (String path : zkc.getChildren("/ledgers/cookies", false)) {
+                zkc.delete("/ledgers/cookies/" + path, -1);
+            }
+
+            // Also clean the on-disk cookie
+            new File(new File(bsConfs[i].getJournalDirNames()[0], "current"), "VERSION").delete();
+
+            // Retry to start the bookie after cleaning the old left cookie
+            bs[i] = new BookieServer(bsConfs[i], NullStatsLogger.INSTANCE);
+
+        }
+        bs[i].start();
+    }
+
     public void startBK() throws Exception {
         for (int i = 0; i < numberOfBookies; i++) {
-
-            try {
-                bs[i] = new BookieServer(bsConfs[i], NullStatsLogger.INSTANCE);
-            } catch (InvalidCookieException e) {
-                // InvalidCookieException can happen if the machine IP has changed
-                // Since we are running here a local bookie that is always accessed
-                // from localhost, we can ignore the error
-                for (String path : zkc.getChildren("/ledgers/cookies", false)) {
-                    zkc.delete("/ledgers/cookies/" + path, -1);
-                }
-
-                // Also clean the on-disk cookie
-                new File(new File(bsConfs[i].getJournalDirNames()[0], "current"), "VERSION").delete();
-
-                // Retry to start the bookie after cleaning the old left cookie
-                bs[i] = new BookieServer(bsConfs[i], NullStatsLogger.INSTANCE);
-
-            }
-            bs[i].start();
+            startBK(i);
         }
     }
 

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperServerTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperServerTest.java
@@ -82,5 +82,9 @@ public class ZookeeperServerTest implements Closeable {
         return serverFactory.getLocalPort();
     }
 
+    public String getHostPort() {
+        return hostPort;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(ZookeeperServerTest.class);
 }


### PR DESCRIPTION
Fixes #7517 

### Motivation
In acquiring/releasing namespace bundle ownership, zk may disconnected before or after these operations persisted in zk cluster. This introduce inconsistency between local ownership cache and zk cluster.

### Modifications
This commit does two things:
* In ownership releasing, don't retain ownership in failure.
* In ownership checking, querying and acquiring, reestablish lost ownership in false negative releasing and false positive acquiring.

i.e. this commit admits that the inconsistency between local ownership cache and zk cluster could not be avoided totally, thus performs ownership correction in checking, querying and acquiring.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
* Add tests to mock zk disconnection in namespace bundle unloading and acquiring. Existing code fails in these tests, this pr pass.
* Add test to verify whether namespace bundle ownership could be reestablish after cache invalidated.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
