### PR TITLE
Await thread pool termination when closing Pulsar client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
@@ -25,10 +25,13 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class ExecutorProvider {
     private final int numThreads;
     private final List<ExecutorService> executors;
@@ -49,6 +52,13 @@ public class ExecutorProvider {
     }
 
     public void shutdownNow() {
-        executors.forEach(executor -> executor.shutdownNow());
+        executors.forEach(executor -> {
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.warn("Shutdown of thread pool was interrupted");
+            }
+        });
     }
 }


### PR DESCRIPTION

### Motivation

Let's wait for thread pool termination in the Pulsar client so we make more of an effort to make sure all Pulsar threads are shutdown when the pulsar client is closed.  This helps in when running Pulsar client on system like flink that dynamically load and unload JARS when jobs are started and stopped.

Example in Flink of an error that can be caused by threads not terminated

`
   extendedStackTrace: java.lang.NoClassDefFoundError: org/apache/pulsar/client/api/PulsarClientException$ConnectException
	at org.apache.pulsar.client.impl.ConsumerImpl.doAcknowledge(ConsumerImpl.java:533) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ConsumerBase.doAcknowledgeWithTxn(ConsumerBase.java:390) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ConsumerBase.acknowledgeCumulativeAsync(ConsumerBase.java:379) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ConsumerBase.acknowledgeCumulativeAsync(ConsumerBase.java:363) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ConsumerBase.acknowledgeCumulativeAsync(ConsumerBase.java:326) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ReaderImpl$1.received(ReaderImpl.java:69) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at org.apache.pulsar.client.impl.ConsumerImpl.lambda$triggerListener$8(ConsumerImpl.java:1237) ~[c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_252]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_252]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_252]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_252]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [c3b063d2-4697-4dfb-9a08-dda707a7456f?version=9b5ac9b0bfb1050ae095a3ac6519433dbd99c156:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.client.api.PulsarClientException$ConnectException
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[?:1.8.0_252]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418) ~[?:1.8.0_252]
	at org.apache.flink.util.ChildFirstClassLoader.loadClass(ChildFirstClassLoader.java:69) ~[flink-dist_2.11-1.9.1-splunk-2.1.jar:1.9.1-splunk-2.1]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_252]
	... 15 more
`
