### PR TITLE
double check from zookeeper if availableBrokers is empty for discovery service

### DIFF
--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/web/ZookeeperCacheLoader.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/web/ZookeeperCacheLoader.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
@@ -124,6 +125,13 @@ public class ZookeeperCacheLoader implements Closeable {
     }
 
     public List<LoadManagerReport> getAvailableBrokers() {
+        if (CollectionUtils.isEmpty(availableBrokers)) {
+            try {
+                updateBrokerList(availableBrokersCache.get());
+            } catch (Exception e) {
+                log.warn("Error updating broker from zookeeper.", e);
+            }
+        }
         return availableBrokers;
     }
 


### PR DESCRIPTION
Fixes #7476 

### Motivation

In some situations,  discovery service can't find active broker while all brokers are running well.  This PR will update from zookeeper if available broker list is empty to avoid  "No active broker is available"  `RestException` happen.


### Modifications

double check from zookeeper if availableBrokers is empty

