### PR TITLE
fix json deserialize byte to string bug

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -19,10 +19,14 @@
 package org.apache.pulsar.schema;
 
 import com.google.common.collect.Sets;
+import javassist.bytecode.ByteArray;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -38,6 +42,7 @@ import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.apache.pulsar.schema.compatibility.SchemaCompatibilityCheckTest.randomName;
 import static org.junit.Assert.assertEquals;
 
+@Slf4j
 public class SchemaTest extends MockedPulsarServiceBaseTest {
 
     private final static String CLUSTER_NAME = "test";
@@ -132,5 +137,60 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
 
         producer.close();
         consumer.close();
+    }
+
+    @Test
+    public void testBytesSchemaDeserialize() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicName = "test-bytes-schema";
+
+        final String topic = TopicName.get(
+                TopicDomain.persistent.value(),
+                tenant,
+                namespace,
+                topicName).toString();
+
+        admin.namespaces().createNamespace(
+                tenant + "/" + namespace,
+                Sets.newHashSet(CLUSTER_NAME));
+
+        admin.topics().createPartitionedTopic(topic, 2);
+        admin.schemas().createSchema(topic, Schema.JSON(Schemas.BytesRecord.class).getSchemaInfo());
+
+        Producer<Schemas.BytesRecord> producer = pulsarClient
+                .newProducer(Schema.JSON(Schemas.BytesRecord.class))
+                .topic(topic)
+                .create();
+
+        Schemas.BytesRecord bytesRecord = new Schemas.BytesRecord();
+        bytesRecord.setId(1);
+        bytesRecord.setName("Tom");
+        bytesRecord.setAddress("test".getBytes());
+
+        byte[] bytesRecordSeri = Schema.JSON(Schemas.BytesRecord.class).encode(bytesRecord);
+        log.info("bytesRecordSeri: []", bytesRecordSeri);
+
+        Consumer<GenericRecord> consumer = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
+                .subscriptionName("test-sub")
+                .topic(topic)
+                .subscribe();
+
+        Consumer<Schemas.BytesRecord> consumer1 = pulsarClient.newConsumer(Schema.JSON(Schemas.BytesRecord.class))
+                .subscriptionName("test-sub1")
+                .topic(topic)
+                .subscribe();
+
+        producer.send(bytesRecord);
+
+        Message<GenericRecord> message = consumer.receive();
+        Message<Schemas.BytesRecord> message1 = consumer1.receive();
+
+        assertEquals(message.getValue().getField("address").getClass(),
+                message1.getValue().getAddress().getClass());
+
+        producer.close();
+        consumer.close();
+        consumer1.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.schema;
 
 import com.google.common.collect.Sets;
-import javassist.bytecode.ByteArray;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Consumer;
@@ -167,9 +166,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         bytesRecord.setId(1);
         bytesRecord.setName("Tom");
         bytesRecord.setAddress("test".getBytes());
-
-        byte[] bytesRecordSeri = Schema.JSON(Schemas.BytesRecord.class).encode(bytesRecord);
-        log.info("bytesRecordSeri: []", bytesRecordSeri);
 
         Consumer<GenericRecord> consumer = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
                 .subscriptionName("test-sub")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/Schemas.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/Schemas.java
