### PR TITLE
Fix security vulnerabilities of Pulsar

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -346,23 +346,23 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.19.jar
     - org.apache.commons-commons-lang3-3.6.jar
  * Netty
-    - io.netty-netty-buffer-4.1.48.Final.jar
-    - io.netty-netty-codec-4.1.48.Final.jar
-    - io.netty-netty-codec-dns-4.1.48.Final.jar
-    - io.netty-netty-codec-http-4.1.48.Final.jar
-    - io.netty-netty-codec-http2-4.1.48.Final.jar
-    - io.netty-netty-codec-socks-4.1.48.Final.jar
-    - io.netty-netty-common-4.1.48.Final.jar
-    - io.netty-netty-handler-4.1.48.Final.jar
-    - io.netty-netty-handler-proxy-4.1.48.Final.jar
-    - io.netty-netty-resolver-4.1.48.Final.jar
-    - io.netty-netty-resolver-dns-4.1.48.Final.jar
-    - io.netty-netty-transport-4.1.48.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.48.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.48.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.48.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.48.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-kqueue-4.1.48.Final-osx-x86_64.jar
+    - io.netty-netty-buffer-4.1.51.Final.jar
+    - io.netty-netty-codec-4.1.51.Final.jar
+    - io.netty-netty-codec-dns-4.1.51.Final.jar
+    - io.netty-netty-codec-http-4.1.51.Final.jar
+    - io.netty-netty-codec-http2-4.1.51.Final.jar
+    - io.netty-netty-codec-socks-4.1.51.Final.jar
+    - io.netty-netty-common-4.1.51.Final.jar
+    - io.netty-netty-handler-4.1.51.Final.jar
+    - io.netty-netty-handler-proxy-4.1.51.Final.jar
+    - io.netty-netty-resolver-4.1.51.Final.jar
+    - io.netty-netty-resolver-dns-4.1.51.Final.jar
+    - io.netty-netty-transport-4.1.51.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.51.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.51.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.51.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.51.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-kqueue-4.1.51.Final-osx-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.30.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@ flexible messaging model and an intuitive client API.</description>
     <clickhouse-jdbc.version>0.2.4</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
     <hdfs-offload-version3>3.2.0</hdfs-offload-version3>
-    <org.eclipse.jetty-hdfs-offload>9.4.31.v20200723</org.eclipse.jetty-hdfs-offload>
+    <org.eclipse.jetty-hdfs-offload>9.3.24.v20180605</org.eclipse.jetty-hdfs-offload>
     <elasticsearch.version>6.3.2</elasticsearch.version>
     <presto.version>332</presto.version>
     <flink.version>1.6.0</flink.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.10.0</bookkeeper.version>
     <zookeeper.version>3.5.7</zookeeper.version>
-    <netty.version>4.1.48.Final</netty.version>
+    <netty.version>4.1.51.Final</netty.version>
     <netty-tc-native.version>2.0.30.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.29.v20200521</jetty.version>
@@ -143,8 +143,7 @@ flexible messaging model and an intuitive client API.</description>
     <clickhouse-jdbc.version>0.2.4</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
     <hdfs-offload-version3>3.2.0</hdfs-offload-version3>
-    <org.eclipse.jetty-hdfs-offload>9.3.24.v20180605</org.eclipse.jetty-hdfs-offload>
-    <test-hdfs-offload-jetty>9.3.24.v20180605</test-hdfs-offload-jetty>
+    <org.eclipse.jetty-hdfs-offload>9.4.31.v20200723</org.eclipse.jetty-hdfs-offload>
     <elasticsearch.version>6.3.2</elasticsearch.version>
     <presto.version>332</presto.version>
     <flink.version>1.6.0</flink.version>
@@ -152,7 +151,7 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.version>1.0.0.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
-    <hbase.version>1.4.9</hbase.version>
+    <hbase.version>2.3.0</hbase.version>
     <guava.version>25.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.12.0</prometheus-jmx.version>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.28</version>
+            <version>1.2.73</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.otter</groupId>
             <artifactId>canal.client</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.4</version>
         </dependency>
     </dependencies>
 

--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <solr.version>7.5.0</solr.version>
+        <solr.version>8.6.0</solr.version>
     </properties>
 
     <artifactId>pulsar-io-solr</artifactId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -223,37 +223,34 @@ The Apache Software License, Version 2.0
  * Guava
     - guava-25.1-jre.jar
  * Google Guice
-    - guice-4.2.0.jar
     - guice-4.2.3.jar
     - guice-multibindings-4.2.0.jar
  * Apache Commons
     - commons-math3-3.6.1.jar
-    - commons-beanutils-core-1.8.3.jar
     - commons-compress-1.19.jar
     - commons-lang3-3.6.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.48.Final.jar
