### PR TITLE
Improve the performance of toString for MessageId Implementations

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
@@ -111,7 +111,15 @@ public class BatchMessageIdImpl extends MessageIdImpl {
 
     @Override
     public String toString() {
-        return String.format("%d:%d:%d:%d", ledgerId, entryId, partitionIndex, batchIndex);
+        return new StringBuilder()
+          .append(ledgerId)
+          .append(':')
+          .append(entryId)
+          .append(':')
+          .append(partitionIndex)
+          .append(':')
+          .append(batchIndex)
+          .toString();
     }
 
     // Serialization

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -83,7 +83,13 @@ public class MessageIdImpl implements MessageId {
 
     @Override
     public String toString() {
-        return String.format("%d:%d:%d", ledgerId, entryId, partitionIndex);
+        return new StringBuilder()
+          .append(ledgerId)
+          .append(':')
+          .append(entryId)
+          .append(':')
+          .append(partitionIndex)
+          .toString();
     }
 
     // / Serialization


### PR DESCRIPTION

### Motivation
String.format() is slow.  Use StringBuilder instead

=