### PR TITLE
Support topic-level inactiveTopicPolicies

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import com.google.common.collect.Sets;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -33,6 +34,9 @@ import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class InactiveTopicDeleteTest extends BrokerTestBase {
 
@@ -125,9 +129,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         }
 
         Assert.assertTrue(policies.isDeleteWhileInactive());
-        Assert.assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_no_subscriptions);
-        Assert.assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
-        Assert.assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace));
+        assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
+        assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace));
 
         admin.namespaces().removeInactiveTopicPolicies(namespace);
         while (true) {
@@ -137,14 +141,14 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 break;
             }
         }
-        Assert.assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies
+        assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies
                 , defaultPolicy);
 
         policies = ((PersistentTopic)pulsar.getBrokerService().getTopic(topic2,false).get().get()).inactiveTopicPolicies;
         Assert.assertTrue(policies.isDeleteWhileInactive());
-        Assert.assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
-        Assert.assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
-        Assert.assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace2));
+        assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
+        assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace2));
 
         admin.namespaces().removeInactiveTopicPolicies(namespace2);
         while (true) {
@@ -154,7 +158,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 break;
             }
         }
-        Assert.assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic2, false).get().get()).inactiveTopicPolicies
+        assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic2, false).get().get()).inactiveTopicPolicies
                 , defaultPolicy);
 
         super.internalCleanup();
@@ -166,7 +170,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         final String namespace2 = "prop/ns-abc2";
         final String namespace3 = "prop/ns-abc3";
         List<String> namespaceList = Arrays.asList(namespace2, namespace3);
-
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
@@ -290,6 +293,192 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         Thread.sleep(4000);
         Assert.assertFalse(admin.topics().getList("prop/ns-abc")
             .contains(topic));
