### PR TITLE
[Issue 7787][pulsar-client-cpp] Throw std::exception types

### DIFF
--- a/pulsar-client-cpp/lib/CompressionCodecSnappy.cc
+++ b/pulsar-client-cpp/lib/CompressionCodecSnappy.cc
@@ -53,15 +53,17 @@ bool CompressionCodecSnappy::decode(const SharedBuffer& encoded, uint32_t uncomp
 
 #else  // No SNAPPY
 
+#include <stdexcept>
+
 namespace pulsar {
 
 SharedBuffer CompressionCodecSnappy::encode(const SharedBuffer& raw) {
-    throw "Snappy compression not supported";
+    throw std::runtime_error("Snappy compression not supported");
 }
 
 bool CompressionCodecSnappy::decode(const SharedBuffer& encoded, uint32_t uncompressedSize,
                                     SharedBuffer& decoded) {
-    throw "Snappy compression not supported";
+    throw std::runtime_error("Snappy compression not supported");
 }
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/CompressionCodecZstd.cc
+++ b/pulsar-client-cpp/lib/CompressionCodecZstd.cc
@@ -56,13 +56,17 @@ bool CompressionCodecZstd::decode(const SharedBuffer& encoded, uint32_t uncompre
 
 #else  // No ZSTD
 
+#include <stdexcept>
+
 namespace pulsar {
 
-SharedBuffer CompressionCodecZstd::encode(const SharedBuffer& raw) { throw "ZStd compression not supported"; }
+SharedBuffer CompressionCodecZstd::encode(const SharedBuffer& raw) {
+    throw std::runtime_error("ZStd compression not supported");
+}
 
 bool CompressionCodecZstd::decode(const SharedBuffer& encoded, uint32_t uncompressedSize,
                                   SharedBuffer& decoded) {
-    throw "ZStd compression not supported";
+    throw std::runtime_error("ZStd compression not supported");
 }
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -18,6 +18,8 @@
  */
 #include <lib/ConsumerConfigurationImpl.h>
 
+#include <stdexcept>
+
 namespace pulsar {
 
 const static std::string emptyString;
@@ -93,7 +95,8 @@ long ConsumerConfiguration::getUnAckedMessagesTimeoutMs() const { return impl_->
 
 void ConsumerConfiguration::setUnAckedMessagesTimeoutMs(const uint64_t milliSeconds) {
     if (milliSeconds < 10000 && milliSeconds != 0) {
-        throw "Consumer Config Exception: Unacknowledged message timeout should be greater than 10 seconds.";
+        throw std::invalid_argument(
+            "Consumer Config Exception: Unacknowledged message timeout should be greater than 10 seconds.");
     }
     impl_->unAckedMessagesTimeoutMs = milliSeconds;
 }

--- a/pulsar-client-cpp/lib/MessageBuilder.cc
+++ b/pulsar-client-cpp/lib/MessageBuilder.cc
@@ -19,6 +19,7 @@
 #include <pulsar/MessageBuilder.h>
 
 #include <memory>
+#include <stdexcept>
 
 #include "MessageImpl.h"
 #include "SharedBuffer.h"
@@ -109,7 +110,7 @@ MessageBuilder& MessageBuilder::setEventTimestamp(uint64_t eventTimestamp) {
 
 MessageBuilder& MessageBuilder::setSequenceId(int64_t sequenceId) {
     if (sequenceId < 0) {
-        throw "sequenceId needs to be >= 0";
+        throw std::invalid_argument("sequenceId needs to be >= 0");
     }
     checkMetadata();
     impl_->metadata.set_sequence_id(sequenceId);

--- a/pulsar-client-cpp/lib/MessageId.cc
+++ b/pulsar-client-cpp/lib/MessageId.cc
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <tuple>
 #include <math.h>
 #include <memory>
@@ -76,7 +77,7 @@ void MessageId::serialize(std::string& result) const {
 MessageId MessageId::deserialize(const std::string& serializedMessageId) {
     proto::MessageIdData idData;
     if (!idData.ParseFromString(serializedMessageId)) {
-        throw "Failed to parse serialized message id";
+        throw std::invalid_argument("Failed to parse serialized message id");
     }
 
     return MessageId(idData.partition(), idData.ledgerid(), idData.entryid(), idData.batch_index());

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -18,6 +18,8 @@
  */
 #include <lib/ProducerConfigurationImpl.h>
 
+#include <stdexcept>
+
 namespace pulsar {
 
 const static std::string emptyString;
@@ -67,7 +69,7 @@ CompressionType ProducerConfiguration::getCompressionType() const { return impl_
 
 ProducerConfiguration& ProducerConfiguration::setMaxPendingMessages(int maxPendingMessages) {
     if (maxPendingMessages <= 0) {
-        throw "maxPendingMessages needs to be greater than 0";
+        throw std::invalid_argument("maxPendingMessages needs to be greater than 0");
     }
     impl_->maxPendingMessages = maxPendingMessages;
     return *this;
@@ -77,7 +79,7 @@ int ProducerConfiguration::getMaxPendingMessages() const { return impl_->maxPend
 
 ProducerConfiguration& ProducerConfiguration::setMaxPendingMessagesAcrossPartitions(int maxPendingMessages) {
     if (maxPendingMessages <= 0) {
-        throw "maxPendingMessages needs to be greater than 0";
+        throw std::invalid_argument("maxPendingMessages needs to be greater than 0");
     }
     impl_->maxPendingMessagesAcrossPartitions = maxPendingMessages;
     return *this;
@@ -131,7 +133,7 @@ const bool& ProducerConfiguration::getBatchingEnabled() const { return impl_->ba
 ProducerConfiguration& ProducerConfiguration::setBatchingMaxMessages(
     const unsigned int& batchingMaxMessages) {
     if (batchingMaxMessages <= 1) {
-        throw "batchingMaxMessages needs to be greater than 1";
+        throw std::invalid_argument("batchingMaxMessages needs to be greater than 1");
     }
     impl_->batchingMaxMessages = batchingMaxMessages;
     return *this;

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -20,6 +20,7 @@
 
 #include <curl/curl.h>
 #include <sstream>
+#include <stdexcept>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -102,7 +103,7 @@ Oauth2CachedToken::Oauth2CachedToken(Oauth2TokenResultPtr token) {
     if (expiredIn > 0) {
         expiresAt_ = expiredIn + currentTimeMillis();
     } else {
-        throw "ExpiresIn in Oauth2TokenResult invalid value: " + expiredIn;
+        throw std::runtime_error("ExpiresIn in Oauth2TokenResult invalid value: " + expiredIn);
     }
     authData_ = AuthenticationDataPtr(new AuthDataOauth2(token->getAccessToken()));
 }

--- a/pulsar-client-cpp/lib/auth/AuthToken.cc
+++ b/pulsar-client-cpp/lib/auth/AuthToken.cc
@@ -20,6 +20,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <functional>
+#include <stdexcept>
 
 #include <sstream>
 #include <fstream>
@@ -52,7 +53,7 @@ static std::string readFromFile(const std::string &tokenFilePath) {
 static std::string readFromEnv(const std::string &envVarName) {
     char *value = getenv(envVarName.c_str());
     if (!value) {
-        throw "Failed to read environment variable " + envVarName;
+        throw std::runtime_error("Failed to read environment variable " + envVarName);
     }
     return std::string(value);
 }
@@ -74,7 +75,7 @@ AuthenticationPtr AuthToken::create(ParamMap &params) {
         std::string envVarName = params["env"];
         return create(std::bind(&readFromEnv, envVarName));
     } else {
-        throw "Invalid configuration for token provider";
+        throw std::runtime_error("Invalid configuration for token provider");
     }
 }
 

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -78,7 +78,7 @@ TEST(BatchMessageTest, testProducerConfig) {
     try {
         conf.setBatchingMaxMessages(1);
         FAIL();
-    } catch (const char* ex) {
+    } catch (const std::exception&) {
         // Ok
     }
 }


### PR DESCRIPTION
* Change throws of const char* to use std::exception types instead

Fixes #7787

### Motivation

Throw std::exception instead of `const char*`

### Modifications

Should be self explanatory.

### Verifying this change

This change should be covered by existing tests, such as BatchMessageTest.  Not sure about the Auth test which catches `...` however.

### Does this pull request potentially affect one of the following parts:

Yes

  - Operations which formerly threw `const char*` now throw a type derived from `std::exception`

### Documentation

The methods that can throw should be documented as such.  This was not implemented.