### PR TITLE
[website] Update the project description on home page

### DIFF
--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -180,7 +180,7 @@ const siteConfig = {
 
   projectDescription: `
     Apache Pulsar is a cloud-native, distributed messaging and streaming platform originally
-    created at Yahoo! and now a top-level Apache Software Foundation
+    created at Yahoo! and now a top-level Apache Software Foundation project
   `,
 
   markdownPlugins: [


### PR DESCRIPTION
### Motivation
Missing the word "project" for the Pulsar description on home page.

### Modifications
Update it.