### PR TITLE
check null point before setting auto read

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1966,7 +1966,8 @@ public class ServerCnx extends PulsarHandler {
         // we can add check (&& pendingSendRequest < MaxPendingSendRequests) here but then it requires
         // pendingSendRequest to be volatile and it can be expensive while writing. also this will be called on if
         // throttling is enable on the topic. so, avoid pendingSendRequest check will be fine.
-        if (!ctx.channel().config().isAutoRead() && !autoReadDisabledRateLimiting && !autoReadDisabledPublishBufferLimiting) {
+        if (ctx != null && !ctx.channel().config().isAutoRead() &&
+                !autoReadDisabledRateLimiting && !autoReadDisabledPublishBufferLimiting) {
             // Resume reading from socket if pending-request is not reached to threshold
             ctx.channel().config().setAutoRead(true);
             // triggers channel read
@@ -1975,7 +1976,7 @@ public class ServerCnx extends PulsarHandler {
     }
 
     public void disableCnxAutoRead() {
-        if (ctx.channel().config().isAutoRead() ) {
+        if (ctx != null && ctx.channel().config().isAutoRead() ) {
             ctx.channel().config().setAutoRead(false);
         }
     }


### PR DESCRIPTION
#7919  was forced to be closed. 
I've opened a new pr to address rebase issue.

Pulsar enable throttler to controll the speed of consuming data. But sometimes ctx will be closed while throttler is running in a independent thread. We should check ctx null point before setting auto read.
NPE will be thrown if throttler is enabled and ctx is closed. It would be more graceful if we check null before enabling auto read

@sijie  @codelipenghui 
