### PR TITLE
allowTopicOperationAsync should check the original role is super user (#1355)

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
@@ -225,12 +226,19 @@ public interface AuthorizationProvider extends Closeable {
      * @param authData
      * @return CompletableFuture<Boolean>
      */
+    @Deprecated
     default CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role,
                                                             TenantOperation operation,
                                                             AuthenticationDataSource authData) {
-        return isTenantAdmin(tenantName, role, null, authData);
+        return allowTenantOperationAsync(
+            tenantName,
+            StringUtils.isBlank(originalRole) ? role : originalRole,
+            operation,
+            authData
+        );
     }
 
+    @Deprecated
     default Boolean allowTenantOperation(String tenantName, String originalRole, String role, TenantOperation operation,
                                       AuthenticationDataSource authData) {
         try {
@@ -243,26 +251,93 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
+     * Check if a given <tt>role</tt> is allowed to execute a given <tt>operation</tt> on the tenant.
+     *
+     * @param tenantName tenant name
+     * @param role role name
+     * @param operation tenant operation
+     * @param authData authenticated data of the role
+     * @return a completable future represents check result
+     */
+    default CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String role,
+                                                                 TenantOperation operation,
+                                                                 AuthenticationDataSource authData) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+            String.format("allowTenantOperation(%s) on tenant %s is not supported by the Authorization" +
+                    " provider you are using.",
+                operation.toString(), tenantName)));
+    }
+
+    default Boolean allowTenantOperation(String tenantName, String role, TenantOperation operation,
+                                         AuthenticationDataSource authData) {
+        try {
+            return allowTenantOperationAsync(tenantName, role, operation, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
+        }
+    }
+
+    /**
+     * Check if a given <tt>role</tt> is allowed to execute a given <tt>operation</tt> on the namespace.
+     *
+     * @param namespaceName namespace name
+     * @param role role name
+     * @param operation namespace operation
+     * @param authData authenticated data
+     * @return a completable future represents check result
+     */
+    default CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                    String role,
+                                                                    NamespaceOperation operation,
+                                                                    AuthenticationDataSource authData) {
+        return FutureUtil.failedFuture(
+            new IllegalStateException("NamespaceOperation is not supported by the Authorization provider you are using."));
+    }
+
+    default Boolean allowNamespaceOperation(NamespaceName namespaceName,
+                                            String role,
+                                            NamespaceOperation operation,
+                                            AuthenticationDataSource authData) {
+        try {
+            return allowNamespaceOperationAsync(namespaceName, role, operation, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
+        }
+    }
+
+    /**
      * Grant authorization-action permission on a namespace to the given client
+     *
      * @param namespaceName
-     * @param originalRole role not overriden by proxy role if request do pass through proxy
-     * @param role originalRole | proxyRole if the request didn't pass through proxy
+     * @param role
      * @param operation
      * @param authData
      * @return CompletableFuture<Boolean>
      */
-    default CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName, String originalRole,
-                                                                 String role, NamespaceOperation operation,
-                                                                 AuthenticationDataSource authData) {
-        return FutureUtil.failedFuture(
-            new IllegalStateException(
-                    String.format("NamespaceOperation(%s) on namespace(%s) by role(%s) is not supported" +
-                    " by the Authorization provider you are using.",
-                            operation.toString(), namespaceName.toString(), role == null ? "null" : role)));
+    @Deprecated
+    default CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                    String originalRole,
+                                                                    String role,
+                                                                    NamespaceOperation operation,
+                                                                    AuthenticationDataSource authData) {
+        return allowNamespaceOperationAsync(
+            namespaceName,
+            StringUtils.isBlank(originalRole) ? role : originalRole,
+            operation,
+            authData
+        );
     }
 
