### PR TITLE
[Transaction] Support produce batch transaction messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -101,6 +101,11 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         produceCommitTest(false);
     }
 
+    @Test
+    public void batchProduceCommitTest() throws Exception {
+        produceCommitTest(true);
+    }
+
     private void produceCommitTest(boolean enableBatch) throws Exception {
         @Cleanup
         MultiTopicsConsumerImpl<byte[]> consumer = (MultiTopicsConsumerImpl<byte[]>) pulsarClient

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -121,7 +121,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .enableBatching(enableBatch)
                 .sendTimeout(0, TimeUnit.SECONDS);
         if (enableBatch) {
-            producerBuilder.batcherBuilder(BatcherBuilder.KEY_BASED);
+            producerBuilder.batcherBuilder(BatcherBuilder.TRANSACTION);
         }
         @Cleanup
         PartitionedProducerImpl<byte[]> producer = (PartitionedProducerImpl<byte[]>) producerBuilder.create();

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatcherBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatcherBuilder.java
@@ -49,6 +49,17 @@ public interface BatcherBuilder extends Serializable {
     BatcherBuilder KEY_BASED = DefaultImplementation.newKeyBasedBatcherBuilder();
 
     /**
+     * transaction batch message container
+     *
+     * <p>incoming single messages:
+     * (txn1, v1), (txn2, v1), (txn3, v1), (txn1, v2), (txn2, v2), (txn3, v2), (txn1, v3), (txn2, v3), (txn3, v3)
+     *
+     * <p>batched into multiple batch messages:
+     * [(txn1, v1), (txn1, v2), (txn1, v3)], [(txn2, v1), (txn2, v2), (txn2, v3)], [(txn3, v1), (txn3, v2), (txn3, v3)]
+     */
+    BatcherBuilder TRANSACTION = DefaultImplementation.newTransactionBatcherBuilder();
+
+    /**
      * Build a new batch message container.
      * @return new batch message container
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -475,4 +475,10 @@ public class DefaultImplementation {
                 () -> (BatcherBuilder) getConstructor("org.apache.pulsar.client.impl.KeyBasedBatcherBuilder")
                         .newInstance());
     }
+
+    public static BatcherBuilder newTransactionBatcherBuilder() {
+        return catchExceptions(
+                () -> (BatcherBuilder) getConstructor(
+                        "org.apache.pulsar.client.impl.TransactionBatcherBuilder").newInstance());
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1409,7 +1409,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         int skippedMessages = 0;
         try {
             int startBatchIndex = Math.max(messageId.getBatchIndex(), 0);
-            for (int i = startBatchIndex; i < batchSize; ++i) {
+            for (int i = 0; i < batchSize; ++i) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] [{}] processing message num - {} in batch", subscription, consumerName, i);
                 }
@@ -1449,7 +1449,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
 
                 BatchMessageIdImpl batchMessageIdImpl = new BatchMessageIdImpl(messageId.getLedgerId(),
-                        messageId.getEntryId(), getPartitionIndex(), i, batchSize, acker);
+                        messageId.getEntryId(), getPartitionIndex(), i + startBatchIndex, batchSize, acker);
                 final MessageImpl<T> message = new MessageImpl<>(topicName.toString(), batchMessageIdImpl,
                         msgMetadata, singleMessageMetadataBuilder.build(), singleMessagePayload,
                         createEncryptionContext(msgMetadata), cnx, schema, redeliveryCount);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionBatcherBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionBatcherBuilder.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.BatchMessageContainer;
+import org.apache.pulsar.client.api.BatcherBuilder;
+
+public class TransactionBatcherBuilder implements BatcherBuilder {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public BatchMessageContainer build() {
+        return new BatchMessageTransactionContainer();
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, we couldn't produce batch transaction messages.

### Modifications

Support produces batch transaction messages based on `BatchMessageKeyBasedContainer`.

### Verifying this change

This change added tests and can be verified as follows:

  - *org.apache.pulsar.client.transaction.EndToEndTest#batchProduceCommitTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
