### PR TITLE
[broker] Fix error code returned to client when service unit is not ready

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1391,7 +1391,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         });
     }
 
-    public boolean isTopicNsOwnedByBroker(TopicName topicName) throws RuntimeException {
+    public boolean isTopicNsOwnedByBroker(TopicName topicName) {
         try {
             return pulsar.getNamespaceService().isServiceUnitOwned(topicName);
         } catch (Exception e) {
@@ -1419,14 +1419,16 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return checkFuture;
     }
 
-    public void checkTopicNsOwnership(final String topic) throws RuntimeException {
+    public void checkTopicNsOwnership(final String topic) throws BrokerServiceException {
         try {
             checkTopicNsOwnershipAsync(topic).join();
         } catch (CompletionException ex) {
-            if (ex.getCause() instanceof RuntimeException) {
-                throw (RuntimeException) ex.getCause();
+            if (ex.getCause() instanceof BrokerServiceException) {
+                throw (BrokerServiceException) ex.getCause();
             }
-            throw new RuntimeException(ex.getCause());
+            throw new BrokerServiceException(ex.getCause());
+        } catch (Exception ex) {
+            throw new BrokerServiceException(ex);
         }
     }
 
@@ -2008,9 +2010,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 createPendingLoadTopic();
                 return null;
             });
-        } catch (RuntimeException re) {
-            log.error("Failed to create pending topic {} {}", topic, re);
-            pendingTopic.getRight().completeExceptionally(re.getCause());
+        } catch (Exception e) {
+            log.error("Failed to create pending topic {}", topic, e);
+            pendingTopic.getRight()
+                    .completeExceptionally((e instanceof RuntimeException && e.getCause() != null) ? e.getCause() : e);
             // schedule to process next pending topic
             inactivityMonitor.schedule(() -> createPendingLoadTopic(), 100, TimeUnit.MILLISECONDS);
         }


### PR DESCRIPTION
### Motivation

The other day, when a namespace bundle was unloaded, the broker got the following exception:
```
18:30:35.309 [ForkJoinPool.commonPool-worker-60] WARN  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:45182][persistent://xxx/xxx/xxx][xxx] Failed to create consumer: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://xxx/xxx/xxx) not served by this instance. Please redo the lookup. Request is denied: namespace=xxx/xxx
java.util.concurrent.CompletionException: java.lang.RuntimeException: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://xxx/xxx/xxx) not served by this instance. Please redo the lookup. Request is denied: namespace=xxx/xxx
        at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:326)
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:998)
        at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2137)
        at org.apache.pulsar.broker.service.ServerCnx.lambda$null$13(ServerCnx.java:682)
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:616)
        at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591)
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488)
        at java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:575)
        at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:943)
        at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:457)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:163)
Caused by: java.lang.RuntimeException: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://xxx/xxx/xxx) not served by this instance. Please redo the lookup. Request is denied: namespace=xxx/xxx
        at org.apache.pulsar.broker.service.BrokerService.checkTopicNsOwnership(BrokerService.java:1016)
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.subscribe(PersistentTopic.java:509)
        at org.apache.pulsar.broker.service.ServerCnx.lambda$null$10(ServerCnx.java:699)
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:995)
        ... 12 common frames omitted
Caused by: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://xxx/xxx/xxx) not served by this instance. Please redo the lookup. Request is denied: namespace=xxx/xxx
        ... 16 common frames omitted
```

If a `ServiceUnitNotReadyException` occurs on the broker side, the client should receive a `ServiceNotReady` error. However, the client received an `UnknownError` at this time.

The broker was unable to return the correct error code to the client because the `ServiceUnitNotReadyException` was wrapped by a `RuntimeException`. Broker returns an `UnknownError` if an unknown exception is thrown:
https://github.com/apache/pulsar/blob/f8b2a2334fb7d2dc5266242a6393c9cc434fba60/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java#L184-L224

### Modifications

Fixed the `BrokerService#checkTopicNsOwnership(String)` method to throw a `BrokerServiceException` instead of a `RuntimeException`.