### PR TITLE
Fix the failed CI issue

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -131,7 +131,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.1.0</version>
+        <version>4.3.0</version>
         <executions>
           <execution>
             <goals>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -98,7 +98,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.1.0</version>
+        <version>4.3.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
---

**Motivation**

Currently, the Pulsar CI always failed by:
```
2020-09-11T00:49:20.3402047Z [ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.1.0:add-source (default) on project flink: Execution default of goal net.alchim31.maven:scala-maven-plugin:4.1.0:add-source failed: Plugin net.alchim31.maven:scala-maven-plugin:4.1.0 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven:maven-compat:jar:3.3.9, org.apache.maven:maven-builder-support:jar:3.3.9, org.apache.maven:maven-settings:jar:3.3.9, org.apache.maven:maven-artifact:jar:3.3.9: Could not transfer artifact org.apache.maven:maven-compat:jar:3.3.9 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar: Connection timed out (Read failed) -> [Help 1]
```

Upgrade the scala-maven-plugin to resolve this issue.
