### PR TITLE
[WIP] Remove the add-source goal in spark module

### DIFF
--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -103,7 +103,6 @@
           <execution>
             <goals>
               <goal>compile</goal>
-              <goal>add-source</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
---


*Motivation*

Test for CI.

The CI always failed by downloading the add-source related file. Trying to remove
it in the spark which is unused to improve the CI.
