### PR TITLE
Set default root log level to debug

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -33,7 +33,7 @@ Configuration:
       - name: "pulsar.log.appender"
         value: "RoutingAppender"
       - name: "pulsar.log.root.level"
-        value: "info"
+        value: "debug"
       - name: "pulsar.log.level"
         value: "info"
       - name: "pulsar.routing.appender.default"


### PR DESCRIPTION
*Motivation*

Since currently the root log level is set to info, it is not easy to turn the logging level
to debug by running `PULSAR_LOG_LEVEL=debug bin/pulsar standalone`.

