### PR TITLE
[Transaction] Support transaction abort on partition

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1717,7 +1717,7 @@ public class ServerCnx extends PulsarHandler {
         final int txnAction = command.getTxnAction().getNumber();
         TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
 
-        service.getTopics().get(command.getTopic()).whenComplete((topic, t) -> {
+        service.getTopics().get(TopicName.get(command.getTopic()).toString()).whenComplete((topic, t) -> {
             if (!topic.isPresent()) {
                 ctx.writeAndFlush(Commands.newEndTxnOnPartitionResponse(
                         command.getRequestId(), ServerError.TopicNotFound,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.impl.PartitionedProducerImpl;
+import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi;
@@ -115,7 +116,6 @@ public class TransactionProduceTest extends TransactionTestBase {
                 .topic(TOPIC_OUTPUT)
                 .sendTimeout(0, TimeUnit.SECONDS)
                 .enableBatching(false)
-                .roundRobinRouterBatchingPartitionSwitchFrequency(1)
                 .create();
 
         int messageCntPerPartition = 3;
@@ -140,35 +140,12 @@ public class TransactionProduceTest extends TransactionTestBase {
         }
 
         // the messageId callback can't be called before commit
-        futureList.forEach(messageIdFuture -> {
-            try {
-                messageIdFuture.get(1, TimeUnit.SECONDS);
-                Assert.fail("MessageId shouldn't be get before txn commit.");
-            } catch (Exception e) {
-                if (e instanceof TimeoutException) {
-                    log.info("This is a expected exception.");
-                } else {
-                    log.error("This exception is not expected.", e);
-                    Assert.fail("This exception is not expected.");
-                }
-            }
-        });
+        checkMessageId(futureList, false);
 
         tnx.commit().get();
 
-        Thread.sleep(3000L);
-
         // the messageId callback should be called after commit
-        futureList.forEach(messageIdFuture -> {
-            try {
-                MessageId messageId = messageIdFuture.get(1, TimeUnit.SECONDS);
-                Assert.assertNotNull(messageId);
-                log.info("Tnx commit success! messageId: {}", messageId);
-            } catch (Exception e) {
-                log.error("Tnx commit failed! tnx: " + tnx, e);
-                Assert.fail("Tnx commit failed! tnx: " + tnx);
-            }
-        });
+        checkMessageId(futureList, true);
 
         for (int i = 0; i < TOPIC_PARTITION; i++) {
             // the target topic partition received the commit marker
@@ -220,13 +197,116 @@ public class TransactionProduceTest extends TransactionTestBase {
         System.out.println("finish test");
     }
 
+    @Test
+    public void produceAndAbortTest() throws Exception {
+        String topic = NAMESPACE1 + "/produce-abort-test";
+        PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
+        TransactionImpl txn = (TransactionImpl) pulsarClientImpl.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.SECONDS)
+                .build().get();
+
+        @Cleanup
+        ProducerImpl<byte[]> outProducer = (ProducerImpl<byte[]>) pulsarClientImpl
+                .newProducer()
+                .topic(topic)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .enableBatching(false)
+                .create();
+
+        int messageCnt = 10;
+        Set<String> messageSet = new HashSet<>();
+        List<CompletableFuture<MessageId>> futureList = new ArrayList<>();
+        for (int i = 0; i < messageCnt; i++) {
+            String msg = "Hello Txn - " + i;
+            messageSet.add(msg);
+            CompletableFuture<MessageId> produceFuture = outProducer
+                    .newMessage(txn).value(msg.getBytes(UTF_8)).sendAsync();
+            futureList.add(produceFuture);
+        }
+
+        // the target topic hasn't the abort marker before commit
+        ReadOnlyCursor originTopicCursor = getOriginTopicCursor(topic, -1);
+        Assert.assertNotNull(originTopicCursor);
+        Assert.assertFalse(originTopicCursor.hasMoreEntries());
+        originTopicCursor.close();
+
+        // the messageId callback can't be called before commit
+        checkMessageId(futureList, false);
+
+        txn.abort().get();
+
+        // the messageId callback should be called after commit
+        checkMessageId(futureList, true);
+
+        // the target topic partition doesn't have any entries
+        originTopicCursor = getOriginTopicCursor(topic, -1);
+        Assert.assertNotNull(originTopicCursor);
+        Assert.assertFalse(originTopicCursor.hasMoreEntries());
+
+        // the target topic transactionBuffer should receive the transaction messages,
+        // committing marker and commit marker
+        ReadOnlyCursor tbTopicCursor = getTBTopicCursor(topic, -1);
+        Assert.assertNotNull(tbTopicCursor);
+        Assert.assertTrue(tbTopicCursor.hasMoreEntries());
+        long tbEntriesCnt = tbTopicCursor.getNumberOfEntries();
+        log.info("transaction buffer entries count: {}", tbEntriesCnt);
+        Assert.assertEquals(tbEntriesCnt, messageCnt + 1);
+
+        PulsarApi.MessageMetadata messageMetadata;
+        List<Entry> entries = tbTopicCursor.readEntries((int) tbEntriesCnt);
+        // check the messages
+        for (int i = 0; i < messageCnt; i++) {
+            messageMetadata = Commands.parseMessageMetadata(entries.get(i).getDataBuffer());
+            Assert.assertEquals(messageMetadata.getTxnidMostBits(), txn.getTxnIdMostBits());
+            Assert.assertEquals(messageMetadata.getTxnidLeastBits(), txn.getTxnIdLeastBits());
+
+            byte[] bytes = new byte[entries.get(i).getDataBuffer().readableBytes()];
+            entries.get(i).getDataBuffer().readBytes(bytes);
+            Assert.assertTrue(messageSet.remove(new String(bytes)));
+        }
+
+        // check abort marker
+        messageMetadata = Commands.parseMessageMetadata(entries.get(messageCnt).getDataBuffer());
+        Assert.assertEquals(PulsarMarkers.MarkerType.TXN_ABORT_VALUE, messageMetadata.getMarkerType());
+
+        Assert.assertEquals(0, messageSet.size());
+        log.info("finish test produceAndAbortTest.");
+    }
+
+    private void checkMessageId(List<CompletableFuture<MessageId>> futureList, boolean isFinished) {
+        futureList.forEach(messageIdFuture -> {
+            try {
+                MessageId messageId = messageIdFuture.get(1, TimeUnit.SECONDS);
+                if (isFinished) {
+                    Assert.assertNotNull(messageId);
+                    log.info("Tnx commit success! messageId: {}", messageId);
+                } else {
+                    Assert.fail("MessageId shouldn't be get before txn abort.");
+                }
+            } catch (Exception e) {
+                if (!isFinished) {
+                    if (e instanceof TimeoutException) {
+                        log.info("This is a expected exception.");
+                    } else {
+                        log.error("This exception is not expected.", e);
+                        Assert.fail("This exception is not expected.");
+                    }
+                } else {
+                    log.error("Tnx commit failed!", e);
+                    Assert.fail("Tnx commit failed!");
+                }
+            }
+        });
+    }
+
     private ReadOnlyCursor getTBTopicCursor(String topic, int partition) {
         try {
-            String tbTopicName = PersistentTransactionBuffer.getTransactionBufferTopicName(
-                    TopicName.get(topic).toString() + TopicName.PARTITIONED_TOPIC_SUFFIX + partition);
+            String topicSuffix = partition >= 0 ? TopicName.PARTITIONED_TOPIC_SUFFIX + partition : "";
+            topic = PersistentTransactionBuffer.getTransactionBufferTopicName(
+                    TopicName.get(topic).toString() + topicSuffix);
 
             return getPulsarServiceList().get(0).getManagedLedgerFactory().openReadOnlyCursor(
-                    TopicName.get(tbTopicName).getPersistenceNamingEncoding(),
+                    TopicName.get(topic).getPersistenceNamingEncoding(),
                     PositionImpl.earliest, new ManagedLedgerConfig());
         } catch (Exception e) {
             log.error("Failed to get transaction buffer topic readonly cursor.", e);
@@ -237,9 +317,11 @@ public class TransactionProduceTest extends TransactionTestBase {
 
     private ReadOnlyCursor getOriginTopicCursor(String topic, int partition) {
         try {
-            String partitionTopic = TopicName.get(topic).toString() + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
+            if (partition >= 0) {
+                topic = TopicName.get(topic).toString() + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
+            }
             return getPulsarServiceList().get(0).getManagedLedgerFactory().openReadOnlyCursor(
-                    TopicName.get(partitionTopic).getPersistenceNamingEncoding(),
+                    TopicName.get(topic).getPersistenceNamingEncoding(),
                     PositionImpl.earliest, new ManagedLedgerConfig());
         } catch (Exception e) {
             log.error("Failed to get origin topic readonly cursor.", e);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -269,6 +269,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     @Override
     CompletableFuture<MessageId> internalSendAsync(Message<?> message, Transaction txn) {
+        if (txn instanceof TransactionImpl) {
+            ((TransactionImpl) txn).registerProducedTopic(topic);
+        }
 
         CompletableFuture<MessageId> future = new CompletableFuture<>();
 
@@ -343,9 +346,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 nextCallback = scb;
             }
         });
-        if (txn instanceof TransactionImpl) {
-            ((TransactionImpl) txn).registerProducedTopic(topic);
-        }
         return future;
     }
 


### PR DESCRIPTION
Fixes https://github.com/streamnative/pulsar/issues/1312

# Motivation

Currently, the transaction abort on partitions operation is not getting through.

### Modifications

Make the transaction abort on partitions operation get through.

### Verifying this change

This change added tests and can be verified as follows:

- *org.apache.pulsar.broker.transaction.TransactionProduceTest#produceAndAbortTest*
- *org.apache.pulsar.client.transaction.EndToEndTest#partitionAbortTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
