### PR TITLE
SinkRecord adds an overridden method

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -25,6 +25,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.functions.api.KVRecord;
@@ -106,4 +107,13 @@ public class SinkRecord<T> implements Record<T> {
         return null;
     }
 
+    @Override
+    public Optional<Long> getEventTime() {
+        return sourceRecord.getEventTime();
+    }
+
+    @Override
+    public Optional<Message<T>> getMessage() {
+        return sourceRecord.getMessage();
+    }
 }


### PR DESCRIPTION
### Motivation


When I was writing the io connector, I needed to use `Message` in the sink, but `SinkRecord` did not implement the `getMessage` method.

### Modifications

Add the implementation of `getMessage` and `getEventTime` to `SinkRecord`.

### Verifying this change
No needed.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
