### PR TITLE
Allow to build Pulsar on JDK14+

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -563,6 +563,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
 
 Eclipse Distribution License 1.0 -- licenses/LICENSE-EDL-1.0.txt
  * Jakarta Activation -- jakarta.activation-jakarta.activation-api-1.2.2.jar
+ * Jakarta Activation -- - com.sun.activation-jakarta.activation-1.2.2.jar
  * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.3.jar
 
 Eclipse Public License 1.0 -- licenses/LICENSE-AspectJ.txt

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -371,7 +371,6 @@ The Apache Software License, Version 2.0
     - io.netty-netty-transport-native-epoll-4.1.51.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.51.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.51.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-kqueue-4.1.51.Final-osx-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.30.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
@@ -563,8 +562,8 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Mimepull -- org.jvnet.mimepull-mimepull-1.9.13.jar
 
 Eclipse Distribution License 1.0 -- licenses/LICENSE-EDL-1.0.txt
- * Jakarta Activation -- jakarta.activation-jakarta.activation-api-1.2.1.jar
- * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.2.jar
+ * Jakarta Activation -- jakarta.activation-jakarta.activation-api-1.2.2.jar
+ * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.3.jar
 
 Eclipse Public License 1.0 -- licenses/LICENSE-AspectJ.txt
  * AspectJ

--- a/pom.xml
+++ b/pom.xml
@@ -206,14 +206,14 @@ flexible messaging model and an intuitive client API.</description>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
     <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin>3.2.4</maven-shade-plugin>
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <maven-archiver.version>2.5</maven-archiver.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-    <git-commit-id-plugin.version>3.0.0</git-commit-id-plugin.version>
+    <git-commit-id-plugin.version>4.0.2</git-commit-id-plugin.version>
     <wagon-ssh-external.version>2.10</wagon-ssh-external.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
@@ -1276,30 +1276,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/_helpers.tpl</exclude>
           </excludes>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>git-info</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <useNativeGit>true</useNativeGit>
-          <prefix>git</prefix>
-          <verbose>false</verbose>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
-          <format>properties</format>
-          <gitDescribe>
-            <skip>true</skip>
-          </gitDescribe>
-        </configuration>
-      </plugin>
+      </plugin>      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>18/version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -203,6 +203,7 @@ flexible messaging model and an intuitive client API.</description>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
     <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -1393,6 +1394,11 @@ flexible messaging model and an intuitive client API.</description>
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>            
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18/version>
+    <version>18</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -178,6 +178,30 @@
   <build>
   <plugins>
     <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <useNativeGit>true</useNativeGit>
+          <prefix>git</prefix>
+          <verbose>false</verbose>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <format>properties</format>
+          <gitDescribe>
+            <skip>true</skip>
+          </gitDescribe>
+        </configuration>
+    </plugin>
+      
+    <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>templating-maven-plugin</artifactId>
       <version>1.0.0</version>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
