### PR TITLE
[Issue 8092]support to specify multi ipv6 hosts in brokerServiceUrl

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
@@ -26,6 +26,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -66,6 +67,39 @@ public class ServiceURI {
      */
     public static ServiceURI create(String uriStr) {
         checkNotNull(uriStr, "service uri string is null");
+
+        if (uriStr.contains("[") && uriStr.contains("]")) {
+            // deal with ipv6 address
+            Splitter splitter = Splitter.on(CharMatcher.anyOf(",;"));
+            List<String> hosts = splitter.splitToList(uriStr);
+
+            if (hosts.size() > 1) {
+                // deal with multi ipv6 hosts
+                String firstHost = hosts.get(0);
+                String lastHost = hosts.get(hosts.size() - 1);
+                boolean hasPath = lastHost.contains("/");
+                String path = hasPath ? lastHost.substring(lastHost.indexOf("/")) : "";
+                firstHost += path;
+
+                URI uri = URI.create(firstHost);
+                ServiceURI serviceURI = create(uri);
+
+                List<String> multiHosts = new ArrayList<>();
+                multiHosts.add(serviceURI.getServiceHosts()[0]);
+                multiHosts.addAll(hosts.subList(1, hosts.size()));
+                multiHosts = multiHosts
+                        .stream()
+                        .map(host -> validateHostName(serviceURI.getServiceName(), serviceURI.getServiceInfos(), host))
+                        .collect(Collectors.toList());
+                return new ServiceURI(
+                        serviceURI.getServiceName(),
+                        serviceURI.getServiceInfos(),
+                        serviceURI.getServiceUser(),
+                        multiHosts.toArray(new String[multiHosts.size()]),
+                        serviceURI.getServicePath(),
+                        serviceURI.getUri());
+            }
+        }
 
         // a service uri first should be a valid java.net.URI
         URI uri = URI.create(uriStr);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/net/ServiceURITest.java
@@ -147,6 +147,30 @@ public class ServiceURITest {
     }
 
     @Test
+    public void testMultiIpv6Uri() {
+        String serviceUri = "pulsar://pulsaruser@[fec0:0:0:ffff::1]:6650,[fec0:0:0:ffff::2]:6650;[fec0:0:0:ffff::3]:6650/path/to/namespace";
+        assertServiceUri(
+                serviceUri,
+                "pulsar",
+                new String[0],
+                "pulsaruser",
+                new String[] { "[fec0:0:0:ffff::1]:6650", "[fec0:0:0:ffff::2]:6650", "[fec0:0:0:ffff::3]:6650" },
+                "/path/to/namespace");
+    }
+
+    @Test
+    public void testMultiIpv6UriWithoutPulsarPort() {
+        String serviceUri = "pulsar://pulsaruser@[fec0:0:0:ffff::1],[fec0:0:0:ffff::2];[fec0:0:0:ffff::3]/path/to/namespace";
+        assertServiceUri(
+                serviceUri,
+                "pulsar",
+                new String[0],
+                "pulsaruser",
+                new String[] { "[fec0:0:0:ffff::1]:6650", "[fec0:0:0:ffff::2]:6650", "[fec0:0:0:ffff::3]:6650" },
+                "/path/to/namespace");
+    }
+
+    @Test
     public void testMultipleHostsSemiColon() {
         String serviceUri = "pulsar://host1:6650;host2:6650;host3:6650/path/to/namespace";
         assertServiceUri(


### PR DESCRIPTION
### Motivation
Fixes #8092

### Modifications

split url string by comma before create URI object when handling multi ipv6 hosts

### Verifying this change

This change added tests and can be verified as follows:

  - add testMultiIpv6Uri() in ServiceURITest.java

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
