### PR TITLE
[build] Add python-dev to pulsar docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -43,8 +43,8 @@ FROM openjdk:8-jdk-slim
 # Install some utilities
 RUN apt-get update \
      && apt-get install -y netcat dnsutils less procps iputils-ping \
-                 python2.7 python-setuptools python-yaml python-kazoo \
-                 python3.7 python3-setuptools python3-yaml python3-kazoo \
+                 python2.7 python2.7-dev python-setuptools python-yaml python-kazoo \
+                 python3.7 python3.7-dev python3-setuptools python3-yaml python3-kazoo \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
                  curl \
      && apt-get clean \


### PR DESCRIPTION
### Motivation

Recently, building Pulsar Docker image in CI jobs has continued to fail. It seems that the header file "Python.h" does not exist.
```
[INFO]   building 'fastavro._read' extension
[INFO]   creating build/temp.linux-x86_64-2.7
[INFO]   creating build/temp.linux-x86_64-2.7/fastavro
[INFO]   x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-2.7.16=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c fastavro/_read.c -o build/temp.linux-x86_64-2.7/fastavro/_read.o
[INFO]   fastavro/_read.c:4:10: fatal error: Python.h: No such file or directory
[INFO]    #include "Python.h"
[INFO]             ^~~~~~~~~~
[INFO]   compilation terminated.
[INFO]   error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
[INFO]   ----------------------------------------
[INFO]
[INFO]   ERROR: Failed building wheel for fastavro
```

### Modifications

I'm not sure why the build has recently failed, but added `python2.7-dev` and `python3.7-dev` to the Docker image.