### PR TITLE
[cpp-client] Fix for not respecting custom LoggerFactory client config

### DIFF
--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -36,7 +36,7 @@ echo "---- Build Pulsar C++ client using image $IMAGE (pass <skip-clean> for inc
 docker pull $IMAGE
 
 VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
-COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j16"
+COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -36,7 +36,7 @@ echo "---- Build Pulsar C++ client using image $IMAGE (pass <skip-clean> for inc
 docker pull $IMAGE
 
 VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
-COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"
+COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j16"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -97,18 +97,20 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
       requestIdGenerator_(0),
       closingError(ResultOk) {
     std::unique_ptr<LoggerFactory> loggerFactory = clientConfiguration_.impl_->takeLogger();
+    if (!loggerFactory) {
 #ifdef USE_LOG4CXX
-    if (!clientConfiguration_.getLogConfFilePath().empty()) {
-        // A log4cxx log file was passed through deprecated parameter. Use that to configure Log4CXX
-        loggerFactory = Log4CxxLoggerFactory::create(clientConfiguration_.getLogConfFilePath());
-    } else {
+        if (!clientConfiguration_.getLogConfFilePath().empty()) {
+            // A log4cxx log file was passed through deprecated parameter. Use that to configure Log4CXX
+            loggerFactory = Log4CxxLoggerFactory::create(clientConfiguration_.getLogConfFilePath());
+        } else {
+            // Use default simple console logger
+            loggerFactory = SimpleLoggerFactory::create();
+        }
+#else
         // Use default simple console logger
         loggerFactory = SimpleLoggerFactory::create();
-    }
-#else
-    // Use default simple console logger
-    loggerFactory = SimpleLoggerFactory::create();
 #endif
+    }
     LogUtils::setLoggerFactory(std::move(loggerFactory));
 
     if (serviceUrl_.compare(0, 4, "http") == 0) {

--- a/pulsar-client-cpp/lib/LogUtils.cc
+++ b/pulsar-client-cpp/lib/LogUtils.cc
@@ -63,4 +63,6 @@ std::string LogUtils::getLoggerName(const std::string& path) {
     return path.substr(startIdx + 1, endIdx - startIdx - 1);
 }
 
+void LogUtils::resetLoggerFactory() { s_loggerFactory.exchange(nullptr, std::memory_order_release); }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -88,6 +88,8 @@ class PULSAR_PUBLIC LogUtils {
 
     static void setLoggerFactory(std::unique_ptr<LoggerFactory> loggerFactory);
 
+    static void resetLoggerFactory();
+
     static LoggerFactory* getLoggerFactory();
 
     static std::string getLoggerName(const std::string& path);

--- a/pulsar-client-cpp/tests/CustomLoggerTest.cc
+++ b/pulsar-client-cpp/tests/CustomLoggerTest.cc
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/Client.h>
+#include <LogUtils.h>
+#include <gtest/gtest.h>
+#include <lib/SimpleLoggerImpl.h>
+#include <thread>
+
+using namespace pulsar;
+
+static std::vector<std::string> logLines;
+
+class MyTestLogger : public Logger {
+   public:
+    MyTestLogger() = default;
+
+    bool isEnabled(Level level) override { return true; }
+
+    void log(Level level, int line, const std::string &message) override {
+        std::stringstream ss;
+        ss << " " << level << ":" << line << " " << message << std::endl;
+        logLines.emplace_back(ss.str());
+    }
+};
+
+class MyTestLoggerFactory : public LoggerFactory {
+   public:
+    Logger *getLogger(const std::string &fileName) override { return logger; }
+
+   private:
+    MyTestLogger *logger = new MyTestLogger;
+};
+
+TEST(CustomLoggerTest, testCustomLogger) {
+    // simulate new client created on a different thread (because logging factory is called once per thread)
+    auto testThread = std::thread([] {
+        ClientConfiguration clientConfig;
+        auto customLogFactory = new MyTestLoggerFactory();
+        clientConfig.setLogger(customLogFactory);
+        // reset to previous log factory
+        Client client("pulsar://localhost:6650", clientConfig);
+        client.close();
+        ASSERT_EQ(logLines.size(), 2);
+        LogUtils::resetLoggerFactory();
+    });
+    testThread.join();
+
+    ClientConfiguration clientConfig;
+    Client client("pulsar://localhost:6650", clientConfig);
+    client.close();
+    // custom logger didn't get any new lines
+    ASSERT_EQ(logLines.size(), 2);
+}


### PR DESCRIPTION
### Motivation

I want to use custom logging factory in cpp client

### Modifications

https://github.com/apache/pulsar/pull/7132 broke custom logger config option. It then was identified in https://github.com/apache/pulsar/pull/7503 (and #7502) but not fixed. This PR actually fixes it by checking the right variable name.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

This PR does not introduce any new functionality, but it fixes existing functionality that presumably is already documented.