### PR TITLE
[Transaction] TransactionBuffer recover from log

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -281,6 +281,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         checkReplicatedSubscriptionControllerState();
+
+        if (!ledger.getProperties().isEmpty()
+                && ledger.getProperties().containsKey(PersistentTransactionBuffer.TB_EXIST_PROPERTY)) {
+            getTransactionBuffer(true);
+        }
     }
     // for testing purposes
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -98,6 +98,7 @@ import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.broker.stats.ReplicationMetrics;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
+import org.apache.pulsar.broker.transaction.buffer.impl.PersistentTransactionBuffer;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
 import org.apache.pulsar.client.api.MessageId;
@@ -2271,9 +2272,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             transactionBufferLock.lock();
             try {
                 if (transactionBuffer == null) {
+                    this.ledger.setProperty(PersistentTransactionBuffer.TB_EXIST_PROPERTY, "true");
                     transactionBuffer = brokerService.getPulsar().getTransactionBufferProvider()
                             .newTransactionBuffer(this);
                 }
+            } catch (InterruptedException | ManagedLedgerException e) {
+                log.error("Update ledger property failed.", e);
             } finally {
                 transactionBufferLock.unlock();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/exceptions/TransactionBufferUnusableException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/exceptions/TransactionBufferUnusableException.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.exceptions;
+
+/**
+ * Exceptions are thrown when the TransactionBuffer unusable.
+ */
+public class TransactionBufferUnusableException extends TransactionBufferException {
+
+    private static final long serialVersionUID = 0L;
+
+    public TransactionBufferUnusableException(String message) {
+        super(message);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/PersistentTransactionBuffer.java
@@ -67,6 +67,8 @@ import java.util.stream.Collectors;
 public class PersistentTransactionBuffer extends PersistentTopic implements TransactionBuffer {
 
     private final static String TB_TOPIC_NAME_SUFFIX = "/_txnlog";
+    public final static String TB_EXIST_PROPERTY = "txn_tb_exist";
+
     private TransactionCursor txnCursor;
     private ManagedCursor retentionCursor;
     private Topic originTopic;
@@ -104,6 +106,7 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
             PositionImpl.earliest, "txn-buffer-retention");
         this.originTopic = originTopic;
         this.pendingCommitTxn = Queues.newConcurrentLinkedQueue();
+        recover();
     }
 
     public static String getTransactionBufferTopicName(String originTopicName) {
@@ -398,7 +401,7 @@ public class PersistentTransactionBuffer extends PersistentTopic implements Tran
 
     public void recover() {
         // TODO recover from snapshot
-        // TODO recover from log
+        recoverFromLog(PositionImpl.earliest);
     }
 
     public void recoverFromLog(PositionImpl startPosition) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -560,18 +560,7 @@ public class TransactionProduceTest extends TransactionTestBase {
                 (ConcurrentMap) txnIndexField.get(recoverTB.getTxnCursor());
         Assert.assertEquals(recoverIndexMap.size(), 0);
 
-        recoverTB.recover();
-
-        for (int i = 0; i < 10; i++) {
-            try {
-                recoverTB.checkState().get();
-                log.info("recover operation finished.");
-                break;
-            } catch (Exception e) {
-                Thread.sleep(1000);
-                log.warn("recover operation is not finished.");
-            }
-        }
+        recoverTB.recover().get();
 
         ConcurrentMap<TxnID, TransactionMetaImpl> originalIndexMap =
                 (ConcurrentMap) txnIndexField.get(transactionBuffer.getTxnCursor());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -536,7 +536,7 @@ public class TransactionProduceTest extends TransactionTestBase {
                         getPulsarServiceList().get(0).getBrokerService(), normalTopic);
 
         Set<TxnID> txnIDSet = new LinkedHashSet<>();
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 2000; i++) {
             TxnID txnID = new TxnID(i, i + 1);
             txnIDSet.add(txnID);
             appendTransactionMessages(txnID, transactionBuffer, 10);
@@ -564,6 +564,17 @@ public class TransactionProduceTest extends TransactionTestBase {
         Assert.assertEquals(recoverIndexMap.size(), 0);
 
         recoverTB.recover();
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                recoverTB.checkState().get();
+                log.info("recover operation finished.");
+                break;
+            } catch (Exception e) {
+                Thread.sleep(1000);
+                log.warn("recover operation is not finished.");
+            }
+        }
 
         ConcurrentMap<TxnID, TransactionMetaImpl> originalIndexMap =
                 (ConcurrentMap) txnIndexField.get(transactionBuffer.getTxnCursor());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -563,7 +563,7 @@ public class TransactionProduceTest extends TransactionTestBase {
                 (ConcurrentMap) txnIndexField.get(recoverTB.getTxnCursor());
         Assert.assertEquals(recoverIndexMap.size(), 0);
 
-        recoverTB.recoverFromLog(PositionImpl.earliest);
+        recoverTB.recover();
 
         ConcurrentMap<TxnID, TransactionMetaImpl> originalIndexMap =
                 (ConcurrentMap) txnIndexField.get(transactionBuffer.getTxnCursor());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -268,9 +268,6 @@ public class TransactionProduceTest extends TransactionTestBase {
 
         txn.abort().get();
 
-        // the messageId callback should be called after commit
-        checkMessageId(futureList, true);
-
         // the target topic partition doesn't have any entries
         for (int i = 0; i < TOPIC_PARTITION; i++) {
             ReadOnlyCursor originTopicCursor = getOriginTopicCursor(PRODUCE_ABORT_TOPIC, i);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -138,9 +138,7 @@ public class TransactionImpl implements Transaction {
                     return;
                 }
                 sendOps.values().forEach(txnSendOp -> {
-                    log.info("commit finished sendOps");
                     txnSendOp.sendFuture.whenComplete((messageId, t) -> {
-                        log.info("sendOps result: {}", messageId);
                         txnSendOp.transactionalSendFuture.complete(messageId);
                     });
                 });


### PR DESCRIPTION
Fix issue https://github.com/streamnative/pulsar/issues/1309

### Motivation

Currently, the TransactionBuffer can't be recovered.

### Modifications

Read the TransactionBuffer log and recover related data.

### Verifying this change

This change added tests and can be verified as follows:

  - *org.apache.pulsar.broker.transaction.TransactionProduceTest#recoverFromLogTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
