### PR TITLE
Fix pending batchIndexAcks bitSet batchSize in PersistentAcknowledgmentsGroupingTracker

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -118,9 +118,10 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
         Assert.assertNull(moreMessage);
 
         // check the mark delete position was changed
+        BatchMessageIdImpl ackedMessageId = (BatchMessageIdImpl) received.get(0);
         PersistentTopicInternalStats stats = admin.topics().getInternalStats(topic);
         String markDeletePosition = stats.cursors.get(subscriptionName).markDeletePosition;
-        Assert.assertNotEquals(markDeletePosition.split(":")[1], "-1");
+        Assert.assertEquals(ackedMessageId.ledgerId + ":" + ackedMessageId.entryId, markDeletePosition);
 
         futures.clear();
         for (int i = 0; i < 50; i++) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -143,8 +143,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             ConcurrentBitSetRecyclable bitSet = pendingIndividualBatchIndexAcks.computeIfAbsent(
                 new MessageIdImpl(msgId.getLedgerId(), msgId.getEntryId(), msgId.getPartitionIndex()), (v) -> {
                     ConcurrentBitSetRecyclable value = ConcurrentBitSetRecyclable.create();
-                    value.set(0, batchSize + 1);
-                    value.clear(batchIndex);
+                    value.set(0, batchSize);
                     return value;
                 });
             bitSet.clear(batchIndex);


### PR DESCRIPTION
### Motivation

The pending batchIndexAcks bitSet batchSize is not correct.

### Modifications

Fix the bitSet batchSize.

### Verifying this change

This change can be verified as follows:

- *org.apache.pulsar.client.impl.BatchMessageIndexAckTest.testBatchMessageIndexAckForSharedSubscription*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
