### PR TITLE
[Transaction] Fix transaction message ack

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
+import org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotSealedException;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
@@ -558,6 +559,12 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 // Topic has been terminated and there are no more entries to read
                 // Notify the consumer only if all the messages were already acknowledged
                 consumerList.forEach(Consumer::reachedEndOfTopic);
+            }
+        } else if (exception.getCause() instanceof TransactionNotSealedException) {
+            waitTimeMillis = 1;
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
+                        cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
             }
         } else if (!(exception instanceof TooManyRequestsException)) {
             log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -563,8 +563,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         } else if (exception.getCause() instanceof TransactionNotSealedException) {
             waitTimeMillis = 1;
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
-                        cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
+                log.debug("[{}] Error reading transaction entries : {}, Read Type {} - Retrying to read in {} seconds",
+                        name, exception.getMessage(), readType, waitTimeMillis / 1000.0);
             }
         } else if (!(exception instanceof TooManyRequestsException)) {
             log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.SendMessageInfo;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
+import org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotSealedException;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
@@ -466,6 +467,12 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
                 // Topic has been terminated and there are no more entries to read
                 // Notify the consumer only if all the messages were already acknowledged
                 consumers.forEach(Consumer::reachedEndOfTopic);
+            }
+        } else if (exception.getCause() instanceof TransactionNotSealedException) {
+            waitTimeMillis = 1;
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Error reading transaction entries : {}, - Retrying to read in {} seconds", name,
+                        exception.getMessage(), waitTimeMillis / 1000.0);
             }
         } else if (!(exception instanceof TooManyRequestsException)) {
             log.error("[{}-{}] Error reading entries at {} : {} - Retrying to read in {} seconds", name, c,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
@@ -20,23 +20,21 @@ package org.apache.pulsar.broker.service.persistent;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import com.google.common.collect.Queues;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
-import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferReader;
-import org.apache.pulsar.broker.transaction.buffer.TransactionEntry;
+import org.apache.pulsar.broker.transaction.buffer.exceptions.EndOfTransactionException;
+import org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotSealedException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 
 /**
@@ -112,6 +110,15 @@ public class TransactionReader {
         }
         transactionBufferReader.thenAccept(reader -> {
             reader.readNext(readMessageNum).whenComplete((transactionEntries, throwable) -> {
+                if (throwable != null && throwable.getCause() instanceof EndOfTransactionException) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("transaction {} read finished.", txnID);
+                    }
+                    resetReader(txnID, reader);
+                    readEntriesCallback.readEntriesComplete(Collections.EMPTY_LIST, ctx);
+                    return;
+                }
+
                 if (throwable != null) {
                     log.error("Read transaction messages failed.", throwable);
                     readEntriesCallback.readEntriesFailed(
@@ -131,15 +138,19 @@ public class TransactionReader {
                                 transactionEntries.get(0).committedAtEntryId()),
                         transactionEntries.get(0).numMessageInTxn());
 
-                if (transactionEntries.size() < readMessageNum) {
-                    resetReader(txnID, reader);
-                }
                 readEntriesCallback.readEntriesComplete(new ArrayList<>(transactionEntries), ctx);
             });
         }).exceptionally(throwable -> {
-            log.error("Open transactionBufferReader failed.", throwable);
-            readEntriesCallback.readEntriesFailed(
-                    ManagedLedgerException.getManagedLedgerException(throwable), ctx);
+            transactionBufferReader = null;
+            if (throwable.getCause() instanceof TransactionNotSealedException) {
+                if (log.isDebugEnabled()) {
+                    log.debug("transaction {} is not sealed, failed to open transactionBufferReader.", txnID);
+                }
+                readEntriesCallback.readEntriesComplete(Collections.EMPTY_LIST, ctx);
+                return null;
+            }
+            log.error("open transactionBufferReader failed.", throwable);
+            readEntriesCallback.readEntriesFailed(ManagedLedgerException.getManagedLedgerException(throwable), ctx);
             return null;
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/TransactionReader.java
@@ -146,7 +146,8 @@ public class TransactionReader {
                 if (log.isDebugEnabled()) {
                     log.debug("transaction {} is not sealed, failed to open transactionBufferReader.", txnID);
                 }
-                readEntriesCallback.readEntriesComplete(Collections.EMPTY_LIST, ctx);
+                readEntriesCallback.readEntriesFailed(
+                        ManagedLedgerException.getManagedLedgerException(throwable.getCause()), ctx);
                 return null;
             }
             log.error("open transactionBufferReader failed.", throwable);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBufferReader.java
@@ -56,7 +56,7 @@ public class PersistentTransactionBufferReader implements TransactionBufferReade
 
     PersistentTransactionBufferReader(TransactionMeta meta, ManagedLedger ledger)
         throws TransactionNotSealedException {
-        if (TxnStatus.OPEN == meta.status()) {
+        if (TxnStatus.COMMITTED != meta.status()) {
             throw new TransactionNotSealedException("Transaction `" + meta.id() + "` is not sealed yet");
         }
         this.meta = meta;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -125,9 +125,9 @@ public class TransactionConsumeTest extends TransactionTestBase {
                 log.info("Receive shared normal msg: {}" + new String(message.getData(), UTF_8));
             } else {
                 // can't receive transaction messages before commit
-                Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+                Message<byte[]> message = exclusiveConsumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNull(message);
-                message = sharedConsumer.receive(2, TimeUnit.SECONDS);
+                message = sharedConsumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNull(message);
                 log.info("Can't receive message before commit.");
             }
@@ -141,13 +141,13 @@ public class TransactionConsumeTest extends TransactionTestBase {
         Map<String, Integer> sharedBatchIndexMap = new HashMap<>();
         // receive transaction messages successfully after commit
         for (int i = 0; i < transactionMessageCnt; i++) {
-            Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+            Message<byte[]> message = exclusiveConsumer.receive();
             Assert.assertNotNull(message);
             Assert.assertTrue(message.getMessageId() instanceof BatchMessageIdImpl);
             checkBatchIndex(exclusiveBatchIndexMap, (BatchMessageIdImpl) message.getMessageId());
             log.info("Receive txn exclusive id: {}, msg: {}", message.getMessageId(), new String(message.getData()));
 
-            message = sharedConsumer.receive(2, TimeUnit.SECONDS);
+            message = sharedConsumer.receive();
             Assert.assertNotNull(message);
             Assert.assertTrue(message.getMessageId() instanceof BatchMessageIdImpl);
             checkBatchIndex(sharedBatchIndexMap, (BatchMessageIdImpl) message.getMessageId());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -114,10 +114,11 @@ public class TransactionConsumeTest extends TransactionTestBase {
         appendTransactionMessages(txnID, transactionBuffer, transactionMessageCnt);
         sendNormalMessages(producer, messageCntBeforeTxn, messageCntAfterTxn);
 
+        Message<byte[]> message;
         for (int i = 0; i < totalMsgCnt; i++) {
             if (i < (messageCntBeforeTxn + messageCntAfterTxn)) {
                 // receive normal messages successfully
-                Message<byte[]> message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
+                message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 log.info("Receive exclusive normal msg: {}" + new String(message.getData(), UTF_8));
                 message = sharedConsumer.receive(2, TimeUnit.SECONDS);
@@ -125,33 +126,34 @@ public class TransactionConsumeTest extends TransactionTestBase {
                 log.info("Receive shared normal msg: {}" + new String(message.getData(), UTF_8));
             } else {
                 // can't receive transaction messages before commit
-                Message<byte[]> message = exclusiveConsumer.receive(5, TimeUnit.SECONDS);
+                message = exclusiveConsumer.receive(2, TimeUnit.SECONDS);
                 Assert.assertNull(message);
-                message = sharedConsumer.receive(5, TimeUnit.SECONDS);
+                log.info("exclusive consumer can't receive message before commit.");
+
+                message = sharedConsumer.receive(2, TimeUnit.SECONDS);
                 Assert.assertNull(message);
-                log.info("Can't receive message before commit.");
+                log.info("shared consumer can't receive message before commit.");
             }
         }
 
-        transactionBuffer.endTxnOnPartition(txnID, PulsarApi.TxnAction.COMMIT.getNumber());
-        Thread.sleep(1000);
+        transactionBuffer.endTxnOnPartition(txnID, PulsarApi.TxnAction.COMMIT.getNumber()).get();
         log.info("Commit txn.");
 
         Map<String, Integer> exclusiveBatchIndexMap = new HashMap<>();
         Map<String, Integer> sharedBatchIndexMap = new HashMap<>();
         // receive transaction messages successfully after commit
         for (int i = 0; i < transactionMessageCnt; i++) {
-            Message<byte[]> message = exclusiveConsumer.receive();
+            message = exclusiveConsumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             Assert.assertTrue(message.getMessageId() instanceof BatchMessageIdImpl);
             checkBatchIndex(exclusiveBatchIndexMap, (BatchMessageIdImpl) message.getMessageId());
             log.info("Receive txn exclusive id: {}, msg: {}", message.getMessageId(), new String(message.getData()));
 
-            message = sharedConsumer.receive();
+            message = sharedConsumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             Assert.assertTrue(message.getMessageId() instanceof BatchMessageIdImpl);
             checkBatchIndex(sharedBatchIndexMap, (BatchMessageIdImpl) message.getMessageId());
-            log.info("Receive txn shared id: {}, msg: {}", message.getMessageId(), new String(message.getData(), UTF_8));
+            log.info("Receive txn shared id: {}, msg: {}", message.getMessageId(), new String(message.getData()));
         }
         log.info("TransactionConsumeTest noSortedTest finish.");
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/transaction/EndToEndTest.java
@@ -346,8 +346,6 @@ public class EndToEndTest extends TransactionTestBase {
         }
         Assert.assertEquals(messageCnt, receiveCnt);
 
-        Thread.sleep(1000);
-
         for (int i = 0; i < TOPIC_PARTITION; i++) {
             Assert.assertEquals(
                     messageIdMap.get(i).getLedgerId() + ":-1",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1150,7 +1150,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     msgMetadata.recycle();
                     return;
                 }
-                msgId = new BatchMessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), getPartitionIndex(), messageId.getBatchIndex(), -1, BatchMessageAckerDisabled.INSTANCE);
+                BatchMessageAcker batchMessageAcker = BatchMessageAcker.newAcker(ackBitSet);
+                msgId = new BatchMessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), getPartitionIndex(), messageId.getBatchIndex(), -1, batchMessageAcker);
             }
 
             final MessageImpl<T> message = new MessageImpl<>(topicName.toString(), msgId, msgMetadata,


### PR DESCRIPTION
### Motivation

The transaction message ack is not well.

### Modifications

Fix the transaction message ack.

### Verifying this change

This change added tests and can be verified as follows:

-*org.apache.pulsar.client.transaction.EndToEndTest#txnBatchMessageAckTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
