### PR TITLE
make number of channels per bookie configurable  for bookie client

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -725,6 +725,9 @@ bookkeeperExplicitLacIntervalInMills=0
 # Expose bookkeeper client managed ledger stats to prometheus. default is false
 # bookkeeperClientExposeStatsToPrometheus=false
 
+# Number of channels per bookie for the bookie client connect to. default is 16
+bookkeeperNumChannelsPerBookie=16
+
 ### --- Managed Ledger --- ###
 
 # Number of bookies to use when creating a ledger

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -500,6 +500,9 @@ bookkeeperExplicitLacIntervalInMills=0
 # Expose bookkeeper client managed ledger stats to prometheus. default is false
 # bookkeeperClientExposeStatsToPrometheus=false
 
+# Number of channels per bookie for the bookie client connect to. default is 16
+bookkeeperNumChannelsPerBookie=16
+
 ### --- Managed Ledger --- ###
 
 # Number of bookies to use when creating a ledger

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1106,6 +1106,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int bookkeeperClientThrottleValue = 0;
 
+    @FieldContext(
+        category = CATEGORY_STORAGE_BK,
+        doc = "number of channels per bookie"
+    )
+    private int bookkeeperNumChannelsPerBookie = 16;
+
     /**** --- Managed Ledger --- ****/
     @FieldContext(
         minValue = 1,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -110,7 +110,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setAddEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setReadEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setSpeculativeReadTimeout(conf.getBookkeeperClientSpeculativeReadTimeoutInMillis());
-        bkConf.setNumChannelsPerBookie(16);
+        bkConf.setNumChannelsPerBookie(conf.getBookkeeperNumChannelsPerBookie());
         bkConf.setUseV2WireProtocol(conf.isBookkeeperUseV2WireProtocol());
         bkConf.setEnableDigestTypeAutodetection(true);
         bkConf.setStickyReadsEnabled(conf.isBookkeeperEnableStickyReads());


### PR DESCRIPTION
### Motivation
In bookie client configuration, the number of channel per bookie is hard code to `16`, it should be configurable in `broker.conf`.

### Changes
make the number of channels per bookie configurable in `broker.conf`