-    - netty-codec-4.1.48.Final.jar
-    - netty-codec-dns-4.1.48.Final.jar
-    - netty-codec-http-4.1.48.Final.jar
-    - netty-codec-socks-4.1.48.Final.jar
-    - netty-common-4.1.48.Final.jar
-    - netty-handler-4.1.48.Final.jar
-    - netty-handler-proxy-4.1.48.Final.jar
+    - netty-buffer-4.1.51.Final.jar
+    - netty-codec-4.1.51.Final.jar
+    - netty-codec-dns-4.1.51.Final.jar
+    - netty-codec-http-4.1.51.Final.jar
+    - netty-codec-socks-4.1.51.Final.jar
+    - netty-common-4.1.51.Final.jar
+    - netty-handler-4.1.51.Final.jar
+    - netty-handler-proxy-4.1.51.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.48.Final.jar
-    - netty-resolver-dns-4.1.48.Final.jar
+    - netty-resolver-4.1.51.Final.jar
+    - netty-resolver-dns-4.1.51.Final.jar
     - netty-tcnative-boringssl-static-2.0.30.Final.jar
-    - netty-transport-4.1.48.Final.jar
-    - netty-transport-native-epoll-4.1.48.Final.jar
-    - netty-transport-native-epoll-4.1.48.Final-linux-x86_64.jar
-    - netty-transport-native-kqueue-4.1.48.Final-osx-x86_64.jar
-    - netty-transport-native-unix-common-4.1.48.Final.jar
-    - netty-transport-native-unix-common-4.1.48.Final-linux-x86_64.jar
+    - netty-transport-4.1.51.Final.jar
+    - netty-transport-native-epoll-4.1.51.Final.jar
+    - netty-transport-native-epoll-4.1.51.Final-linux-x86_64.jar
+    - netty-transport-native-kqueue-4.1.51.Final-osx-x86_64.jar
+    - netty-transport-native-unix-common-4.1.51.Final.jar
+    - netty-transport-native-unix-common-4.1.51.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.10.5.jar
-    - joda-time-2.10.1.jar
  * Jetty
     - http2-client-9.4.27.v20200227.jar
     - http2-common-9.4.27.v20200227.jar
@@ -272,21 +269,18 @@ The Apache Software License, Version 2.0
   * Asynchronous Http Client
     - async-http-client-1.9.40.jar
   * Apache BVal
-    - bval-core-1.1.1.jar
-    - bval-jsr-1.1.1.jar
     - bval-jsr-2.0.0.jar
   * Bytecode
     - bytecode-1.2.jar
   * CGLIB Nodep
-    - cglib-nodep-3.2.5.jar
     - cglib-nodep-3.3.0.jar
   * Airlift
     - aircompressor-0.16.jar
     - airline-0.8.jar
-    - bootstrap-0.170.jar
+    - bootstrap-0.199.jar
     - bootstrap-0.195.jar
     - concurrent-0.195.jar
-    - configuration-0.170.jar
+    - configuration-0.199.jar
     - configuration-0.195.jar
     - discovery-0.195.jar
     - discovery-server-1.29.jar
@@ -297,11 +291,11 @@ The Apache Software License, Version 2.0
     - jmx-http-0.195.jar
     - jmx-http-rpc-0.159.jar
     - joni-2.1.5.3.jar
-    - json-0.170.jar
+    - json-0.199.jar
     - json-0.195.jar
-    - log-0.170.jar
+    - log-0.199.jar
     - log-0.195.jar
-    - log-manager-0.170.jar
+    - log-manager-0.199.jar
     - log-manager-0.195.jar
     - node-0.195.jar
     - parameternames-1.4.jar
@@ -329,8 +323,8 @@ The Apache Software License, Version 2.0
     - leveldb-0.10.jar
     - leveldb-api-0.10.jar
   * Log4j implemented over SLF4J
-    - log4j-over-slf4j-1.7.25.jar
     - log4j-over-slf4j-1.7.29.jar
+    - log4j-over-slf4j-1.7.30.jar
   * Lucene Common Analyzers
     - lucene-analyzers-common-8.4.1.jar
     - lucene-core-8.4.1.jar
@@ -438,6 +432,7 @@ The Apache Software License, Version 2.0
     - gson-2.8.2.jar
   * Jackson
     - jackson-module-parameter-names-2.10.0.jar
+    - jackson-module-parameter-names-2.11.1.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty
@@ -492,9 +487,9 @@ MIT License
  * PCollections
    - pcollections-2.1.2.jar
  * SLF4J
-   - slf4j-jdk14-1.7.25.jar
    - slf4j-jdk14-1.7.29.jar
    - slf4j-api-1.7.25.jar
+   - slf4j-jdk14-1.7.30.jar
  * JCL 1.2 Implemented Over SLF4J
    - jcl-over-slf4j-1.7.25.jar
    - jcl-over-slf4j-1.7.29.jar
@@ -529,7 +524,6 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-common-2.26.jar
  * JAXB
     - jaxb-api-2.3.1.jar
-    - jaxb-impl-2.2.6.jar
 
  Eclipse Public License 1.0 -- licenses/LICENSE-AspectJ.txt
   * Aether

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -33,7 +33,7 @@
     <name>Pulsar SQL :: Pulsar Presto Connector Packaging</name>
 
     <properties>
