### PR TITLE
Allow disabling forwarding source message properties

### DIFF
--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -215,7 +215,7 @@ public class LocalRunner {
             String userCodeFile;
             int parallelism;
             if (functionConfig != null) {
-                FunctionConfigUtils.inferMissingArguments(functionConfig);
+                FunctionConfigUtils.inferMissingArguments(functionConfig, true);
                 ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
                 parallelism = functionConfig.getParallelism();
                 if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -469,6 +469,11 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     )
     private int maxPendingAsyncRequests = 1000;
 
+    @FieldContext(
+        doc = "Whether to forward the source message properties to the output message"
+    )
+    private boolean forwardSourceMessageProperty = true;
+
     public String getFunctionMetadataTopic() {
         return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionMetadataTopicName);
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -189,7 +189,7 @@ public class FunctionConfigUtils {
         if (!StringUtils.isBlank(functionConfig.getOutputSchemaType())) {
             sinkSpecBuilder.setSchemaType(functionConfig.getOutputSchemaType());
         }
-        if (functionConfig.getForwardSourceMessageProperty() != null) {
+        if (functionConfig.getForwardSourceMessageProperty() == Boolean.TRUE) {
             sinkSpecBuilder.setForwardSourceMessageProperty(functionConfig.getForwardSourceMessageProperty());
         }
         if (functionConfig.getCustomSchemaOutputs() != null && functionConfig.getOutput() != null) {
@@ -379,7 +379,9 @@ public class FunctionConfigUtils {
         if (!isEmpty(functionDetails.getLogTopic())) {
             functionConfig.setLogTopic(functionDetails.getLogTopic());
         }
-        functionConfig.setForwardSourceMessageProperty(functionDetails.getSink().getForwardSourceMessageProperty());
+        if (functionDetails.getSink().getForwardSourceMessageProperty()) {
+            functionConfig.setForwardSourceMessageProperty(functionDetails.getSink().getForwardSourceMessageProperty());
+        }
         functionConfig.setRuntime(FunctionCommon.convertRuntime(functionDetails.getRuntime()));
         if (functionDetails.hasRetryDetails()) {
             functionConfig.setMaxMessageRetries(functionDetails.getRetryDetails().getMaxMessageRetries());
@@ -434,7 +436,7 @@ public class FunctionConfigUtils {
     }
 
     public static void inferMissingArguments(FunctionConfig functionConfig,
-                                             boolean forwardSourceMessagePropertyDefault) {
+                                             boolean forwardSourceMessagePropertyEnabled) {
         if (StringUtils.isEmpty(functionConfig.getName())) {
             org.apache.pulsar.common.functions.Utils.inferMissingFunctionName(functionConfig);
         }
@@ -453,10 +455,13 @@ public class FunctionConfigUtils {
         	functionConfig.setMaxPendingAsyncRequests(MAX_PENDING_ASYNC_REQUESTS_DEFAULT);
         }
 
-        if (functionConfig.getForwardSourceMessageProperty() == null
+        if (forwardSourceMessagePropertyEnabled) {
+            if (functionConfig.getForwardSourceMessageProperty() == null) {
+                functionConfig.setForwardSourceMessageProperty(FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT);
+            }
+        } else {
             // if worker disables forward source message property, we don't need to set the default value.
-            && forwardSourceMessagePropertyDefault) {
-        	functionConfig.setForwardSourceMessageProperty(FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT);
+            functionConfig.setForwardSourceMessageProperty(null);
         }
 
         if (functionConfig.getJar() != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -433,7 +433,8 @@ public class FunctionConfigUtils {
         return functionConfig;
     }
 
-    public static void inferMissingArguments(FunctionConfig functionConfig) {
+    public static void inferMissingArguments(FunctionConfig functionConfig,
+                                             boolean forwardSourceMessagePropertyDefault) {
         if (StringUtils.isEmpty(functionConfig.getName())) {
             org.apache.pulsar.common.functions.Utils.inferMissingFunctionName(functionConfig);
         }
@@ -452,7 +453,9 @@ public class FunctionConfigUtils {
         	functionConfig.setMaxPendingAsyncRequests(MAX_PENDING_ASYNC_REQUESTS_DEFAULT);
         }
 
-        if (functionConfig.getForwardSourceMessageProperty() == null) {
+        if (functionConfig.getForwardSourceMessageProperty() == null
+            // if worker disables forward source message property, we don't need to set the default value.
+            && forwardSourceMessagePropertyDefault) {
         	functionConfig.setForwardSourceMessageProperty(FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT);
         }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -718,7 +718,8 @@ public class FunctionsImpl extends ComponentImpl {
         functionConfig.setTenant(tenant);
         functionConfig.setNamespace(namespace);
         functionConfig.setName(componentName);
-        FunctionConfigUtils.inferMissingArguments(functionConfig);
+        FunctionConfigUtils.inferMissingArguments(
+            functionConfig, worker().getWorkerConfig().isForwardSourceMessageProperty());
 
         if (!StringUtils.isEmpty(functionConfig.getJar())) {
             String builtinArchive = functionConfig.getJar();


### PR DESCRIPTION
Motivation

Some old function images don't support this feature. They are not able to recognize this option.