### PR TITLE
Fix protobuf version to 3.11.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -321,7 +321,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.11.1.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.11.1.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
- * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
+ * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
  * Joda -- org.joda-joda-convert-2.2.1.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.2.jar
  * Gson
@@ -445,26 +445,38 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.1.3.jar
- * OkHttp - com.squareup.okhttp-okhttp-2.5.0.jar
+ * OkHttp
+    - com.squareup.okhttp-okhttp-2.7.4.jar
  * Okio - com.squareup.okio-okio-1.13.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
   * gRPC
-    - io.grpc-grpc-all-1.18.0.jar
-    - io.grpc-grpc-auth-1.18.0.jar
-    - io.grpc-grpc-context-1.18.0.jar
-    - io.grpc-grpc-core-1.18.0.jar
-    - io.grpc-grpc-netty-1.18.0.jar
-    - io.grpc-grpc-okhttp-1.18.0.jar
-    - io.grpc-grpc-protobuf-1.18.0.jar
-    - io.grpc-grpc-protobuf-lite-1.18.0.jar
+    - io.grpc-grpc-all-1.30.2.jar
+    - io.grpc-grpc-alts-1.30.2.jar
+    - io.grpc-grpc-api-1.30.2.jar
+    - io.grpc-grpc-auth-1.30.2.jar
+    - io.grpc-grpc-context-1.30.2.jar
+    - io.grpc-grpc-core-1.30.2.jar
+    - io.grpc-grpc-grpclb-1.30.2.jar
+    - io.grpc-grpc-netty-1.30.2.jar
+    - io.grpc-grpc-netty-shaded-1.30.2.jar
+    - io.grpc-grpc-okhttp-1.30.2.jar
+    - io.grpc-grpc-protobuf-1.30.2.jar
+    - io.grpc-grpc-protobuf-lite-1.30.2.jar
+    - io.grpc-grpc-services-1.30.2.jar
+    - io.grpc-grpc-stub-1.30.2.jar
+    - io.grpc-grpc-xds-1.30.2.jar
     - io.grpc-grpc-protobuf-nano-1.18.0.jar
-    - io.grpc-grpc-stub-1.18.0.jar
     - io.grpc-grpc-testing-1.18.0.jar
   * OpenCensus
     - io.opencensus-opencensus-api-0.18.0.jar
     - io.opencensus-opencensus-contrib-grpc-metrics-0.18.0.jar
+    - io.opencensus-opencensus-contrib-http-util-0.24.0.jar
+    - io.opencensus-opencensus-proto-0.2.0.jar
   * Jodah
     - net.jodah-typetools-0.5.0.jar
+  * Apache HTTP
+    - org.apache.httpcomponents-httpclient-4.5.10.jar
+    - org.apache.httpcomponents-httpcore-4.4.12.jar
   * Apache Avro
     - org.apache.avro-avro-1.9.1.jar
     - org.apache.avro-avro-protobuf-1.9.1.jar
@@ -508,7 +520,9 @@ The Apache Software License, Version 2.0
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
-    - com.google.auth-google-auth-library-credentials-0.9.0.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-credentials-0.20.0.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-oauth2-http-0.20.0.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auto.value-auto-value-annotations-1.7.jar -- licenses/LICENSE-google-auth-library.txt
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt
  * JavaHamcrest -- org.hamcrest-hamcrest-core-1.3.jar -- licenses/LICENSE-Hamcrest.txt
@@ -524,15 +538,20 @@ MIT License
     - org.slf4j-jcl-over-slf4j-1.7.25.jar
  * Animal Sniffer Annotations
     - org.codehaus.mojo-animal-sniffer-annotations-1.14.jar
+    - org.conscrypt-conscrypt-openjdk-uber-2.2.1.jar
  * The Checker Framework
  	- org.checkerframework-checker-compat-qual-2.5.2.jar
     - org.checkerframework-checker-qual-2.0.0.jar
 
 Protocol Buffers License
  * Protocol Buffers
