### PR TITLE
Add ChannelFutures utility class to pulsar-common.

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/ChannelFutures.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/ChannelFutures.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Static utility methods for operating on {@link ChannelFuture}s.
+ *
+ */
+public class ChannelFutures {
+
+    private ChannelFutures() {
+        throw new AssertionError("Class with static utility methods only cannot be instantiated");
+    }
+
+    /**
+     * Convert a {@link ChannelFuture} into a {@link CompletableFuture}.
+     *
+     * @param channelFuture the {@link ChannelFuture}
+     * @return a {@link CompletableFuture} that completes successfully when the channelFuture completes successfully,
+     *         and completes exceptionally if the channelFuture completes with a {@link Throwable}
+     */
+    public static CompletableFuture<Channel> toCompletableFuture(ChannelFuture channelFuture) {
+        Objects.requireNonNull(channelFuture, "channelFuture cannot be null");
+
+        CompletableFuture<Channel> adapter = new CompletableFuture<>();
+        if (channelFuture.isDone()) {
+            if (channelFuture.isSuccess()) {
+                adapter.complete(channelFuture.channel());
+            } else {
+                adapter.completeExceptionally(channelFuture.cause());
+            }
+        } else {
+            channelFuture.addListener((ChannelFuture cf) -> {
+                if (cf.isSuccess()) {
+                    adapter.complete(cf.channel());
+                } else {
+                    adapter.completeExceptionally(cf.cause());
+                }
+            });
+        }
+        return adapter;
+    }
+}
+

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.netty.channel.Channel;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.DefaultEventLoop;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link ChannelFutures}.
+ */
+public class ChannelFuturesTest {
+
+    @Mock
+    private Channel channel;
+
+    private DefaultEventLoop eventLoop;
+
+    private DefaultChannelPromise channelFuture;
+
+    @BeforeTest
+    public void initEventLoop() {
+        eventLoop = new DefaultEventLoop();
+    }
+
+    @AfterTest
+    public void shutdownEventLoop() throws InterruptedException {
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await(100);
+    }
+
+    @BeforeMethod
+    public void setup() {
+        initMocks(this);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        channelFuture = new DefaultChannelPromise(channel);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void toCompletableFuture_shouldRequireNonNullArgument() {
+        ChannelFutures.toCompletableFuture(null);
+    }
+
+    @Test
+    public void toCompletableFuture_shouldCompleteSuccessfully_channelFutureCompletedBefore() throws Exception {
+        channelFuture.setSuccess();
+        Assert.assertEquals(ChannelFutures.toCompletableFuture(channelFuture).get(1,  TimeUnit.SECONDS), channel);
+    }
+
+    @Test
+    public void toCompletableFuture_shouldCompleteSuccessfully_channelFutureCompletedAfter() throws Exception {
+        CompletableFuture<Channel> future = ChannelFutures.toCompletableFuture(channelFuture);
+        Assert.assertFalse(future.isDone());
+
+        channelFuture.setSuccess();
+        Assert.assertEquals(future.get(1,  TimeUnit.SECONDS), channel);
+    }
+
+    @Test
+    public void toCompletableFuture_shouldCompleteExceptionally_channelFutureCompletedBefore() throws Exception {
+        Exception failure = new Exception();
+        channelFuture.setFailure(failure);
+        try {
+            ChannelFutures.toCompletableFuture(channelFuture).get(1, TimeUnit.SECONDS);
+            Assert.fail("Should complete exceptionally");
+        } catch (ExecutionException e) {
+            Assert.assertSame(e.getCause(), failure);
+        }
+    }
+
+    @Test
+    public void toCompletableFuture_shouldCompleteExceptionally_channelFutureCompletedAfter() throws Exception {
+        CompletableFuture<Channel> future = ChannelFutures.toCompletableFuture(channelFuture);
+        Assert.assertFalse(future.isDone());
+
+        Exception failure = new Exception();
+        channelFuture.setFailure(failure);
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            Assert.fail("Should complete exceptionally");
+        } catch (ExecutionException e) {
+            Assert.assertSame(e.getCause(), failure);
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

Pulsar code uses `CompletableFuture` to implement asynchronous execution paths. When interacting with Netty, a common pattern is to create a `CompletableFuture` and some glue code to listen for Netty `ChannelFuture` completions and then complete the `CompletableFuture`. Pulsar code would be more ease to write, read, and maintain if we add a static utility method for adapting a `io.netty.channel.ChannelFuture` to a `java.util.concurrent.CompletableFuture`.

Example:

```java
public CompletableFuture<Client> connect() {
  CompletableFuture<Client> clientFuture = new CompletableFuture<>();
  bootstrap.connect().addListener((ChannelFuture cf) -> {
    if (cf.isSuccess()) {
      client.complete(new Client(cf.channel()));
    } else {
      client.completeExceptionally(cf.cause());
    }
  });
  return clientFuture;
}
```
can be written as:

```java
public CompletableFuture<Client> connect() {
  return ChannelFutures.toCompletableFuture(bootstrap.connect()).thenApply(channel -> new Client(channel));
}
```

### Modifications

- Added `org.apache.pulsar.common.util.netty.ChannelFutures`

### Verifying this change

- Added test class `ChannelFuturesTest`

### Documentation

  - JavaDocs