### PR TITLE
[Transaction] Support consume transaction messages.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -95,6 +95,7 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
                 if (Markers.isTxnCommitMarker(msgMetadata)) {
                     entries.set(i, null);
                     pendingTxnQueue.add(new TxnID(msgMetadata.getTxnidMostBits(), msgMetadata.getTxnidLeastBits()));
+                    continue;
                 } else if (msgMetadata == null || Markers.isServerOnlyMarker(msgMetadata)) {
                     PositionImpl pos = (PositionImpl) entry.getPosition();
                     // Message metadata was corrupted or the messages was a server-only marker

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -175,4 +175,12 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     public boolean havePendingTxnToRead() {
         return pendingTxnQueue.size() > 0;
     }
+
+    public Subscription getSubscription() {
+        return this.subscription;
+    }
+
+    public ConcurrentLinkedQueue<TxnID> getPendingTxnQueue() {
+        return this.pendingTxnQueue;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -104,6 +104,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     protected final ServiceConfiguration serviceConfig;
     protected Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
 
+    private TransactionReader transactionReader = new TransactionReader();
+
     enum ReadType {
         Normal, Replay
     }
@@ -351,6 +353,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             } else if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE) {
                 log.warn("[{}] Dispatcher read is blocked due to unackMessages {} reached to max {}", name,
                         totalUnackedMessages, topic.getMaxUnackedMessagesOnSubscription());
+            } else if (havePendingTxnToRead()) {
+                transactionReader.read(subscription.getTopic(), pendingTxnQueue, messagesToRead, ReadType.Normal, this);
             } else if (!havePendingRead) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule read of {} messages for {} consumers", name, messagesToRead,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -73,7 +73,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
 
     private final RedeliveryTracker redeliveryTracker;
 
