### PR TITLE
[Docs] Cleanup broker documentation 

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -336,7 +336,7 @@ admin.namespaces().getPersistence(namespace)
 
 #### unload namespace bundle
 
-The namespace bundle is a virtual group of topics which belong to the same namespace. If the broker gets overloaded with the number of bundles, this command can help unload heavy bundle from that broker, so it can be served by some other less-loaded brokers. The namespace bundle ID ranges from 0x00000000 to 0xffffffff.
+The namespace bundle is a virtual group of topics which belong to the same namespace. If the broker gets overloaded with the number of bundles, this command can help unload a bundle from that broker, so it can be served by some other less-loaded brokers. The namespace bundle ID ranges from 0x00000000 to 0xffffffff.
 
 ###### CLI
 
@@ -417,7 +417,7 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 
 #### split bundle
 
-Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. If bundle gets heavy with multiple live topics in it then it creates load on that broker and in order to resolve this issue, admin can split bundle using this command.
+Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. If a bundle has multiple live heavily-used topics in it, then it creates load on that broker and in order to resolve this issue an admin can split the bundle using this command permitting the new bundles to be spread across the cluster.
 
 ###### CLI
 

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -127,7 +127,7 @@ admin.namespaces().deleteNamespace(namespace);
 ```
 
 
-#### set replication cluster
+#### Set replication cluster
 
 It sets replication clusters for a namespace, so Pulsar can internally replicate publish message from one colo to another colo.
 
@@ -150,7 +150,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 admin.namespaces().setNamespaceReplicationClusters(namespace, clusters);
 ```
 
-#### get replication cluster
+#### Get replication cluster
 
 It gives a list of replication clusters for a given namespace.
 
@@ -176,7 +176,7 @@ cl2
 admin.namespaces().getNamespaceReplicationClusters(namespace)
 ```
 
-#### set backlog quota policies
+#### Set backlog quota policies
 
 Backlog quota helps the broker to restrict bandwidth/storage of a namespace once it reaches a certain threshold limit. Admin can set the limit and take corresponding action after the limit is reached.
 
@@ -210,7 +210,7 @@ N/A
 admin.namespaces().setBacklogQuota(namespace, new BacklogQuota(limit, policy))
 ```
 
-#### get backlog quota policies
+#### Get backlog quota policies
 
 It shows a configured backlog quota for a given namespace.
 
@@ -241,7 +241,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 admin.namespaces().getBacklogQuotaMap(namespace);
 ```
 
-#### remove backlog quota policies
+#### Remove backlog quota policies
 
 It removes backlog quota policies for a given namespace
 
@@ -267,7 +267,7 @@ N/A
 admin.namespaces().removeBacklogQuota(namespace, backlogQuotaType)
 ```
 
-#### set persistence policies
+#### Set persistence policies
 
 Persistence policies allow to configure persistency-level for all topic messages under a given namespace.
 
