### PR TITLE
[WIP] [Transaction] Support Ack Transaction Message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshot;
@@ -46,6 +47,8 @@ public interface Subscription {
     void consumerFlow(Consumer consumer, int additionalNumberOfMessages);
 
     void acknowledgeMessage(List<Position> positions, AckType ackType, Map<String,Long> properties);
+
+    void acknowledgeTxnMessage(Map<TxnID, List<Position>> txnPositionsMap, AckType ackType, Map<String, Long> properties);
 
     String getTopicName();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.broker.service.HashRangeExclusiveStickyKeyConsumerSelec
 import org.apache.pulsar.broker.service.StickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
@@ -193,6 +194,11 @@ public class NonPersistentSubscription implements Subscription {
 
     @Override
     public void acknowledgeMessage(List<Position> position, AckType ackType, Map<String, Long> properties) {
+        // No-op
+    }
+
+    @Override
+    public void acknowledgeTxnMessage(Map<TxnID, List<Position>> txnPositionsMap, AckType ackType, Map<String, Long> properties) {
         // No-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/CompactorSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/CompactorSubscription.java
@@ -28,6 +28,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.compaction.CompactedTopic;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferReader.java
@@ -41,7 +41,7 @@ public interface TransactionBufferReader extends AutoCloseable {
      * @throws EndOfTransactionException if reaching end of the transaction and no
      *         more entries to return.
      */
-    CompletableFuture<List<TransactionEntry>> readNext(int numEntries);
+    CompletableFuture<List<TransactionEntry>> readNext(String subName, int numEntries);
 
     /**
      * {@inheritDoc}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionMeta.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionMeta.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.transaction.buffer;
 
 import com.google.common.annotations.Beta;
+
+import java.util.List;
 import java.util.SortedMap;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Position;
@@ -76,11 +78,12 @@ public interface TransactionMeta {
     /**
      * Read the entries from start sequence id.
      *
+     * @param subName subscription name
      * @param num the entries number need to read
      * @param startSequenceId the start position of the entries
      * @return
      */
-    CompletableFuture<SortedMap<Long, Position>> readEntries(int num, long startSequenceId);
+    CompletableFuture<SortedMap<Long, Position>> readEntries(String subName, int num, long startSequenceId);
 
     /**
      * Add transaction entry into the transaction.
@@ -112,5 +115,7 @@ public interface TransactionMeta {
      * @return
      */
     CompletableFuture<TransactionMeta> abortTxn();
+
+    CompletableFuture<Boolean> acknowledge(String subName, List<Position> positionsAcked);
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -97,7 +97,7 @@ class InMemTransactionBuffer implements TransactionBuffer {
         }
 
         @Override
-        public CompletableFuture<SortedMap<Long, Position>> readEntries(int num, long startSequenceId) {
+        public CompletableFuture<SortedMap<Long, Position>> readEntries(String subName, int num, long startSequenceId) {
             return FutureUtil.failedFuture(new UnsupportedOperationException());
         }
 
@@ -197,6 +197,10 @@ class InMemTransactionBuffer implements TransactionBuffer {
             );
         }
 
+        @Override
+        public CompletableFuture<Boolean> acknowledge(String subName, List<Position> positionsAcked) {
+            return CompletableFuture.completedFuture(true);
+        }
     }
 
     final ConcurrentMap<TxnID, TxnBuffer> buffers;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferReader.java
@@ -52,7 +52,7 @@ public class InMemTransactionBufferReader implements TransactionBufferReader {
     }
 
     @Override
-    public synchronized CompletableFuture<List<TransactionEntry>> readNext(int numEntries) {
+    public synchronized CompletableFuture<List<TransactionEntry>> readNext(String subName, int numEntries) {
         CompletableFuture<List<TransactionEntry>> readFuture = new CompletableFuture<>();
 
         if (numEntries <= 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -343,7 +343,7 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
             log.debug("Start to delete txn {} entries", txnID);
         }
         return txnCursor.getTxnMeta(txnID, false)
-                 .thenCompose(meta -> meta.readEntries(meta.numEntries(), -1L))
+                 .thenCompose(meta -> meta.readEntries(null, meta.numEntries(), -1L))
                  .thenCompose(longPositionSortedMap -> deleteEntries(longPositionSortedMap, txnID));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -63,8 +63,8 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
     }
 
     @Override
-    public CompletableFuture<List<TransactionEntry>> readNext(int numEntries) {
-        return meta.readEntries(numEntries, currentSequenceId)
+    public CompletableFuture<List<TransactionEntry>> readNext(String subName, int numEntries) {
+        return meta.readEntries(subName, numEntries, currentSequenceId)
                    .thenCompose(this::readEntry)
                    .thenApply(entries -> entries.stream()
                                                 .sorted(Comparator.comparingLong(entry -> entry.sequenceId()))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -75,7 +75,6 @@ import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
-import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.ServerCnx.State;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -181,8 +180,6 @@ public class ServerCnxTest {
         doReturn(zkCache).when(pulsar).getLocalZkCacheService();
 
         brokerService = spy(new BrokerService(pulsar));
-        BrokerInterceptor interceptor = mock(BrokerInterceptor.class);
-        doReturn(interceptor).when(brokerService).getInterceptor();
         doReturn(brokerService).when(pulsar).getBrokerService();
         doReturn(executor).when(pulsar).getOrderedExecutor();
 
@@ -1251,7 +1248,7 @@ public class ServerCnxTest {
 
         PositionImpl pos = new PositionImpl(0, 0);
 
-        clientCommand = Commands.newAck(1 /* consumer id */, pos.getLedgerId(), pos.getEntryId(), null, AckType.Individual,
+        clientCommand = Commands.newAck(1 /* consumer id */, pos.getLedgerId(), pos.getEntryId(), -1L, -1L, null, AckType.Individual,
                                         null, Collections.emptyMap());
         channel.writeInbound(clientCommand);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/InMemTransactionBufferReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/InMemTransactionBufferReaderTest.java
@@ -54,7 +54,7 @@ public class InMemTransactionBufferReaderTest {
             33L
         )) {
             try {
-                reader.readNext(-1).join();
+                reader.readNext(null, -1).join();
                 fail("Should fail to readNext if `numEntries` is invalid");
             } catch (CompletionException ce) {
                 assertTrue(ce.getCause() instanceof IllegalArgumentException);
@@ -79,7 +79,7 @@ public class InMemTransactionBufferReaderTest {
 
             int numEntriesToRead = 10;
             // read 10 entries
-            List<TransactionEntry> txnEntries = reader.readNext(numEntriesToRead).get();
+            List<TransactionEntry> txnEntries = reader.readNext(null, numEntriesToRead).get();
             verifyAndReleaseEntries(txnEntries, txnID, 0L, numEntriesToRead);
             verifyEntriesReleased(entries, 0L, numEntriesToRead);
         }
@@ -105,14 +105,14 @@ public class InMemTransactionBufferReaderTest {
 
             int numEntriesToRead = numEntries + 10;
             // read all entries
-            List<TransactionEntry> txnEntries = reader.readNext(numEntriesToRead).get();
+            List<TransactionEntry> txnEntries = reader.readNext(null, numEntriesToRead).get();
             verifyAndReleaseEntries(txnEntries, txnID, 0L, numEntries);
             verifyEntriesReleased(entries, 0L, numEntries);
 
             // since all the entries has been read, the read next operation will be
             // failed with EndOfTransactionException
             try {
-                reader.readNext(1).get();
+                reader.readNext(null, 1).get();
                 fail("should fail to read entries if there is no more in the transaction buffer");
             } catch (ExecutionException ee) {
                 assertTrue(ee.getCause() instanceof EndOfTransactionException);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/PersistentTransactionBufferTest.java
@@ -409,10 +409,10 @@ public class PersistentTransactionBufferTest extends MockedBookKeeperTestCase {
         assertEquals(TxnStatus.COMMITTED, meta.status());
 
         try (TransactionBufferReader reader = buffer.openTransactionBufferReader(txnID, 0L).get()) {
-            List<TransactionEntry> entries = reader.readNext(numEntries).get();
+            List<TransactionEntry> entries = reader.readNext(null, numEntries).get();
             verifyAndReleaseEntries(entries, txnID, 0L, numEntries);
 
-            reader.readNext(1).get();
+            reader.readNext(null, 1).get();
             Assert.fail("Should cause the exception `EndOfTransactionException`.");
         } catch (ExecutionException ee) {
              assertTrue(ee.getCause() instanceof EndOfTransactionException);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
@@ -118,7 +118,7 @@ public class TransactionBufferTest {
             txnId, 0L
         ).get()) {
             // read 10 entries
-            List<TransactionEntry> txnEntries = reader.readNext(numEntries).get();
+            List<TransactionEntry> txnEntries = reader.readNext(null, numEntries).get();
             verifyAndReleaseEntries(txnEntries, txnId, 0L, numEntries);
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.client.transaction;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
@@ -37,11 +37,12 @@ public class BatchMessageIdImpl extends MessageIdImpl {
     }
 
     public BatchMessageIdImpl(long ledgerId, long entryId, int partitionIndex, int batchIndex) {
-        this(ledgerId, entryId, partitionIndex, batchIndex, 0, BatchMessageAckerDisabled.INSTANCE);
+        this(ledgerId, entryId, partitionIndex, batchIndex, 0, BatchMessageAckerDisabled.INSTANCE, -1L, -1L);
     }
 
-    public BatchMessageIdImpl(long ledgerId, long entryId, int partitionIndex, int batchIndex, int batchSize, BatchMessageAcker acker) {
-        super(ledgerId, entryId, partitionIndex);
+    public BatchMessageIdImpl(long ledgerId, long entryId, int partitionIndex, int batchIndex, int batchSize,
+                              BatchMessageAcker acker, long messageTxnidMostBits, long messageTxnidLeastBits) {
+        super(ledgerId, entryId, partitionIndex, messageTxnidMostBits, messageTxnidLeastBits);
         this.batchIndex = batchIndex;
         this.batchSize = batchSize;
         this.acker = acker;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -27,6 +27,7 @@ import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
 
+import lombok.Getter;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
@@ -40,6 +41,11 @@ public class MessageIdImpl implements MessageId {
     protected final long entryId;
     protected final int partitionIndex;
 
+    @Getter
+    protected long messageTxnidMostBits = -1L;
+    @Getter
+    protected long messageTxnidLeastBits = -1L;
+
     // Private constructor used only for json deserialization
     @SuppressWarnings("unused")
     private MessageIdImpl() {
@@ -50,6 +56,13 @@ public class MessageIdImpl implements MessageId {
         this.ledgerId = ledgerId;
         this.entryId = entryId;
         this.partitionIndex = partitionIndex;
+    }
+
+    public MessageIdImpl(long ledgerId, long entryId, int partitionIndex,
+                         long messageTxnidMostBits, long messageTxnidLeastBits) {
+        this(ledgerId, entryId, partitionIndex);
+        this.messageTxnidMostBits = messageTxnidMostBits;
+        this.messageTxnidLeastBits = messageTxnidLeastBits;
     }
 
     public long getLedgerId() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -204,7 +204,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             bitSet.clear(batchIndex);
         }
 
-        final ByteBuf cmd = Commands.newAck(consumer.consumerId, msgId.ledgerId, msgId.entryId, bitSet, ackType, null, properties);
+        final ByteBuf cmd = Commands.newAck(consumer.consumerId, msgId.ledgerId, msgId.entryId,
+                msgId.getMessageTxnidMostBits(), msgId.getMessageTxnidLeastBits(), bitSet, ackType, null, properties);
         bitSet.recycle();
         cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
         return true;
@@ -333,6 +334,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             } else {
                 for (MessageIdImpl cMsgId : chunkMsgIds) {
                     ByteBuf cmd = Commands.newAck(consumerId, cMsgId.getLedgerId(), cMsgId.getEntryId(),
+                            cMsgId.getMessageTxnidMostBits(), cMsgId.getMessageTxnidLeastBits(),
                             lastCumulativeAckSet, ackType, validationError, map);
                     if (flush) {
                         cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
@@ -343,7 +345,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             }
             this.consumer.unAckedChunckedMessageIdSequenceMap.remove(msgId);
         } else {
-            ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(), lastCumulativeAckSet,
+            ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(),
+                    msgId.getMessageTxnidMostBits(), msgId.getMessageTxnidLeastBits(), lastCumulativeAckSet,
                     ackType, validationError, map);
             if (flush) {
                 cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -76,7 +76,7 @@ public class BatchMessageIdImplTest {
     public void deserializationTest() {
         // initialize BitSet with null
         BatchMessageAcker ackerDisabled = new BatchMessageAcker(null, 0);
-        BatchMessageIdImpl batchMsgId = new BatchMessageIdImpl(0, 0, 0, 0, 0, ackerDisabled);
+        BatchMessageIdImpl batchMsgId = new BatchMessageIdImpl(0, 0, 0, 0, 0, ackerDisabled, -1L, -1L);
 
         ObjectWriter writer = ObjectMapperFactory.create().writerWithDefaultPrettyPrinter();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -1141,6 +1141,14 @@ public final class PulsarApi {
     java.util.List<java.lang.Long> getAckSetList();
     int getAckSetCount();
     long getAckSet(int index);
+    
+    // optional uint64 txnid_least_bits = 6;
+    boolean hasTxnidLeastBits();
+    long getTxnidLeastBits();
+    
+    // optional uint64 txnid_most_bits = 7;
+    boolean hasTxnidMostBits();
+    long getTxnidMostBits();
   }
   public static final class MessageIdData extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -1231,12 +1239,34 @@ public final class PulsarApi {
       return ackSet_.get(index);
     }
     
+    // optional uint64 txnid_least_bits = 6;
+    public static final int TXNID_LEAST_BITS_FIELD_NUMBER = 6;
+    private long txnidLeastBits_;
+    public boolean hasTxnidLeastBits() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    public long getTxnidLeastBits() {
+      return txnidLeastBits_;
+    }
+    
+    // optional uint64 txnid_most_bits = 7;
+    public static final int TXNID_MOST_BITS_FIELD_NUMBER = 7;
+    private long txnidMostBits_;
+    public boolean hasTxnidMostBits() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    public long getTxnidMostBits() {
+      return txnidMostBits_;
+    }
+    
     private void initFields() {
       ledgerId_ = 0L;
       entryId_ = 0L;
       partition_ = -1;
       batchIndex_ = -1;
       ackSet_ = java.util.Collections.emptyList();;
+      txnidLeastBits_ = 0L;
+      txnidMostBits_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1278,6 +1308,12 @@ public final class PulsarApi {
       for (int i = 0; i < ackSet_.size(); i++) {
         output.writeInt64(5, ackSet_.get(i));
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeUInt64(6, txnidLeastBits_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeUInt64(7, txnidMostBits_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -1310,6 +1346,14 @@ public final class PulsarApi {
         }
         size += dataSize;
         size += 1 * getAckSetList().size();
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(6, txnidLeastBits_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(7, txnidMostBits_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -1434,6 +1478,10 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000008);
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        txnidLeastBits_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
+        txnidMostBits_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
       
@@ -1488,6 +1536,14 @@ public final class PulsarApi {
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.ackSet_ = ackSet_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.txnidLeastBits_ = txnidLeastBits_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.txnidMostBits_ = txnidMostBits_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -1515,6 +1571,12 @@ public final class PulsarApi {
             ackSet_.addAll(other.ackSet_);
           }
           
+        }
+        if (other.hasTxnidLeastBits()) {
+          setTxnidLeastBits(other.getTxnidLeastBits());
+        }
+        if (other.hasTxnidMostBits()) {
+          setTxnidMostBits(other.getTxnidMostBits());
         }
         return this;
       }
@@ -1576,6 +1638,16 @@ public final class PulsarApi {
             case 40: {
               ensureAckSetIsMutable();
               ackSet_.add(input.readInt64());
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              txnidLeastBits_ = input.readUInt64();
+              break;
+            }
+            case 56: {
+              bitField0_ |= 0x00000040;
+              txnidMostBits_ = input.readUInt64();
               break;
             }
           }
@@ -1709,6 +1781,48 @@ public final class PulsarApi {
       public Builder clearAckSet() {
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        
+        return this;
+      }
+      
+      // optional uint64 txnid_least_bits = 6;
+      private long txnidLeastBits_ ;
+      public boolean hasTxnidLeastBits() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      public long getTxnidLeastBits() {
+        return txnidLeastBits_;
+      }
+      public Builder setTxnidLeastBits(long value) {
+        bitField0_ |= 0x00000020;
+        txnidLeastBits_ = value;
+        
+        return this;
+      }
+      public Builder clearTxnidLeastBits() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        txnidLeastBits_ = 0L;
+        
+        return this;
+      }
+      
+      // optional uint64 txnid_most_bits = 7;
+      private long txnidMostBits_ ;
+      public boolean hasTxnidMostBits() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      public long getTxnidMostBits() {
+        return txnidMostBits_;
+      }
+      public Builder setTxnidMostBits(long value) {
+        bitField0_ |= 0x00000040;
+        txnidMostBits_ = value;
+        
+        return this;
+      }
+      public Builder clearTxnidMostBits() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        txnidMostBits_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -930,12 +930,16 @@ public class Commands {
         return res;
     }
 
-    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
+    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId,
+                                 long messageTxnidMostBits, long messageTxnidLeastBits,
+                                 BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties) {
-        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError, properties, 0, 0);
+        return newAck(consumerId, ledgerId, -1, -1, entryId, ackSet, ackType, validationError, properties, 0, 0);
     }
 
-    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
+    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId,
+                                 long messageTxnIdLeastBits, long messageTxnIdMostBits,
+                                 BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
                                  long txnIdMostBits) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -55,6 +55,10 @@ message MessageIdData {
     optional int32 partition = 3 [default = -1];
     optional int32 batch_index = 4 [default = -1];
     repeated int64 ack_set = 5;
+
+    // transaction related message info
+    optional uint64 txnid_least_bits = 6;
+    optional uint64 txnid_most_bits = 7;
 }
 
 message KeyValue {


### PR DESCRIPTION
Fix issue: https://github.com/streamnative/pulsar/issues/1305

Master Issue: #2664 

### Motivation

The Pulsar Consumer consumes transaction messages from the Broker, the transaction messages saved in TransactionBuffer, when all the messages belong to one transaction are acknowledged, the commit marker in the topic partition could be acknowledged.

### Modifications

1. Update MessageIdData in PulsarApi.proto.

```
optional uint64 txnid_least_bits = 6;
optional uint64 txnid_most_bits = 7;
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Ack transaction messages test*
`org.apache.pulsar.client.transaction.EndToEndTest.ackTest`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (yes)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
