### PR TITLE
[Doc] Fix wrong argument name

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -473,7 +473,7 @@ class Client:
            published by the producer. First message will be using
            `(initialSequenceId + 1)`` as its sequence id and subsequent messages will
            be assigned incremental sequence ids, if not otherwise specified.
-        * `send_timeout_seconds`:
+        * `send_timeout_millis`:
           If a message is not acknowledged by the server before the
           `send_timeout` expires, an error will be reported.
         * `compression_type`:


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Wrong document is confusing.

> ![image](https://user-images.githubusercontent.com/96157/92191825-ae515d00-ee9f-11ea-8120-3cd5697dfbe7.png)
>
> [pulsar API documentation](https://pulsar.apache.org/api/python/2.6.0-SNAPSHOT/#pulsar.Client.create_producer)


### Modifications

Fixed. Correct argument name is `send_timeout_millis` not `send_timeout_seconds`

https://github.com/apache/pulsar/blob/62e3df39155599f56f736f103a71069d1778a6c6/pulsar-client-cpp/python/pulsar/__init__.py#L437

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

- Does this pull request introduce a new feature? (no)