-    default Boolean allowNamespaceOperation(NamespaceName namespaceName, String originalRole, String role,
-                                         NamespaceOperation operation, AuthenticationDataSource authData) {
+    @Deprecated
+    default Boolean allowNamespaceOperation(NamespaceName namespaceName,
+                                            String originalRole,
+                                            String role,
+                                            NamespaceOperation operation,
+                                            AuthenticationDataSource authData) {
         try {
             return allowNamespaceOperationAsync(namespaceName, originalRole, role, operation, authData).get();
         } catch (InterruptedException e) {
@@ -273,6 +348,39 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
+     * Check if a given <tt>role</tt> is allowed to execute a given policy <tt>operation</tt> on the namespace.
+     *
+     * @param namespaceName namespace name
+     * @param policy policy name
+     * @param operation policy operation
+     * @param role role name
+     * @param authData authenticated data
+     * @return a completable future represents check result
+     */
+    default CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                          PolicyName policy,
+                                                                          PolicyOperation operation,
+                                                                          String role,
+                                                                          AuthenticationDataSource authData) {
+        return FutureUtil.failedFuture(
+                new IllegalStateException("NamespacePolicyOperation is not supported by the Authorization provider you are using."));
+    }
+
+    default Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
+                                                  PolicyName policy,
+                                                  PolicyOperation operation,
+                                                  String role,
+                                                  AuthenticationDataSource authData) {
+        try {
+            return allowNamespacePolicyOperationAsync(namespaceName, policy, operation, role, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
+        }
+    }
+
+    /**
      * Grant authorization-action permission on a namespace to the given client
      * @param namespaceName
      * @param originalRole role not overriden by proxy role if request do pass through proxy
@@ -281,16 +389,32 @@ public interface AuthorizationProvider extends Closeable {
      * @param authData
      * @return CompletableFuture<Boolean>
      */
-    default CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName, PolicyName policy,
-                                                                          PolicyOperation operation, String originalRole,
-                                                                          String role, AuthenticationDataSource authData) {
-        return isTenantAdmin(namespaceName.getTenant(), role, null, authData);
+    @Deprecated
+    default CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                          PolicyName policy,
+                                                                          PolicyOperation operation,
+                                                                          String originalRole,
+                                                                          String role,
+                                                                          AuthenticationDataSource authData) {
+        return allowNamespacePolicyOperationAsync(
+            namespaceName,
+            policy,
+            operation,
+            StringUtils.isBlank(originalRole) ? role : originalRole,
+            authData
+        );
     }
 
-    default Boolean allowNamespacePolicyOperation(NamespaceName namespaceName, PolicyName policy, PolicyOperation operation,
-                                                  String originalRole, String role, AuthenticationDataSource authData) {
+    @Deprecated
+    default Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
+                                                  PolicyName policy,
+                                                  PolicyOperation operation,
+                                                  String originalRole,
+                                                  String role,
+                                                  AuthenticationDataSource authData) {
         try {
-            return allowNamespacePolicyOperationAsync(namespaceName, policy, operation, originalRole, role, authData).get();
+            return allowNamespacePolicyOperationAsync(
+                namespaceName, policy, operation, originalRole, role, authData).get();
         } catch (InterruptedException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {
@@ -298,6 +422,35 @@ public interface AuthorizationProvider extends Closeable {
         }
     }
 
+    /**
+     * Check if a given <tt>role</tt> is allowed to execute a given topic <tt>operation</tt> on the topic.
+     *
+     * @param topic topic name
+     * @param role role name
+     * @param operation topic operation
+     * @param authData authenticated data
+     * @return CompletableFuture<Boolean>
+     */
+    default CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
+                                                                String role,
+                                                                TopicOperation operation,
+                                                                AuthenticationDataSource authData) {
+        return FutureUtil.failedFuture(
+            new IllegalStateException("TopicOperation is not supported by the Authorization provider you are using."));
+    }
+
+    default Boolean allowTopicOperation(TopicName topicName,
+                                        String role,
+                                        TopicOperation operation,
+                                        AuthenticationDataSource authData) {
+        try {
+            return allowTopicOperationAsync(topicName, role, operation, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
+        }
+    }
 
     /**
      * Grant authorization-action permission on a topic to the given client
@@ -308,27 +461,26 @@ public interface AuthorizationProvider extends Closeable {
      * @param authData
      * @return CompletableFuture<Boolean>
      */
-    default CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic, String originalRole, String role,
-                                                             TopicOperation operation,
-                                                             AuthenticationDataSource authData) {
-        switch (operation) {
-            case PRODUCE:
-                return canProduceAsync(topic, role, authData);
-            case CONSUME:
-                return canConsumeAsync(topic, role, authData, null);
-            case LOOKUP:
-                return canLookupAsync(topic, role, authData);
-            default:
-                return FutureUtil.failedFuture(
-                        new IllegalStateException(
-                                String.format("TopicOperation(%s) on topic(%s) by role(%s) is not supported" +
-                                                " by the Authorization provider you are using.",
-                                        operation.toString(), topic.toString(), role == null ? "null" : null)));
-        }
+    @Deprecated
+    default CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
+                                                                String originalRole,
+                                                                String role,
+                                                                TopicOperation operation,
+                                                                AuthenticationDataSource authData) {
+        return allowTopicOperationAsync(
+            topic,
+            StringUtils.isBlank(originalRole) ? role : originalRole,
+            operation,
+            authData
+        );
     }
 
-    default Boolean allowTopicOperation(TopicName topicName, String originalRole, String role, TopicOperation operation,
-                                     AuthenticationDataSource authData) {
+    @Deprecated
+    default Boolean allowTopicOperation(TopicName topicName,
+                                        String originalRole,
+                                        String role,
+                                        TopicOperation operation,
+                                        AuthenticationDataSource authData) {
         try {
             return allowTopicOperationAsync(topicName, originalRole, role, operation, authData).get();
         } catch (InterruptedException e) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pulsar.broker.authorization;
 
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
-import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -35,11 +37,9 @@ import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.RestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -341,45 +341,84 @@ public class AuthorizationService {
         return provider.allowSinkOpsAsync(namespaceName, role, authenticationData);
     }
 
+    private static void validateOriginalPrincipal(Set<String> proxyRoles, String authenticatedPrincipal,
+                                                  String originalPrincipal) {
+        if (proxyRoles.contains(authenticatedPrincipal)) {
+            // Request has come from a proxy
+            if (StringUtils.isBlank(originalPrincipal)) {
+                log.warn("Original principal empty in request authenticated as {}", authenticatedPrincipal);
+                throw new RestException(Response.Status.UNAUTHORIZED, "Original principal cannot be empty if the request is via proxy.");
+            }
+            if (proxyRoles.contains(originalPrincipal)) {
+                log.warn("Original principal {} cannot be a proxy role ({})", originalPrincipal, proxyRoles);
+                throw new RestException(Response.Status.UNAUTHORIZED, "Original principal cannot be a proxy role");
+            }
+        }
+    }
+
+    private boolean isProxyRole(String role) {
+        return role != null && conf.getProxyRoles().contains(role);
+    }
+
     /**
      * Grant authorization-action permission on a tenant to the given client
      *
-     * @param tenantName
-     * @param operation
-     * @param originalRole
-     * @param role
+     * @param tenantName tenant name
+     * @param operation tenant operation
+     * @param role role name
      * @param authData
      *            additional authdata in json for targeted authorization provider
      * @return IllegalArgumentException when tenant not found
      * @throws IllegalStateException
      *             when failed to grant permission
      */
-    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, TenantOperation operation,
-                                                                 String originalRole, String role,
-                                                                 AuthenticationDataSource authData) {
+    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName,
+                                                                TenantOperation operation,
+                                                                String role,
+                                                                AuthenticationDataSource authData) {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
 
         if (provider != null) {
-            return provider.allowTenantOperationAsync(tenantName, originalRole, role, operation, authData);
+            return provider.allowTenantOperationAsync(tenantName, role, operation, authData);
         }
 
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for " +
                 "allowTenantOperationAsync"));
     }
 
-    public Boolean allowTenantOperation(String tenantName, TenantOperation operation, String orignalRole, String role,
+    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName,
+                                                                TenantOperation operation,
+                                                                String originalRole,
+                                                                String role,
+                                                                AuthenticationDataSource authData) {
+        validateOriginalPrincipal(conf.getProxyRoles(), role, originalRole);
+        if (isProxyRole(role)) {
+            CompletableFuture<Boolean> isRoleAuthorizedFuture = allowTenantOperationAsync(
+                tenantName, operation, role, authData);
+            CompletableFuture<Boolean> isOriginalAuthorizedFuture = allowTenantOperationAsync(
+                tenantName, operation, originalRole, authData);
+            return isRoleAuthorizedFuture.thenCombine(isOriginalAuthorizedFuture,
+                (isRoleAuthorized, isOriginalAuthorized) -> isRoleAuthorized && isOriginalAuthorized);
+        } else {
+            return allowTenantOperationAsync(tenantName, operation, role, authData);
+        }
+    }
+
+    public boolean allowTenantOperation(String tenantName,
+                                        TenantOperation operation,
+                                        String originalRole,
+                                        String role,
                                         AuthenticationDataSource authData) {
-        if (!this.conf.isAuthorizationEnabled()) {
-            return true;
+        try {
+            return allowTenantOperationAsync(
+                tenantName, operation, originalRole, role, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
         }
-
-        if (provider != null) {
-            return provider.allowTenantOperation(tenantName, orignalRole, role, operation, authData);
-        }
-
-        throw new IllegalStateException("No authorization provider configured for allowTenantOperation");
     }
 
     /**
@@ -387,7 +426,6 @@ public class AuthorizationService {
      *
      * @param namespaceName
      * @param operation
-     * @param originalRole
      * @param role
      * @param authData
      *            additional authdata in json for targeted authorization provider
@@ -397,31 +435,51 @@ public class AuthorizationService {
      */
     public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
                                                                    NamespaceOperation operation,
-                                                                   String originalRole, String role,
+                                                                   String role,
                                                                    AuthenticationDataSource authData) {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
 
         if (provider != null) {
-            return provider.allowNamespaceOperationAsync(namespaceName, originalRole, role, operation, authData);
+            return provider.allowNamespaceOperationAsync(namespaceName, role, operation, authData);
         }
 
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for " +
                 "allowNamespaceOperationAsync"));
     }
 