-   - com.google.protobuf-protobuf-java-3.5.1.jar -- licenses/LICENSE-protobuf.txt
-   - com.google.protobuf-protobuf-java-util-3.5.1.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-3.11.4.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-util-3.11.4.jar -- licenses/LICENSE-protobuf.txt
    - com.google.protobuf.nano-protobuf-javanano-3.0.0-alpha-5.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.auto.value-auto-value-annotations-1.7.jar
+   - com.google.http-client-google-http-client-1.34.0.jar
+   - com.google.http-client-google-http-client-jackson2-1.34.0.jar
+   - com.google.re2j-re2j-1.2.jar
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -321,7 +321,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.11.1.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.11.1.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
- * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
+ * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.12.0.jar
  * Joda -- org.joda-joda-convert-2.2.1.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.2.jar
  * Gson
@@ -446,37 +446,26 @@ The Apache Software License, Version 2.0
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.1.3.jar
  * OkHttp
-    - com.squareup.okhttp-okhttp-2.7.4.jar
+    - com.squareup.okhttp-okhttp-2.5.0.jar
  * Okio - com.squareup.okio-okio-1.13.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
   * gRPC
-    - io.grpc-grpc-all-1.30.2.jar
-    - io.grpc-grpc-alts-1.30.2.jar
-    - io.grpc-grpc-api-1.30.2.jar
-    - io.grpc-grpc-auth-1.30.2.jar
-    - io.grpc-grpc-context-1.30.2.jar
-    - io.grpc-grpc-core-1.30.2.jar
-    - io.grpc-grpc-grpclb-1.30.2.jar
-    - io.grpc-grpc-netty-1.30.2.jar
-    - io.grpc-grpc-netty-shaded-1.30.2.jar
-    - io.grpc-grpc-okhttp-1.30.2.jar
-    - io.grpc-grpc-protobuf-1.30.2.jar
-    - io.grpc-grpc-protobuf-lite-1.30.2.jar
-    - io.grpc-grpc-services-1.30.2.jar
-    - io.grpc-grpc-stub-1.30.2.jar
-    - io.grpc-grpc-xds-1.30.2.jar
+    - io.grpc-grpc-all-1.18.0.jar
+    - io.grpc-grpc-auth-1.18.0.jar
+    - io.grpc-grpc-context-1.18.0.jar
+    - io.grpc-grpc-core-1.18.0.jar
+    - io.grpc-grpc-netty-1.18.0.jar
+    - io.grpc-grpc-okhttp-1.18.0.jar
+    - io.grpc-grpc-protobuf-1.18.0.jar
+    - io.grpc-grpc-protobuf-lite-1.18.0.jar
+    - io.grpc-grpc-stub-1.18.0.jar
     - io.grpc-grpc-protobuf-nano-1.18.0.jar
     - io.grpc-grpc-testing-1.18.0.jar
   * OpenCensus
     - io.opencensus-opencensus-api-0.18.0.jar
     - io.opencensus-opencensus-contrib-grpc-metrics-0.18.0.jar
-    - io.opencensus-opencensus-contrib-http-util-0.24.0.jar
-    - io.opencensus-opencensus-proto-0.2.0.jar
   * Jodah
     - net.jodah-typetools-0.5.0.jar
-  * Apache HTTP
-    - org.apache.httpcomponents-httpclient-4.5.10.jar
-    - org.apache.httpcomponents-httpcore-4.4.12.jar
   * Apache Avro
     - org.apache.avro-avro-1.9.1.jar
     - org.apache.avro-avro-protobuf-1.9.1.jar
@@ -520,9 +509,7 @@ The Apache Software License, Version 2.0
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
-    - com.google.auth-google-auth-library-credentials-0.20.0.jar -- licenses/LICENSE-google-auth-library.txt
-    - com.google.auth-google-auth-library-oauth2-http-0.20.0.jar -- licenses/LICENSE-google-auth-library.txt
-    - com.google.auto.value-auto-value-annotations-1.7.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-credentials-0.9.0.jar -- licenses/LICENSE-google-auth-library.txt
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt
  * JavaHamcrest -- org.hamcrest-hamcrest-core-1.3.jar -- licenses/LICENSE-Hamcrest.txt
