### PR TITLE
[Pulsar-client-cli] fix some params on consumer broken by #4400 (regex, initialSouscriptionPosition)

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -205,16 +205,16 @@ public class CmdConsume {
                 builder.topic(topic);
             }
 
-            ConsumerBuilder<byte[]> consumerBuilder = client.newConsumer().topic(topic);
             if (this.maxPendingChuckedMessage > 0) {
-                consumerBuilder.maxPendingChuckedMessage(this.maxPendingChuckedMessage);
+                builder.maxPendingChuckedMessage(this.maxPendingChuckedMessage);
             }
             if (this.receiverQueueSize > 0) {
-                consumerBuilder.maxPendingChuckedMessage(this.receiverQueueSize);
+                builder.receiverQueueSize(this.receiverQueueSize);
             }
-            Consumer<byte[]> consumer = consumerBuilder.subscriptionName(this.subscriptionName)
-                    .autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull)
-                    .subscriptionType(subscriptionType).subscribe();
+
+            builder.autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull);
+
+            Consumer<byte[]> consumer = builder.subscribe();
 
             RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
             while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {


### PR DESCRIPTION
### Motivation
The PR #4400 introduced new params on the pulsar-client consume command but it broked some old ones.

### Modifications

This PR fixes this problem to restore the good param behavior.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options:no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  