@@ -302,7 +302,7 @@ admin.namespaces().setPersistence(namespace,new PersistencePolicies(bookkeeperEn
 ```
 
 
-#### get persistence policies
+#### Get persistence policies
 
 It shows the configured persistence policies of a given namespace.
 
@@ -334,7 +334,7 @@ admin.namespaces().getPersistence(namespace)
 ```
 
 
-#### unload namespace bundle
+#### Unload namespace bundle
 
 The namespace bundle is a virtual group of topics which belong to the same namespace. If the broker gets overloaded with the number of bundles, this command can help unload a bundle from that broker, so it can be served by some other less-loaded brokers. The namespace bundle ID ranges from 0x00000000 to 0xffffffff.
 
@@ -361,7 +361,7 @@ admin.namespaces().unloadNamespaceBundle(namespace, bundle)
 ```
 
 
-#### set message-ttl
+#### Set message-ttl
 
 It configures message’s time to live (in seconds) duration.
 
@@ -387,7 +387,7 @@ N/A
 admin.namespaces().setNamespaceMessageTTL(namespace, messageTTL)
 ```
 
-#### get message-ttl
+#### Get message-ttl
 
 It gives a message ttl of configured namespace.
 
@@ -418,7 +418,7 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 #### Split bundle
 
 Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. 
-If a single bundle is creating an excessive load on a broker an admin can split the bundle using this command permitting one or more of the new bundles to be unloaded thus spreading the load across the brokers.
+If a single bundle is creating an excessive load on a broker, an admin splits the bundle using this command permitting one or more of the new bundles to be unloaded thus spreading the load across the brokers.
 
 ###### CLI
 
@@ -443,7 +443,7 @@ admin.namespaces().splitNamespaceBundle(namespace, bundle)
 ```
 
 
-#### clear backlog
+#### Clear backlog
 
 It clears all message backlog for all the topics that belong to a specific namespace. You can also clear backlog for a specific subscription as well.
 
@@ -470,7 +470,7 @@ admin.namespaces().clearNamespaceBacklogForSubscription(namespace, subscription)
 ```
 
 
-#### clear bundle backlog
+#### Clear bundle backlog
 
 It clears all message backlog for all the topics that belong to a specific NamespaceBundle. You can also clear backlog for a specific subscription as well.
 
@@ -497,7 +497,7 @@ admin.namespaces().clearNamespaceBundleBacklogForSubscription(namespace, bundle,
 ```
 
 
-#### set retention
+#### Set retention
 
 Each namespace contains multiple topics and the retention size (storage size) of each topic should not exceed a specific threshold or it should be stored for a certain period. This command helps configure the retention size and time of topics in a given namespace.
 
@@ -524,7 +524,7 @@ admin.namespaces().setRetention(namespace, new RetentionPolicies(retentionTimeIn
 ```
 
 
-#### get retention
+#### Get retention
 
 It shows retention information of a given namespace.
 
@@ -553,7 +553,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 admin.namespaces().getRetention(namespace)
 ```
 
-#### set dispatch throttling
+#### Set dispatch throttling
 
 It sets message dispatch rate for all the topics under a given namespace. 
 The dispatch rate can be restricted by the number of messages per X seconds (`msg-dispatch-rate`) or by the number of message-bytes per X second (`byte-dispatch-rate`).
@@ -588,7 +588,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 admin.namespaces().setDispatchRate(namespace, new DispatchRate(1000, 1048576, 1))
 ```
 
-#### get configured message-rate
+#### Get configured message-rate
 
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 
@@ -619,7 +619,7 @@ admin.namespaces().getDispatchRate(namespace)
 ```
 
 
-#### set dispatch throttling for subscription
+#### Set dispatch throttling for subscription
 
 It sets message dispatch rate for all the subscription of topics under a given namespace.
 The dispatch rate can be restricted by the number of messages per X seconds (`msg-dispatch-rate`) or by the number of message-bytes per X second (`byte-dispatch-rate`).
@@ -647,7 +647,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 admin.namespaces().setSubscriptionDispatchRate(namespace, new DispatchRate(1000, 1048576, 1))
 ```
 
-#### get configured message-rate
+#### Get configured message-rate
 
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 
@@ -677,7 +677,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 admin.namespaces().getSubscriptionDispatchRate(namespace)
 ```
 
-#### set dispatch throttling for replicator
+#### Set dispatch throttling for replicator
 
 It sets message dispatch rate for all the replicator between replication clusters under a given namespace.
 The dispatch rate can be restricted by the number of messages per X seconds (`msg-dispatch-rate`) or by the number of message-bytes per X second (`byte-dispatch-rate`).
@@ -705,7 +705,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 admin.namespaces().setReplicatorDispatchRate(namespace, new DispatchRate(1000, 1048576, 1))
 ```
 
-#### get configured message-rate
+#### Get configured message-rate
 
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -415,9 +415,10 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 
 
-#### split bundle
+#### Split bundle
 
-Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. If a bundle has multiple live heavily-used topics in it, then it creates load on that broker and in order to resolve this issue an admin can split the bundle using this command permitting the new bundles to be spread across the cluster.
+Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. 
+If a single bundle is creating an excessive load on a broker an admin can split the bundle using this command permitting one or more of the new bundles to be unloaded thus spreading the load across the brokers.
 
 ###### CLI
 

--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -151,4 +151,4 @@ from pulsar import Client
 client = Client('pulsar://pulsar-cluster.acme.com:6650')
 ```
 
-Note that in Pulsar, each topic is handled by only one broker. Therefore, for creating, reading, updating and deleting topics, requests are sent to any broker initially. If the broker finds that it cannot handle the request for this topic, it redirects the client to the correct broker. 
+Note: In Pulsar, each topic is handled by only one broker. Initial requests from a client to read, update or delete a topic are sent to a broker that may not be the topic owner. If the broker cannot handle the request for this topic, it redirects the request to the appropriate broker.

--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -151,5 +151,5 @@ from pulsar import Client
 client = Client('pulsar://pulsar-cluster.acme.com:6650')
 ```
 
-**Note**
-In Pulsar, each topic is handled by only one broker. Initial requests from a client to read, update or delete a topic are sent to a broker that may not be the topic owner. If the broker cannot handle the request for this topic, it redirects the request to the appropriate broker.
+> **Note**
+> In Pulsar, each topic is handled by only one broker. Initial requests from a client to read, update or delete a topic are sent to a broker that may not be the topic owner. If the broker cannot handle the request for this topic, it redirects the request to the appropriate broker.

--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -48,7 +48,7 @@ Clusters can replicate amongst themselves using [geo-replication](concepts-repli
 Pulsar uses [Apache Zookeeper](https://zookeeper.apache.org/) for metadata storage, cluster configuration, and coordination. In a Pulsar instance:
 
 * A configuration store quorum stores configuration for tenants, namespaces, and other entities that need to be globally consistent.
-* Each cluster has its own local ZooKeeper ensemble that stores cluster-specific configuration and coordination such as ownership metadata, broker load reports, BookKeeper ledger metadata, and more.
+* Each cluster has its own local ZooKeeper ensemble that stores cluster-specific configuration and coordination such as which brokers are responsible for which topics as well as ownership metadata, broker load reports, BookKeeper ledger metadata, and more.
 
 ## Persistent storage
 
@@ -150,3 +150,5 @@ from pulsar import Client
 
 client = Client('pulsar://pulsar-cluster.acme.com:6650')
 ```
+
+Note that in Pulsar, each topic is handled by only one broker. Therefore, for creating, reading, updating and deleting topics, requests are sent to any broker initially. If the broker finds that it cannot handle the request for this topic, it redirects the client to the correct broker. 

--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -151,4 +151,5 @@ from pulsar import Client
 client = Client('pulsar://pulsar-cluster.acme.com:6650')
 ```
 
-Note: In Pulsar, each topic is handled by only one broker. Initial requests from a client to read, update or delete a topic are sent to a broker that may not be the topic owner. If the broker cannot handle the request for this topic, it redirects the request to the appropriate broker.
+**Note**
+In Pulsar, each topic is handled by only one broker. Initial requests from a client to read, update or delete a topic are sent to a broker that may not be the topic owner. If the broker cannot handle the request for this topic, it redirects the request to the appropriate broker.

--- a/site2/docs/concepts-authentication.md
+++ b/site2/docs/concepts-authentication.md
@@ -4,5 +4,5 @@ title: Authentication and Authorization
 sidebar_label: Authentication and Authorization
 ---
 
-Pulsar supports a pluggable [authentication](security-overview.md) mechanism which can be configured at broker and it also supports authorization to identify client and its access rights on topics and tenants.
+Pulsar supports a pluggable [authentication](security-overview.md) mechanism which can be configured at the proxy and/or the broker. Pulsar also supports a pluggable [authorization](security-authorization.md) mechanism. These mechanisms work together to identify the client and its access rights on topics, namespaces and tenants.
 


### PR DESCRIPTION
clarify broker/topic ownership, role of AuthN and AuthZ working together, fix readability of bundle docs

### Motivation
The architecture diagrams generally do not show Brokers being aware of each other but they are not entirely stateless and are aware of which brokers own which namespace bundles. So clarify that as well as cleanup some other areas (e.g. AuthN occurs at proxy not just broker)

### Modifications
Updated documentation

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options:  no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
