### PR TITLE
Fix dispatchRate is overwritten

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1283,10 +1283,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return subscriptions;
     }
 
+    @Override
     public PersistentSubscription getSubscription(String subscriptionName) {
         return subscriptions.get(subscriptionName);
     }
 
+    @Override
     public ConcurrentOpenHashMap<String, Replicator> getReplicators() {
         return replicators;
     }
@@ -1837,7 +1839,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     , cfg.getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(), cfg.isBrokerDeleteInactiveTopicsEnabled());
         }
 
-
         initializeDispatchRateLimiterIfNeeded(Optional.ofNullable(data));
 
         this.updateMaxPublishRate(data);
@@ -1862,7 +1863,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         CompletableFuture<Void> persistentPoliciesFuture = checkPersistencePolicies();
         // update rate-limiter if policies updated
         if (this.dispatchRateLimiter.isPresent()) {
-            dispatchRateLimiter.get().onPoliciesUpdate(data);
+            if (topicPolicies == null || !topicPolicies.isDispatchRateSet()) {
+                dispatchRateLimiter.get().onPoliciesUpdate(data);
+            }
         }
         if (this.subscribeRateLimiter.isPresent()) {
             subscribeRateLimiter.get().onPoliciesUpdate(data);
@@ -2354,10 +2357,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         Optional<Policies> namespacePolicies = getNamespacePolicies();
         initializeTopicDispatchRateLimiterIfNeeded(policies);
-        if (this.dispatchRateLimiter.isPresent() && policies.getDispatchRate() != null) {
-            dispatchRateLimiter.ifPresent(dispatchRateLimiter ->
-                dispatchRateLimiter.updateDispatchRate(policies.getDispatchRate()));
-        }
+
+        dispatchRateLimiter.ifPresent(limiter -> {
+            if (policies.isDispatchRateSet()) {
+                dispatchRateLimiter.get().updateDispatchRate(policies.getDispatchRate());
+            } else {
+                dispatchRateLimiter.get().updateDispatchRate();
+            }
+        });
 
         if (policies.getPublishRate() != null) {
             topicPolicyPublishRate = policies.getPublishRate();
@@ -2366,17 +2373,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         if (policies.isInactiveTopicPoliciesSet()) {
             inactiveTopicPolicies = policies.getInactiveTopicPolicies();
+        } else if (namespacePolicies.isPresent() && namespacePolicies.get().inactive_topic_policies != null) {
+            //topic-level policies is null , so use namespace-level
+            inactiveTopicPolicies = namespacePolicies.get().inactive_topic_policies;
         } else {
-            //topic-level policies is null , so use namespace-level or broker-level
-            namespacePolicies.ifPresent(nsPolicies -> {
-                if (nsPolicies.inactive_topic_policies != null) {
-                    inactiveTopicPolicies = nsPolicies.inactive_topic_policies;
-                } else {
-                    ServiceConfiguration cfg = brokerService.getPulsar().getConfiguration();
-                    resetInactiveTopicPolicies(cfg.getBrokerDeleteInactiveTopicsMode()
-                            , cfg.getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(), cfg.isBrokerDeleteInactiveTopicsEnabled());
-                }
-            });
+            //namespace-level policies is null , so use broker level
+            ServiceConfiguration cfg = brokerService.getPulsar().getConfiguration();
+            resetInactiveTopicPolicies(cfg.getBrokerDeleteInactiveTopicsMode()
+                    , cfg.getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(), cfg.isBrokerDeleteInactiveTopicsEnabled());
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -303,11 +303,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setSystemTopicEnabled(true);
         conf.setTopicLevelPoliciesEnabled(true);
         super.baseSetup();
-
+        //wait for cache init
+        Thread.sleep(3000);
         final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
-        //wait for cache init
-        Thread.sleep(2000);
+
         InactiveTopicPolicies inactiveTopicPolicies = admin.topics().getInactiveTopicPolicies(topicName);
         assertNull(inactiveTopicPolicies);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -303,8 +303,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setSystemTopicEnabled(true);
         conf.setTopicLevelPoliciesEnabled(true);
         super.baseSetup();
-        //wait for cache init
-        Thread.sleep(3000);
         final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
 
@@ -316,6 +314,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         policies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
         policies.setMaxInactiveDurationSeconds(10);
         admin.topics().setInactiveTopicPolicies(topicName, policies);
+        //wait for init
+        Thread.sleep(3000);
         for (int i = 0; i < 50; i++) {
             if (admin.topics().getInactiveTopicPolicies(topicName) != null) {
                 break;


### PR DESCRIPTION
Fixes #7863

### Motivation
1) Topic level policy will be overwritten by namespace level
2) After removing the topic level policy, `DispatchLimiter` does not take effect,  the namespace level policy should be used

### Modifications
1）If there is a topic-level policy, it will not be overwritten by the namespace-level policy when the policy is updated
2）When removing topic-level policy, namespace-level policy will be used. If the namespace-level policy does not exist, the broker level will be used

### Verifying this change
unit test:
TopicPoliciesTest#testPolicyOverwrittenByNamespaceLevel
