### PR TITLE
[Issue #6709] Support non-durable subscription for pulsar-client cli

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -42,15 +42,6 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
-
-        /*WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
-        config.setWebServicePort(Optional.of(0));
-        config.setClusterName("test");
-        config.setConfigurationStoreServers("dummy-zk-servers");
-        service = spy(new WebSocketService(config));
-        doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
-        proxyServer = new ProxyServer(config);
-        WebSocketServiceStarter.start(proxyServer, service);*/
     }
 
     @AfterMethod
@@ -58,8 +49,6 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
     protected void cleanup() throws Exception {
         super.resetConfig();
         super.internalCleanup();
-        //service.close();
-        //proxyServer.stop();
     }
 
     @Test(timeOut = 20000)

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -18,98 +18,57 @@
  */
 package org.apache.pulsar.client.cli;
 
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.websocket.WebSocketService;
+import org.apache.pulsar.websocket.service.ProxyServer;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
-public class PulsarClientToolTest extends BrokerTestBase {
+public class PulsarClientToolWsTest extends BrokerTestBase {
+    private ProxyServer proxyServer;
+    private WebSocketService service;
 
-    @BeforeClass
+    @BeforeMethod
     @Override
-    public void setup() throws Exception {
+    protected void setup() throws Exception {
         super.internalSetup();
+
+        /*WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
+        config.setWebServicePort(Optional.of(0));
+        config.setClusterName("test");
+        config.setConfigurationStoreServers("dummy-zk-servers");
+        service = spy(new WebSocketService(config));
+        doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
+        proxyServer = new ProxyServer(config);
+        WebSocketServiceStarter.start(proxyServer, service);*/
     }
 
-    @AfterClass
+    @AfterMethod
     @Override
-    public void cleanup() throws Exception {
+    protected void cleanup() throws Exception {
+        super.resetConfig();
         super.internalCleanup();
-    }
-
-    @Test
-    public void testInitialzation() throws InterruptedException, ExecutionException, PulsarAdminException {
-
-        Properties properties = new Properties();
-        properties.setProperty("serviceUrl", brokerUrl.toString());
-        properties.setProperty("useTls", "false");
-
-        String tenantName = UUID.randomUUID().toString();
-
-        TenantInfo tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant(tenantName, tenantInfo);
-
-        String topicName = String.format("persistent://%s/ns/topic-scale-ns-0/topic", tenantName);
-
-        int numberOfMessages = 10;
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        executor.execute(() -> {
-            PulsarClientTool pulsarClientToolConsumer;
-            try {
-                pulsarClientToolConsumer = new PulsarClientTool(properties);
-                String[] args = { "consume", "-t", "Exclusive", "-s", "sub-name", "-n",
-                        Integer.toString(numberOfMessages), "--hex", "-r", "30", topicName };
-                Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
-                future.complete(null);
-            } catch (Throwable t) {
-                future.completeExceptionally(t);
-            }
-        });
-
-        // Make sure subscription has been created
-        while (true) {
-            try {
-                List<String> subscriptions = admin.topics().getSubscriptions(topicName);
-                if(subscriptions.size() == 1){
-                    break;
-                }
-            } catch (Exception e){
-            }
-            Thread.sleep(200);
-        }
-
-        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
-
-        String[] args = { "produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
-                "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName };
-        Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
-
-        future.get();
-        executor.shutdown();
+        //service.close();
+        //proxyServer.stop();
     }
 
     @Test(timeOut = 20000)
-    public void testNonDurableSubscribe() throws Exception {
-
+    public void testWebSocketNonDurableSubscriptionMode() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("serviceUrl", brokerUrl.toString());
         properties.setProperty("useTls", "false");
 
-        final String topicName = "persistent://prop/ns-abc/test/topic-" + UUID.randomUUID().toString();
+        final String topicName = "persistent://my-property/my-ns/test/topic-" + UUID.randomUUID();
 
         int numberOfMessages = 10;
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -146,7 +105,6 @@ public class PulsarClientToolTest extends BrokerTestBase {
         Assert.assertFalse(future.isCompletedExceptionally());
         future.get();
         executor.shutdown();
-
         while (true) {
             try {
                 List<String> subscriptions = admin.topics().getSubscriptions(topicName);
@@ -160,13 +118,12 @@ public class PulsarClientToolTest extends BrokerTestBase {
     }
 
     @Test(timeOut = 20000)
-    public void testDurableSubscribe() throws Exception {
-
+    public void testWebSocketDurableSubscriptionMode() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("serviceUrl", brokerUrl.toString());
         properties.setProperty("useTls", "false");
 
-        final String topicName = "persistent://prop/ns-abc/test/topic-" + UUID.randomUUID().toString();
+        final String topicName = "persistent://my-property/my-ns/test/topic-" + UUID.randomUUID();
 
         int numberOfMessages = 10;
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -203,6 +160,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         Assert.assertFalse(future.isCompletedExceptionally());
         future.get();
         executor.shutdown();
+
         //wait for close
         Thread.sleep(2000);
         List<String> subscriptions = admin.topics().getSubscriptions(topicName);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
@@ -81,6 +82,9 @@ public class CmdConsume {
 
     @Parameter(names = { "-t", "--subscription-type" }, description = "Subscription type.")
     private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+
+    @Parameter(names = { "-m", "--subscription-mode" }, description = "Subscription mode.")
+    private SubscriptionMode subscriptionMode = SubscriptionMode.Durable;
 
     @Parameter(names = { "-p", "--subscription-position" }, description = "Subscription position.")
     private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
@@ -197,6 +201,7 @@ public class CmdConsume {
             ConsumerBuilder<byte[]> builder = client.newConsumer()
                     .subscriptionName(this.subscriptionName)
                     .subscriptionType(subscriptionType)
+                    .subscriptionMode(subscriptionMode)
                     .subscriptionInitialPosition(subscriptionInitialPosition);
 
             if (isRegex) {
@@ -255,9 +260,9 @@ public class CmdConsume {
 
         String wsTopic = String.format(
                 "%s/%s/" + (StringUtils.isEmpty(topicName.getCluster()) ? "" : topicName.getCluster() + "/")
-                        + "%s/%s/%s?subscriptionType=%s",
+                        + "%s/%s/%s?subscriptionType=%s&subscriptionMode=%s",
                 topicName.getDomain(), topicName.getTenant(), topicName.getNamespacePortion(), topicName.getLocalName(),
-                subscriptionName, subscriptionType.toString());
+                subscriptionName, subscriptionType.toString(), subscriptionMode.toString());
 
         String consumerBaseUri = serviceURL + (serviceURL.endsWith("/") ? "" : "/") + "ws/consumer/" + wsTopic;
         URI consumerUri = URI.create(consumerBaseUri);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
 import org.apache.pulsar.client.api.PulsarClientException.ConsumerBusyException;
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
 import org.apache.pulsar.common.util.DateFormatter;
@@ -70,6 +71,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
 
     private String subscription = null;
     private SubscriptionType subscriptionType;
+    private SubscriptionMode subscriptionMode;
     private Consumer<byte[]> consumer;
 
     private int maxPendingMessages = 0;
@@ -103,6 +105,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
                         : builder.getConf().getReceiverQueueSize();
             }
             this.subscriptionType = builder.getConf().getSubscriptionType();
+            this.subscriptionMode = builder.getConf().getSubscriptionMode();
 
             if (!checkAuth(response)) {
                 return;
@@ -284,6 +287,10 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         return subscriptionType;
     }
 
+    public SubscriptionMode getSubscriptionMode() {
+        return subscriptionMode;
+    }
+
     public long getAndResetNumMsgsDelivered() {
         return numMsgsDelivered.sumThenReset();
     }
@@ -317,6 +324,12 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             checkArgument(Enums.getIfPresent(SubscriptionType.class, queryParams.get("subscriptionType")).isPresent(),
                     "Invalid subscriptionType %s", queryParams.get("subscriptionType"));
             builder.subscriptionType(SubscriptionType.valueOf(queryParams.get("subscriptionType")));
+        }
+
+        if (queryParams.containsKey("subscriptionMode")) {
+            checkArgument(Enums.getIfPresent(SubscriptionMode.class, queryParams.get("subscriptionMode")).isPresent(),
+                    "Invalid subscriptionMode %s", queryParams.get("subscriptionMode"));
+            builder.subscriptionMode(SubscriptionMode.valueOf(queryParams.get("subscriptionMode")));
         }
 
         if (queryParams.containsKey("receiverQueueSize")) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyTopicStat.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyTopicStat.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.websocket.stats;
 
 import java.util.Set;
 
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.websocket.ConsumerHandler;
 import org.apache.pulsar.websocket.ProducerHandler;
@@ -62,6 +63,7 @@ public class ProxyTopicStat {
         public ConsumerStats(ConsumerHandler handler) {
             this.subscriptionName = handler.getSubscription();
             this.subscriptionType = handler.getSubscriptionType();
+            this.subscriptionMode = handler.getSubscriptionMode();
             this.remoteConnection = handler.getRemote().getInetSocketAddress().toString();
             this.numberOfMsgDelivered = handler.getMsgDeliveredCounter();
         }
@@ -76,6 +78,7 @@ public class ProxyTopicStat {
         public String remoteConnection;
         public String subscriptionName;
         public SubscriptionType subscriptionType;
+        public SubscriptionMode subscriptionMode;
         public long numberOfMsgDelivered;
     }
 


### PR DESCRIPTION

Fixes #6709

### Motivation
After running pulsar-client consume the subscription is kept active and it is not possible to unsubscribe without using the admin interface.

### Modifications
Add subscriptionMode option for cli

### Verifying this change
unit tests:
PulsarClientToolTest
PulsarClientToolWsTest