### PR TITLE
[CPP client]Fix the issuer_url parsing failure in oauth2

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -183,6 +183,7 @@ Oauth2TokenResultPtr ClientCredentialFlow::authenticate() {
     curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "POST");
 
     // set URL: issuerUrl
+    issuerUrl_.append("/oauth/token");
     curl_easy_setopt(handle, CURLOPT_URL, issuerUrl_.c_str());
 
     // Write callback

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -342,7 +342,7 @@ TEST(AuthPluginTest, testOauth2) {
     pulsar::AuthenticationDataPtr data;
     std::string params = R"({
         "type": "client_credentials",
-        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com/oauth/token",
+        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com",
         "client_id": "Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
         "client_secret": "rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb",
         "audience": "https://dev-kt-aa9ne.us.auth0.com/api/v2/"})";
@@ -363,7 +363,7 @@ TEST(AuthPluginTest, testOauth2WrongSecret) {
 
         std::string params = R"({
         "type": "client_credentials",
-        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com/oauth/token",
+        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com",
         "client_id": "Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
         "client_secret": "rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ",
         "audience": "https://dev-kt-aa9ne.us.auth0.com/api/v2/"})";
@@ -387,7 +387,7 @@ TEST(AuthPluginTest, testOauth2CredentialFile) {
     pulsar::AuthenticationDataPtr data;
     std::string params = R"({
         "type": "client_credentials",
-        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com/oauth/token",
+        "issuer_url": "https://dev-kt-aa9ne.us.auth0.com",
         "private_key": "../../pulsar-broker/src/test/resources/authentication/token/cpp_credentials_file.json",
         "audience": "https://dev-kt-aa9ne.us.auth0.com/api/v2/"})";
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation

The `issuer_url` in the current cpp example needs to be suffixed with `/oauth/token`, otherwise it cannot be recognized correctly and the following error will be returned:

```
OAuth2 auth data: 2020-08-10 15:21:06.117 ERROR [0x10ff855c0] AuthOauth2:243 | Response failed for issuerurl https://cloud.streamnative.dev/oauth2/token. response Code 404 passedin: {
    "grant_type": "client_credentials",
    "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
    "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
    "audience": "urn:sn:pulsar:pi-ns:pi-name"
}

libc++abi.dylib: terminating with uncaught exception of type char const*
```


### Modifications

Add a fixed suffix of `/oauth/token` to issuer_url

### Verifying this change

Fix test cases as follows:

- testOauth2CredentialFile
- testOauth2WrongSecret
- testOauth2