### PR TITLE
[Transaction] Txn ack abort process on subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1748,8 +1748,9 @@ public class ServerCnx extends PulsarHandler {
         final long txnidLeastBits = command.getTxnidLeastBits();
         final String topic = command.getSubscription().getTopic();
         final String subName = command.getSubscription().getSubscription();
+        final int txnAction = command.getTxnAction().getNumber();
 
-        service.getTopics().get(command.getSubscription().getTopic())
+        service.getTopics().get(TopicName.get(command.getSubscription().getTopic()).toString())
             .thenAccept(optionalTopic -> {
                 if (!optionalTopic.isPresent()) {
                     log.error("The topic {} is not exist in broker.", command.getSubscription().getTopic());
@@ -1771,7 +1772,7 @@ public class ServerCnx extends PulsarHandler {
                 }
 
                 CompletableFuture<Void> completableFuture =
-                        subscription.endTxn(txnidMostBits, txnidLeastBits, command.getTxnAction().getNumber());
+                        subscription.endTxn(txnidMostBits, txnidLeastBits, txnAction);
                 completableFuture.whenComplete((ignored, throwable) -> {
                     if (throwable != null) {
                         log.error("Handle end txn on subscription failed for request {}", requestId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1255,7 +1255,12 @@ public class PersistentSubscription implements Subscription {
         if (PulsarApi.TxnAction.COMMIT.getNumber() == txnAction) {
             completableFuture = commitTxn(txnID, Collections.emptyMap());
         } else if (PulsarApi.TxnAction.ABORT.getNumber() == txnAction) {
-            completableFuture = abortTxn(txnID, null);
+            Consumer redeliverConsumer = null;
+            if (getDispatcher() instanceof PersistentDispatcherSingleActiveConsumer) {
+                redeliverConsumer = ((PersistentDispatcherSingleActiveConsumer)
+                        getDispatcher()).getActiveConsumer();
+            }
+            completableFuture = abortTxn(txnID, redeliverConsumer);
         } else {
             completableFuture.completeExceptionally(new Exception("Unsupported txnAction " + txnAction));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -483,38 +483,6 @@ public class TransactionProduceTest extends TransactionTestBase {
         log.info("finish test ackAbortTest");
     }
 
-    @Test
-    public void normalReconsumeTest() throws Exception {
-        String topic = NAMESPACE1 + "/reconsume-test";
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic(topic)
-                .create();
-
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic(topic)
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscriptionName("test")
-                .subscriptionType(SubscriptionType.Shared)
-                .subscribe();
-
-        for (int i = 0; i < 10; i++) {
-            producer.newMessage().value("hello".getBytes()).sendAsync();
-        }
-
-        for (int i = 0; i < 10; i++) {
-            Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
-            System.out.println("receive msg: " + new String(message.getData()));
-        }
-
-        consumer.redeliverUnacknowledgedMessages();
-
-        for (int i = 0; i < 10; i++) {
-            Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
-            Assert.assertNotNull(message);
-            System.out.println("receive msg: " + new String(message.getData()));
-        }
-    }
-
     private int getPendingAckCount(String topic, String subscriptionName) throws Exception {
         Class<PersistentSubscription> clazz = PersistentSubscription.class;
         Field field = clazz.getDeclaredField("pendingAckMessages");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
@@ -28,9 +28,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
+import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.PartitionedProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -88,11 +92,7 @@ public class EndToEndTest extends TransactionTestBase {
 
     @Test
     public void partitionCommitTest() throws Exception {
-        Transaction txn = ((PulsarClientImpl) pulsarClient)
-                .newTransaction()
-                .withTransactionTimeout(2, TimeUnit.SECONDS)
-                .build()
-                .get();
+        Transaction txn = getTxn();
 
         @Cleanup
         PartitionedProducerImpl<byte[]> producer = (PartitionedProducerImpl<byte[]>) pulsarClient
@@ -151,11 +151,7 @@ public class EndToEndTest extends TransactionTestBase {
 
     @Test
     public void partitionAbortTest() throws Exception {
-        Transaction txn = ((PulsarClientImpl) pulsarClient)
-                .newTransaction()
-                .withTransactionTimeout(2, TimeUnit.SECONDS)
-                .build()
-                .get();
+        Transaction txn = getTxn();
 
         @Cleanup
         PartitionedProducerImpl<byte[]> producer = (PartitionedProducerImpl<byte[]>) pulsarClient
@@ -190,6 +186,94 @@ public class EndToEndTest extends TransactionTestBase {
         Assert.assertNull(message);
 
         log.info("finished test partitionAbortTest");
+    }
+
+    @Test
+    public void batchDisableAndSharedSubTest() throws Exception {
+        txnAckTest(false, 1, SubscriptionType.Shared);
+    }
+
+    private void txnAckTest(boolean batchEnable, int maxBatchSize,
+                         SubscriptionType subscriptionType) throws Exception {
+        String normalTopic = NAMESPACE1 + "/normal-topic";
+
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(normalTopic)
+                .subscriptionName("test")
+                .enableBatchIndexAcknowledgment(true)
+                .subscriptionType(subscriptionType)
+                .subscribe();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(normalTopic)
+                .enableBatching(batchEnable)
+                .batchingMaxMessages(maxBatchSize)
+                .create();
+
+        for (int retryCnt = 0; retryCnt < 2; retryCnt++) {
+            Transaction txn = getTxn();
+
+            int messageCnt = 10;
+            // produce normal messages
+            for (int i = 0; i < messageCnt; i++){
+                producer.newMessage().value("hello".getBytes()).sendAsync();
+            }
+
+            // consume and ack messages with txn
+            for (int i = 0; i < messageCnt; i++) {
+                Message<byte[]> message = consumer.receive();
+                Assert.assertNotNull(message);
+                log.info("receive msgId: {}", message.getMessageId());
+                consumer.acknowledgeAsync(message.getMessageId(), txn);
+            }
+            Thread.sleep(2000);
+
+            consumer.redeliverUnacknowledgedMessages();
+
+            // the messages are pending ack state and can't be received
+            Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
+            Assert.assertNull(message);
+
+            // 1) txn abort
+            txn.abort().get();
+
+            // after transaction abort, the messages could be received
+            Transaction commitTxn = getTxn();
+            for (int i = 0; i < messageCnt; i++) {
+                message = consumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertNotNull(message);
+                consumer.acknowledgeAsync(message.getMessageId(), commitTxn);
+                log.info("receive msgId: {}", message.getMessageId());
+            }
+
+            // 2) ack committed by a new txn
+            commitTxn.commit().get();
+
+            // after transaction commit, the messages can't be received
+            message = consumer.receive(2, TimeUnit.SECONDS);
+            Assert.assertNull(message);
+
+            try {
+                commitTxn.commit().get();
+                Assert.fail("recommit one transaction should be failed.");
+            } catch (Exception reCommitError) {
+                // recommit one transaction should be failed
+                log.info("expected exception for recommit one transaction.");
+                Assert.assertNotNull(reCommitError);
+                Assert.assertTrue(reCommitError.getCause() instanceof
+                        TransactionCoordinatorClientException.InvalidTxnStatusException);
+            }
+        }
+    }
+
+    private Transaction getTxn() throws Exception {
+        return ((PulsarClientImpl) pulsarClient)
+                .newTransaction()
+                .withTransactionTimeout(2, TimeUnit.SECONDS)
+                .build()
+                .get();
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -390,7 +390,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             this.consumer.unAckedChunckedMessageIdSequenceMap.remove(msgId);
         } else {
             ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(), lastCumulativeAckSet,
-                    ackType, validationError, map);
+                    ackType, validationError, map, txnidLeastBits, txnidMostBits);
             if (flush) {
                 cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
             } else {


### PR DESCRIPTION
Fixes https://github.com/streamnative/pulsar/issues/1314

### Motivation

Currently, the transaction ack abort process is not well.

### Modifications

Make some changes for the transaction ack abort process.

### Verifying this change

This change added tests and can be verified as follows:

-*org.apache.pulsar.broker.transaction.TransactionProduceTest#ackAbortTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