@@ -538,7 +525,6 @@ MIT License
     - org.slf4j-jcl-over-slf4j-1.7.25.jar
  * Animal Sniffer Annotations
     - org.codehaus.mojo-animal-sniffer-annotations-1.14.jar
-    - org.conscrypt-conscrypt-openjdk-uber-2.2.1.jar
  * The Checker Framework
  	- org.checkerframework-checker-compat-qual-2.5.2.jar
     - org.checkerframework-checker-qual-2.0.0.jar
@@ -548,10 +534,6 @@ Protocol Buffers License
    - com.google.protobuf-protobuf-java-3.11.4.jar -- licenses/LICENSE-protobuf.txt
    - com.google.protobuf-protobuf-java-util-3.11.4.jar -- licenses/LICENSE-protobuf.txt
    - com.google.protobuf.nano-protobuf-javanano-3.0.0-alpha-5.jar -- licenses/LICENSE-protobuf.txt
-   - com.google.auto.value-auto-value-annotations-1.7.jar
-   - com.google.http-client-google-http-client-1.34.0.jar
-   - com.google.http-client-google-http-client-jackson2-1.34.0.jar
-   - com.google.re2j-re2j-1.2.jar
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,8 @@ flexible messaging model and an intuitive client API.</description>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.11.4</protobuf3.version>
     <protoc3.version>3.11.4</protoc3.version>
-    <grpc.version>1.30.2</grpc.version>
-    <protoc-gen-grpc-java.version>1.30.2</protoc-gen-grpc-java.version>
+    <grpc.version>1.18.0</grpc.version>
+    <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,10 +123,10 @@ flexible messaging model and an intuitive client API.</description>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
     <protobuf2.version>2.4.1</protobuf2.version>
-    <protobuf3.version>3.5.1</protobuf3.version>
-    <protoc3.version>3.5.1-1</protoc3.version>
-    <grpc.version>1.18.0</grpc.version>
-    <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
+    <protobuf3.version>3.11.4</protobuf3.version>
+    <protoc3.version>3.11.4</protoc3.version>
+    <grpc.version>1.30.2</grpc.version>
+    <protoc-gen-grpc-java.version>1.30.2</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
@@ -886,6 +886,12 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-stub</artifactId>
         <version>${grpc.version}</version>
       </dependency>
 

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -85,7 +85,16 @@
           <groupId>io.grpc</groupId>
           <artifactId>grpc-all</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
     </dependency>
 
     <!-- `grpc-all` is excluded from `stream-storage-server` at root pom file -->
@@ -97,6 +106,16 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -294,7 +294,7 @@ public class KubernetesRuntime implements Runtime {
             for (int i = 0; i < instanceConfig.getFunctionDetails().getParallelism(); ++i) {
                 String address = getServiceUrl(jobName, jobNamespace, i);
                 channel[i] = ManagedChannelBuilder.forAddress(address, grpcPort)
-                        .usePlaintext(true)
+                        .usePlaintext()
                         .build();
                 stub[i] = InstanceControlGrpc.newFutureStub(channel[i]);
             }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -163,7 +163,7 @@ class ProcessRuntime implements Runtime {
         startProcess();
         if (channel == null && stub == null) {
             channel = ManagedChannelBuilder.forAddress("127.0.0.1", instancePort)
-                    .usePlaintext(true)
+                    .usePlaintext()
                     .build();
             stub = InstanceControlGrpc.newFutureStub(channel);
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -462,8 +462,8 @@ The Apache Software License, Version 2.0
 Protocol Buffers License
  * Protocol Buffers
    - protobuf-shaded-2.1.0-incubating.jar
-   - protobuf-java-3.5.1.jar
-   - protobuf-java-util-3.5.1.jar
+   - protobuf-java-3.11.4.jar
+   - protobuf-java-util-3.11.4.jar
 
 BSD 3-clause "New" or "Revised" License
   *  RE2J TD -- re2j-td-1.4.jar


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #7869

### Motivation

The old protobuf version causes issues within Pulsar functions when a functions jar file includes protoc generated classes which have been created with a recent protoc version.

### Modifications


- Upgrade protobuf version to 3.11.4
- Upgrade protoc3 version to 3.11.4