-    public Boolean allowNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation,
-                                           String originalPrincipal, String role, AuthenticationDataSource authData) {
-        if (!this.conf.isAuthorizationEnabled()) {
-            return true;
+    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                   NamespaceOperation operation,
+                                                                   String originalRole,
+                                                                   String role,
+                                                                   AuthenticationDataSource authData) {
+        validateOriginalPrincipal(conf.getProxyRoles(), role, originalRole);
+        if (isProxyRole(role)) {
+            CompletableFuture<Boolean> isRoleAuthorizedFuture = allowNamespaceOperationAsync(
+                namespaceName, operation, role, authData);
+            CompletableFuture<Boolean> isOriginalAuthorizedFuture = allowNamespaceOperationAsync(
+                namespaceName, operation, originalRole, authData);
+            return isRoleAuthorizedFuture.thenCombine(isOriginalAuthorizedFuture,
+                (isRoleAuthorized, isOriginalAuthorized) -> isRoleAuthorized && isOriginalAuthorized);
+        } else {
+            return allowNamespaceOperationAsync(namespaceName, operation, role, authData);
         }
+    }
 
-        if (provider != null) {
-            return provider.allowNamespaceOperation(namespaceName, originalPrincipal, role, operation, authData);
+    public boolean allowNamespaceOperation(NamespaceName namespaceName,
+                                           NamespaceOperation operation,
+                                           String originalRole,
+                                           String role,
+                                           AuthenticationDataSource authData) {
+        try {
+            return allowNamespaceOperationAsync(
+                namespaceName, operation, originalRole, role, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
         }
-
-        throw new IllegalStateException("No authorization provider configured for allowNamespaceOperation");
     }
 
     /**
@@ -429,7 +487,6 @@ public class AuthorizationService {
      *
      * @param namespaceName
      * @param operation
-     * @param originalRole
      * @param role
      * @param authData
      *            additional authdata in json for targeted authorization provider
@@ -437,33 +494,56 @@ public class AuthorizationService {
      * @throws IllegalStateException
      *             when failed to grant permission
      */
-    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName, PolicyName policy,
-                                                                         PolicyOperation operation, String originalRole,
-                                                                         String role, AuthenticationDataSource authData) {
+    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                         PolicyName policy,
+                                                                         PolicyOperation operation,
+                                                                         String role,
+                                                                         AuthenticationDataSource authData) {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
 
         if (provider != null) {
-            return provider.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, originalRole, role, authData);
+            return provider.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, role, authData);
         }
 
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for " +
                 "allowNamespacePolicyOperationAsync"));
     }
 
