### PR TITLE
[pulsar-broker] Support Disable Replicated Subscriptions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -328,6 +328,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         readFailureBackoff.reduceToHalf();
 
         boolean atLeastOneMessageSentForReplication = false;
+        boolean isEnableReplicatedSubscriptions = brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions();
 
         try {
             // This flag is set to true when we skip atleast one local message,
@@ -348,7 +349,9 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
                     continue;
                 }
 
-                checkReplicatedSubscriptionMarker(entry.getPosition(), msg, headersAndPayload);
+                if (isEnableReplicatedSubscriptions) {
+                    checkReplicatedSubscriptionMarker(entry.getPosition(), msg, headersAndPayload);
+                }
 
                 if (msg.isReplicated()) {
                     // Discard messages that were already replicated into this region

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionConfigTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionConfigTest.java
@@ -25,6 +25,7 @@ import lombok.Cleanup;
 
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.testng.annotations.AfterClass;
@@ -47,6 +48,7 @@ public class ReplicatedSubscriptionConfigTest extends ProducerConsumerBase {
 
     @Test
     public void createReplicatedSubscription() throws Exception {
+        this.conf.setEnableReplicatedSubscriptions(true);
         String topic = "createReplicatedSubscription-" + System.nanoTime();
 
         @Cleanup
@@ -68,6 +70,7 @@ public class ReplicatedSubscriptionConfigTest extends ProducerConsumerBase {
 
     @Test
     public void upgradeToReplicatedSubscription() throws Exception {
+        this.conf.setEnableReplicatedSubscriptions(true);
         String topic = "upgradeToReplicatedSubscription-" + System.nanoTime();
 
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
@@ -93,6 +96,7 @@ public class ReplicatedSubscriptionConfigTest extends ProducerConsumerBase {
 
     @Test
     public void upgradeToReplicatedSubscriptionAfterRestart() throws Exception {
+        this.conf.setEnableReplicatedSubscriptions(true);
         String topic = "upgradeToReplicatedSubscriptionAfterRestart-" + System.nanoTime();
 
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
@@ -116,5 +120,16 @@ public class ReplicatedSubscriptionConfigTest extends ProducerConsumerBase {
         stats = admin.topics().getStats(topic);
         assertTrue(stats.subscriptions.get("sub").isReplicated);
         consumer.close();
+    }
+
+    @Test(expectedExceptions = PulsarClientException.NotAllowedException.class)
+    public void testDisableReplicatedSubscriptions() throws PulsarClientException {
+        this.conf.setEnableReplicatedSubscriptions(false);
+        String topic = "disableReplicatedSubscriptions-" + System.nanoTime();
+        pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("sub")
+                .replicateSubscriptionState(true)
+                .subscribe();
     }
 }


### PR DESCRIPTION
Support disabling "Replicated Subscriptions".

### Motivation
https://github.com/apache/pulsar/issues/8030
"Replicated Subscriptions" is always enabled because enableReplicatedSubscriptions is not used.

### Modifications

- When `enableReplicatedSubscriptions` is false,
  - Brokers don't create `ReplicatedSubscriptionsController`.
  - Brokers don't check marker messages.
  - Brokers send `NotAllowedException` to consumers that use `replicateSubscriptionState(true)`
