### PR TITLE
Fix no return value of GetMaxProducers in cli

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1466,7 +1466,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            admin.topics().getMaxProducers(persistentTopic);
+            print(admin.topics().getMaxProducers(persistentTopic));
         }
     }
 


### PR DESCRIPTION
Master Issue: #2688

### Motivation
In `cmdTopics.java`, `GetMaxProducers` did not call the print method, resulting in no return value in the cli

### Modifications
add print

### Verifying this change