-    public Boolean allowNamespacePolicyOperation(NamespaceName namespaceName, PolicyName policy,
-                                                 PolicyOperation operation, String originalPrincipal, String role,
-                                                 AuthenticationDataHttps authData) {
-        if (!this.conf.isAuthorizationEnabled()) {
-            return true;
+    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                         PolicyName policy,
+                                                                         PolicyOperation operation,
+                                                                         String originalRole,
+                                                                         String role,
+                                                                         AuthenticationDataSource authData) {
+        validateOriginalPrincipal(conf.getProxyRoles(), role, originalRole);
+        if (isProxyRole(role)) {
+            CompletableFuture<Boolean> isRoleAuthorizedFuture = allowNamespacePolicyOperationAsync(
+                namespaceName, policy, operation, role, authData);
+            CompletableFuture<Boolean> isOriginalAuthorizedFuture = allowNamespacePolicyOperationAsync(
+                namespaceName, policy, operation, originalRole, authData);
+            return isRoleAuthorizedFuture.thenCombine(isOriginalAuthorizedFuture,
+                (isRoleAuthorized, isOriginalAuthorized) -> isRoleAuthorized && isOriginalAuthorized);
+        } else {
+            return allowNamespacePolicyOperationAsync(namespaceName, policy, operation, role, authData);
         }
+    }
 
-        if (provider != null) {
-            return provider.allowNamespacePolicyOperation(namespaceName, policy, operation, originalPrincipal, role, authData);
+    public boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
+                                                 PolicyName policy,
+                                                 PolicyOperation operation,
+                                                 String originalRole,
+                                                 String role,
+                                                 AuthenticationDataSource authData) {
+        try {
+            return allowNamespacePolicyOperationAsync(
+                namespaceName, policy, operation, originalRole, role, authData).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            throw new RestException(e.getCause());
         }
-
-        throw new IllegalStateException("No authorization provider configured for allowNamespacePolicyOperation");
     }
 
     /**
@@ -478,32 +558,43 @@ public class AuthorizationService {
      * @throws IllegalStateException
      *             when failed to grant permission
      */
-    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topicName, TopicOperation operation,
-                                                               String originalRole, String role,
+    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topicName,
+                                                               TopicOperation operation,
+                                                               String role,
                                                                AuthenticationDataSource authData) {
+        if (log.isDebugEnabled()) {
+            log.debug("Check if role {} is allowed to execute topic operation {} on topic {}",
+                role, operation, topicName);
+        }
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
 
         if (provider != null) {
-            return provider.allowTopicOperationAsync(topicName, originalRole, role, operation, authData);
+            CompletableFuture<Boolean> allowFuture =
+                provider.allowTopicOperationAsync(topicName, role, operation, authData);
+            if (log.isDebugEnabled()) {
+                return allowFuture.whenComplete((allowed, exception) -> {
+                    if (exception == null) {
+                        if (allowed) {
+                            log.debug("Topic operation {} on topic {} is allowed: role = {}",
+                                operation, topicName, role);
+                        } else{
+                            log.debug("Topic operation {} on topic {} is NOT allowed: role = {}",
+                                operation, topicName, role);
+                        }
+                    } else {
+                        log.debug("Failed to check if topic operation {} on topic {} is allowed:"
+                                + " role = {}",
+                            operation, topicName, role, exception);
+                    }
+                });
+            } else {
+                return allowFuture;
+            }
         }
 
         return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for " +
                 "allowTopicOperationAsync"));
