### PR TITLE
Exclude vertx from bookkeeper-http package

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -192,12 +192,16 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <!--TODO: When pulsar uses https://github.com/apache/bookkeeper/pull/2410 in -->
+        <!--      the next bk version, please remove the following content.-->
         <exclusion>
           <groupId>io.vertx</groupId>
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
+    <!--TODO: When pulsar uses https://github.com/apache/bookkeeper/pull/2410 in -->
+    <!--      the next bk version, please remove the following content.-->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
@@ -222,6 +226,7 @@
       <artifactId>vertx-web</artifactId>
       <version>${vertx.version}</version>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -192,7 +192,35 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
   </dependencies>
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -490,9 +490,10 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.4.1.jar
-    - io.vertx-vertx-core-3.4.1.jar
-    - io.vertx-vertx-web-3.4.1.jar
+    - io.vertx-vertx-auth-common-3.5.3.jar
+    - io.vertx-vertx-bridge-common-3.5.3.jar
+    - io.vertx-vertx-core-3.5.3.jar
+    - io.vertx-vertx-web-3.5.3.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.5.7.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
+    <vertx.version>3.5.3</vertx.version>
     <rocksdb.version>5.13.3</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


Fixes #7931

### Motivation

```
$ mvn dependency:tree|grep vertx
```

Output:
```
[INFO] +- org.apache.bookkeeper.http:vertx-http-server:jar:4.10.0:compile
[INFO] +- io.vertx:vertx-core:jar:3.5.3:compile
[INFO] +- io.vertx:vertx-web:jar:3.5.3:compile
[INFO] |  +- io.vertx:vertx-auth-common:jar:3.5.3:compile
[INFO] |  \- io.vertx:vertx-bridge-common:jar:3.5.3:compile
[INFO] |  +- org.apache.bookkeeper.http:vertx-http-server:jar:4.10.0:provided
[INFO] |  +- io.vertx:vertx-core:jar:3.5.3:provided
[INFO] |  \- io.vertx:vertx-web:jar:3.5.3:provided
[INFO] |     +- io.vertx:vertx-auth-common:jar:3.5.3:provided
[INFO] |     \- io.vertx:vertx-bridge-common:jar:3.5.3:provided
```

### Modifications

- exclude `vertx` from bookkeeper-http package and include vertx of `3.5.3` to `vertx-http-server`
 