+
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 20000)
+    public void testTopicLevelInActiveTopicApi() throws Exception {
+        super.resetConfig();
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        super.baseSetup();
+
+        final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
+        admin.topics().createPartitionedTopic(topicName, 3);
+        //wait for cache init
+        Thread.sleep(2000);
+        InactiveTopicPolicies inactiveTopicPolicies = admin.topics().getInactiveTopicPolicies(topicName);
+        assertNull(inactiveTopicPolicies);
+
+        InactiveTopicPolicies policies = new InactiveTopicPolicies();
+        policies.setDeleteWhileInactive(true);
+        policies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        policies.setMaxInactiveDurationSeconds(10);
+        admin.topics().setInactiveTopicPolicies(topicName, policies);
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topicName) != null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertEquals(admin.topics().getInactiveTopicPolicies(topicName), policies);
+        admin.topics().removeInactiveTopicPolicies(topicName);
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topicName) == null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertNull(admin.topics().getInactiveTopicPolicies(topicName));
+
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testTopicLevelInactivePolicyUpdateAndClean() throws Exception {
+        super.resetConfig();
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setBrokerDeleteInactiveTopicsEnabled(true);
+        conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(1000);
+        conf.setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        InactiveTopicPolicies defaultPolicy = new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions
+                , 1000, true);
+
+        super.baseSetup();
+        //wait for cache init
+        Thread.sleep(2000);
+        final String namespace = "prop/ns-abc";
+        final String topic = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        final String topic2 = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        final String topic3 = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        List<String> topics = Arrays.asList(topic, topic2, topic3);
+
+        for (String tp : topics) {
+            admin.topics().createNonPartitionedTopic(tp);
+        }
+
+        InactiveTopicPolicies inactiveTopicPolicies =
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true);
+        admin.topics().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
+        inactiveTopicPolicies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        admin.topics().setInactiveTopicPolicies(topic2, inactiveTopicPolicies);
+        inactiveTopicPolicies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        admin.topics().setInactiveTopicPolicies(topic3, inactiveTopicPolicies);
+
+        //wait for cache
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topic) != null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        InactiveTopicPolicies policies = ((PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).get().get()).inactiveTopicPolicies;
+        Assert.assertTrue(policies.isDeleteWhileInactive());
+        assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
+        assertEquals(policies, admin.topics().getInactiveTopicPolicies(topic));
+
+        admin.topics().removeInactiveTopicPolicies(topic);
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topic) == null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        //Only the broker-level policies is set, so after removing the topic-level policies
+        // , the topic will use the broker-level policies
+        assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies
+                , defaultPolicy);
+
+        policies = ((PersistentTopic)pulsar.getBrokerService().getTopic(topic2,false).get().get()).inactiveTopicPolicies;
+        Assert.assertTrue(policies.isDeleteWhileInactive());
+        assertEquals(policies.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        assertEquals(policies.getMaxInactiveDurationSeconds(), 1);
+        assertEquals(policies, admin.topics().getInactiveTopicPolicies(topic2));
+        inactiveTopicPolicies.setMaxInactiveDurationSeconds(999);
+        //Both broker level and namespace level policies are set, so after removing the topic level policies
+        // , the topic will use the namespace level policies
+        admin.namespaces().setInactiveTopicPolicies(namespace, inactiveTopicPolicies);
+        //wait for zk
+        Thread.sleep(1000);
+        admin.topics().removeInactiveTopicPolicies(topic2);
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topic2) == null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        InactiveTopicPolicies nsPolicies = ((PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic2, false).get().get()).inactiveTopicPolicies;
+        assertEquals(nsPolicies.getMaxInactiveDurationSeconds(), 999);
+
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testDeleteWhenNoSubscriptionsWithTopicLevelPolicies() throws Exception {
+        final String namespace = "prop/ns-abc";
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setBrokerDeleteInactiveTopicsEnabled(true);
+        conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
+        super.baseSetup();
+        //wait for cache init
+        Thread.sleep(2000);
+        final String topic = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        final String topic2 = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        final String topic3 = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        List<String> topics = Arrays.asList(topic, topic2, topic3);
+        //create producer/consumer and close
+        Map<String, String> topicToSub = new HashMap<>();
+        for (String tp : topics) {
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(tp).create();
+            String subName = "sub" + System.currentTimeMillis();
+            topicToSub.put(tp, subName);
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(tp).subscriptionName(subName).subscribe();
+            for (int i = 0; i < 10; i++) {
+                producer.send("Pulsar".getBytes());
+            }
+            consumer.close();
+            producer.close();
+            Thread.sleep(1);
+        }
+        // "topic" use delete_when_no_subscriptions, "topic2" use delete_when_subscriptions_caught_up
+        // "topic3" use default:delete_when_no_subscriptions
+        InactiveTopicPolicies inactiveTopicPolicies =
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,1,true);
+        admin.topics().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
+        inactiveTopicPolicies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        admin.topics().setInactiveTopicPolicies(topic2, inactiveTopicPolicies);
+
+        //wait for update
+        for (int i = 0; i < 50; i++) {
+            if (admin.topics().getInactiveTopicPolicies(topic2) != null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        // topic should still exist
+        Thread.sleep(2000);
+        Assert.assertTrue(admin.topics().getList(namespace).contains(topic));
+        Assert.assertTrue(admin.topics().getList(namespace).contains(topic2));
+        Assert.assertTrue(admin.topics().getList(namespace).contains(topic3));
+
+        // no backlog, trigger delete_when_subscriptions_caught_up
+        admin.topics().skipAllMessages(topic2, topicToSub.remove(topic2));
+        Thread.sleep(2000);
+        Assert.assertFalse(admin.topics().getList(namespace).contains(topic2));
+        // delete subscription, trigger delete_when_no_subscriptions
+        for (Map.Entry<String, String> entry : topicToSub.entrySet()) {
+            admin.topics().deleteSubscription(entry.getKey(), entry.getValue());
+        }
+        Thread.sleep(2000);
+        Assert.assertFalse(admin.topics().getList(namespace).contains(topic));
+        Assert.assertFalse(admin.topics().getList(namespace).contains(topic3));
 
         super.internalCleanup();
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1732,7 +1732,8 @@ public interface Topics {
      * @param maxNum
      * @throws PulsarAdminException
      */
-    void setInactiveTopicPolicies(String topic, InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException;
+    void setInactiveTopicPolicies(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException;
 
     /**
      * set inactive topic policies of a topic asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
 import org.apache.pulsar.common.policies.data.PartitionedTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
@@ -1709,6 +1710,51 @@ public interface Topics {
      * @return
      */
     CompletableFuture<Void> removeMaxUnackedMessagesOnConsumerAsync(String topic);
+
+    /**
+     * get inactive topic policies of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * get inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic);
+
+    /**
+     * set inactive topic policies of a topic.
+     * @param topic
+     * @param maxNum
+     * @throws PulsarAdminException
+     */
+    void setInactiveTopicPolicies(String topic, InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException;
+
+    /**
+     * set inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @param maxNum
+     * @return
+     */
+    CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic, InactiveTopicPolicies inactiveTopicPolicies);
+
+    /**
+     * remove inactive topic policies of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeInactiveTopicPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * remove inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeInactiveTopicPoliciesAsync(String topic);
 
     /**
      * get offload policies of a topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1544,14 +1544,16 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic, InactiveTopicPolicies inactiveTopicPolicies) {
+    public CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
         return asyncPostRequest(path, Entity.entity(inactiveTopicPolicies, MediaType.APPLICATION_JSON));
     }
 
     @Override
-    public void setInactiveTopicPolicies(String topic, InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException {
+    public void setInactiveTopicPolicies(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException {
         try {
             setInactiveTopicPoliciesAsync(topic, inactiveTopicPolicies)
                     .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -760,6 +760,14 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("set-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
         verify(mockTopics).setMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", 99);
 
+        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).removeInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("set-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -e -t 1s -m delete_when_no_subscriptions"));
+        verify(mockTopics).setInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1"
+                , new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
+
         // argument matcher for the timestamp in reset cursor. Since we can't verify exact timestamp, we check for a
         // range of +/- 1 second of the expected timestamp
         class TimestampMatcher implements ArgumentMatcher<Long> {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -50,13 +50,18 @@ public class TopicPolicies {
     private Long delayedDeliveryTickTimeMillis = null;
     private Boolean delayedDeliveryEnabled = null;
     private OffloadPolicies offloadPolicies;
+    private InactiveTopicPolicies inactiveTopicPolicies = null;
+    private DispatchRate dispatchRate = null;
+    private Long compactionThreshold = null;
+    private PublishRate publishRate = null;
+
+    public boolean isInactiveTopicPoliciesSet() {
+        return inactiveTopicPolicies != null;
+    }
 
     public boolean isOffloadPoliciesSet() {
         return offloadPolicies != null;
     }
-    private DispatchRate dispatchRate = null;
-    private Long compactionThreshold = null;
-    private PublishRate publishRate = null;
 
     public boolean isMaxUnackedMessagesOnConsumerSet() {
         return maxUnackedMessagesOnConsumer != null;


### PR DESCRIPTION

Master Issue: #2688

### Motivation
Support topic-level inactiveTopicPolicies

### Modifications
Support set/get/remove inactiveTopicPolicies policy on topic level.

### Verifying this change
unit tests:

org.apache.pulsar.admin.cli.PulsarAdminToolTest#topics
org.apache.pulsar.broker.service.InactiveTopicDeleteTest#testTopicLevelInActiveTopicApi
org.apache.pulsar.broker.service.InactiveTopicDeleteTest#testTopicLevelInactivePolicyUpdateAndClean
org.apache.pulsar.broker.service.InactiveTopicDeleteTest#testDeleteWhenNoSubscriptionsWithTopicLevelPolicies