-    }
-
-    public Boolean allowTopicOperation(TopicName topicName, TopicOperation operation,
-                                         String orignalRole, String role,
-                                         AuthenticationDataSource authData) {
-        if (!this.conf.isAuthorizationEnabled()) {
-            return true;
-        }
-
-        if (provider != null) {
-            return provider.allowTopicOperation(topicName, orignalRole, role, operation, authData);
-        }
-
-        throw new IllegalStateException("No authorization provider configured for allowTopicOperation");
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.authorization;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
+import static org.apache.pulsar.common.util.ObjectMapperFactory.getThreadLocal;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -29,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Joiner;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
@@ -39,8 +39,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.Policies;
-import static org.apache.pulsar.common.util.ObjectMapperFactory.getThreadLocal;
-
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -528,38 +526,43 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role,
-                                                           TenantOperation operation,
-                                                           AuthenticationDataSource authData) {
-        return validateTenantAdminAccess(tenantName, originalRole, role, authData);
+    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName,
+                                                                String role,
+                                                                TenantOperation operation,
+                                                                AuthenticationDataSource authData) {
+        return validateTenantAdminAccess(tenantName, role, authData);
     }
 
     @Override
-    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName, String originalRole,
-                                                              String role, NamespaceOperation operation,
-                                                              AuthenticationDataSource authData) {
-        return validateTenantAdminAccess(namespaceName.getTenant(), originalRole, role, authData);
+    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                   String role,
+                                                                   NamespaceOperation operation,
+                                                                   AuthenticationDataSource authData) {
+        return validateTenantAdminAccess(namespaceName.getTenant(), role, authData);
     }
 
     @Override
-    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName, PolicyName policy,
-                                                                         PolicyOperation operation, String originalRole,
-                                                                         String role, AuthenticationDataSource authData) {
-        return validateTenantAdminAccess(namespaceName.getTenant(), originalRole, role, authData);
+    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                         PolicyName policy,
+                                                                         PolicyOperation operation,
+                                                                         String role,
+                                                                         AuthenticationDataSource authData) {
+        return validateTenantAdminAccess(namespaceName.getTenant(), role, authData);
     }
 
     @Override