@@ -28,14 +28,14 @@ public class Schemas {
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PersonOne{
+    public static class PersonOne {
         int id;
     }
 
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PersonTwo{
+    public static class PersonTwo {
         int id;
 
         @AvroDefault("\"Tom\"")
@@ -45,7 +45,7 @@ public class Schemas {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PersonThree{
+    public static class PersonThree {
         int id;
 
         String name;
@@ -54,11 +54,20 @@ public class Schemas {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PersonFour{
+    public static class PersonFour {
         int id;
 
         String name;
 
         int age;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class BytesRecord {
+        int id;
+        String name;
+        byte[] address;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
@@ -49,12 +49,21 @@ public class GenericJsonReader implements SchemaReader<GenericRecord> {
         this.schemaInfo = schemaInfo;
     }
 
+    public GenericJsonReader(List<Field> fields){
+        this(fields, null);
+    }
+
+    public GenericJsonReader(byte[] schemaVersion, List<Field> fields){
+        this(schemaVersion, fields, null);
+    }
+
     public GenericJsonReader(byte[] schemaVersion, List<Field> fields, SchemaInfo schemaInfo){
         this.objectMapper = new ObjectMapper();
         this.fields = fields;
         this.schemaVersion = schemaVersion;
         this.schemaInfo = schemaInfo;
     }
+
     @Override
     public GenericJsonRecord read(byte[] bytes, int offset, int length) {
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 
+import org.apache.pulsar.common.schema.SchemaInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,22 +40,26 @@ public class GenericJsonReader implements SchemaReader<GenericRecord> {
     private final ObjectMapper objectMapper;
     private final byte[] schemaVersion;
     private final List<Field> fields;
-    public GenericJsonReader(List<Field> fields){
+    private SchemaInfo schemaInfo;
+
+    public GenericJsonReader(List<Field> fields, SchemaInfo schemaInfo){
         this.fields = fields;
         this.schemaVersion = null;
         this.objectMapper = new ObjectMapper();
+        this.schemaInfo = schemaInfo;
     }
 
-    public GenericJsonReader(byte[] schemaVersion, List<Field> fields){
+    public GenericJsonReader(byte[] schemaVersion, List<Field> fields, SchemaInfo schemaInfo){
         this.objectMapper = new ObjectMapper();
         this.fields = fields;
         this.schemaVersion = schemaVersion;
+        this.schemaInfo = schemaInfo;
     }
     @Override
     public GenericJsonRecord read(byte[] bytes, int offset, int length) {
         try {
             JsonNode jn = objectMapper.readTree(new String(bytes, offset, length, UTF_8));
-            return new GenericJsonRecord(schemaVersion, fields, jn);
+            return new GenericJsonRecord(schemaVersion, fields, jn, schemaInfo);
         } catch (IOException ioe) {
             throw new SchemaSerializationException(ioe);
         }
@@ -64,7 +69,7 @@ public class GenericJsonReader implements SchemaReader<GenericRecord> {
     public GenericRecord read(InputStream inputStream) {
         try {
             JsonNode jn = objectMapper.readTree(inputStream);
-            return new GenericJsonRecord(schemaVersion, fields, jn);
+            return new GenericJsonRecord(schemaVersion, fields, jn, schemaInfo);
         } catch (IOException ioe) {
             throw new SchemaSerializationException(ioe);
         } finally {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -65,6 +66,12 @@ public class GenericJsonRecord extends VersionedGenericRecord {
             }
         } else if (fn.isNumber()) {
             return fn.numberValue();
+        } else if (fn.isBinary()) {
+            try {
+                return fn.binaryValue();
+            } catch (IOException e) {
+                return fn.asText();
+            }
         } else {
             return fn.asText();
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -40,6 +40,12 @@ public class GenericJsonRecord extends VersionedGenericRecord {
 
     GenericJsonRecord(byte[] schemaVersion,
                       List<Field> fields,
+                      JsonNode jn) {
+        this(schemaVersion, fields, jn, null);
+    }
+
+    GenericJsonRecord(byte[] schemaVersion,
+                      List<Field> fields,
                       JsonNode jn, SchemaInfo schemaInfo) {
         super(schemaVersion, fields);
         this.jn = jn;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -18,20 +18,15 @@
  */
 package org.apache.pulsar.client.impl.schema.generic;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
-import org.apache.pulsar.client.impl.schema.SchemaUtils;
-import org.apache.pulsar.client.impl.schema.StructSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 
 /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
@@ -44,7 +44,7 @@ class GenericJsonSchema extends GenericSchemaImpl {
                       boolean useProvidedSchemaAsReaderSchema) {
         super(schemaInfo, useProvidedSchemaAsReaderSchema);
         setWriter(new GenericJsonWriter());
-        setReader(new GenericJsonReader(fields));
+        setReader(new GenericJsonReader(fields, schemaInfo));
     }
 
     @Override
@@ -64,7 +64,7 @@ class GenericJsonSchema extends GenericSchemaImpl {
                     readerSchema.getFields()
                             .stream()
                             .map(f -> new Field(f.name(), f.pos()))
-                            .collect(Collectors.toList()));
+                            .collect(Collectors.toList()), schemaInfo);
         } else {
             log.warn("No schema found for version({}), use latest schema : {}",
                 SchemaUtils.getStringSchemaVersion(schemaVersion.get()),


### PR DESCRIPTION
Fix #7657 

### Motivation
In `GenericJsonRecord.java`, it deserialize byte to String.
```
public Object getField(String fieldName) {
        JsonNode fn = jn.get(fieldName);
        if (fn.isContainerNode()) {
            AtomicInteger idx = new AtomicInteger(0);
            List<Field> fields = Lists.newArrayList(fn.fieldNames())
                .stream()
                .map(f -> new Field(f, idx.getAndIncrement()))
                .collect(Collectors.toList());
            return new GenericJsonRecord(schemaVersion, fields, fn);
        } else if (fn.isBoolean()) {
            return fn.asBoolean();
        } else if (fn.isFloatingPointNumber()) {
            return fn.asDouble();
        } else if (fn.isBigInteger()) {
            if (fn.canConvertToLong()) {
                return fn.asLong();
            } else {
                return fn.asText();
            }
        } else if (fn.isNumber()) {
            return fn.numberValue();
        } else {
            return fn.asText();
        }
    }
```
### Changes
Add check the jsonNode binary type and convert to binaryValue instead of `asText`.