### PR TITLE
Use tlsEnableHostnameVerification for ClientBuilder in PulsarClientTool

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -123,6 +123,7 @@ public class PulsarClientTool {
         }
         clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
         clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
+        clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(serviceURL);
 
         clientBuilder.useKeyStoreTls(useKeyStoreTls)


### PR DESCRIPTION
Use 'tlsEnableHostnameVerification' for ClientBuilder object in PulsarClientTool.
This correctly uses the config value specified in 'conf/client.conf'