### PR TITLE
[pulsar-client] Avoid subscribing the same topic again

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -608,7 +608,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
     @Test
     public void testResubscribeSameTopic() throws Exception {
-        final String localTopicName = "TopicsConsumerResubscribeWithDefaultNamespaceTest";
+        final String localTopicName = "TopicsConsumerResubscribeSameTopicTest";
         final String localPartitionName = localTopicName + "-partition-0";
         final String topicNameWithNamespace = "public/default/" + localTopicName;
         final String topicNameWithDomain = "persistent://" + topicNameWithNamespace;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -472,7 +472,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         }).get();
         ((MultiTopicsConsumerImpl) consumer).subscribeAsync(topicName, 3).handle((res, exception) -> {
             assertTrue(exception instanceof PulsarClientException.AlreadyClosedException);
-            assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Topic name not valid");
+            assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Already subscribed to " + topicName);
             return null;
         }).get();
     }
@@ -602,7 +602,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         String partitionName = topicName2 + "-partition-0";
         ((MultiTopicsConsumerImpl<byte[]>) consumer).subscribeAsync(partitionName, false).handle((res, exception) -> {
             assertTrue(exception instanceof PulsarClientException.AlreadyClosedException);
-            assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Topic name not valid");
+            assertEquals(exception.getMessage(), "Already subscribed to " + partitionName);
             return null;
         }).get();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -598,6 +598,14 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         assertEquals(consumers.size(), 6);
         assertEquals(((MultiTopicsConsumerImpl<byte[]>) consumer).getTopics().size(), 3);
 
+        // 12. resubscribe a partition of a subscribed partitioned topic should be invalid
+        String partitionName = topicName2 + "-partition-0";
+        ((MultiTopicsConsumerImpl<byte[]>) consumer).subscribeAsync(partitionName, false).handle((res, exception) -> {
+            assertTrue(exception instanceof PulsarClientException.AlreadyClosedException);
+            assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Topic name not valid");
+            return null;
+        }).get();
+
         consumer.unsubscribe();
         consumer.close();
         producer1.close();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -743,13 +743,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     // subscribe one more given topic
     public CompletableFuture<Void> subscribeAsync(String topicName, boolean createTopicIfDoesNotExist) {
         TopicName topicNameInstance = getTopicName(topicName);
-        if (topicNameInstance == null
-                || topics.containsKey(topicNameInstance.toString())
-                || topics.containsKey(topicNameInstance.getPartitionedTopicName())) {
+        if (topicNameInstance == null) {
             return FutureUtil.failedFuture(
-                new PulsarClientException.AlreadyClosedException("Topic name not valid"));
+                    new PulsarClientException.AlreadyClosedException("Topic name not valid"));
         }
         String fullTopicName = topicNameInstance.toString();
+        if (topics.containsKey(fullTopicName) || topics.containsKey(topicNameInstance.getPartitionedTopicName())) {
+            return FutureUtil.failedFuture(
+                    new PulsarClientException.AlreadyClosedException("Already subscribed to " + topicName));
+        }
 
         if (getState() == State.Closing || getState() == State.Closed) {
             return FutureUtil.failedFuture(
@@ -805,16 +807,14 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @VisibleForTesting
     CompletableFuture<Void> subscribeAsync(String topicName, int numberPartitions) {
         TopicName topicNameInstance = getTopicName(topicName);
-        if (topicNameInstance == null
-                || topics.containsKey(topicNameInstance.toString())
-                || topics.containsKey(topicNameInstance.getPartitionedTopicName())) {
+        if (topicNameInstance == null) {
             return FutureUtil.failedFuture(
                     new PulsarClientException.AlreadyClosedException("Topic name not valid"));
         }
         String fullTopicName = topicNameInstance.toString();
-        if (fullTopicName == null || topics.containsKey(fullTopicName)) {
+        if (topics.containsKey(fullTopicName) || topics.containsKey(topicNameInstance.getPartitionedTopicName())) {
             return FutureUtil.failedFuture(
-                    new PulsarClientException.AlreadyClosedException("Topic name not valid"));
+                    new PulsarClientException.AlreadyClosedException("Already subscribed to " + topicName));
         }
 
         if (getState() == State.Closing || getState() == State.Closed) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -722,13 +722,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     private String getFullTopicName(String topic) {
         try {
-            TopicName topicName = TopicName.get(topic);
-            if (!topics.containsKey(topicName.toString())) {
-                return topicName.toString();
-            }
+            return TopicName.get(topic).toString();
         } catch (Exception ignored) {
         }
-        return null;  // `topic` is invalid or already exists
+        return null;  // `topic` is invalid
     }
 
     private void removeTopic(String topic) {
@@ -741,7 +738,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     // subscribe one more given topic
     public CompletableFuture<Void> subscribeAsync(String topicName, boolean createTopicIfDoesNotExist) {
         final String fullTopicName = getFullTopicName(topicName);
-        if (fullTopicName == null) {
+        if (fullTopicName == null || topics.containsKey(fullTopicName)) {
             return FutureUtil.failedFuture(
                 new PulsarClientException.AlreadyClosedException("Topic name not valid"));
         }
@@ -800,7 +797,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @VisibleForTesting
     CompletableFuture<Void> subscribeAsync(String topicName, int numberPartitions) {
         final String fullTopicName = getFullTopicName(topicName);
-        if (fullTopicName == null) {
+        if (fullTopicName == null || topics.containsKey(fullTopicName)) {
             return FutureUtil.failedFuture(
                     new PulsarClientException.AlreadyClosedException("Topic name not valid"));
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -108,9 +108,7 @@ public class MultiTopicsConsumerImplTest {
         Throwable t = expectThrows(ExecutionException.class, secondInvocation::get);
         Throwable cause = t.getCause();
         assertEquals(cause.getClass(), PulsarClientException.class);
-        assertTrue(cause.getMessage().endsWith(
-            "Failed to subscribe for topic [parallel-subscribe-async-topic] in topics consumer. "
-                + "Topic is already being subscribed for in other thread."));
+        assertTrue(cause.getMessage().endsWith("Topic is already being subscribed for in other thread."));
     }
 
     private <T> PulsarClientImpl setUpPulsarClientMock(Schema<T> schema, int completionDelayMillis) {


### PR DESCRIPTION
### Motivation

The current key of `MultiTopicsConsumerImpl.topics` is the topic name passed by user. The `topicNameValid` method checks if the name is valid and `topics` doesn't contain the key.

However, if a multi topics consumer subscribed a partition of a subscribed partitioned topic,  `subscribeAsync` succeed and a new `ConsumerImpl` of the same partition was created, which is redundant.

Also, if a multi topics consumer subscribed `public/default/topic` or `persistent://public/default/topic`, while the initial subscribed topic is `topic`, the redundant consumers would be created.

### Modifications

- Use full topic name as key of `MultiTopicsConsumerImpl.topics`
- Check both full topic name and full partitioned topic name not exist in `MultiTopicsConsumerImpl.topics` when `subscribeAsync` is called
- Throw a different exception to differ topic is invalid and topic is already subscribed
- Add a unit test for subscribing a partition of a subscribed partitioned topic or the same topic with prefix