@@ -30,7 +30,11 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.pulsar.functions.api.*;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.common.functions.WindowConfig;
 import org.apache.pulsar.functions.windowing.evictors.CountEvictionPolicy;

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/PublishWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/PublishWindowFunction.java
@@ -19,9 +19,9 @@
 package org.apache.pulsar.functions.api.examples.window;
 
 import java.util.Collection;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.functions.api.*;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
 
 /**
  * Example function that uses the built in publish function in the context

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/UserExceptionWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/UserExceptionWindowFunction.java
@@ -19,7 +19,9 @@
 package org.apache.pulsar.functions.api.examples.window;
 
 import java.util.Collection;
-import org.apache.pulsar.functions.api.*;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
 
 
 /**

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/WordCountWindowFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/window/WordCountWindowFunction.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.functions.api.examples.window;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.apache.pulsar.functions.api.*;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
 
 /**
  * The classic word count example done using pulsar functions

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -235,10 +235,8 @@ The Apache Software License, Version 2.0
     - netty-codec-4.1.51.Final.jar
     - netty-codec-dns-4.1.51.Final.jar
     - netty-codec-http-4.1.51.Final.jar
-    - netty-codec-socks-4.1.51.Final.jar
     - netty-common-4.1.51.Final.jar
     - netty-handler-4.1.51.Final.jar
-    - netty-handler-proxy-4.1.51.Final.jar
     - netty-reactive-streams-2.0.4.jar
     - netty-resolver-4.1.51.Final.jar
     - netty-resolver-dns-4.1.51.Final.jar
@@ -246,7 +244,6 @@ The Apache Software License, Version 2.0
     - netty-transport-4.1.51.Final.jar
     - netty-transport-native-epoll-4.1.51.Final.jar
     - netty-transport-native-epoll-4.1.51.Final-linux-x86_64.jar
-    - netty-transport-native-kqueue-4.1.51.Final-osx-x86_64.jar
     - netty-transport-native-unix-common-4.1.51.Final.jar
     - netty-transport-native-unix-common-4.1.51.Final-linux-x86_64.jar
  * Joda Time
@@ -267,6 +264,7 @@ The Apache Software License, Version 2.0
     - jetty-server-9.4.27.v20200227.jar
     - jetty-servlet-9.4.27.v20200227.jar
     - jetty-util-9.4.27.v20200227.jar
+    - jetty-alpn-java-client-9.4.27.v20200227.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode
@@ -363,9 +361,11 @@ The Apache Software License, Version 2.0
   * Javax
     - javax.inject-1.jar
     - javax.inject-1.jar
+    - javax.inject-2.5.0-b42.jar
     - javax.servlet-api-3.1.0.jar
     - javax.servlet-api-4.0.1.jar
     - javax.ws.rs-api-2.1.jar
+    - javassist-3.22.0-CR2.jar
   * JCommander
     - jcommander-1.78.jar
   * FindBugs JSR305
@@ -391,6 +391,7 @@ The Apache Software License, Version 2.0
     - snakeyaml-1.26.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
+    - validation-api-1.1.0.Final.jar
   * Objectsize
     - objectsize-0.0.12.jar
   * Dropwizard Metrics
@@ -500,7 +501,7 @@ MIT License
 
 CDDL - 1.0
  * OSGi Resource Locator
-    - osgi-resource-locator-1.0.1.jar
+    - osgi-resource-locator-1.0.3.jar
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
@@ -509,6 +510,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - javax.activation-1.2.0.jar
    - javax.activation-api-1.2.0.jar
    - jakarta.activation-api-1.2.1.jar
+   - jakarta.activation-1.2.2.jar
  * HK2 - Dependency Injection Kernel
    - hk2-api-2.5.0-b42.jar
    - hk2-locator-2.5.0-b42.jar
@@ -522,6 +524,15 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-media-jaxb-2.26.jar
     - jersey-server-2.26.jar
     - jersey-common-2.26.jar
+    - jersey-client-2.31.jar
+    - jersey-common-2.31.jar
+    - jersey-entity-filtering-2.31.jar
+    - jersey-hk2-2.31.jar
+    - jersey-media-json-jackson-2.31.jar
+    - jersey-media-multipart-2.31.jar
+    - aopalliance-repackaged-2.5.0-b42.jar
+    - aopalliance-repackaged-2.6.1.jar
+
  * JAXB
     - jaxb-api-2.3.1.jar
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -361,11 +361,9 @@ The Apache Software License, Version 2.0
   * Javax
     - javax.inject-1.jar
     - javax.inject-1.jar
-    - javax.inject-2.5.0-b42.jar
     - javax.servlet-api-3.1.0.jar
     - javax.servlet-api-4.0.1.jar
     - javax.ws.rs-api-2.1.jar
-    - javassist-3.22.0-CR2.jar
   * JCommander
     - jcommander-1.78.jar
   * FindBugs JSR305
@@ -391,7 +389,6 @@ The Apache Software License, Version 2.0
     - snakeyaml-1.26.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
-    - validation-api-1.1.0.Final.jar
   * Objectsize
     - objectsize-0.0.12.jar
   * Dropwizard Metrics
@@ -510,27 +507,28 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - javax.activation-1.2.0.jar
    - javax.activation-api-1.2.0.jar
    - jakarta.activation-api-1.2.1.jar
+   - jakarta.activation-api-1.2.2.jar
    - jakarta.activation-1.2.2.jar
+   - jakarta.validation-api-2.0.2.jar
+   - jakarta.ws.rs-api-2.1.6.jar
  * HK2 - Dependency Injection Kernel
-   - hk2-api-2.5.0-b42.jar
-   - hk2-locator-2.5.0-b42.jar
-   - hk2-utils-2.5.0-b42.jar
+   - hk2-api-2.6.1.jar
+   - hk2-locator-2.6.1.jar
+   - hk2-utils-2.6.1.jar
+   - jakarta.inject-2.6.1.jar 
  * Jersey
     - jaxrs-0.195.jar
-    - jersey-client-2.26.jar
-    - jersey-container-servlet-2.26.jar
-    - jersey-container-servlet-core-2.26.jar
-    - jersey-hk2-2.26.jar
-    - jersey-media-jaxb-2.26.jar
-    - jersey-server-2.26.jar
-    - jersey-common-2.26.jar
     - jersey-client-2.31.jar
+    - jersey-container-servlet-2.31.jar
+    - jersey-container-servlet-core-2.31.jar
+    - jersey-hk2-2.31.jar
+    - jersey-media-jaxb-2.31.jar
+    - jersey-server-2.31.jar
     - jersey-common-2.31.jar
     - jersey-entity-filtering-2.31.jar
     - jersey-hk2-2.31.jar
     - jersey-media-json-jackson-2.31.jar
     - jersey-media-multipart-2.31.jar
-    - aopalliance-repackaged-2.5.0-b42.jar
     - aopalliance-repackaged-2.6.1.jar
 
  * JAXB
@@ -554,6 +552,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - mimepull-1.9.13.jar
   * XML Bind API
     - jakarta.xml.bind-api-2.3.2.jar
+    - jakarta.xml.bind-api-2.3.3.jar
 
 Eclipse Public License - v2.0 -- licenses/LICENSE-EPL-2.0.txt
  * jakarta.annotation-api-1.3.5.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -34,6 +34,7 @@
     <version>2.7.0-SNAPSHOT</version>
 
     <properties>
+        <jersey.version>2.31</jersey.version>
         <presto.version>332</presto.version>
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
@@ -52,7 +53,31 @@
     </properties>
 
     <dependencies>
-
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
@@ -180,7 +205,7 @@
         </dependency>
 
     </dependencies>
-    
+
     <dependencyManagement>
       <dependencies>
         <dependency>
@@ -193,7 +218,7 @@
           <artifactId>netty</artifactId>
           <version>3.10.6.Final</version>
         </dependency>
-      
+
         <dependency>
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-core</artifactId>

--- a/src/check-binary-license
+++ b/src/check-binary-license
@@ -87,7 +87,7 @@ for J in $NOTICEJARS; do
 done
 
 # check pulsar sql jars
-JARS=$(tar -tf $TARBALL | grep '\.jar' | grep 'lib/presto/' | grep -v 'managed-ledger' | grep -v  'pulsar-client-admin' | grep -v  'pulsar-client-api' | grep -v 'pulsar-functions-api' | grep -v 'pulsar-presto-connector-original' | grep -v 'pulsar-presto-distribution' | grep -v 'pulsar-common' | grep -v 'pulsar-functions-proto' | grep -v 'pulsar-functions-utils' | grep -v 'pulsar-io-core' | grep -v 'pulsar-transaction-common' | sed 's!.*/!!' | sort)
+JARS=$(tar -tf $TARBALL | grep '\.jar' | grep 'lib/presto/' | grep -v pulsar-client | grep -v pulsar-metadata | grep -v 'managed-ledger' | grep -v  'pulsar-client-admin' | grep -v  'pulsar-client-api' | grep -v 'pulsar-functions-api' | grep -v 'pulsar-presto-connector-original' | grep -v 'pulsar-presto-distribution' | grep -v 'pulsar-common' | grep -v 'pulsar-functions-proto' | grep -v 'pulsar-functions-utils' | grep -v 'pulsar-io-core' | grep -v 'pulsar-transaction-common' | sed 's!.*/!!' | sort)
 LICENSEPATH=$(tar -tf $TARBALL  | awk '/^[^\/]*\/lib\/presto\/LICENSE/')
 LICENSE=$(tar -O -xf $TARBALL "$LICENSEPATH")
 LICENSEJARS=$(echo "$LICENSE" | sed -nE 's!.* (.*\.jar).*!\1!gp')


### PR DESCRIPTION
### Motivation
Currently Pulsar does not build on JDK14

### Modifications

- update Maven Assembly plugin
- use explicit import for Record class (prevent clash with java.lang.Record)
- move maven-git-commit-id plugin execution only inside Pulsar Common (in order to speed up the build)

### Verifying this change

This change is already covered by existing tests