-    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topicName, String originalRole, String role,
+    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topicName,
+                                                               String role,
                                                                TopicOperation operation,
                                                                AuthenticationDataSource authData) {
         CompletableFuture<Boolean> isAuthorizedFuture;
 
         switch (operation) {
-            case LOOKUP: isAuthorizedFuture = canLookupAsync(topicName, StringUtils.isBlank(originalRole) ? role : originalRole, authData);
+            case LOOKUP: isAuthorizedFuture = canLookupAsync(topicName, role, authData);
                 break;
-            case PRODUCE: isAuthorizedFuture = canProduceAsync(topicName, StringUtils.isBlank(originalRole) ? role : originalRole, authData);
+            case PRODUCE: isAuthorizedFuture = canProduceAsync(topicName, role, authData);
                 break;
-            case CONSUME: isAuthorizedFuture = canConsumeAsync(topicName, StringUtils.isBlank(originalRole) ? role : originalRole, authData, authData.getSubscription());
+            case CONSUME: isAuthorizedFuture = canConsumeAsync(topicName, role, authData, authData.getSubscription());
                 break;
             default: isAuthorizedFuture = FutureUtil.failedFuture(
                     new IllegalStateException("TopicOperation is not supported."));
@@ -568,7 +571,14 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         CompletableFuture<Boolean> isSuperUserFuture = isSuperUser(role, authData, conf);
 
         return isSuperUserFuture
-                .thenCombine(isAuthorizedFuture, (isSuperUser, isAuthorized) -> isSuperUser || isAuthorized);
+                .thenCombine(isAuthorizedFuture, (isSuperUser, isAuthorized) -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Verify if role {} is allowed to {} to topic {}:"
+                                + " isSuperUser={}, isAuthorized={}",
+                            role, operation, topicName, isSuperUser, isAuthorized);
+                    }
+                    return isSuperUser || isAuthorized;
+                });
     }
 
     private static String path(String... parts) {
@@ -578,43 +588,20 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         return sb.toString();
     }
 
-    private CompletableFuture<Boolean> validateTenantAdminAccess(String tenantName, String originalRole, String role,
+    private CompletableFuture<Boolean> validateTenantAdminAccess(String tenantName,
+                                                                 String role,
                                                                 AuthenticationDataSource authData) {
         try {
             TenantInfo tenantInfo = configCache.propertiesCache()
                     .get(path(POLICIES, tenantName))
                     .orElseThrow(() -> new RestException(Response.Status.NOT_FOUND, "Tenant does not exist"));
 
-            validateOriginalPrincipal(conf.getProxyRoles(), role, originalRole);
-
-            if (role != null && conf.getProxyRoles().contains(role)) {
-                // role check
-                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, authData, conf);
-                CompletableFuture<Boolean> isRoleTenantAdminFuture = isTenantAdmin(tenantName, role, tenantInfo, authData);
-                CompletableFuture<Boolean> isRoleAuthorizedFuture = isRoleSuperUserFuture
-                        .thenCombine(isRoleTenantAdminFuture, (isRoleSuperUser, isRoleTenantAdmin) ->
-                                isRoleSuperUser || isRoleTenantAdmin);
-
-                // originalRole check
-                CompletableFuture<Boolean> isOriginalRoleSuperUserFuture = isSuperUser(originalRole, authData, conf);
-                CompletableFuture<Boolean> isOriginalRoleTenantAdminFuture = isTenantAdmin(tenantName, originalRole,
-                        tenantInfo, authData);
-                CompletableFuture<Boolean> isOriginalRoleAuthorizedFuture = isOriginalRoleSuperUserFuture
-                        .thenCombine(isOriginalRoleTenantAdminFuture, (isOriginalRoleSuperUser, isOriginalRoleTenantAdmin) ->
-                                isOriginalRoleSuperUser || isOriginalRoleTenantAdmin);
-
-                // merging
-                return isRoleAuthorizedFuture
-                        .thenCombine(isOriginalRoleAuthorizedFuture, (isRoleAuthorized, isOriginalRoleAuthorized) ->
-                                isRoleAuthorized && isOriginalRoleAuthorized);
-            } else {
-                // role check
-                CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, authData, conf);
-                CompletableFuture<Boolean> isRoleTenantAdminFuture = isTenantAdmin(tenantName, role, tenantInfo, authData);
-                return isRoleSuperUserFuture
-                        .thenCombine(isRoleTenantAdminFuture, (isRoleSuperUser, isRoleTenantAdmin) ->
-                                isRoleSuperUser || isRoleTenantAdmin);
-            }
+            // role check
+            CompletableFuture<Boolean> isRoleSuperUserFuture = isSuperUser(role, authData, conf);
+            CompletableFuture<Boolean> isRoleTenantAdminFuture = isTenantAdmin(tenantName, role, tenantInfo, authData);
+            return isRoleSuperUserFuture
+                    .thenCombine(isRoleTenantAdminFuture, (isRoleSuperUser, isRoleTenantAdmin) ->
+                            isRoleSuperUser || isRoleTenantAdmin);
         } catch (KeeperException.NoNodeException e) {
             log.warn("Failed to get tenant info data for non existing tenant {}", tenantName);
             throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
@@ -624,18 +611,4 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         }
     }
 
