### PR TITLE
take seek time into account in Reader#hasMessageAvailable

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -76,4 +76,6 @@ public interface PulsarCommandSender {
     Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
             int partitionIdx, List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
             RedeliveryTracker redeliveryTracker);
+
+    void sendSeekResponse(long requestId, PulsarApi.MessageIdData messageIdData);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -314,6 +314,16 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         return writePromise;
     }
 
+    @Override
+    public void sendSeekResponse(long requestId, MessageIdData messageIdData) {
+        PulsarApi.BaseCommand command = Commands.newSeekResponse(requestId, messageIdData);
+        safeIntercept(command, cnx);
+        ByteBuf outBuf = Commands.serializeWithSize(command);
+        command.getPartitionMetadataResponse().recycle();
+        command.recycle();
+        cnx.ctx().writeAndFlush(outBuf);
+    }
+
     private void safeIntercept(PulsarApi.BaseCommand command, ServerCnx cnx) {
         try {
             this.interceptor.onPulsarCommand(command, cnx);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1369,10 +1369,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     msgIdData.getEntryId(), ackSet);
 
 
-            subscription.resetCursor(position).thenRun(() -> {
+            subscription.resetCursor(position).thenAccept((messageIdData) -> {
                 log.info("[{}] [{}][{}] Reset subscription to message id {}", remoteAddress,
                         subscription.getTopic().getName(), subscription.getName(), position);
-                commandSender.sendSuccessResponse(requestId);
+                commandSender.sendSeekResponse(requestId, messageIdData);
             }).exceptionally(ex -> {
                 log.warn("[{}][{}] Failed to reset subscription: {}", remoteAddress, subscription, ex.getMessage(), ex);
                 commandSender.sendErrorResponse(requestId, ServerError.UnknownError,
@@ -1384,10 +1384,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             Subscription subscription = consumer.getSubscription();
             long timestamp = seek.getMessagePublishTime();
 
-            subscription.resetCursor(timestamp).thenRun(() -> {
+            subscription.resetCursor(timestamp).thenAccept((messageIdData) -> {
                 log.info("[{}] [{}][{}] Reset subscription to publish time {}", remoteAddress,
                         subscription.getTopic().getName(), subscription.getName(), timestamp);
-                commandSender.sendSuccessResponse(requestId);
+                commandSender.sendSeekResponse(requestId, messageIdData);
             }).exceptionally(ex -> {
                 log.warn("[{}][{}] Failed to reset subscription: {}", remoteAddress, subscription, ex.getMessage(), ex);
                 commandSender.sendErrorResponse(requestId, ServerError.UnknownError,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1569,6 +1569,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         .setLedgerId(position.getLedgerId())
                         .setEntryId(position.getEntryId())
                         .setPartition(partitionIndex)
+                        .setBatchSize(batchSize)
                         .setBatchIndex(largestBatchIndex).build();
 
                 ctx.writeAndFlush(Commands.newGetLastMessageIdResponse(requestId, messageId));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshot;
 
 public interface Subscription {
@@ -74,9 +75,9 @@ public interface Subscription {
 
     CompletableFuture<Void> skipMessages(int numMessagesToSkip);
 
-    CompletableFuture<Void> resetCursor(long timestamp);
+    CompletableFuture<MessageIdData> resetCursor(long timestamp);
 
-    CompletableFuture<Void> resetCursor(Position position);
+    CompletableFuture<MessageIdData> resetCursor(Position position);
 
     CompletableFuture<Entry> peekNthMessage(int messagePosition);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.NonPersistentSubscriptionStats;
@@ -250,7 +251,7 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> resetCursor(long timestamp) {
+    public CompletableFuture<MessageIdData> resetCursor(long timestamp) {
         // No-op
         return CompletableFuture.completedFuture(null);
     }
@@ -475,7 +476,7 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> resetCursor(Position position) {
+    public CompletableFuture<MessageIdData> resetCursor(Position position) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeySharedMeta;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.TxnAction;
 import org.apache.pulsar.common.api.proto.PulsarMarkers.ReplicatedSubscriptionsSnapshot;
@@ -70,6 +71,7 @@ import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.SafeCollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -536,8 +538,8 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> resetCursor(long timestamp) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
+    public CompletableFuture<MessageIdData> resetCursor(long timestamp) {
+        CompletableFuture<MessageIdData> future = new CompletableFuture<>();
         PersistentMessageFinder persistentMessageFinder = new PersistentMessageFinder(topicName, cursor);
 
         if (log.isDebugEnabled()) {
@@ -582,13 +584,13 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> resetCursor(Position position) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
+    public CompletableFuture<MessageIdData> resetCursor(Position position) {
+        CompletableFuture<MessageIdData> future = new CompletableFuture<>();
         resetCursor(position, future);
         return future;
     }
 
-    private void resetCursor(Position finalPosition, CompletableFuture<Void> future) {
+    private void resetCursor(Position finalPosition, CompletableFuture<MessageIdData> future) {
         if (!IS_FENCED_UPDATER.compareAndSet(PersistentSubscription.this, FALSE, TRUE)) {
             future.completeExceptionally(new SubscriptionBusyException("Failed to fence subscription"));
             return;
@@ -633,7 +635,13 @@ public class PersistentSubscription implements Subscription {
                             dispatcher.cursorIsReset();
                         }
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        future.complete(null);
+                        PositionImpl position = (PositionImpl) ctx;
+                        MessageIdData messageIdData = MessageIdData.newBuilder()
+                                .setLedgerId(position.getLedgerId())
+                                .setEntryId(position.getEntryId())
+                                .addAllAckSet(SafeCollectionUtils.longArrayToList(position.getAckSet()))
+                                .build();
+                        future.complete(messageIdData);
                     }
 
                     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -168,8 +168,8 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         assertEquals(topicRef.getSubscriptions().size(), 1);
 
         consumer.seek(MessageId.earliest);
-        Message<String> receiveBeforEarliest = consumer.receive();
-        assertEquals(receiveBeforEarliest.getValue(), messages.get(0));
+        Message<String> receiveBeforeEarliest = consumer.receive();
+        assertEquals(receiveBeforeEarliest.getValue(), messages.get(0));
         consumer.seek(MessageId.latest);
         Message<String> receiveAfterLatest = consumer.receive(1, TimeUnit.SECONDS);
         assertNull(receiveAfterLatest);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3426,8 +3426,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         latch.await();
 
-        log.info("### resetPosition {}", resetPos);
-
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
                 .topic(topicName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3426,6 +3426,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         latch.await();
 
+        log.info("### resetPosition {}", resetPos);
+
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
                 .topic(topicName);
 

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -143,6 +143,8 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     Future<Result, ResponseData> sendRequestWithId(SharedBuffer cmd, int requestId);
 
+    Future<Result, MessageId> sendSeekRequestWithId(SharedBuffer cmd, int requestId);
+
     const std::string& brokerAddress() const;
 
     const std::string& cnxString() const;
@@ -167,6 +169,11 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     struct LookupRequestData {
         LookupDataResultPromisePtr promise;
+        DeadlineTimerPtr timer;
+    };
+
+    struct SeekRequestData {
+        Promise<Result, MessageId> promise;
         DeadlineTimerPtr timer;
     };
 
@@ -304,6 +311,9 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     typedef std::map<long, Promise<Result, NamespaceTopicsPtr>> PendingGetNamespaceTopicsMap;
     PendingGetNamespaceTopicsMap pendingGetNamespaceTopicsRequests_;
+
+    typedef std::map<long, Promise<Result, MessageId>> PendingSeekRequestsMap;
+    PendingSeekRequestsMap pendingSeekRequests_;
 
     std::mutex mutex_;
     typedef std::unique_lock<std::mutex> Lock;

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -561,6 +561,9 @@ std::string Commands::messageType(BaseCommand_Type type) {
         case BaseCommand::SEEK:
             return "SEEK";
             break;
+        case BaseCommand::SEEK_RESPONSE:
+            return "SEEK_RESPONSE";
+            break;
         case BaseCommand::ACTIVE_CONSUMER_CHANGE:
             return "ACTIVE_CONSUMER_CHANGE";
             break;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
@@ -40,6 +40,10 @@ public class BatchMessageIdImpl extends MessageIdImpl {
         this(ledgerId, entryId, partitionIndex, batchIndex, 0, BatchMessageAckerDisabled.INSTANCE);
     }
 
+    public BatchMessageIdImpl(long ledgerId, long entryId, int partitionIndex, int batchIndex, int batchSize) {
+        this(ledgerId, entryId, partitionIndex, batchIndex, batchSize, BatchMessageAcker.newAcker(batchSize));
+    }
+
     public BatchMessageIdImpl(long ledgerId, long entryId, int partitionIndex, int batchIndex, int batchSize, BatchMessageAcker acker) {
         super(ledgerId, entryId, partitionIndex);
         this.batchIndex = batchIndex;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2141,7 +2141,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             result.getEntryId(), result.getPartition()));
                 } else {
                     future.complete(new BatchMessageIdImpl(result.getLedgerId(),
-                            result.getEntryId(), result.getPartition(), result.getBatchIndex()));
+                            result.getEntryId(), result.getPartition(), result.getBatchIndex(), result.getBatchSize()));
                 }
             }).exceptionally(e -> {
                 log.error("[{}][{}] Failed getLastMessageId command", topic, subscription);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1179,7 +1179,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             } else {
                 for (int batchIndex = 0; batchIndex < msgs.size(); batchIndex++) {
                     msgs.get(batchIndex)
-                            .setMessageId(new BatchMessageIdImpl(ledgerId, entryId, partitionIndex, batchIndex));
+                            .setMessageId(new BatchMessageIdImpl(ledgerId, entryId, partitionIndex, batchIndex, msgs.size()));
                 }
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/MessageIdUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/MessageIdUtils.java
@@ -20,6 +20,9 @@ package org.apache.pulsar.client.util;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.util.SafeCollectionUtils;
+import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 
 public class MessageIdUtils {
     public static final long getOffset(MessageId messageId) {
@@ -40,5 +43,12 @@ public class MessageIdUtils {
         long entryId = offset & 0x0F_FF_FF_FFL;
 
         return new MessageIdImpl(ledgerId, entryId, -1);
+    }
+
+    public static int getBathIndexFromMessageIdData(PulsarApi.MessageIdData messageIdData) {
+        BitSetRecyclable bitSetRecyclable = BitSetRecyclable.valueOf(
+                SafeCollectionUtils.longListToArray(messageIdData.getAckSetList()));
+        return (messageIdData.getAckSetList() == null || messageIdData.getAckSetList().size() == 0)
+                ? -1 : (bitSetRecyclable.length() - bitSetRecyclable.cardinality());
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -38,6 +38,10 @@ import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.util.MessageIdUtils;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.util.SafeCollectionUtils;
+import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -168,5 +172,24 @@ public class ConsumerImplTest {
         future.cancel(true);
         // then
         Assert.assertFalse(consumer.hasPendingBatchReceive());
+    }
+
+    @Test
+    public void testGetBathIndexFromMessageIdData() {
+        int batchSize = 99;
+        int batchIndex = 55;
+
+        BitSetRecyclable ackSet = BitSetRecyclable.create();
+        ackSet.set(0, batchSize);
+        ackSet.clear(0, batchIndex);
+
+        PulsarApi.MessageIdData messageIdData = PulsarApi.MessageIdData.newBuilder()
+                .setEntryId(1)
+                .setLedgerId(1)
+                .setBatchIndex(batchIndex)
+                .addAllAckSet(SafeCollectionUtils.longArrayToList(ackSet.toLongArray()))
+                .build();
+        int batchIndexRes = MessageIdUtils.getBathIndexFromMessageIdData(messageIdData);
+        Assert.assertEquals(batchIndex, batchIndexRes);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -22689,6 +22689,434 @@ public final class PulsarApi {
     // @@protoc_insertion_point(class_scope:pulsar.proto.CommandSeek)
   }
   
+  public interface CommandSeekResponseOrBuilder
+      extends org.apache.pulsar.shaded.com.google.protobuf.v241.MessageLiteOrBuilder {
+    
+    // required uint64 request_id = 1;
+    boolean hasRequestId();
+    long getRequestId();
+    
+    // required .pulsar.proto.MessageIdData messageIdData = 2;
+    boolean hasMessageIdData();
+    org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageIdData();
+  }
+  public static final class CommandSeekResponse extends
+      org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
+      implements CommandSeekResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use CommandSeekResponse.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSeekResponse(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<CommandSeekResponse> RECYCLER = new io.netty.util.Recycler<CommandSeekResponse>() {
+            protected CommandSeekResponse newObject(Handle handle) {
+              return new CommandSeekResponse(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private CommandSeekResponse(boolean noInit) {}
+    
+    private static final CommandSeekResponse defaultInstance;
+    public static CommandSeekResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public CommandSeekResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required uint64 request_id = 1;
+    public static final int REQUEST_ID_FIELD_NUMBER = 1;
+    private long requestId_;
+    public boolean hasRequestId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public long getRequestId() {
+      return requestId_;
+    }
+    
+    // required .pulsar.proto.MessageIdData messageIdData = 2;
+    public static final int MESSAGEIDDATA_FIELD_NUMBER = 2;
+    private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageIdData_;
+    public boolean hasMessageIdData() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageIdData() {
+      return messageIdData_;
+    }
+    
+    private void initFields() {
+      requestId_ = 0L;
+      messageIdData_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasRequestId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasMessageIdData()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getMessageIdData().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeUInt64(1, requestId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(2, messageIdData_);
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(1, requestId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeMessageSize(2, messageIdData_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(byte[] data)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        byte[] data,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse parseFrom(
+        org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite.Builder<
+          org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse, Builder>
+        implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        requestId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        messageIdData_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse getDefaultInstanceForType() {
+        return org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance();
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse build() {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse buildParsed()
+          throws org.apache.pulsar.shaded.com.google.protobuf.v241.InvalidProtocolBufferException {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse buildPartial() {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse result = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.requestId_ = requestId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.messageIdData_ = messageIdData_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse other) {
+        if (other == org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance()) return this;
+        if (other.hasRequestId()) {
+          setRequestId(other.getRequestId());
+        }
+        if (other.hasMessageIdData()) {
+          mergeMessageIdData(other.getMessageIdData());
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasRequestId()) {
+          
+          return false;
+        }
+        if (!hasMessageIdData()) {
+          
+          return false;
+        }
+        if (!getMessageIdData().isInitialized()) {
+          
+          return false;
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.shaded.com.google.protobuf.v241.CodedInputStream input,
+                              org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          org.apache.pulsar.shaded.com.google.protobuf.v241.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              requestId_ = input.readUInt64();
+              break;
+            }
+            case 18: {
+              org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder();
+              if (hasMessageIdData()) {
+                subBuilder.mergeFrom(getMessageIdData());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setMessageIdData(subBuilder.buildPartial());
+              subBuilder.recycle();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required uint64 request_id = 1;
+      private long requestId_ ;
+      public boolean hasRequestId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public long getRequestId() {
+        return requestId_;
+      }
+      public Builder setRequestId(long value) {
+        bitField0_ |= 0x00000001;
+        requestId_ = value;
+        
+        return this;
+      }
+      public Builder clearRequestId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        requestId_ = 0L;
+        
+        return this;
+      }
+      
+      // required .pulsar.proto.MessageIdData messageIdData = 2;
+      private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageIdData_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+      public boolean hasMessageIdData() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageIdData() {
+        return messageIdData_;
+      }
+      public Builder setMessageIdData(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        messageIdData_ = value;
+        
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder setMessageIdData(
+          org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
+        messageIdData_ = builderForValue.build();
+        
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder mergeMessageIdData(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (((bitField0_ & 0x00000002) == 0x00000002) &&
+            messageIdData_ != org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance()) {
+          messageIdData_ =
+            org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder(messageIdData_).mergeFrom(value).buildPartial();
+        } else {
+          messageIdData_ = value;
+        }
+        
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder clearMessageIdData() {
+        messageIdData_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+        
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandSeekResponse)
+    }
+    
+    static {
+      defaultInstance = new CommandSeekResponse(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.CommandSeekResponse)
+  }
+  
   public interface CommandReachedEndOfTopicOrBuilder
       extends org.apache.pulsar.shaded.com.google.protobuf.v241.MessageLiteOrBuilder {
     
@@ -39950,6 +40378,10 @@ public final class PulsarApi {
     // optional .pulsar.proto.CommandEndTxnOnSubscriptionResponse endTxnOnSubscriptionResponse = 61;
     boolean hasEndTxnOnSubscriptionResponse();
     org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnSubscriptionResponse getEndTxnOnSubscriptionResponse();
+    
+    // optional .pulsar.proto.CommandSeekResponse seekResponse = 62;
+    boolean hasSeekResponse();
+    org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse getSeekResponse();
   }
   public static final class BaseCommand extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -40039,6 +40471,7 @@ public final class PulsarApi {
       END_TXN_ON_PARTITION_RESPONSE(48, 59),
       END_TXN_ON_SUBSCRIPTION(49, 60),
       END_TXN_ON_SUBSCRIPTION_RESPONSE(50, 61),
+      SEEK_RESPONSE(51, 62),
       ;
       
       public static final int CONNECT_VALUE = 2;
@@ -40092,6 +40525,7 @@ public final class PulsarApi {
       public static final int END_TXN_ON_PARTITION_RESPONSE_VALUE = 59;
       public static final int END_TXN_ON_SUBSCRIPTION_VALUE = 60;
       public static final int END_TXN_ON_SUBSCRIPTION_RESPONSE_VALUE = 61;
+      public static final int SEEK_RESPONSE_VALUE = 62;
       
       
       public final int getNumber() { return value; }
@@ -40149,6 +40583,7 @@ public final class PulsarApi {
           case 59: return END_TXN_ON_PARTITION_RESPONSE;
           case 60: return END_TXN_ON_SUBSCRIPTION;
           case 61: return END_TXN_ON_SUBSCRIPTION_RESPONSE;
+          case 62: return SEEK_RESPONSE;
           default: return null;
         }
       }
@@ -40696,6 +41131,16 @@ public final class PulsarApi {
       return endTxnOnSubscriptionResponse_;
     }
     
+    // optional .pulsar.proto.CommandSeekResponse seekResponse = 62;
+    public static final int SEEKRESPONSE_FIELD_NUMBER = 62;
+    private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse seekResponse_;
+    public boolean hasSeekResponse() {
+      return ((bitField1_ & 0x00100000) == 0x00100000);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse getSeekResponse() {
+      return seekResponse_;
+    }
+    
     private void initFields() {
       type_ = org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand.Type.CONNECT;
       connect_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect.getDefaultInstance();
@@ -40749,6 +41194,7 @@ public final class PulsarApi {
       endTxnOnPartitionResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnPartitionResponse.getDefaultInstance();
       endTxnOnSubscription_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnSubscription.getDefaultInstance();
       endTxnOnSubscriptionResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnSubscriptionResponse.getDefaultInstance();
+      seekResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -41041,6 +41487,12 @@ public final class PulsarApi {
           return false;
         }
       }
+      if (hasSeekResponse()) {
+        if (!getSeekResponse().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -41208,6 +41660,9 @@ public final class PulsarApi {
       }
       if (((bitField1_ & 0x00080000) == 0x00080000)) {
         output.writeMessage(61, endTxnOnSubscriptionResponse_);
+      }
+      if (((bitField1_ & 0x00100000) == 0x00100000)) {
+        output.writeMessage(62, seekResponse_);
       }
     }
     
@@ -41424,6 +41879,10 @@ public final class PulsarApi {
       if (((bitField1_ & 0x00080000) == 0x00080000)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeMessageSize(61, endTxnOnSubscriptionResponse_);
+      }
+      if (((bitField1_ & 0x00100000) == 0x00100000)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeMessageSize(62, seekResponse_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -41642,6 +42101,8 @@ public final class PulsarApi {
         bitField1_ = (bitField1_ & ~0x00040000);
         endTxnOnSubscriptionResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnSubscriptionResponse.getDefaultInstance();
         bitField1_ = (bitField1_ & ~0x00080000);
+        seekResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance();
+        bitField1_ = (bitField1_ & ~0x00100000);
         return this;
       }
       
@@ -41885,6 +42346,10 @@ public final class PulsarApi {
           to_bitField1_ |= 0x00080000;
         }
         result.endTxnOnSubscriptionResponse_ = endTxnOnSubscriptionResponse_;
+        if (((from_bitField1_ & 0x00100000) == 0x00100000)) {
+          to_bitField1_ |= 0x00100000;
+        }
+        result.seekResponse_ = seekResponse_;
         result.bitField0_ = to_bitField0_;
         result.bitField1_ = to_bitField1_;
         return result;
@@ -42047,6 +42512,9 @@ public final class PulsarApi {
         }
         if (other.hasEndTxnOnSubscriptionResponse()) {
           mergeEndTxnOnSubscriptionResponse(other.getEndTxnOnSubscriptionResponse());
+        }
+        if (other.hasSeekResponse()) {
+          mergeSeekResponse(other.getSeekResponse());
         }
         return this;
       }
@@ -42334,6 +42802,12 @@ public final class PulsarApi {
         }
         if (hasEndTxnOnSubscriptionResponse()) {
           if (!getEndTxnOnSubscriptionResponse().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasSeekResponse()) {
+          if (!getSeekResponse().isInitialized()) {
             
             return false;
           }
@@ -42879,6 +43353,16 @@ public final class PulsarApi {
               }
               input.readMessage(subBuilder, extensionRegistry);
               setEndTxnOnSubscriptionResponse(subBuilder.buildPartial());
+              subBuilder.recycle();
+              break;
+            }
+            case 498: {
+              org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.newBuilder();
+              if (hasSeekResponse()) {
+                subBuilder.mergeFrom(getSeekResponse());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setSeekResponse(subBuilder.buildPartial());
               subBuilder.recycle();
               break;
             }
@@ -45103,6 +45587,49 @@ public final class PulsarApi {
         endTxnOnSubscriptionResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandEndTxnOnSubscriptionResponse.getDefaultInstance();
         
         bitField1_ = (bitField1_ & ~0x00080000);
+        return this;
+      }
+      
+      // optional .pulsar.proto.CommandSeekResponse seekResponse = 62;
+      private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse seekResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance();
+      public boolean hasSeekResponse() {
+        return ((bitField1_ & 0x00100000) == 0x00100000);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse getSeekResponse() {
+        return seekResponse_;
+      }
+      public Builder setSeekResponse(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        seekResponse_ = value;
+        
+        bitField1_ |= 0x00100000;
+        return this;
+      }
+      public Builder setSeekResponse(
+          org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.Builder builderForValue) {
+        seekResponse_ = builderForValue.build();
+        
+        bitField1_ |= 0x00100000;
+        return this;
+      }
+      public Builder mergeSeekResponse(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse value) {
+        if (((bitField1_ & 0x00100000) == 0x00100000) &&
+            seekResponse_ != org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance()) {
+          seekResponse_ =
+            org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.newBuilder(seekResponse_).mergeFrom(value).buildPartial();
+        } else {
+          seekResponse_ = value;
+        }
+        
+        bitField1_ |= 0x00100000;
+        return this;
+      }
+      public Builder clearSeekResponse() {
+        seekResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse.getDefaultInstance();
+        
+        bitField1_ = (bitField1_ & ~0x00100000);
         return this;
       }
       

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -93,6 +93,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekResponse;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSend;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt;
@@ -1381,6 +1382,19 @@ public class Commands {
             .setType(Type.GET_LAST_MESSAGE_ID_RESPONSE)
             .setGetLastMessageIdResponse(response.build()));
         response.recycle();
+        return res;
+    }
+
+    public static BaseCommand newSeekResponse(long requestId, MessageIdData messageIdData) {
+        CommandSeekResponse.Builder seekResponseBuilder = CommandSeekResponse.newBuilder();
+        seekResponseBuilder.setRequestId(requestId);
+        seekResponseBuilder.setMessageIdData(messageIdData);
+        CommandSeekResponse seekResponse =  seekResponseBuilder.build();
+
+        BaseCommand.Builder builder = BaseCommand.newBuilder();
+        BaseCommand res = builder.setType(Type.SEEK_RESPONSE).setSeekResponse(seekResponse).build();
+        seekResponseBuilder.recycle();
+        builder.recycle();
         return res;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -292,7 +292,11 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     cmd.getSeek().recycle();
                 }
                 break;
-
+            case SEEK_RESPONSE:
+                checkArgument(cmd.hasSeekResponse());
+                handleSeekResponse(cmd.getSeekResponse());
+                cmd.getSeek().recycle();
+                break;
             case PING:
                 checkArgument(cmd.hasPing());
                 handlePing(cmd.getPing());
@@ -588,6 +592,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleSeek(CommandSeek seek) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleSeekResponse(PulsarApi.CommandSeekResponse seekResponse) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -575,6 +575,12 @@ message CommandSeek {
     optional uint64 message_publish_time = 4;
 }
 
+// Response for reset an existing consumer to a particular message id or timestamp
+message CommandSeekResponse {
+    required uint64 request_id  = 1;
+    required MessageIdData messageIdData = 2;
+}
+
 // Message sent by broker to client when a topic
 // has been forcefully terminated and there are no more
 // messages left to consume
@@ -923,6 +929,7 @@ message BaseCommand {
         END_TXN_ON_SUBSCRIPTION = 60;
         END_TXN_ON_SUBSCRIPTION_RESPONSE = 61;
 
+        SEEK_RESPONSE = 62;
     }
 
 
@@ -997,4 +1004,5 @@ message BaseCommand {
     optional CommandEndTxnOnPartitionResponse endTxnOnPartitionResponse = 59;
     optional CommandEndTxnOnSubscription endTxnOnSubscription = 60;
     optional CommandEndTxnOnSubscriptionResponse endTxnOnSubscriptionResponse = 61;
+    optional CommandSeekResponse seekResponse = 62;
 }


### PR DESCRIPTION

Fixes #7796 

### Motivation
This PR takes seek time into account in Reader#hasMessageAvailable.


### Modifications

1.  mark the timestamp in `Reader`  when `seek(timestamp)`
2. compare the marked timestamp with the publish time of last messag to decide `Reader#hasMessageAvailable`  give true or false