-        <dep.airlift.version>0.170</dep.airlift.version>
+        <dep.airlift.version>0.199</dep.airlift.version>
         <jctools.version>2.1.2</jctools.version>
         <dslJson.verson>1.8.4</dslJson.verson>
     </properties>


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation

Based on the scan results of `Black Duck`, we found that there are security vulnerabilities in the components currently used by pulsar, some are directly referenced by pulsar, and some are indirectly referenced by the pulsar.

### Modifications

- Remove `<test-hdfs-offload-jetty>9.3.24.v20180605</test-hdfs-offload-jetty>` because no one uses.

- **Upgrade netty version from `4.1.48.Final` to `4.1.51.Final`** (directly referenced)


Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
-- | -- | -- | -- | --
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM
Netty Project | 4.1.48.Final | maven | BDSA-2018-4022 | MEDIUM

- **Upgrade hbase version from `1.4.9` to `2.3.0`**(indirectly referenced)


Apache Tomcat | 5.5.23 | maven | CVE-2007-2449 | MEDIUM
-- | -- | -- | -- | --
Apache Tomcat | 5.5.23 | maven | CVE-2007-3382 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-3385 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-3386 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-5342 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-5333 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-6286 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-2370 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-2938 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0781 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0033 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0580 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0783 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-5515 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2693 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2901 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2902 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2010-2227 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2696 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2010-4476 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-0013 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-2526 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-3190 | HIGH
Apache Tomcat | 5.5.23 | maven | CVE-2011-4858 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-1184 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5062 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5063 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5064 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-0022 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5885 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5886 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5887 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5568 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-3546 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-1976 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-6357 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-2185 | HIGH
Apache Tomcat | 5.5.23 | maven | CVE-2013-4286 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4322 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4590 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0075 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0096 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0099 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0119 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4444 | MEDIUM
Apache Tomcat | 5.5.23 | maven | BDSA-2009-0001 (CVE-2009-3548) | HIGH
Apache Tomcat | 5.5.23 | maven | BDSA-2016-0056 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2020-8022 | HIGH
Apache Tomcat | 5.5.23 | maven | CVE-2007-2449 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-3382 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-3385 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-3386 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-5342 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-5333 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2007-6286 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-2370 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-2938 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0781 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0033 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0580 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-0783 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2008-5515 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2693 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2901 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2902 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2010-2227 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2009-2696 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2010-4476 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-0013 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-2526 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-3190 | HIGH
Apache Tomcat | 5.5.23 | maven | CVE-2011-4858 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-1184 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5062 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5063 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2011-5064 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-0022 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5885 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5886 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5887 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-5568 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2012-3546 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-1976 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-6357 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-2185 | HIGH
Apache Tomcat | 5.5.23 | maven | CVE-2013-4286 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4322 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4590 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0075 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0096 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0099 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2014-0119 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2013-4444 | MEDIUM
Apache Tomcat | 5.5.23 | maven | BDSA-2009-0001 (CVE-2009-3548) | HIGH
Apache Tomcat | 5.5.23 | maven | BDSA-2016-0056 | MEDIUM
Apache Tomcat | 5.5.23 | maven | CVE-2020-8022 | HIGH

and

Apache HttpClient | 3.1 | maven | CVE-2015-5262 | MEDIUM
-- | -- | -- | -- | --
Apache HttpClient | 3.1 | maven | BDSA-2012-0025 (CVE-2012-5783) | MEDIUM
Apache HttpClient | 3.1 | maven | BDSA-2014-0112 (CVE-2012-6153) | MEDIUM


- **Upgrade fastjson version from `1.2.28` to `1.2.73`**(directly referenced)


fastjson | 1.2.28 | maven | BDSA-2019-3073 | MEDIUM
-- | -- | -- | -- | --
fastjson | 1.2.28 | maven | BDSA-2019-3073 | MEDIUM


- **Upgrade canal.client version from `1.1.1` to `1.1.4`**

Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
-- | -- | -- | -- | --
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-0994 (CVE-2018-1270) | MEDIUM
Spring Framework | 3.2.18 | maven | BDSA-2018-1042 | MEDIUM


- **Upgrade solr version from `7.5.0` to `8.6.0`**(directly referenced)

apache lucene-solr | 7.5.0 | maven | BDSA-2018-4775 (CVE-2017-3164) | MEDIUM
-- | -- | -- | -- | --
apache lucene-solr | 7.5.0 | maven | BDSA-2019-2386 (CVE-2019-0193) | MEDIUM
apache lucene-solr | 7.5.0 | maven | BDSA-2019-3379 (CVE-2019-17558) | MEDIUM

- Upgrade `dep.airlift` version from `0.170` to `0.199` (indirectly referenced)

Apache Commons BeanUtils | 1.8.3 | maven | BDSA-2014-0001 (CVE-2014-0114) | MEDIUM
-- | -- | -- | -- | --
Apache Commons BeanUtils | 1.8.3 | maven | BDSA-2014-0129 (CVE-2019-10086) | MEDIUM