-    private static void validateOriginalPrincipal(Set<String> proxyRoles, String authenticatedPrincipal,
-                                                  String originalPrincipal) {
-        if (proxyRoles.contains(authenticatedPrincipal)) {
-            // Request has come from a proxy
-            if (StringUtils.isBlank(originalPrincipal)) {
-                log.warn("Original principal empty in request authenticated as {}", authenticatedPrincipal);
-                throw new RestException(Response.Status.UNAUTHORIZED, "Original principal cannot be empty if the request is via proxy.");
-            }
-            if (proxyRoles.contains(originalPrincipal)) {
-                log.warn("Original principal {} cannot be a proxy role ({})", originalPrincipal, proxyRoles);
-                throw new RestException(Response.Status.UNAUTHORIZED, "Original principal cannot be a proxy role");
-            }
-        }
-    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/AuthenticationFilter.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/AuthenticationFilter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.web;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.io.IOException;
 
 import javax.servlet.Filter;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -152,7 +152,7 @@ public class Consumer {
         this.bytesOutCounter = new LongAdder();
         this.msgOutCounter = new LongAdder();
         this.appId = appId;
-        this.authenticationData = cnx.authenticationData;
+        this.authenticationData = cnx.getAuthenticationData();
         this.preciseDispatcherFlowControl = cnx.isPreciseDispatcherFlowControl();
 
         PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.set(this, 0);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -99,7 +99,7 @@ public class Producer {
         this.epoch = epoch;
         this.closeFuture = new CompletableFuture<>();
         this.appId = appId;
-        this.authenticationData = cnx.authenticationData;
+        this.authenticationData = cnx.getAuthenticationData();
         this.msgIn = new Rate();
         this.chuckedMessageRate = new Rate();
         this.isNonPersistentTopic = topic instanceof NonPersistentTopic;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -75,6 +75,7 @@ import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
+import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.ServerCnx.State;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -180,6 +181,8 @@ public class ServerCnxTest {
         doReturn(zkCache).when(pulsar).getLocalZkCacheService();
 
         brokerService = spy(new BrokerService(pulsar));
+        BrokerInterceptor interceptor = mock(BrokerInterceptor.class);
+        doReturn(interceptor).when(brokerService).getInterceptor();
         doReturn(brokerService).when(pulsar).getBrokerService();
         doReturn(executor).when(pulsar).getOrderedExecutor();
 
@@ -474,7 +477,7 @@ public class ServerCnxTest {
     public void testProducerCommandWithAuthorizationPositive() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any());
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         resetChannel();
@@ -605,7 +608,7 @@ public class ServerCnxTest {
     public void testProducerCommandWithAuthorizationNegative() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any());
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
@@ -1195,7 +1198,7 @@ public class ServerCnxTest {
     public void testSubscribeCommandWithAuthorizationPositive() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any());
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
@@ -1217,7 +1220,7 @@ public class ServerCnxTest {
     public void testSubscribeCommandWithAuthorizationNegative() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any());
         doReturn(authorizationService).when(brokerService).getAuthorizationService();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -22,20 +22,18 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.fail;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
 import javax.naming.AuthenticationException;
 
 import lombok.Cleanup;
-
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
@@ -54,15 +52,11 @@ import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
-import org.apache.pulsar.common.util.RestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(AuthorizationProducerConsumerTest.class);
@@ -435,7 +429,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+        public CompletableFuture<Boolean> isSuperUser(String role,
+                                                      ServiceConfiguration serviceConfiguration) {
             Set<String> superUserRoles = serviceConfiguration.getSuperUserRoles();
             return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role) ? true : false);
         }
@@ -509,32 +504,38 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role, TenantOperation operation, AuthenticationDataSource authData) {
+        public CompletableFuture<Boolean> allowTenantOperationAsync(
+            String tenantName, String role, TenantOperation operation, AuthenticationDataSource authData) {
             return CompletableFuture.completedFuture(true);
         }
 
         @Override
-        public Boolean allowTenantOperation(String tenantName, String originalRole, String role, TenantOperation operation, AuthenticationDataSource authData) {
+        public Boolean allowTenantOperation(
+            String tenantName, String role, TenantOperation operation, AuthenticationDataSource authData) {
             return true;
         }
 
         @Override
-        public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName, String originalRole, String role, NamespaceOperation operation, AuthenticationDataSource authData) {
+        public CompletableFuture<Boolean> allowNamespaceOperationAsync(
+            NamespaceName namespaceName, String role, NamespaceOperation operation, AuthenticationDataSource authData) {
             return CompletableFuture.completedFuture(true);
         }
 
         @Override
-        public Boolean allowNamespaceOperation(NamespaceName namespaceName, String originalRole, String role, NamespaceOperation operation, AuthenticationDataSource authData) {
+        public Boolean allowNamespaceOperation(
+            NamespaceName namespaceName, String role, NamespaceOperation operation, AuthenticationDataSource authData) {
             return null;
         }
 
         @Override
-        public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic, String originalRole, String role, TopicOperation operation, AuthenticationDataSource authData) {
+        public CompletableFuture<Boolean> allowTopicOperationAsync(
+            TopicName topic, String role, TopicOperation operation, AuthenticationDataSource authData) {
             return CompletableFuture.completedFuture(true);
         }
 
         @Override
-        public Boolean allowTopicOperation(TopicName topicName, String originalRole, String role, TopicOperation operation, AuthenticationDataSource authData) {
+        public Boolean allowTopicOperation(
+            TopicName topicName, String role, TopicOperation operation, AuthenticationDataSource authData) {
             return true;
         }
     }
@@ -566,18 +567,10 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
     public static class TestAuthorizationProviderWithSubscriptionPrefix extends TestAuthorizationProvider {
         @Override
-        public Boolean allowTopicOperation(TopicName topicName, String originalRole, String role, TopicOperation operation, AuthenticationDataSource authData) {
-            try {
-                return allowTopicOperationAsync(topicName, originalRole, role, operation, authData).get();
-            } catch (InterruptedException e) {
-                throw new RestException(e);
-            } catch (ExecutionException e) {
-                throw new RestException(e.getCause());
-            }
-        }
-
-        @Override
-        public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic, String originalRole, String role, TopicOperation operation, AuthenticationDataSource authData) {
+        public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
+                                                                   String role,
+                                                                   TopicOperation operation,
+                                                                   AuthenticationDataSource authData) {
             CompletableFuture<Boolean> future = new CompletableFuture<>();
             if (authData.hasSubscription()) {
                 String subscription = authData.getSubscription();

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -62,7 +62,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class AdminProxyHandler extends ProxyServlet {
+
     private static final Logger LOG = LoggerFactory.getLogger(AdminProxyHandler.class);
+
+    private static final String ORIGINAL_PRINCIPAL_HEADER = "X-Original-Principal";
+
     private static final Set<String> functionRoutes = new HashSet<>(Arrays.asList(
         "/admin/v3/function",
         "/admin/v2/function",
@@ -334,7 +338,7 @@ class AdminProxyHandler extends ProxyServlet {
         super.addProxyHeaders(clientRequest, proxyRequest);
         String user = (String) clientRequest.getAttribute(AuthenticationFilter.AuthenticatedRoleAttributeName);
         if (user != null) {
-            proxyRequest.header("X-Original-Principal", user);
+            proxyRequest.header(ORIGINAL_PRINCIPAL_HEADER, user);
         }
     }
 }


### PR DESCRIPTION
*Motivation*

In 2.6.0, allowTopicOperationAsync checks if topic operations are allowed for the original role. But it checks if the proxy role is a super-user by mistake. It should check if the original role is a super-user.

*Modifications*

Fix the `allowTopicOperationAsync` to checks if the original role is a super-user role or topic operations are allowed.

The current authorization provider interface is also confused. Because some of the interfaces verify both the proxy role and original role and some don't. The authorization provider doesn't have to care about the proxy role and original role. Hence this pull request refactors the authorization provider to authorize a given role and move the logic of verifying proxy and original roles to AuthorizationService. 


