### PR TITLE
[C++] Support key based batching

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -172,6 +172,7 @@ class PULSAR_PUBLIC Message {
     friend class ProducerImpl;
     friend class Commands;
     friend class BatchMessageContainer;
+    friend class BatchMessageKeyBasedContainer;
     friend class BatchAcknowledgementTracker;
     friend class PulsarWrapper;
     friend class MessageBatch;

--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -171,8 +171,7 @@ class PULSAR_PUBLIC Message {
     friend class ConsumerImpl;
     friend class ProducerImpl;
     friend class Commands;
-    friend class BatchMessageContainer;
-    friend class BatchMessageKeyBasedContainer;
+    friend class BatchMessageContainerBase;
     friend class BatchAcknowledgementTracker;
     friend class PulsarWrapper;
     friend class MessageBatch;

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -55,6 +55,30 @@ class PULSAR_PUBLIC ProducerConfiguration {
         BoostHash,
         JavaStringHash
     };
+    enum BatchingType
+    {
+        /**
+         * Default batching.
+         *
+         * <p>incoming single messages:
+         * (k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)
+         *
+         * <p>batched into single batch message:
+         * [(k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)]
+         */
+        DefaultBatching,
+
+        /**
+         * Key based batching.
+         *
+         * <p>incoming single messages:
+         * (k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)
+         *
+         * <p>batched into single batch message:
+         * [(k1, v1), (k1, v2), (k1, v3)], [(k2, v1), (k2, v2), (k2, v3)], [(k3, v1), (k3, v2), (k3, v3)]
+         */
+        KeyBasedBatching
+    };
 
     ProducerConfiguration();
     ~ProducerConfiguration();
@@ -151,6 +175,12 @@ class PULSAR_PUBLIC ProducerConfiguration {
 
     ProducerConfiguration& setBatchingMaxPublishDelayMs(const unsigned long& batchingMaxPublishDelayMs);
     const unsigned long& getBatchingMaxPublishDelayMs() const;
+
+    /**
+     * @see BatchingType
+     */
+    ProducerConfiguration& setBatchingType(BatchingType batchingType);
+    BatchingType getBatchingType() const;
 
     const CryptoKeyReaderPtr getCryptoKeyReader() const;
     ProducerConfiguration& setCryptoKeyReader(CryptoKeyReaderPtr cryptoKeyReader);

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -158,7 +158,7 @@ class PULSAR_PUBLIC ProducerConfiguration {
     ProducerCryptoFailureAction getCryptoFailureAction() const;
     ProducerConfiguration& setCryptoFailureAction(ProducerCryptoFailureAction action);
 
-    std::set<std::string>& getEncryptionKeys();
+    const std::set<std::string>& getEncryptionKeys() const;
     bool isEncryptionEnabled() const;
     ProducerConfiguration& addEncryptionKey(std::string key);
 

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -21,7 +21,6 @@
 #include "Commands.h"
 #include "LogUtils.h"
 #include "MessageImpl.h"
-#include "ObjectPool.h"
 #include "ProducerImpl.h"
 #include "TimeUtils.h"
 #include <stdexcept>

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -123,7 +123,7 @@ bool BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
     }
     impl_->payload = encryptedPayload;
 
-    if (impl_->payload.readableBytes() > producer_.keepMaxMessageSize_) {
+    if (impl_->payload.readableBytes() > ClientConnection::getMaxMessageSize()) {
         // At this point the compressed batch is above the overall MaxMessageSize. There
         // can only 1 single message in the batch at this point.
         batchMessageCallBack(ResultMessageTooBig, MessageId{}, messagesContainerListPtr_, nullptr);

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -17,180 +17,99 @@
  * under the License.
  */
 #include "BatchMessageContainer.h"
-#include <memory>
-#include <functional>
+#include "ClientConnection.h"
+#include "Commands.h"
+#include "LogUtils.h"
+#include "MessageImpl.h"
+#include "ObjectPool.h"
+#include "ProducerImpl.h"
+#include "TimeUtils.h"
+#include <stdexcept>
+
+DECLARE_LOG_OBJECT()
 
 namespace pulsar {
 
-static ObjectPool<MessageImpl, 1000> messagePool;
-static ObjectPool<BatchMessageContainer::MessageContainerList, 1000> messageContainerListPool;
-DECLARE_LOG_OBJECT()
-
-BatchMessageContainer::BatchMessageContainer(ProducerImpl& producer)
-    : maxAllowedNumMessagesInBatch_(producer.conf_.getBatchingMaxMessages()),
-      maxAllowedMessageBatchSizeInBytes_(producer.conf_.getBatchingMaxAllowedSizeInBytes()),
-      topicName_(producer.topic_),
-      producerName_(producer.producerName_),
-      compressionType_(producer.conf_.getCompressionType()),
-      producer_(producer),
-      impl_(messagePool.create()),
-      timer_(producer.executor_->createDeadlineTimer()),
-      batchSizeInBytes_(0),
-      messagesContainerListPtr_(messageContainerListPool.create()),
-      averageBatchSize_(0),
-      numberOfBatchesSent_(0) {
-    messagesContainerListPtr_->reserve(1000);
-    LOG_INFO(*this << " BatchMessageContainer constructed");
-}
-
-bool BatchMessageContainer::add(const Message& msg, SendCallback sendCallback, bool disableCheck) {
-    // disableCheck is needed to avoid recursion in case the batchSizeInKB < IndividualMessageSizeInKB
-    LOG_DEBUG(*this << " Called add function for [message = " << msg << "] [disableCheck = " << disableCheck
-                    << "]");
-    if (!(disableCheck || hasSpaceInBatch(msg))) {
-        LOG_DEBUG(*this << " Batch is full");
-        bool hasMessages = !messagesContainerListPtr_->empty();
-        bool pushedToPendingQueue = sendMessage(NULL);
-        bool result = add(msg, sendCallback, true);
-        if (hasMessages && !pushedToPendingQueue) {
-            // The msg failed to be pushed to the producer's queue, so the reserved spot before won't be
-            // released and we must return false to tell the producer to release the spot.
-            // Exceptionally, `hasSpaceInBatch` returns false just because `msg` is too big before compressed,
-            // while there're no messages before. In this case, the spots have already been released so we
-            // can't return false simply.
-            return false;
-        }
-        return result;
-    }
-    if (messagesContainerListPtr_->empty()) {
-        // First message to be added
-        startTimer();
-        Commands::initBatchMessageMetadata(msg, impl_->metadata);
-        // TODO - add this to Commands.cc
-        impl_->metadata.set_producer_name(producerName_);
-    }
-    batchSizeInBytes_ += msg.impl_->payload.readableBytes();
-
-    LOG_DEBUG(*this << " Before serialization payload size in bytes = " << impl_->payload.readableBytes());
-    Commands::serializeSingleMessageInBatchWithPayload(msg, impl_->payload,
-                                                       maxAllowedMessageBatchSizeInBytes_);
-    LOG_DEBUG(*this << " After serialization payload size in bytes = " << impl_->payload.readableBytes());
-
-    messagesContainerListPtr_->emplace_back(msg, sendCallback);
-
-    LOG_DEBUG(*this << " Number of messages in Batch = " << messagesContainerListPtr_->size());
-    LOG_DEBUG(*this << " Batch Payload Size In Bytes = " << batchSizeInBytes_);
-    bool hasOnlyOneMessage = (messagesContainerListPtr_->size() == 1);
-    if (isFull()) {
-        LOG_DEBUG(*this << " Batch is full.");
-        // If there're more than one messages in the batch, even if it was pushed to the queue successfully,
-        // we also returns false to release one spot, because there're two spots to be released. One is
-        // reserved when the first message arrived, another is reserved when the current message arrived.
-        bool pushedToPendingQueue = sendMessage(NULL);
-        return hasOnlyOneMessage && pushedToPendingQueue;
-    }
-    // A batch of messages only need one spot, so returns false when more messages were added to the batch,
-    // then outer ProducerImpl::sendAsync() will release unnecessary reserved spots
-    return hasOnlyOneMessage;
-}
-
-void BatchMessageContainer::startTimer() {
-    const unsigned long& publishDelayInMs = producer_.conf_.getBatchingMaxPublishDelayMs();
-    LOG_DEBUG(*this << " Timer started with expiry after " << publishDelayInMs);
-    timer_->expires_from_now(boost::posix_time::milliseconds(publishDelayInMs));
-    timer_->async_wait(
-        std::bind(&pulsar::ProducerImpl::batchMessageTimeoutHandler, &producer_, std::placeholders::_1));
-}
-
-bool BatchMessageContainer::sendMessage(FlushCallback flushCallback) {
-    // Call this function after acquiring the ProducerImpl lock
-    LOG_DEBUG(*this << "Sending the batch message container");
-    if (isEmpty()) {
-        LOG_DEBUG(*this << " Batch is empty - returning.");
-        if (flushCallback) {
-            flushCallback(ResultOk);
-        }
-        return false;
-    }
-    impl_->metadata.set_num_messages_in_batch(messagesContainerListPtr_->size());
-    compressPayLoad();
-
-    SharedBuffer encryptedPayload;
-    if (!producer_.encryptMessage(impl_->metadata, impl_->payload, encryptedPayload)) {
-        batchMessageCallBack(ResultCryptoError, MessageId{}, messagesContainerListPtr_, nullptr);
-        clear();
-        return false;
-    }
-    impl_->payload = encryptedPayload;
-
-    if (impl_->payload.readableBytes() > ClientConnection::getMaxMessageSize()) {
-        // At this point the compressed batch is above the overall MaxMessageSize. There
-        // can only 1 single message in the batch at this point.
-        batchMessageCallBack(ResultMessageTooBig, MessageId{}, messagesContainerListPtr_, nullptr);
-        clear();
-        return false;
-    }
-
-    Message msg;
-    msg.impl_ = impl_;
-
-    // bind keeps a copy of the parameters
-    SendCallback callback = std::bind(&BatchMessageContainer::batchMessageCallBack, std::placeholders::_1,
-                                      std::placeholders::_2, messagesContainerListPtr_, flushCallback);
-
-    producer_.sendMessage(msg, callback);
-    clear();
-    return true;
-}
-
-void BatchMessageContainer::compressPayLoad() {
-    if (compressionType_ != CompressionNone) {
-        impl_->metadata.set_compression(CompressionCodecProvider::convertType(compressionType_));
-        impl_->metadata.set_uncompressed_size(impl_->payload.readableBytes());
-    }
-    impl_->payload = CompressionCodecProvider::getCodec(compressionType_).encode(impl_->payload);
-}
-
-SharedBuffer BatchMessageContainer::getBatchedPayload() { return impl_->payload; }
-
-void BatchMessageContainer::clear() {
-    LOG_DEBUG(*this << " BatchMessageContainer::clear() called");
-    timer_->cancel();
-    averageBatchSize_ = (messagesContainerListPtr_->size() + (averageBatchSize_ * numberOfBatchesSent_)) /
-                        (numberOfBatchesSent_ + 1);
-    numberOfBatchesSent_++;
-    messagesContainerListPtr_ = messageContainerListPool.create();
-    // Try to optimize this
-    messagesContainerListPtr_->reserve(10000);
-    impl_ = messagePool.create();
-    batchSizeInBytes_ = 0;
-}
-
-void BatchMessageContainer::batchMessageCallBack(Result r, const MessageId& messageId,
-                                                 MessageContainerListPtr messagesContainerListPtr,
-                                                 FlushCallback flushCallback) {
-    if (!messagesContainerListPtr) {
-        if (flushCallback) {
-            flushCallback(ResultOk);
-        }
-        return;
-    }
-    LOG_DEBUG("BatchMessageContainer::batchMessageCallBack called with [Result = "
-              << r << "] [numOfMessages = " << messagesContainerListPtr->size() << "]");
-    size_t batch_size = messagesContainerListPtr->size();
-    for (size_t i = 0; i < batch_size; i++) {
-        MessageId messageIdInBatch(messageId.partition(), messageId.ledgerId(), messageId.entryId(), i);
-        messagesContainerListPtr->operator[](i).callBack(r, messageIdInBatch);
-    }
-    if (flushCallback) {
-        flushCallback(ResultOk);
-    }
-}
+BatchMessageContainer::BatchMessageContainer(const ProducerImpl& producer)
+    : BatchMessageContainerBase(producer) {}
 
 BatchMessageContainer::~BatchMessageContainer() {
-    timer_->cancel();
-    LOG_DEBUG(*this << " BatchMessageContainer Object destructed");
+    LOG_DEBUG(*this << " destructed");
     LOG_INFO("[numberOfBatchesSent = " << numberOfBatchesSent_
-                                       << "] [averageBatchSize = " << averageBatchSize_ << "]");
+                                       << "] [averageBatchSize_ = " << averageBatchSize_ << "]");
 }
+
+bool BatchMessageContainer::add(const Message& msg, const SendCallback& callback) {
+    LOG_DEBUG("Before add: " << *this << " [message = " << msg << "]");
+    batch_.add(msg, callback);
+    updateStats(msg);
+    LOG_DEBUG("After add: " << *this);
+    return isFull();
+}
+
+void BatchMessageContainer::clear() {
+    averageBatchSize_ =
+        (batch_.size() + averageBatchSize_ * numberOfBatchesSent_) / (numberOfBatchesSent_ + 1);
+    numberOfBatchesSent_++;
+    batch_.clear();
+    resetStats();
+    LOG_DEBUG(*this << " clear() called");
+}
+
+Result BatchMessageContainer::createOpSendMsg(OpSendMsg& opSendMsg,
+                                              const FlushCallback& flushCallback) const {
+    if (batch_.empty()) {
+        return ResultOperationNotSupported;
+    }
+
+    MessageImplPtr impl = batch_.msgImpl();
+    impl->metadata.set_num_messages_in_batch(batch_.size());
+    auto compressionType = producerConfig_.getCompressionType();
+    if (compressionType != CompressionNone) {
+        impl->metadata.set_compression(CompressionCodecProvider::convertType(compressionType));
+        impl->metadata.set_uncompressed_size(impl->payload.readableBytes());
+    }
+    impl->payload = CompressionCodecProvider::getCodec(compressionType).encode(impl->payload);
+
+    SharedBuffer encryptedPayload;
+    if (!encryptMessage(impl->metadata, impl->payload, encryptedPayload)) {
+        return ResultCryptoError;
+    }
+
+    if (impl->payload.readableBytes() > ClientConnection::getMaxMessageSize()) {
+        return ResultMessageTooBig;
+    }
+
+    opSendMsg.msg_.impl_ = impl;
+    if (flushCallback) {
+        opSendMsg.sendCallback_ = [this, flushCallback](Result result, const MessageId& id) {
+            batch_.complete(result, id);
+            flushCallback(result);
+        };
+    } else {
+        opSendMsg.sendCallback_ = batch_.createSendCallback();
+    }
+    opSendMsg.sequenceId_ = impl->metadata.sequence_id();
+    opSendMsg.producerId_ = producerId_;
+    opSendMsg.timeout_ = TimeUtils::now() + milliseconds(producerConfig_.getSendTimeout());
+
+    return ResultOk;
+}
+
+std::vector<Result> BatchMessageContainer::createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
+                                                            const FlushCallback& flushCallback) const {
+    throw std::runtime_error("createOpSendMsgs is not supported for BatchMessageContainer");
+}
+
+void BatchMessageContainer::serialize(std::ostream& os) const {
+    os << "{ BatchMessageContainer [ size = " << numMessages_    //
+       << "] [ bytes = " << sizeInBytes_                         //
+       << "] [ maxSize = " << getMaxNumMessages()                //
+       << "] [ maxBytes = " << getMaxSizeInBytes()               //
+       << "] [ topicName = " << topicName_                       //
+       << "] [ numberOfBatchesSent_ = " << numberOfBatchesSent_  //
+       << "] [ averageBatchSize_ = " << averageBatchSize_        //
+       << "]}";
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "BatchMessageContainerBase.h"
+#include "MessageCrypto.h"
+#include "ProducerImpl.h"
+#include "SharedBuffer.h"
+#include "PulsarApi.pb.h"
+
+namespace pulsar {
+
+BatchMessageContainerBase::BatchMessageContainerBase(const ProducerImpl& producer)
+    : topicName_(producer.topic_),
+      producerConfig_(producer.conf_),
+      producerName_(producer.producerName_),
+      producerId_(producer.producerId_),
+      msgCryptoWeakPtr_(producer.msgCrypto_) {}
+
+bool BatchMessageContainerBase::encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
+                                               SharedBuffer& encryptedPayload) const {
+    auto msgCrypto = msgCryptoWeakPtr_.lock();
+    if (!msgCrypto || producerConfig_.isEncryptionEnabled()) {
+        encryptedPayload = payload;
+        return true;
+    }
+
+    return msgCrypto->encrypt(producerConfig_.getEncryptionKeys(), producerConfig_.getCryptoKeyReader(),
+                              metadata, payload, encryptedPayload);
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.h
@@ -29,6 +29,7 @@
 
 #include <boost/noncopyable.hpp>
 
+#include "MessageAndCallbackBatch.h"
 #include "OpSendMsg.h"
 
 namespace pulsar {
@@ -132,8 +133,8 @@ class BatchMessageContainerBase : public boost::noncopyable {
     void updateStats(const Message& msg);
     void resetStats();
 
-    bool encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
-                        SharedBuffer& encryptedPayload) const;
+    Result createOpSendMsgHelper(OpSendMsg& opSendMsg, const FlushCallback& flushCallback,
+                                 const MessageAndCallbackBatch& batch) const;
 };
 
 inline bool BatchMessageContainerBase::hasEnoughSpace(const Message& msg) const noexcept {

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.h
@@ -85,6 +85,7 @@ class BatchMessageContainerBase : public boost::noncopyable {
      * @param opSendMsg the OpSendMsg object to create
      * @param flushCallback the callback to trigger after the OpSendMsg was completed
      * @return ResultOk if create successfully
+     * @note OpSendMsg's sendCallback_ must be set even if it failed
      */
     virtual Result createOpSendMsg(OpSendMsg& opSendMsg,
                                    const FlushCallback& flushCallback = nullptr) const = 0;
@@ -95,6 +96,7 @@ class BatchMessageContainerBase : public boost::noncopyable {
      * @param opSendMsgList the OpSendMsg list to create
      * @param flushCallback the callback to trigger after the OpSendMsg was completed
      * @return all create results of `opSendMsgs`, ResultOk means create successfully
+     * @note OpSendMsg's sendCallback_ must be set even if it failed
      */
     virtual std::vector<Result> createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
                                                  const FlushCallback& flushCallback = nullptr) const = 0;

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.h
@@ -109,7 +109,6 @@ class BatchMessageContainerBase : public boost::noncopyable {
     virtual void serialize(std::ostream& os) const = 0;
 
     bool hasEnoughSpace(const Message& msg) const noexcept;
-    bool isFull() const noexcept;
     bool isEmpty() const noexcept;
 
    protected:
@@ -127,6 +126,8 @@ class BatchMessageContainerBase : public boost::noncopyable {
 
     unsigned int numMessages_ = 0;
     unsigned long sizeInBytes_ = 0;
+
+    bool isFull() const noexcept;
 
     void updateStats(const Message& msg);
     void resetStats();

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.h
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.h
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_BATCHMESSAGECONTAINERBASE_H_
+#define LIB_BATCHMESSAGECONTAINERBASE_H_
+
+#include <pulsar/Result.h>
+#include <pulsar/Message.h>
+#include <pulsar/ProducerConfiguration.h>
+#include <pulsar/Producer.h>
+
+#include <memory>
+#include <vector>
+
+#include <boost/noncopyable.hpp>
+
+#include "OpSendMsg.h"
+
+namespace pulsar {
+
+class MessageCrypto;
+class ProducerImpl;
+class SharedBuffer;
+
+namespace proto {
+class MessageMetadata;
+}  // namespace proto
+
+class BatchMessageContainerBase : public boost::noncopyable {
+   public:
+    BatchMessageContainerBase(const ProducerImpl& producer);
+
+    virtual ~BatchMessageContainerBase() {}
+
+    /**
+     * Get number of batches in the batch message container
+     *
+     * @return number of batches
+     */
+    virtual size_t getNumBatches() const = 0;
+
+    /**
+     * Check the message will be the 1st message to be added to the batch
+     *
+     * This method is used to check if the reversed spot should be released. Because we won't released the
+     * reserved spot for 1st message. The released spot is to contain the whole batched message.
+     *
+     * @param msg the message to be added to the batch
+     * @return true if `msg` is the 1st message to be added to the batch
+     */
+    virtual bool isFirstMessageToAdd(const Message& msg) const = 0;
+
+    /**
+     * Add a message to the batch message container
+     *
+     * @param msg message will add to the batch message container
+     * @param callback message send callback
+     * @return true if the batch is full, otherwise false
+     */
+    virtual bool add(const Message& msg, const SendCallback& callback) = 0;
+
+    /**
+     * Clear the batch message container
+     */
+    virtual void clear() = 0;
+
+    /**
+     * Create a OpSendMsg object to send
+     *
+     * @param opSendMsg the OpSendMsg object to create
+     * @param flushCallback the callback to trigger after the OpSendMsg was completed
+     * @return ResultOk if create successfully
+     */
+    virtual Result createOpSendMsg(OpSendMsg& opSendMsg,
+                                   const FlushCallback& flushCallback = nullptr) const = 0;
+
+    /**
+     * Create a OpSendMsg list to send
+     *
+     * @param opSendMsgList the OpSendMsg list to create
+     * @param flushCallback the callback to trigger after the OpSendMsg was completed
+     * @return all create results of `opSendMsgs`, ResultOk means create successfully
+     */
+    virtual std::vector<Result> createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
+                                                 const FlushCallback& flushCallback = nullptr) const = 0;
+
+    /**
+     * Serialize into a std::ostream for logging
+     *
+     * @param os the std::ostream to serialize current batch container
+     */
+    virtual void serialize(std::ostream& os) const = 0;
+
+    bool hasEnoughSpace(const Message& msg) const noexcept;
+    bool isFull() const noexcept;
+    bool isEmpty() const noexcept;
+
+   protected:
+    // references to ProducerImpl's fields
+    const std::string& topicName_;
+    const ProducerConfiguration& producerConfig_;
+    const std::string& producerName_;
+    const uint64_t& producerId_;
+    const std::weak_ptr<MessageCrypto> msgCryptoWeakPtr_;
+
+    unsigned int getMaxNumMessages() const noexcept { return producerConfig_.getBatchingMaxMessages(); }
+    unsigned long getMaxSizeInBytes() const noexcept {
+        return producerConfig_.getBatchingMaxAllowedSizeInBytes();
+    }
+
+    unsigned int numMessages_ = 0;
+    unsigned long sizeInBytes_ = 0;
+
+    void updateStats(const Message& msg);
+    void resetStats();
+
+    bool encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
+                        SharedBuffer& encryptedPayload) const;
+};
+
+inline bool BatchMessageContainerBase::hasEnoughSpace(const Message& msg) const noexcept {
+    return (numMessages_ < getMaxNumMessages()) && (sizeInBytes_ + msg.getLength() <= getMaxSizeInBytes());
+}
+
+inline bool BatchMessageContainerBase::isFull() const noexcept {
+    return (numMessages_ >= getMaxNumMessages()) || (sizeInBytes_ >= getMaxSizeInBytes());
+}
+
+inline bool BatchMessageContainerBase::isEmpty() const noexcept { return numMessages_ == 0; }
+
+inline void BatchMessageContainerBase::updateStats(const Message& msg) {
+    numMessages_++;
+    sizeInBytes_ += msg.getLength();
+}
+
+inline void BatchMessageContainerBase::resetStats() {
+    numMessages_ = 0;
+    sizeInBytes_ = 0;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const BatchMessageContainerBase& container) {
+    container.serialize(os);
+    return os;
+}
+
+}  // namespace pulsar
+
+#endif  // LIB_BATCHMESSAGECONTAINERBASE_H_

--- a/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.cc
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "BatchMessageKeyBasedContainer.h"
+#include "ClientConnection.h"
+#include "Commands.h"
+#include "LogUtils.h"
+#include "MessageImpl.h"
+#include "ProducerImpl.h"
+#include "TimeUtils.h"
+
+#include <algorithm>
+#include <map>
+
+DECLARE_LOG_OBJECT()
+
+namespace pulsar {
+
+inline std::string getKey(const Message& msg) {
+    return msg.hasOrderingKey() ? msg.getOrderingKey() : msg.getPartitionKey();
+}
+
+BatchMessageKeyBasedContainer::BatchMessageKeyBasedContainer(const ProducerImpl& producer)
+    : BatchMessageContainerBase(producer) {}
+
+BatchMessageKeyBasedContainer::~BatchMessageKeyBasedContainer() {
+    LOG_DEBUG(*this << " destructed");
+    LOG_INFO("[numberOfBatchesSent = " << numberOfBatchesSent_
+                                       << "] [averageBatchSize_ = " << averageBatchSize_ << "]");
+}
+
+bool BatchMessageKeyBasedContainer::isFirstMessageToAdd(const Message& msg) const {
+    auto it = batches_.find(getKey(msg));
+    if (it == batches_.end()) {
+        return true;
+    } else {
+        return it->second.empty();
+    }
+}
+
+bool BatchMessageKeyBasedContainer::add(const Message& msg, const SendCallback& callback) {
+    LOG_DEBUG("Before add: " << *this << " [message = " << msg << "]");
+    batches_[getKey(msg)].add(msg, callback);
+    updateStats(msg);
+    LOG_DEBUG("After add: " << *this);
+    return isFull();
+}
+
+void BatchMessageKeyBasedContainer::clear() {
+    averageBatchSize_ =
+        (numMessages_ + averageBatchSize_ * numberOfBatchesSent_) / (numberOfBatchesSent_ + batches_.size());
+    numberOfBatchesSent_ += batches_.size();
+    batches_.clear();
+    resetStats();
+    LOG_DEBUG(*this << " clear() called");
+}
+
+Result BatchMessageKeyBasedContainer::createOpSendMsg(OpSendMsg& opSendMsg,
+                                                      const FlushCallback& flushCallback) const {
+    throw std::runtime_error("createOpSendMsgs is not supported for BatchMessageKeyBasedContainer");
+}
+
+std::vector<Result> BatchMessageKeyBasedContainer::createOpSendMsgs(
+    std::vector<OpSendMsg>& opSendMsgs, const FlushCallback& flushCallback) const {
+    // Sorted the batches by sequence id
+    std::vector<const MessageAndCallbackBatch*> sortedBatches;
+    for (const auto& kv : batches_) {
+        sortedBatches.emplace_back(&kv.second);
+    }
+    std::sort(sortedBatches.begin(), sortedBatches.end(),
+              [](const MessageAndCallbackBatch* lhs, const MessageAndCallbackBatch* rhs) {
+                  return lhs->sequenceId() < rhs->sequenceId();
+              });
+
+    size_t numBatches = sortedBatches.size();
+    opSendMsgs.resize(numBatches);
+
+    for (size_t i = 0; i < numBatches; i++) {
+        opSendMsgs[i].sendCallback_ = sortedBatches[i]->createSendCallback();
+    }
+
+    // add flushCallback to the last message
+    if (flushCallback) {
+        auto& lastOpSendMsg = opSendMsgs.back();
+        auto callback = lastOpSendMsg.sendCallback_;
+        lastOpSendMsg.sendCallback_ = [callback, flushCallback](Result result, const MessageId& id) {
+            callback(result, id);
+            flushCallback(result);
+        };
+    }
+
+    std::vector<Result> results(numBatches);
+    for (size_t i = 0; i < numBatches; i++) {
+        auto& batch = *(sortedBatches[i]);
+        MessageImplPtr impl = batch.msgImpl();
+
+        impl->metadata.set_num_messages_in_batch(batch.size());
+        auto compressionType = producerConfig_.getCompressionType();
+        if (compressionType != CompressionNone) {
+            impl->metadata.set_compression(CompressionCodecProvider::convertType(compressionType));
+            impl->metadata.set_uncompressed_size(impl->payload.readableBytes());
+        }
+        impl->payload = CompressionCodecProvider::getCodec(compressionType).encode(impl->payload);
+
+        SharedBuffer encryptedPayload;
+        if (!encryptMessage(impl->metadata, impl->payload, encryptedPayload)) {
+            results[i] = ResultCryptoError;
+            continue;
+        }
+
+        if (impl->payload.readableBytes() > ClientConnection::getMaxMessageSize()) {
+            results[i] = ResultMessageTooBig;
+            continue;
+        }
+
+        auto& opSendMsg = opSendMsgs[i];
+        opSendMsg.msg_.impl_ = impl;
+        opSendMsg.sequenceId_ = impl->metadata.sequence_id();
+        opSendMsg.producerId_ = producerId_;
+    }
+    auto timeout = TimeUtils::now() + milliseconds(producerConfig_.getSendTimeout());
+    for (auto& opSendMsg : opSendMsgs) {
+        opSendMsg.timeout_ = timeout;
+    }
+    return results;
+}
+
+void BatchMessageKeyBasedContainer::serialize(std::ostream& os) const {
+    os << "{ BatchMessageKeyBasedContainer [size = " << numMessages_  //
+       << "] [bytes = " << sizeInBytes_                               //
+       << "] [maxSize = " << getMaxNumMessages()                      //
+       << "] [maxBytes = " << getMaxSizeInBytes()                     //
+       << "] [topicName = " << topicName_                             //
+       << "] [numberOfBatchesSent_ = " << numberOfBatchesSent_        //
+       << "] [averageBatchSize_ = " << averageBatchSize_              //
+       << "]";
+
+    std::map<std::string, const MessageAndCallbackBatch*> sortedBatches;
+    for (const auto& kv : batches_) {
+        sortedBatches.emplace(kv.first, &kv.second);
+    }
+    for (const auto& kv : sortedBatches) {
+        const auto& key = kv.first;
+        const auto& batch = *(kv.second);
+        os << "\n  key: " << key << " | numMessages: " << batch.size();
+    }
+    os << " }";
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.h
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_BATCHMESSAGEKEYBASEDCONTAINER_H_
+#define LIB_BATCHMESSAGEKEYBASEDCONTAINER_H_
+
+#include <unordered_map>
+
+#include "BatchMessageContainerBase.h"
+#include "MessageAndCallbackBatch.h"
+
+namespace pulsar {
+
+class BatchMessageKeyBasedContainer : public BatchMessageContainerBase {
+   public:
+    BatchMessageKeyBasedContainer(const ProducerImpl& producer);
+
+    ~BatchMessageKeyBasedContainer();
+
+    size_t getNumBatches() const override { return batches_.size(); }
+
+    bool isFirstMessageToAdd(const Message& msg) const override;
+
+    bool add(const Message& msg, const SendCallback& callback) override;
+
+    void clear() override;
+
+    Result createOpSendMsg(OpSendMsg& opSendMsg, const FlushCallback& flushCallback) const override;
+
+    std::vector<Result> createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
+                                         const FlushCallback& flushCallback) const override;
+
+    void serialize(std::ostream& os) const override;
+
+   private:
+    // key: message key, ordering key has higher priority than partitioned key
+    std::unordered_map<std::string, MessageAndCallbackBatch> batches_;
+    size_t numberOfBatchesSent_ = 0;
+    double averageBatchSize_ = 0;
+};
+
+}  // namespace pulsar
+
+#endif

--- a/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.h
+++ b/pulsar-client-cpp/lib/BatchMessageKeyBasedContainer.h
@@ -52,6 +52,9 @@ class BatchMessageKeyBasedContainer : public BatchMessageContainerBase {
     std::unordered_map<std::string, MessageAndCallbackBatch> batches_;
     size_t numberOfBatchesSent_ = 0;
     double averageBatchSize_ = 0;
+
+    Result createOpSendMsg(OpSendMsg& opSendMsg, const FlushCallback& flushCallback,
+                           MessageAndCallbackBatch& batch) const;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <deque>
+#include <atomic>
 
 #include "ExecutorService.h"
 #include "Future.h"
@@ -148,7 +149,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     int getServerProtocolVersion() const;
 
-    int getMaxMessageSize() const;
+    static int32_t getMaxMessageSize();
 
     Commands::ChecksumType getChecksumType() const;
 
@@ -251,7 +252,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     TimeDuration operationsTimeout_;
     AuthenticationPtr authentication_;
     int serverProtocolVersion_;
-    int maxMessageSize_;
+    static std::atomic<int32_t> maxMessageSize_;
 
     ExecutorServicePtr executor_;
 

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -638,8 +638,8 @@ void Commands::initBatchMessageMetadata(const Message& msg, pulsar::proto::Messa
     // TODO: set other optional fields
 }
 
-void Commands::serializeSingleMessageInBatchWithPayload(const Message& msg, SharedBuffer& batchPayLoad,
-                                                        unsigned long maxMessageSizeInBytes) {
+uint64_t Commands::serializeSingleMessageInBatchWithPayload(const Message& msg, SharedBuffer& batchPayLoad,
+                                                            unsigned long maxMessageSizeInBytes) {
     SingleMessageMetadata metadata;
     if (msg.impl_->hasPartitionKey()) {
         metadata.set_partition_key(msg.impl_->getPartitionKey());
@@ -681,6 +681,8 @@ void Commands::serializeSingleMessageInBatchWithPayload(const Message& msg, Shar
     metadata.SerializeToArray(batchPayLoad.mutableData(), msgMetadataSize);
     batchPayLoad.bytesWritten(msgMetadataSize);
     batchPayLoad.write(msg.impl_->payload.data(), payloadSize);
+
+    return msg.impl_->metadata.sequence_id();
 }
 
 Message Commands::deSerializeSingleMessageInBatch(Message& batchedMessage, int32_t batchIndex) {

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -115,9 +115,8 @@ class Commands {
 
     static void initBatchMessageMetadata(const Message& msg, pulsar::proto::MessageMetadata& batchMetadata);
 
-    static PULSAR_PUBLIC void serializeSingleMessageInBatchWithPayload(const Message& msg,
-                                                                       SharedBuffer& batchPayLoad,
-                                                                       unsigned long maxMessageSizeInBytes);
+    static PULSAR_PUBLIC uint64_t serializeSingleMessageInBatchWithPayload(
+        const Message& msg, SharedBuffer& batchPayLoad, unsigned long maxMessageSizeInBytes);
 
     static Message deSerializeSingleMessageInBatch(Message& batchedMessage, int32_t batchIndex);
 

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -116,7 +116,7 @@ class Commands {
     static void initBatchMessageMetadata(const Message& msg, pulsar::proto::MessageMetadata& batchMetadata);
 
     static PULSAR_PUBLIC void serializeSingleMessageInBatchWithPayload(
-        const Message& msg, SharedBuffer& batchPayLoad, const unsigned long& maxMessageSizeInBytes);
+        const Message& msg, SharedBuffer& batchPayLoad, unsigned long maxMessageSizeInBytes);
 
     static Message deSerializeSingleMessageInBatch(Message& batchedMessage, int32_t batchIndex);
 

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -115,8 +115,9 @@ class Commands {
 
     static void initBatchMessageMetadata(const Message& msg, pulsar::proto::MessageMetadata& batchMetadata);
 
-    static PULSAR_PUBLIC void serializeSingleMessageInBatchWithPayload(
-        const Message& msg, SharedBuffer& batchPayLoad, unsigned long maxMessageSizeInBytes);
+    static PULSAR_PUBLIC void serializeSingleMessageInBatchWithPayload(const Message& msg,
+                                                                       SharedBuffer& batchPayLoad,
+                                                                       unsigned long maxMessageSizeInBytes);
 
     static Message deSerializeSingleMessageInBatch(Message& batchedMessage, int32_t batchIndex);
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -510,7 +510,7 @@ bool ConsumerImpl::uncompressMessageIfNeeded(const ClientConnectionPtr& cnx, con
     uint32_t uncompressedSize = metadata.uncompressed_size();
     uint32_t payloadSize = payload.readableBytes();
     if (cnx) {
-        if (payloadSize > cnx->getMaxMessageSize()) {
+        if (payloadSize > ClientConnection::getMaxMessageSize()) {
             // Uncompressed size is itself corrupted since it cannot be bigger than the MaxMessageSize
             LOG_ERROR(getName() << "Got corrupted payload message size " << payloadSize  //
                                 << " at  " << msg.message_id().ledgerid() << ":"

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "MessageAndCallbackBatch.h"
+#include "ClientConnection.h"
+#include "Commands.h"
+#include "LogUtils.h"
+#include "MessageImpl.h"
+
+DECLARE_LOG_OBJECT()
+
+namespace pulsar {
+
+void MessageAndCallbackBatch::add(const Message& msg, const SendCallback& callback) {
+    if (empty()) {
+        msgImpl_.reset(new MessageImpl);
+        Commands::initBatchMessageMetadata(msg, msgImpl_->metadata);
+    }
+    LOG_DEBUG(" Before serialization payload size in bytes = " << msgImpl_->payload.readableBytes());
+    Commands::serializeSingleMessageInBatchWithPayload(msg, msgImpl_->payload,
+                                                       ClientConnection::getMaxMessageSize());
+    LOG_DEBUG(" After serialization payload size in bytes = " << msgImpl_->payload.readableBytes());
+    callbacks_.emplace_back(callback);
+}
+
+void MessageAndCallbackBatch::clear() {
+    msgImpl_.reset();
+    callbacks_.clear();
+}
+
+static void completeSendCallbacks(const std::vector<SendCallback>& callbacks, Result result,
+                                  const MessageId& id) {
+    int32_t numOfMessages = static_cast<int32_t>(callbacks.size());
+    LOG_DEBUG("Batch complete [Result = " << result << "] [numOfMessages = " << numOfMessages << "]");
+    for (int32_t i = 0; i < numOfMessages; i++) {
+        MessageId idInBatch(id.partition(), id.ledgerId(), id.entryId(), i);
+        callbacks[i](result, idInBatch);
+    }
+}
+
+void MessageAndCallbackBatch::complete(Result result, const MessageId& id) const {
+    completeSendCallbacks(callbacks_, result, id);
+}
+
+SendCallback MessageAndCallbackBatch::createSendCallback() const {
+    const auto& callbacks = callbacks_;
+    return [callbacks]  // save a copy of `callbacks_`
+        (Result result, const MessageId& id) { completeSendCallbacks(callbacks, result, id); };
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
@@ -32,8 +32,8 @@ void MessageAndCallbackBatch::add(const Message& msg, const SendCallback& callba
         Commands::initBatchMessageMetadata(msg, msgImpl_->metadata);
     }
     LOG_DEBUG(" Before serialization payload size in bytes = " << msgImpl_->payload.readableBytes());
-    Commands::serializeSingleMessageInBatchWithPayload(msg, msgImpl_->payload,
-                                                       ClientConnection::getMaxMessageSize());
+    sequenceId_ = Commands::serializeSingleMessageInBatchWithPayload(msg, msgImpl_->payload,
+                                                                     ClientConnection::getMaxMessageSize());
     LOG_DEBUG(" After serialization payload size in bytes = " << msgImpl_->payload.readableBytes());
     callbacks_.emplace_back(callback);
 }

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
@@ -19,6 +19,7 @@
 #ifndef LIB_MESSAGEANDCALLBACK_BATCH_H_
 #define LIB_MESSAGEANDCALLBACK_BATCH_H_
 
+#include <atomic>
 #include <vector>
 
 #include <pulsar/Message.h>
@@ -68,10 +69,12 @@ class MessageAndCallbackBatch : public boost::noncopyable {
     SendCallback createSendCallback() const;
 
     const MessageImplPtr& msgImpl() const { return msgImpl_; }
+    uint64_t sequenceId() const noexcept { return sequenceId_; }
 
    private:
     MessageImplPtr msgImpl_;
     std::vector<SendCallback> callbacks_;
+    std::atomic<uint64_t> sequenceId_{static_cast<uint64_t>(-1L)};
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_MESSAGEANDCALLBACK_BATCH_H_
+#define LIB_MESSAGEANDCALLBACK_BATCH_H_
+
+#include <vector>
+
+#include <pulsar/Message.h>
+#include <pulsar/ProducerConfiguration.h>
+
+#include <boost/noncopyable.hpp>
+
+namespace pulsar {
+
+class MessageImpl;
+using MessageImplPtr = std::shared_ptr<MessageImpl>;
+
+class MessageAndCallbackBatch : public boost::noncopyable {
+   public:
+    // Wrapper methods of STL container
+    bool empty() const noexcept { return callbacks_.empty(); }
+    size_t size() const noexcept { return callbacks_.size(); }
+
+    /**
+     * Add a message and the associated send callback to the batch
+     *
+     * @param message
+     * @callback the associated send callback
+     */
+    void add(const Message& msg, const SendCallback& callback);
+
+    /**
+     * Clear the internal stats
+     */
+    void clear();
+
+    /**
+     * Complete all the callbacks with given parameters
+     *
+     * @param result this batch's send result
+     * @param id this batch's message id
+     */
+    void complete(Result result, const MessageId& id) const;
+
+    /**
+     * Create a single callback to trigger all the internal callbacks in order
+     * It's used when you want to clear and add new messages and callbacks but current callbacks need to be
+     * triggered later.
+     *
+     * @return the merged send callback
+     */
+    SendCallback createSendCallback() const;
+
+    const MessageImplPtr& msgImpl() const { return msgImpl_; }
+
+   private:
+    MessageImplPtr msgImpl_;
+    std::vector<SendCallback> callbacks_;
+};
+
+}  // namespace pulsar
+
+#endif

--- a/pulsar-client-cpp/lib/MessageCrypto.cc
+++ b/pulsar-client-cpp/lib/MessageCrypto.cc
@@ -141,7 +141,7 @@ std::string MessageCrypto::stringToHex(const std::string& inputStr, size_t len) 
     return stringToHex(inputStr.c_str(), len);
 }
 
-Result MessageCrypto::addPublicKeyCipher(std::set<std::string>& keyNames,
+Result MessageCrypto::addPublicKeyCipher(const std::set<std::string>& keyNames,
                                          const CryptoKeyReaderPtr keyReader) {
     Lock lock(mutex_);
 
@@ -219,7 +219,7 @@ bool MessageCrypto::removeKeyCipher(const std::string& keyName) {
     return true;
 }
 
-bool MessageCrypto::encrypt(std::set<std::string>& encKeys, const CryptoKeyReaderPtr keyReader,
+bool MessageCrypto::encrypt(const std::set<std::string>& encKeys, const CryptoKeyReaderPtr keyReader,
                             proto::MessageMetadata& msgMetadata, SharedBuffer& payload,
                             SharedBuffer& encryptedPayload) {
     if (!encKeys.size()) {

--- a/pulsar-client-cpp/lib/MessageCrypto.h
+++ b/pulsar-client-cpp/lib/MessageCrypto.h
@@ -57,7 +57,7 @@ class MessageCrypto {
      * @return ResultOk if succeeded
      *
      */
-    Result addPublicKeyCipher(std::set<std::string>& keyNames, const CryptoKeyReaderPtr keyReader);
+    Result addPublicKeyCipher(const std::set<std::string>& keyNames, const CryptoKeyReaderPtr keyReader);
 
     /*
      * Remove a key <p> Remove the key identified by the keyName from the list of keys.<p>
@@ -79,7 +79,7 @@ class MessageCrypto {
      *
      * @return true if success
      */
-    bool encrypt(std::set<std::string>& encKeys, const CryptoKeyReaderPtr keyReader,
+    bool encrypt(const std::set<std::string>& encKeys, const CryptoKeyReaderPtr keyReader,
                  proto::MessageMetadata& msgMetadata, SharedBuffer& payload, SharedBuffer& encryptedPayload);
 
     /*

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_OPSENDMSG_H_
+#define LIB_OPSENDMSG_H_
+
+#include <pulsar/Message.h>
+#include <pulsar/Producer.h>
+#include <boost/date_time/posix_time/ptime.hpp>
+
+#include "TimeUtils.h"
+
+namespace pulsar {
+
+struct OpSendMsg {
+    Message msg_;
+    SendCallback sendCallback_;
+    uint64_t producerId_;
+    uint64_t sequenceId_;
+    boost::posix_time::ptime timeout_;
+
+    OpSendMsg() = default;
+
+    OpSendMsg(const Message& msg, const SendCallback& sendCallback, uint64_t producerId, uint64_t sequenceId,
+              int sendTimeoutMs)
+        : msg_(msg),
+          sendCallback_(sendCallback),
+          producerId_(producerId),
+          sequenceId_(sequenceId),
+          timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)) {}
+};
+
+}  // namespace pulsar
+
+#endif

--- a/pulsar-client-cpp/lib/PendingFailures.h
+++ b/pulsar-client-cpp/lib/PendingFailures.h
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_PENDINGFAILURES_H_
+#define LIB_PENDINGFAILURES_H_
+
+#include <functional>
+#include <vector>
+
+namespace pulsar {
+
+class PendingFailures {
+   public:
+    void add(const std::function<void()>& failure) { failures.emplace_back(failure); }
+
+    bool empty() const noexcept { return failures.empty(); }
+
+    void complete() {
+        for (auto& failure : failures) {
+            failure();
+        }
+    }
+
+   private:
+    std::vector<std::function<void()>> failures;
+};
+
+}  // namespace pulsar
+
+#endif

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -162,6 +162,19 @@ const unsigned long& ProducerConfiguration::getBatchingMaxPublishDelayMs() const
     return impl_->batchingMaxPublishDelayMs;
 }
 
+ProducerConfiguration& ProducerConfiguration::setBatchingType(BatchingType batchingType) {
+    if (batchingType < ProducerConfiguration::DefaultBatching ||
+        batchingType > ProducerConfiguration::KeyBasedBatching) {
+        throw std::invalid_argument("Unsupported batching type: " + std::to_string(batchingType));
+    }
+    impl_->batchingType = batchingType;
+    return *this;
+}
+
+ProducerConfiguration::BatchingType ProducerConfiguration::getBatchingType() const {
+    return impl_->batchingType;
+}
+
 const CryptoKeyReaderPtr ProducerConfiguration::getCryptoKeyReader() const { return impl_->cryptoKeyReader; }
 
 ProducerConfiguration& ProducerConfiguration::setCryptoKeyReader(CryptoKeyReaderPtr cryptoKeyReader) {

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -178,7 +178,9 @@ ProducerConfiguration& ProducerConfiguration::setCryptoFailureAction(ProducerCry
     return *this;
 }
 
-std::set<std::string>& ProducerConfiguration::getEncryptionKeys() { return impl_->encryptionKeys; }
+const std::set<std::string>& ProducerConfiguration::getEncryptionKeys() const {
+    return impl_->encryptionKeys;
+}
 
 bool ProducerConfiguration::isEncryptionEnabled() const {
     return (!impl_->encryptionKeys.empty() && (impl_->cryptoKeyReader != NULL));

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -42,6 +42,7 @@ struct ProducerConfigurationImpl {
     unsigned int batchingMaxMessages;
     unsigned long batchingMaxAllowedSizeInBytes;
     unsigned long batchingMaxPublishDelayMs;
+    ProducerConfiguration::BatchingType batchingType;
     CryptoKeyReaderPtr cryptoKeyReader;
     std::set<std::string> encryptionKeys;
     ProducerCryptoFailureAction cryptoFailureAction;
@@ -59,6 +60,7 @@ struct ProducerConfigurationImpl {
           batchingMaxMessages(1000),
           batchingMaxAllowedSizeInBytes(128 * 1024),  // 128 KB
           batchingMaxPublishDelayMs(10),              // 10 milli seconds
+          batchingType(ProducerConfiguration::DefaultBatching),
           cryptoKeyReader(),
           encryptionKeys(),
           cryptoFailureAction(ProducerCryptoFailureAction::FAIL) {}

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -22,32 +22,22 @@
 #include "TimeUtils.h"
 #include "PulsarApi.pb.h"
 #include "Commands.h"
+#include "BatchMessageContainerBase.h"
 #include "BatchMessageContainer.h"
 #include <boost/date_time/local_time/local_time.hpp>
 #include <lib/TopicName.h>
+#include "MessageAndCallbackBatch.h"
 
 namespace pulsar {
 DECLARE_LOG_OBJECT()
 
-OpSendMsg::OpSendMsg() : msg_(), sendCallback_(), producerId_(), sequenceId_(), timeout_() {}
-
-OpSendMsg::OpSendMsg(uint64_t producerId, uint64_t sequenceId, const Message& msg,
-                     const SendCallback& sendCallback, const ProducerConfiguration& conf)
-    : msg_(msg),
-      sendCallback_(sendCallback),
-      producerId_(producerId),
-      sequenceId_(sequenceId),
-      timeout_(TimeUtils::now() + milliseconds(conf.getSendTimeout())) {}
-
 struct ProducerImpl::PendingCallbacks {
     std::vector<OpSendMsg> opSendMsgs;
-    BatchMessageContainer::MessageContainerListPtr messageContainerListPtr;
 
     void complete(Result result) {
         for (const auto& opSendMsg : opSendMsgs) {
             opSendMsg.sendCallback_(result, opSendMsg.msg_.getMessageId());
         }
-        BatchMessageContainer::batchMessageCallBack(result, MessageId{}, messageContainerListPtr, nullptr);
     }
 };
 
@@ -72,11 +62,6 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
     lastSequenceIdPublished_ = initialSequenceId;
     msgSequenceGenerator_ = initialSequenceId + 1;
 
-    // std::ref is used to drop the constantness constraint of make_shared
-    if (conf_.getBatchingEnabled()) {
-        batchMessageContainer = std::make_shared<BatchMessageContainer>(std::ref(*this));
-    }
-
     unsigned int statsIntervalInSeconds = client->getClientConfig().getStatsIntervalInSeconds();
     if (statsIntervalInSeconds) {
         producerStatsBasePtr_ =
@@ -91,6 +76,11 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const
         std::string logCtx = logCtxStream.str();
         msgCrypto_ = std::make_shared<MessageCrypto>(logCtx, true);
         msgCrypto_->addPublicKeyCipher(conf_.getEncryptionKeys(), conf_.getCryptoKeyReader());
+    }
+
+    if (conf_.getBatchingEnabled()) {
+        batchMessageContainer_.reset(new BatchMessageContainer(*this));
+        batchTimer_ = executor_->createDeadlineTimer();
     }
 }
 
@@ -167,9 +157,6 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         producerName_ = responseData.producerName;
         schemaVersion_ = responseData.schemaVersion;
         producerStr_ = "[" + topic_ + ", " + producerName_ + "] ";
-        if (batchMessageContainer) {
-            batchMessageContainer->producerName_ = producerName_;
-        }
 
         if (lastSequenceIdPublished_ == -1 && conf_.getInitialSequenceId() == -1) {
             lastSequenceIdPublished_ = responseData.lastSequenceId;
@@ -248,9 +235,12 @@ std::shared_ptr<ProducerImpl::PendingCallbacks> ProducerImpl::getPendingCallback
         callbacks->opSendMsgs.push_back(*it);
     }
 
-    if (batchMessageContainer) {
-        callbacks->messageContainerListPtr = batchMessageContainer->messagesContainerListPtr_;
-        batchMessageContainer->clear();
+    if (batchMessageContainer_) {
+        OpSendMsg opSendMsg;
+        if (batchMessageContainer_->createOpSendMsg(opSendMsg) == ResultOk) {
+            callbacks->opSendMsgs.emplace_back(opSendMsg);
+        }
+        batchMessageContainer_->clear();
     }
     pendingMessagesQueue_.clear();
 
@@ -305,42 +295,18 @@ void ProducerImpl::statsCallBackHandler(Result res, const MessageId& msgId, Send
 }
 
 void ProducerImpl::flushAsync(FlushCallback callback) {
-    if (batchMessageContainer) {
-        if (!flushPromise_ || flushPromise_->isComplete()) {
-            flushPromise_ = std::make_shared<Promise<Result, bool_type>>();
-        } else {
-            // already in flushing, register a listener callback
-            std::function<void(Result, bool)> listenerCallback = [this, callback](Result result,
-                                                                                  bool_type v) {
-                if (v) {
-                    callback(ResultOk);
-                } else {
-                    callback(ResultUnknownError);
-                }
-                return;
-            };
-
-            flushPromise_->getFuture().addListener(listenerCallback);
-            return;
-        }
-
-        FlushCallback innerCallback = [this, callback](Result result) {
-            flushPromise_->setValue(true);
-            callback(result);
-            return;
-        };
-
+    if (batchMessageContainer_) {
         Lock lock(mutex_);
-        batchMessageContainer->sendMessage(innerCallback);
+        batchMessageAndSend(callback);
     } else {
         callback(ResultOk);
     }
 }
 
 void ProducerImpl::triggerFlush() {
-    if (batchMessageContainer) {
+    if (batchMessageContainer_) {
         Lock lock(mutex_);
-        batchMessageContainer->sendMessage(NULL);
+        batchMessageAndSend();
     }
 }
 
@@ -356,7 +322,7 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
     uint32_t uncompressedSize = payload.readableBytes();
     uint32_t payloadSize = uncompressedSize;
     ClientConnectionPtr cnx = getCnx().lock();
-    if (!batchMessageContainer) {
+    if (!batchMessageContainer_) {
         // If batching is enabled we compress all the payloads together before sending the batch
         payload = CompressionCodecProvider::getCodec(conf_.getCompressionType()).encode(payload);
         payloadSize = payload.readableBytes();
@@ -404,7 +370,7 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
         return;
     }
 
-    int64_t sequenceId;
+    uint64_t sequenceId;
     if (!msg.impl_->metadata.has_sequence_id()) {
         sequenceId = msgSequenceGenerator_++;
     } else {
@@ -416,9 +382,9 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
     if (!conf_.getBlockIfQueueFull() && !pendingMessagesQueue_.tryReserve(1)) {
         LOG_DEBUG(getName() << " - Producer Queue is full");
         // If queue is full sending the batch immediately, no point waiting till batchMessagetimeout
-        if (batchMessageContainer) {
+        if (batchMessageContainer_) {
             LOG_DEBUG(getName() << " - sending batch message immediately");
-            batchMessageContainer->sendMessage(NULL);
+            batchMessageAndSend();
         }
         lock.unlock();
         cb(ResultProducerQueueIsFull, msg.getMessageId());
@@ -427,26 +393,82 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
 
     // If we reach this point then you have a reserved spot on the queue
 
-    if (batchMessageContainer && !msg.impl_->metadata.has_deliver_at_time()) {
+    if (batchMessageContainer_ && !msg.impl_->metadata.has_deliver_at_time()) {
         // Batching is enabled and the message is not delayed
-        if (!batchMessageContainer->add(msg, cb)) {
-            pendingMessagesQueue_.release(1);
+        if (!batchMessageContainer_->hasEnoughSpace(msg)) {
+            batchMessageAndSend();
         }
-        return;
+        bool isFirstMessage = batchMessageContainer_->isFirstMessageToAdd(msg);
+        if (batchMessageContainer_->hasEnoughSpace(msg)) {
+            bool isFull = batchMessageContainer_->add(msg, cb);
+            if (isFirstMessage) {
+                batchTimer_->expires_from_now(
+                    boost::posix_time::milliseconds(conf_.getBatchingMaxPublishDelayMs()));
+                batchTimer_->async_wait(std::bind(&ProducerImpl::batchMessageTimeoutHandler,
+                                                  shared_from_this(), std::placeholders::_1));
+            }
+            if (!isFirstMessage) {
+                pendingMessagesQueue_.release(1);
+            }  // else: retain the spot only for the 1st single message of batch
+            if (isFull) {
+                batchMessageAndSend();
+            }
+        } else {
+            lock.unlock();
+            cb(ResultMessageTooBig, msg.getMessageId());
+        }
+    } else {
+        sendMessage(OpSendMsg{msg, cb, producerId_, sequenceId, conf_.getSendTimeout()});
     }
-    sendMessage(msg, cb);
+}
+
+// It must be called while `mutex_` is acquired
+void ProducerImpl::batchMessageAndSend(const FlushCallback& flushCallback) {
+    LOG_DEBUG("batchMessageAndSend " << *batchMessageContainer_);
+    batchTimer_->cancel();
+
+    if (PULSAR_UNLIKELY(batchMessageContainer_->isEmpty())) {
+        if (flushCallback) {
+            flushCallback(ResultOk);
+        }
+    } else {
+        const size_t numBatches = batchMessageContainer_->getNumBatches();
+        if (numBatches == 1) {
+            OpSendMsg opSendMsg;
+            Result result = batchMessageContainer_->createOpSendMsg(opSendMsg, flushCallback);
+            if (result == ResultOk) {
+                sendMessage(opSendMsg);
+            } else {
+                // A spot has been reserved for this batch, but the batch failed to be pushed to the queue, so
+                // we need to release the spot manually
+                LOG_ERROR("batchMessageAndSend | Failed to createOpSendMsg: " << result);
+                pendingMessagesQueue_.release(1);
+            }
+        } else if (numBatches > 1) {
+            std::vector<OpSendMsg> opSendMsgs;
+            std::vector<Result> results = batchMessageContainer_->createOpSendMsgs(opSendMsgs, flushCallback);
+            for (size_t i = 0; i < results.size(); i++) {
+                if (results[i] == ResultOk) {
+                    sendMessage(opSendMsgs[i]);
+                } else {
+                    // A spot has been reserved for this batch, but the batch failed to be pushed to the
+                    // queue, so we need to release the spot manually
+                    LOG_ERROR("batchMessageAndSend | Failed to createOpSendMsgs[" << i
+                                                                                  << "]: " << results[i]);
+                    pendingMessagesQueue_.release(1);
+                }
+            }
+        }  // else numBatches is 0, do nothing
+    }
+
+    batchMessageContainer_->clear();
 }
 
 // Precondition -
 // a. we have a reserved spot on the queue
 // b. call this function after acquiring the ProducerImpl mutex_
-void ProducerImpl::sendMessage(const Message& msg, SendCallback callback) {
-    const uint64_t& sequenceId = msg.impl_->metadata.sequence_id();
-    LOG_DEBUG(getName() << "Sending msg: " << sequenceId
-                        << " -- queue_size: " << pendingMessagesQueue_.size());
-
-    OpSendMsg op(producerId_, sequenceId, msg, callback, conf_);
-
+void ProducerImpl::sendMessage(const OpSendMsg& op) {
+    const auto sequenceId = op.msg_.impl_->metadata.sequence_id();
     LOG_DEBUG("Inserting data to pendingMessagesQueue_");
     pendingMessagesQueue_.push(op, true);
     LOG_DEBUG("Completed Inserting data to pendingMessagesQueue_");
@@ -469,12 +491,12 @@ void ProducerImpl::batchMessageTimeoutHandler(const boost::system::error_code& e
     }
     LOG_DEBUG(getName() << " - Batch Message Timer expired");
     Lock lock(mutex_);
-    batchMessageContainer->sendMessage(NULL);
+    batchMessageAndSend();
 }
 
 void ProducerImpl::printStats() {
-    if (batchMessageContainer) {
-        LOG_INFO("Producer - " << producerStr_ << ", [batchMessageContainer = " << *batchMessageContainer
+    if (batchMessageContainer_) {
+        LOG_INFO("Producer - " << producerStr_ << ", [batchMessageContainer = " << *batchMessageContainer_
                                << "]");
     } else {
         LOG_INFO("Producer - " << producerStr_ << ", [batching  = off]");
@@ -717,6 +739,11 @@ void ProducerImpl::cancelTimers() {
         dataKeyGenTImer_.reset();
     }
 
+    if (batchTimer_) {
+        batchTimer_->cancel();
+        batchTimer_.reset();
+    }
+
     if (sendTimer_) {
         sendTimer_->cancel();
         sendTimer_.reset();
@@ -731,5 +758,6 @@ bool ProducerImpl::isClosed() {
     Lock lock(mutex_);
     return state_ == Closed;
 }
+
 }  // namespace pulsar
 /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -66,8 +66,6 @@ class ProducerImpl : public HandlerBase,
                  const ProducerConfiguration& producerConfiguration, int32_t partition = -1);
     ~ProducerImpl();
 
-    int keepMaxMessageSize_;
-
     virtual const std::string& getTopic() const;
 
     virtual void sendAsync(const Message& msg, SendCallback callback);
@@ -158,6 +156,7 @@ class ProducerImpl : public HandlerBase,
     uint64_t producerId_;
     int64_t msgSequenceGenerator_;
     proto::BaseCommand cmd_;
+
     BatchMessageContainerPtr batchMessageContainer;
 
     volatile int64_t lastSequenceIdPublished_;

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -33,6 +33,7 @@
 #include "PulsarApi.pb.h"
 #include "OpSendMsg.h"
 #include "BatchMessageContainerBase.h"
+#include "PendingFailures.h"
 
 using namespace pulsar;
 
@@ -147,7 +148,7 @@ class ProducerImpl : public HandlerBase,
 
     std::unique_ptr<BatchMessageContainerBase> batchMessageContainer_;
     DeadlineTimerPtr batchTimer_;
-    void batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
+    PendingFailures batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
 
     volatile int64_t lastSequenceIdPublished_;
     std::string schemaVersion_;

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -81,6 +81,9 @@ TEST(BatchMessageTest, testProducerConfig) {
     } catch (const std::exception&) {
         // Ok
     }
+    ASSERT_EQ(ProducerConfiguration::DefaultBatching, conf.getBatchingType());
+    conf.setBatchingType(ProducerConfiguration::KeyBasedBatching);
+    ASSERT_EQ(ProducerConfiguration::KeyBasedBatching, conf.getBatchingType());
 }
 
 TEST(BatchMessageTest, testProducerTimeout) {

--- a/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
+++ b/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <time.h>
+#include <atomic>
+
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+#include <lib/Latch.h>
+
+using namespace pulsar;
+
+static ProducerConfiguration createDefaultProducerConfig() {
+    // The default producer configuration only use number of messages to limit batching
+    return ProducerConfiguration()
+        .setBatchingType(ProducerConfiguration::KeyBasedBatching)
+        .setBatchingMaxAllowedSizeInBytes(static_cast<unsigned long>(-1))
+        .setBatchingMaxPublishDelayMs(static_cast<unsigned long>(-1));
+}
+
+class KeyBasedBatchingTest : public ::testing::Test {
+   protected:
+    KeyBasedBatchingTest() : client_("pulsar://localhost:6650") {}
+
+    void TearDown() override { client_.close(); }
+
+    void setTopicName(const std::string& topicName) { topicName_ = topicName; }
+    void initTopicName(const std::string& testName) {
+        topicName_ = "KeyBasedBatchingTest-" + testName + "-" + std::to_string(time(nullptr));
+    }
+
+    void initProducer(const ProducerConfiguration& producerConfig) {
+        ASSERT_EQ(ResultOk, client_.createProducer(topicName_, producerConfig, producer_));
+    }
+
+    void initConsumer() { ASSERT_EQ(ResultOk, client_.subscribe(topicName_, "SubscriptionName", consumer_)); }
+
+    void receiveAndAck(Message& msg) {
+        ASSERT_EQ(ResultOk, consumer_.receive(msg, 3000));
+        ASSERT_EQ(ResultOk, consumer_.acknowledge(msg));
+    }
+
+    Client client_;
+    Producer producer_;
+    Consumer consumer_;
+    std::string topicName_;
+};
+
+TEST_F(KeyBasedBatchingTest, testFlush) {
+    initTopicName("Flush");
+    // no limits for batching
+    initProducer(createDefaultProducerConfig()
+                     .setBatchingMaxMessages(static_cast<unsigned int>(-1))  // no limits for batching
+                     // only 2+1=3 spots are needed because there're at most only 2 batches to send
+                     .setMaxPendingMessages(3));
+
+    constexpr int numMessages = 100;
+    const std::string keys[] = {"A", "B"};
+    std::atomic_int numMessageSent{0};
+    for (int i = 0; i < numMessages; i++) {
+        producer_.sendAsync(MessageBuilder().setOrderingKey(keys[i % 2]).setContent("x").build(),
+                            [&numMessageSent](Result result, const MessageId&) {
+                                numMessageSent++;
+                                ASSERT_EQ(result, ResultOk);
+                            });
+    }
+
+    ASSERT_EQ(ResultOk, producer_.flush());
+    ASSERT_EQ(numMessageSent.load(), numMessages);
+}
+
+TEST_F(KeyBasedBatchingTest, testOrderingKeyPriority) {
+    initTopicName("OrderingKeyPriority");
+    initProducer(createDefaultProducerConfig().setBatchingMaxMessages(3));
+    initConsumer();
+
+    Latch latch(3);
+    auto sendCallback = [&latch](Result result, const MessageId& id) {
+        ASSERT_EQ(result, ResultOk);
+        latch.countdown();
+    };
+    // "0" is send to batch of "A" because ordering key has higher priority
+    producer_.sendAsync(MessageBuilder().setContent("0").setOrderingKey("A").setPartitionKey("B").build(),
+                        sendCallback);
+    producer_.sendAsync(MessageBuilder().setContent("1").setOrderingKey("A").build(), sendCallback);
+    producer_.sendAsync(MessageBuilder().setContent("2").setOrderingKey("B").build(), sendCallback);
+    latch.countdown();
+
+    Message msg;
+    receiveAndAck(msg);
+    ASSERT_EQ("0", msg.getDataAsString());
+    ASSERT_EQ("A", msg.getOrderingKey());
+    ASSERT_EQ("B", msg.getPartitionKey());
+    receiveAndAck(msg);
+    ASSERT_EQ("1", msg.getDataAsString());
+    ASSERT_EQ("A", msg.getOrderingKey());
+    receiveAndAck(msg);
+    ASSERT_EQ("2", msg.getDataAsString());
+    ASSERT_EQ("B", msg.getOrderingKey());
+}
+
+TEST_F(KeyBasedBatchingTest, testSequenceId) {
+    initTopicName("SequenceId");
+    initProducer(createDefaultProducerConfig().setBatchingMaxMessages(6));
+    initConsumer();
+
+    Latch latch(6);
+    auto sendAsync = [this, &latch](const std::string& key, const std::string& value) {
+        producer_.sendAsync(MessageBuilder().setOrderingKey(key).setContent(value).build(),
+                            [&latch](Result result, const MessageId& id) {
+                                ASSERT_EQ(result, ResultOk);
+                                latch.countdown();
+                            });
+    };
+    sendAsync("A", "0");
+    sendAsync("B", "1");
+    sendAsync("C", "2");
+    sendAsync("B", "3");
+    sendAsync("C", "4");
+    sendAsync("A", "5");
+    // sequence id: B < C < A, so there are 3 batches in order as following:
+    //   B: 1, 3
+    //   C: 2, 4
+    //   A: 0, 5
+    latch.wait();
+
+    std::vector<std::string> receivedKeys;
+    std::vector<std::string> receivedValues;
+    for (int i = 0; i < 6; i++) {
+        Message msg;
+        receiveAndAck(msg);
+        receivedKeys.emplace_back(msg.getOrderingKey());
+        receivedValues.emplace_back(msg.getDataAsString());
+    }
+
+    decltype(receivedKeys) expectedKeys{"B", "B", "C", "C", "A", "A"};
+    decltype(receivedValues) expectedValues{"1", "3", "2", "4", "0", "5"};
+    EXPECT_EQ(receivedKeys, expectedKeys);
+    EXPECT_EQ(receivedValues, expectedValues);
+}

--- a/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
+++ b/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
@@ -30,7 +30,7 @@ static ProducerConfiguration createDefaultProducerConfig() {
     return ProducerConfiguration()
         .setBatchingType(ProducerConfiguration::KeyBasedBatching)
         .setBatchingMaxAllowedSizeInBytes(static_cast<unsigned long>(-1))
-        .setBatchingMaxPublishDelayMs(static_cast<unsigned long>(-1));
+        .setBatchingMaxPublishDelayMs(3600 * 1000);
 }
 
 class KeyBasedBatchingTest : public ::testing::Test {


### PR DESCRIPTION
### Motivation

Support key based batching for C++ client. This is a catch up work on #4435.

In addition, currently the implementation of `BatchMessageContainer` is coupling to `ProducerImpl` tightly. The  batch message container registers a timer to producer's executor and the timeout callback is also producer's method. Even its `add` method could call `sendMessage` to send batch to producer's pending queue. These should be producer's work.

### Modifications

- Add a `MessageAndCallbackBatch` to store a `MessageImpl` of serialized single messages and a callback list.
- Add a `BatchMessageContainerBase` to provide interface methods and methods like update/clear message number/bytes, create `OpSendMsg`.
- Let `ProducerImpl` manage the batch timer and determine whether to create `OpSendMsg` from `BatchMessageContainerBase` and send.
- Make `BatchMessageContainer` inherit `BatchMessageContainerBase`, it only manages a `MessageAndCallbackBatch`.
- Add a `BatchMessageKeyBasedContainer` that inherits `BatchMessageContainerBase`, it manages a map of message key and `MessageAndCallbackBatch`.
- Add a producer config to change batching type.
- Add some units tests for key based batching and a unit test for key shared subscription.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows: 

  - Current tests affected by default batching type, like `BatchMessageTest.*` and `BasicEndToEndTest.*`
  - Newly added tests: `KeyBasedBatchingTest.*` and `KeySharedConsumerTest.testKeyBasedBatching`

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
