### PR TITLE
[Python Build] Add python-dev to pulsar standalone docker image

### DIFF
--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -29,7 +29,7 @@ FROM openjdk:8-jdk
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update
-RUN apt-get -y install python2.7 python-pip postgresql sudo nginx supervisor libpq-dev
+RUN apt-get -y install python2.7 python2.7-dev python-pip postgresql sudo nginx supervisor libpq-dev
 
 # Postgres configuration
 COPY --from=dashboard /etc/postgresql/11/main/postgresql.conf /etc/postgresql/11/main/postgresql.conf


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation

Follow #7857 In the pulsar standalone Dockerfile, we also need to do the same operation

### Modifications

Add `python2.7-dev` to pulsar standalone docker image
