### PR TITLE
Support use `BitSet` generate the `BatchMessageAcker`

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAcker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageAcker.java
@@ -34,6 +34,11 @@ class BatchMessageAcker {
         return new BatchMessageAcker(bitSet, batchSize);
     }
 
+    // Use the param bitSet as the BatchMessageAcker's bitSet, don't care about the batchSize.
+    static BatchMessageAcker newAcker(BitSet bitSet) {
+        return new BatchMessageAcker(bitSet, -1);
+    }
+
     // bitset shared across messages in the same batch.
     private final int batchSize;
     private final BitSet bitSet;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1356,16 +1356,21 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         // create ack tracker for entry aka batch
         MessageIdImpl batchMessage = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(),
                 getPartitionIndex());
-        BatchMessageAcker acker = BatchMessageAcker.newAcker(batchSize);
         List<MessageImpl<T>> possibleToDeadLetter = null;
         if (deadLetterPolicy != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()) {
             possibleToDeadLetter = new ArrayList<>();
         }
-        int skippedMessages = 0;
+
+        BatchMessageAcker acker;
         BitSetRecyclable ackBitSet = null;
         if (ackSet != null && ackSet.size() > 0) {
             ackBitSet = BitSetRecyclable.valueOf(SafeCollectionUtils.longListToArray(ackSet));
+            acker = BatchMessageAcker.newAcker(BitSet.valueOf(SafeCollectionUtils.longListToArray(ackSet)));
+        } else {
+            acker = BatchMessageAcker.newAcker(batchSize);
         }
+
+        int skippedMessages = 0;
         try {
             int startBatchIndex = Math.max(messageId.getBatchIndex(), 0);
             for (int i = startBatchIndex; i < batchSize; ++i) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageAckerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageAckerTest.java
@@ -22,8 +22,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.BitSet;
 
 public class BatchMessageAckerTest {
 
@@ -66,6 +69,15 @@ public class BatchMessageAckerTest {
 
         assertTrue(acker.ackIndividual(7));
         assertEquals(0, acker.getOutstandingAcks());
+    }
+
+    @Test
+    public void testBitSetAcker() {
+        BitSet bitSet = BitSet.valueOf(acker.getBitSet().toLongArray());
+        BatchMessageAcker bitSetAcker = BatchMessageAcker.newAcker(bitSet);
+
+        Assert.assertEquals(acker.getBitSet(), bitSetAcker.getBitSet());
+        Assert.assertEquals(acker.getOutstandingAcks(), bitSetAcker.getOutstandingAcks());
     }
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclable.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.util.collections;
 
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import java.util.BitSet;
 
 /**
  * Safe multithreaded version of {@code BitSet} and leverage netty recycler.
@@ -41,6 +42,12 @@ public class ConcurrentBitSetRecyclable extends ConcurrentBitSet {
 
     public static ConcurrentBitSetRecyclable create() {
         return RECYCLER.get();
+    }
+
+    public static ConcurrentBitSetRecyclable create(BitSet bitSet) {
+        ConcurrentBitSetRecyclable recyclable = RECYCLER.get();
+        recyclable.or(bitSet);
+        return recyclable;
     }
 
     public void recycle() {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclableTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclableTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.util.collections;
 
+import java.util.BitSet;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,5 +34,27 @@ public class ConcurrentBitSetRecyclableTest {
         Assert.assertSame(bitset2, bitset1);
         Assert.assertFalse(bitset2.get(3));
         Assert.assertNotSame(bitset3, bitset1);
+    }
+
+    @Test
+    public void testGenerateByBitSet() {
+        BitSet bitSet = new BitSet();
+        ConcurrentBitSetRecyclable bitSetRecyclable = ConcurrentBitSetRecyclable.create(bitSet);
+        Assert.assertEquals(bitSet, bitSetRecyclable);
+
+        bitSet.set(0, 10);
+        bitSetRecyclable.recycle();
+        bitSetRecyclable = ConcurrentBitSetRecyclable.create(bitSet);
+        Assert.assertEquals(bitSet, bitSetRecyclable);
+
+        bitSet.clear(5);
+        bitSetRecyclable.recycle();
+        bitSetRecyclable = ConcurrentBitSetRecyclable.create(bitSet);
+        Assert.assertEquals(bitSet, bitSetRecyclable);
+
+        bitSet.clear();
+        bitSetRecyclable.recycle();
+        bitSetRecyclable = ConcurrentBitSetRecyclable.create(bitSet);
+        Assert.assertEquals(bitSet, bitSetRecyclable);
     }
 }


### PR DESCRIPTION
### Motivation

Currently, we have to know the batchSize to generate `BatchMessageAcker`. If we could get the batch index ack bitSet from Broker we could generate the `BatchMessageAcker` by the bitSet, this is useful for consuming transaction messages, we don't need to change the protocol to get the total message number of one transaction.

### Modifications

Add a new static method to generate the `BatchMessageAcker` by `BitSet`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