-    private TransactionReader transactionReader = new TransactionReader();
+    private TransactionReader transactionReader;
 
     public PersistentDispatcherSingleActiveConsumer(ManagedCursor cursor, SubType subscriptionType, int partitionIndex,
             PersistentTopic topic, Subscription subscription) {
@@ -86,6 +86,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
         this.readBatchSize = serviceConfig.getDispatcherMaxReadBatchSize();
         this.redeliveryTracker = RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED;
         this.initializeDispatchRateLimiterIfNeeded(Optional.empty());
+        this.transactionReader  = new TransactionReader(this);
     }
 
     protected void scheduleReadOnActiveConsumer() {
@@ -456,7 +457,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
             havePendingRead = true;
 
             if (havePendingTxnToRead()) {
-                transactionReader.read(subscription.getTopic(), pendingTxnQueue, messagesToRead, consumer, this);
+                transactionReader.read(messagesToRead, consumer, this);
             } else if (consumer.readCompacted()) {
                 topic.getCompactedTopic().asyncReadEntriesOrWait(cursor, messagesToRead, this, consumer);
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
+import org.apache.pulsar.client.api.transaction.TxnID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Slf4j
+public class TransactionReader {
+
+    private TransactionBuffer transactionBuffer;
+    private volatile long startSequenceId = 0;
+
+    public void read(Topic topic, ConcurrentLinkedQueue<TxnID> transactionQueue,
+                     int readMessageNum, Object ctx,
+                     AsyncCallbacks.ReadEntriesCallback readEntriesCallback) {
+        if (transactionBuffer == null) {
+            topic.getTransactionBuffer(false).whenComplete((tb, throwable) -> {
+                if (throwable != null) {
+                    log.error("Get transactionBuffer failed.", throwable);
+                    readEntriesCallback.readEntriesFailed(
+                            ManagedLedgerException.getManagedLedgerException(throwable), ctx);
+                    return;
+                }
+                transactionBuffer = tb;
+                read(transactionQueue, readMessageNum, ctx, readEntriesCallback);
+            });
+        } else {
+            read(transactionQueue, readMessageNum, ctx, readEntriesCallback);
+        }
+    }
+
+    private void read(ConcurrentLinkedQueue<TxnID> transactionQueue,
+                     int readMessageNum, Object ctx,
+                     AsyncCallbacks.ReadEntriesCallback readEntriesCallback) {
+        final TxnID txnID = transactionQueue.peek();
+        transactionBuffer.openTransactionBufferReader(txnID, startSequenceId).thenAccept(reader -> {
+            reader.readNext(readMessageNum).whenComplete((transactionEntries, throwable) -> {
+                if (throwable != null) {
+                    log.error("Read transaction messages failed.", throwable);
+                    readEntriesCallback.readEntriesFailed(
+                            ManagedLedgerException.getManagedLedgerException(throwable), ctx);
+                    return;
+                }
+                if (transactionEntries == null || transactionEntries.size() < readMessageNum) {
+                    startSequenceId = 0;
+                    transactionQueue.remove(txnID);
+                    reader.close();
+                }
+                List<Entry> entryList = new ArrayList<>(transactionEntries.size());
+                for (int i = 0; i < transactionEntries.size(); i++) {
+                    if (i == (transactionEntries.size() -1)) {
+                        startSequenceId = transactionEntries.get(i).sequenceId();
+                    }
+                    entryList.add(transactionEntries.get(i).getEntry());
+                }
+                readEntriesCallback.readEntriesComplete(entryList, ctx);
+            });
+        }).exceptionally(throwable -> {
+            log.error("Open transactionBufferReader failed.", throwable);
+            readEntriesCallback.readEntriesFailed(
+                    ManagedLedgerException.getManagedLedgerException(throwable), ctx);
+            return null;
+        });
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntry.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.transaction.buffer;
 import com.google.common.annotations.Beta;
 import io.netty.buffer.ByteBuf;
 
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.client.api.transaction.TxnID;
 
 /**
@@ -63,6 +64,8 @@ public interface TransactionEntry extends AutoCloseable {
      * @return the entry buffer.
      */
     ByteBuf getEntryBuffer();
+
+    Entry getEntry();
 
     /**
      * Close the entry to release the resource that it holds.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntry.java
@@ -59,12 +59,10 @@ public interface TransactionEntry extends AutoCloseable {
     long committedAtEntryId();
 
     /**
-     * Returns the entry buffer.
+     * Returns the entry saved in {@link TransactionBuffer}.
      *
-     * @return the entry buffer.
+     * @return the {@link Entry}
      */
-    ByteBuf getEntryBuffer();
-
     Entry getEntry();
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
@@ -69,7 +69,6 @@ public class InMemTransactionBufferReader implements TransactionBufferReader {
             TransactionEntry txnEntry = new TransactionEntryImpl(
                 txnId,
                 entry.getKey(),
-                entry.getValue(),
                 EntryImpl.create(-1L, -1L, entry.getValue()),
                 committedAtLedgerId,
                 committedAtEntryId

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferReader;
 import org.apache.pulsar.broker.transaction.buffer.TransactionEntry;
 import org.apache.pulsar.broker.transaction.buffer.exceptions.EndOfTransactionException;
@@ -68,6 +70,7 @@ public class InMemTransactionBufferReader implements TransactionBufferReader {
                 txnId,
                 entry.getKey(),
                 entry.getValue(),
+                EntryImpl.create(-1L, -1L, entry.getValue()),
                 committedAtLedgerId,
                 committedAtEntryId
             );

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -83,9 +83,7 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
                     tmpFuture.completeExceptionally(throwable);
                 } else {
                     TransactionEntry txnEntry = new TransactionEntryImpl(meta.id(), longPositionEntry.getKey(),
-                                                                         entry.getDataBuffer(), entry,
-                                                                         meta.committedAtLedgerId(),
-                                                                         meta.committedAtEntryId());
+                            entry, meta.committedAtLedgerId(), meta.committedAtEntryId());
                     synchronized (txnEntries) {
                         txnEntries.add(txnEntry);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -83,7 +83,7 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
                     tmpFuture.completeExceptionally(throwable);
                 } else {
                     TransactionEntry txnEntry = new TransactionEntryImpl(meta.id(), longPositionEntry.getKey(),
-                                                                         entry.getDataBuffer(),
+                                                                         entry.getDataBuffer(), entry,
                                                                          meta.committedAtLedgerId(),
                                                                          meta.committedAtEntryId());
                     synchronized (txnEntries) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
@@ -84,5 +84,8 @@ public class TransactionEntryImpl implements TransactionEntry {
         if (null != entryBuf) {
             entryBuf.release();
         }
+        if (null != entry) {
+            entry.release();
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.pulsar.broker.transaction.buffer.TransactionEntry;
 import org.apache.pulsar.client.api.transaction.TxnID;
 
@@ -32,18 +33,15 @@ public class TransactionEntryImpl implements TransactionEntry {
     private final long sequenceId;
     private final long committedAtLedgerId;
     private final long committedAtEntryId;
-    private final ByteBuf entryBuf;
     private final Entry entry;
 
     public TransactionEntryImpl(TxnID txnId,
                          long sequenceId,
-                         ByteBuf entryBuf,
                          Entry entry,
                          long committedAtLedgerId,
                          long committedAtEntryId) {
         this.txnId = txnId;
         this.sequenceId = sequenceId;
-        this.entryBuf = entryBuf;
         this.entry = entry;
         this.committedAtLedgerId = committedAtLedgerId;
         this.committedAtEntryId = committedAtEntryId;
@@ -70,20 +68,12 @@ public class TransactionEntryImpl implements TransactionEntry {
     }
 
     @Override
-    public ByteBuf getEntryBuffer() {
-        return entryBuf;
-    }
-
-    @Override
     public Entry getEntry() {
         return entry;
     }
 
     @Override
     public void close() {
-        if (null != entryBuf) {
-            entryBuf.release();
-        }
         if (null != entry) {
             entry.release();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
@@ -75,6 +75,7 @@ public class TransactionEntryImpl implements TransactionEntry {
     @Override
     public void close() {
         if (null != entry) {
+            entry.getDataBuffer().release();
             entry.release();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionEntryImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.transaction.buffer.TransactionEntry;
 import org.apache.pulsar.client.api.transaction.TxnID;
 
@@ -32,15 +33,18 @@ public class TransactionEntryImpl implements TransactionEntry {
     private final long committedAtLedgerId;
     private final long committedAtEntryId;
     private final ByteBuf entryBuf;
+    private final Entry entry;
 
     public TransactionEntryImpl(TxnID txnId,
                          long sequenceId,
                          ByteBuf entryBuf,
+                         Entry entry,
                          long committedAtLedgerId,
                          long committedAtEntryId) {
         this.txnId = txnId;
         this.sequenceId = sequenceId;
         this.entryBuf = entryBuf;
+        this.entry = entry;
         this.committedAtLedgerId = committedAtLedgerId;
         this.committedAtEntryId = committedAtEntryId;
     }
@@ -68,6 +72,11 @@ public class TransactionEntryImpl implements TransactionEntry {
     @Override
     public ByteBuf getEntryBuffer() {
         return entryBuf;
+    }
+
+    @Override
+    public Entry getEntry() {
+        return entry;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionMetaImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionMetaImpl.java
@@ -90,7 +90,7 @@ public class TransactionMetaImpl implements TransactionMeta {
 
         SortedMap<Long, Position> readEntries = entries;
         if (startSequenceId != PersistentTransactionBufferReader.DEFAULT_START_SEQUENCE_ID) {
-            readEntries = entries.tailMap(startSequenceId);
+            readEntries = entries.tailMap(startSequenceId + 1);
         }
 
         if (readEntries.isEmpty()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction;
+
+import com.google.common.collect.Sets;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
+import org.apache.pulsar.broker.transaction.buffer.impl.PersistentTransactionBuffer;
+import org.apache.pulsar.broker.transaction.coordinator.TransactionMetaStoreTestBase;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarMarkers;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.Markers;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Slf4j
+public class TransactionConsumeTest extends TransactionMetaStoreTestBase {
+
+    private final static String CONSUME_TOPIC = "persistent://public/txn/txn-consume-test";
+    private final static String NORMAL_MSG_CONTENT = "Normal - ";
+    private final static String TXN_MSG_CONTENT = "Txn - ";
+
+    @BeforeClass
+    public void init() throws Exception {
+        BROKER_COUNT = 1;
+        super.setup();
+
+        pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
+        pulsarAdmins[0].tenants().createTenant("public", new TenantInfo(Sets.newHashSet(), Sets.newHashSet("my-cluster")));
+        pulsarAdmins[0].namespaces().createNamespace("public/txn", 10);
+        pulsarAdmins[0].topics().createNonPartitionedTopic(CONSUME_TOPIC);
+    }
+
+    @Test
+    public void test() throws Exception {
+        int messageCntBeforeTxn = 10;
+        int transactionMessageCnt = 10;
+        int messageCntAfterTxn = 10;
+        int totalMsgCnt = messageCntBeforeTxn + transactionMessageCnt + messageCntAfterTxn;
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(CONSUME_TOPIC)
+                .create();
+
+        Consumer<byte[]> exclusiveConsumer = pulsarClient.newConsumer()
+                .topic(CONSUME_TOPIC)
+                .subscriptionName("exclusive-test")
+                .subscribe();
+
+        Consumer<byte[]> sharedConsumer = pulsarClient.newConsumer()
+                .topic(CONSUME_TOPIC)
+                .subscriptionName("shared-test")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+
+        long mostSigBits = 2L;
+        long leastSigBits = 5L;
+        TxnID txnID = new TxnID(mostSigBits, leastSigBits);
+
+        String transactionBufferName = CONSUME_TOPIC + "_txnlog";
+        ManagedLedger managedLedger = pulsarServices[0].getManagedLedgerFactory()
+                .open(TopicName.get(transactionBufferName).getPersistenceNamingEncoding(), new ManagedLedgerConfig());
+        PersistentTransactionBuffer transactionBuffer = new PersistentTransactionBuffer(
+                transactionBufferName, managedLedger, pulsarServices[0].getBrokerService());
+        log.info("transactionBuffer init finish.");
+
+        sendNormalMessages(producer, 0, messageCntBeforeTxn);
+
+        // append messages to TB
+        appendTransactionMessages(txnID, transactionBuffer, transactionMessageCnt);
+
+        sendNormalMessages(producer, messageCntBeforeTxn, messageCntAfterTxn);
+
+        for (int i = 0; i < totalMsgCnt; i++) {
+            if (i < (messageCntBeforeTxn + messageCntAfterTxn)) {
+                Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertNotNull(message);
+                log.info("Receive exclusive normal msg: {}" + new String(message.getData(), UTF_8));
+                message = sharedConsumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertNotNull(message);
+                log.info("Receive shared normal msg: {}" + new String(message.getData(), UTF_8));
+            } else {
+                Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertNull(message);
+                message = sharedConsumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertNull(message);
+                log.info("Can't receive message before commit.");
+            }
+        }
+
+        PersistentTopic persistentTopic = (PersistentTopic) pulsarServices[0].getBrokerService()
+                .getTopic(CONSUME_TOPIC, false).get().get();
+
+        Class<PersistentTopic> persistentTopicClass = PersistentTopic.class;
+        Field field = persistentTopicClass.getDeclaredField("transactionBuffer");
+        field.setAccessible(true);
+        field.set(persistentTopic, transactionBuffer);
+
+        // append commit marker to topic
+        PulsarMarkers.MessageIdData messageIdData = PulsarMarkers.MessageIdData
+                .newBuilder()
+                .setLedgerId(-1L)
+                .setEntryId(-1L)
+                .build();
+        ByteBuf commitMarker = Markers.newTxnCommitMarker(1L, mostSigBits, leastSigBits, messageIdData);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        persistentTopic.publishMessage(commitMarker, new Topic.PublishContext() {
+            @Override
+            public void completed(Exception e, long ledgerId, long entryId) {
+                log.info("Publish commit marker ledgerId: {}, entryId: {}", ledgerId, entryId);
+                transactionBuffer.commitTxn(txnID, ledgerId, entryId).thenRun(countDownLatch::countDown);
+            }
+        });
+        countDownLatch.await();
+        log.info("Append commit marker to topic partition.");
+
+        for (int i = 0; i < transactionMessageCnt; i++) {
+            Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+            Assert.assertNotNull(message);
+            log.info("Receive txn exclusive msg: {}", new String(message.getData()));
+            message = sharedConsumer.receive(2, TimeUnit.SECONDS);
+            Assert.assertNotNull(message);
+            log.info("Receive txn shared msg: {}", new String(message.getData(), UTF_8));
+        }
+
+        exclusiveConsumer.close();
+        sharedConsumer.close();
+    }
+
+    private void sendNormalMessages(Producer<byte[]> producer, int startMsgCnt, int messageCnt)
+            throws PulsarClientException {
+        for (int i = 0; i < messageCnt; i++) {
+            producer.newMessage().value((NORMAL_MSG_CONTENT + (startMsgCnt + i)).getBytes(UTF_8)).send();
+        }
+    }
+
+    private void appendTransactionMessages(TxnID txnID, TransactionBuffer tb, int transactionMsgCnt) {
+        for (int i = 0; i < transactionMsgCnt; i++) {
+            PulsarApi.MessageMetadata.Builder builder = PulsarApi.MessageMetadata.newBuilder();
+            builder.setProducerName("producerName");
+            builder.setSequenceId(10L);
+            builder.setTxnidMostBits(txnID.getMostSigBits());
+            builder.setTxnidLeastBits(txnID.getLeastSigBits());
+            builder.setPublishTime(System.currentTimeMillis());
+
+            ByteBuf headerAndPayload = Commands.serializeMetadataAndPayload(
+                    Commands.ChecksumType.Crc32c, builder.build(),
+                    Unpooled.copiedBuffer((TXN_MSG_CONTENT + i).getBytes(UTF_8)));
+            tb.appendBufferToTxn(txnID, i, headerAndPayload);
+        }
+        log.info("append messages to TB finish.");
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -18,6 +18,12 @@
  */
 package org.apache.pulsar.broker.transaction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -46,12 +52,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Field;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+/**
+ * Test for consuming transaction messages.
+ */
 @Slf4j
 public class TransactionConsumeTest extends TransactionMetaStoreTestBase {
 
@@ -71,7 +74,7 @@ public class TransactionConsumeTest extends TransactionMetaStoreTestBase {
     }
 
     @Test
-    public void test() throws Exception {
+    public void noSortedTest() throws Exception {
         int messageCntBeforeTxn = 10;
         int transactionMessageCnt = 10;
         int messageCntAfterTxn = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -58,7 +58,7 @@ import org.testng.annotations.Test;
  * Pulsar client transaction test.
  */
 @Slf4j
-public class PulsarClientTransactionTest extends TransactionTestBase {
+public class TransactionProduceTest extends TransactionTestBase {
 
     private final static int TOPIC_PARTITION = 3;
 
@@ -105,7 +105,7 @@ public class PulsarClientTransactionTest extends TransactionTestBase {
     }
 
     @Test
-    public void produceCommitTest() throws Exception {
+    public void produceAndCommitTest() throws Exception {
         PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
         Transaction tnx = pulsarClientImpl.newTransaction()
                 .withTransactionTimeout(5, TimeUnit.SECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/InMemTransactionBufferReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/InMemTransactionBufferReaderTest.java
@@ -132,7 +132,7 @@ public class InMemTransactionBufferReaderTest {
                 assertEquals(txnEntry.txnId(), txnID);
                 assertEquals(txnEntry.sequenceId(), startSequenceId + i);
                 assertEquals(new String(
-                    ByteBufUtil.getBytes(txnEntry.getEntryBuffer()),
+                    ByteBufUtil.getBytes(txnEntry.getEntry().getDataBuffer()),
                     UTF_8
                 ), "message-" + i);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
@@ -105,6 +105,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -412,7 +413,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
             verifyAndReleaseEntries(entries, txnID, 0L, numEntries);
 
             reader.readNext(1).get();
-
+            Assert.fail("Should cause the exception `EndOfTransactionException`.");
         } catch (ExecutionException ee) {
              assertTrue(ee.getCause() instanceof EndOfTransactionException);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
@@ -414,7 +414,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
             reader.readNext(1).get();
 
         } catch (ExecutionException ee) {
-            assertTrue(ee.getCause() instanceof EndOfTransactionException);
+             assertTrue(ee.getCause() instanceof EndOfTransactionException);
         }
 
     }
@@ -754,7 +754,7 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
                 assertEquals(txnEntry.txnId(), txnID);
                 assertEquals(txnEntry.sequenceId(), startSequenceId + i);
                 assertEquals(new String(
-                    ByteBufUtil.getBytes(txnEntry.getEntryBuffer()),
+                    ByteBufUtil.getBytes(txnEntry.getEntry().getDataBuffer()),
                     UTF_8
                 ), "message-" + i);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
@@ -258,7 +258,7 @@ public class TransactionBufferTest {
                 assertEquals(txnEntry.txnId(), txnID);
                 assertEquals(txnEntry.sequenceId(), startSequenceId + i);
                 assertEquals(new String(
-                    ByteBufUtil.getBytes(txnEntry.getEntryBuffer()),
+                    ByteBufUtil.getBytes(txnEntry.getEntry().getDataBuffer()),
                     UTF_8
                 ), "message-" + i);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionEntryImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.testng.annotations.Test;
@@ -39,6 +40,7 @@ public class TransactionEntryImplTest {
             new TxnID(1234L, 3456L),
             0L,
             buffer,
+            EntryImpl.create(33L, 44L, buffer),
             33L,
             44L
         );

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
@@ -40,11 +40,11 @@ public class TransactionEntryImplTest {
             new TxnID(1234L, 3456L),
             0L,
             buffer,
-            EntryImpl.create(33L, 44L, buffer),
+            EntryImpl.create(12L, 23L, buffer),
             33L,
             44L
         );
-        assertEquals(buffer.refCnt(), 1);
+        assertEquals(buffer.refCnt(), 2);
         entry.close();
         assertEquals(buffer.refCnt(), 0);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionEntryImplTest.java
@@ -39,7 +39,6 @@ public class TransactionEntryImplTest {
         TransactionEntryImpl entry = new TransactionEntryImpl(
             new TxnID(1234L, 3456L),
             0L,
-            buffer,
             EntryImpl.create(12L, 23L, buffer),
             33L,
             44L

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
@@ -40,7 +40,7 @@ public class TransactionMetaStoreTestBase {
     LocalBookkeeperEnsemble bkEnsemble;
     protected PulsarAdmin[] pulsarAdmins = new PulsarAdmin[BROKER_COUNT];
     protected PulsarClient pulsarClient;
-    protected static final int BROKER_COUNT = 5;
+    protected static int BROKER_COUNT = 5;
     protected ServiceConfiguration[] configurations = new ServiceConfiguration[BROKER_COUNT];
     protected PulsarService[] pulsarServices = new PulsarService[BROKER_COUNT];
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.client.transaction;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
@@ -1,0 +1,112 @@
+package org.apache.pulsar.client.transaction;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.Sets;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.transaction.TransactionTestBase;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
+import org.apache.pulsar.client.impl.PartitionedProducerImpl;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End to end transaction test.
+ */
+@Slf4j
+public class EndToEndTest extends TransactionTestBase {
+
+
+    private final static int TOPIC_PARTITION = 3;
+
+    private final static String CLUSTER_NAME = "test";
+    private final static String TENANT = "tnx";
+    private final static String NAMESPACE1 = TENANT + "/ns1";
+    private final static String TOPIC_OUTPUT = NAMESPACE1 + "/output";
+
+    @BeforeMethod
+    protected void setup() throws Exception {
+        internalSetup();
+
+        int webServicePort = getServiceConfigurationList().get(0).getWebServicePort().get();
+        admin.clusters().createCluster(CLUSTER_NAME, new ClusterData("http://localhost:" + webServicePort));
+        admin.tenants().createTenant(TENANT,
+                new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
+        admin.namespaces().createNamespace(NAMESPACE1);
+        admin.topics().createPartitionedTopic(TOPIC_OUTPUT, 3);
+
+        admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
+                new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), 16);
+
+        int brokerPort = getServiceConfigurationList().get(0).getBrokerServicePort().get();
+        pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:" + brokerPort)
+                .statsInterval(0, TimeUnit.SECONDS)
+                .enableTransaction(true)
+                .build();
+
+        Thread.sleep(1000 * 3);
+    }
+
+    @Test
+    public void test() throws Exception {
+        Transaction txn = ((PulsarClientImpl) pulsarClient)
+                .newTransaction()
+                .withTransactionTimeout(2, TimeUnit.SECONDS)
+                .build()
+                .get();
+
+        @Cleanup
+        PartitionedProducerImpl<byte[]> producer = (PartitionedProducerImpl<byte[]>) pulsarClient
+                .newProducer()
+                .topic(TOPIC_OUTPUT)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .enableBatching(false)
+                .create();
+
+        int messageCnt = 10;
+        for (int i = 0; i < messageCnt; i++) {
+            producer.newMessage(txn).value(("Hello Txn - " + i).getBytes(UTF_8)).sendAsync();
+        }
+
+        @Cleanup
+        MultiTopicsConsumerImpl<byte[]> consumer = (MultiTopicsConsumerImpl<byte[]>) pulsarClient
+                .newConsumer()
+                .topic(TOPIC_OUTPUT)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName("test")
+                .subscribe();
+
+        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+        // Can't receive transaction messages before commit.
+        Assert.assertNull(message);
+
+        txn.commit().get();
+
+        Thread.sleep(2000);
+
+        int receiveCnt = 0;
+        for (int i = 0; i < messageCnt; i++) {
+            message = consumer.receive(2, TimeUnit.SECONDS);
+            Assert.assertNotNull(message);
+            receiveCnt ++;
+        }
+        Assert.assertEquals(messageCnt, receiveCnt);
+        log.info("receive transaction messages count: {}", receiveCnt);
+    }
+
+}


### PR DESCRIPTION
Master Issue: #2664 

Fix https://github.com/streamnative/pulsar/issues/1304

### Motivation

Currently, the consumer can't receive transaction messages.

### Modifications

Support process the commit marker in the topic partition and fetch transaction messages from TransactionBuffer. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- *Added unit test for consuming transaction messages*
`org.apache.pulsar.broker.transaction.TransactionConsumeTest`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
