### PR TITLE
[client] Fix issue where paused consumer receives new message when reconnecting

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -332,6 +333,58 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
         pulsarClient.close();
         log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test(timeOut = 30000)
+    public void testPauseAndResumeWithUnloading() throws Exception {
+        final String topicName = "persistent://my-property/my-ns/pause-and-resume-with-unloading"
+                + System.currentTimeMillis();
+        final String subName = "sub";
+        final int receiverQueueSize = 20;
+        final int numPartitions = 2;
+        final int numMessages = receiverQueueSize * numPartitions;
+
+        PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+        admin.topics().createPartitionedTopic(topicName, numPartitions);
+
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(numMessages));
+        AtomicInteger received = new AtomicInteger();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(receiverQueueSize).messageListener((c1, msg) -> {
+                    assertNotNull(msg, "Message cannot be null");
+                    c1.acknowledgeAsync(msg);
+                    received.incrementAndGet();
+                    latch.get().countDown();
+                }).subscribe();
+        consumer.pause();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(false).create();
+
+        for (int i = 0; i < numMessages * 2; i++) {
+            producer.send(("my-message-" + i).getBytes());
+        }
+
+        // Paused consumer receives only `numMessages` messages
+        assertTrue(latch.get().await(numMessages, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+
+        // Make sure no flow permits are sent when the consumer reconnects to the topic
+        for (int i = 0; i < numPartitions; i++) {
+            String partition = TopicName.get(topicName).getPartition(i).toString();
+            admin.topics().unload(partition);
+        }
+
+        Thread.sleep(2000);
+        assertEquals(received.intValue(), numMessages, "Consumer received messages while paused");
+
+        latch.set(new CountDownLatch(numMessages));
+        consumer.resume();
+        assertTrue(latch.get().await(numMessages, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+
+        consumer.unsubscribe();
+        producer.close();
+        pulsarClient.close();
+        admin.topics().deletePartitionedTopic(topicName, true);
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -28,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.Lists;
 
@@ -413,6 +417,81 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         Assert.assertEquals(receivedMessages.size(), messages);
 
         consumer.close();
+        producer.close();
+    }
+
+    @Test(timeOut = 30000)
+    public void testPauseAndResume() throws Exception {
+        final String topicName = "persistent://prop/ns-abc/zero-queue-pause-and-resume";
+        final String subName = "sub";
+
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
+        AtomicInteger received = new AtomicInteger();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(0).messageListener((c1, msg) -> {
+                    assertNotNull(msg, "Message cannot be null");
+                    c1.acknowledgeAsync(msg);
+                    received.incrementAndGet();
+                    latch.get().countDown();
+                }).subscribe();
+        consumer.pause();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(false).create();
+
+        for (int i = 0; i < 2; i++) {
+            producer.send(("my-message-" + i).getBytes());
+        }
+
+        // Paused consumer receives only one message
+        assertTrue(latch.get().await(2, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+        Thread.sleep(2000);
+        assertEquals(received.intValue(), 1, "Consumer received messages while paused");
+
+        latch.set(new CountDownLatch(1));
+        consumer.resume();
+        assertTrue(latch.get().await(2, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+
+        consumer.unsubscribe();
+        producer.close();
+    }
+
+    @Test(timeOut = 30000)
+    public void testPauseAndResumeWithUnloading() throws Exception {
+        final String topicName = "persistent://prop/ns-abc/zero-queue-pause-and-resume-with-unloading";
+        final String subName = "sub";
+
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
+        AtomicInteger received = new AtomicInteger();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(0).messageListener((c1, msg) -> {
+                    assertNotNull(msg, "Message cannot be null");
+                    c1.acknowledgeAsync(msg);
+                    received.incrementAndGet();
+                    latch.get().countDown();
+                }).subscribe();
+        consumer.pause();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(false).create();
+
+        for (int i = 0; i < 2; i++) {
+            producer.send(("my-message-" + i).getBytes());
+        }
+
+        // Paused consumer receives only one message
+        assertTrue(latch.get().await(2, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+
+        // Make sure no flow permits are sent when the consumer reconnects to the topic
+        admin.topics().unload(topicName);
+        Thread.sleep(2000);
+        assertEquals(received.intValue(), 1, "Consumer received messages while paused");
+
+        latch.set(new CountDownLatch(1));
+        consumer.resume();
+        assertTrue(latch.get().await(2, TimeUnit.SECONDS), "Timed out waiting for message listener acks");
+
+        consumer.unsubscribe();
         producer.close();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -852,7 +852,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             // For readers too (isDurable==false), the partition idx will be set though we have to
             // send available permits immediately after establishing the reader session
             if (!(firstTimeConnect && hasParentConsumer && isDurable) && conf.getReceiverQueueSize() != 0) {
-                sendFlowPermitsToBroker(cnx, conf.getReceiverQueueSize());
+                increaseAvailablePermits(cnx, conf.getReceiverQueueSize());
             }
         }).exceptionally((e) -> {
             cnx.removeConsumer(consumerId);
@@ -945,7 +945,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     /**
      * send the flow command to have the broker start pushing messages
      */
-    void sendFlowPermitsToBroker(ClientCnx cnx, int numMessages) {
+    private void sendFlowPermitsToBroker(ClientCnx cnx, int numMessages) {
         if (cnx != null) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Adding {} additional permits", topic, subscription, numMessages);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -203,7 +203,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
         if (getState() == State.Ready) {
             newConsumers.forEach(consumer -> {
-                consumer.sendFlowPermitsToBroker(consumer.getConnectionHandler().cnx(), conf.getReceiverQueueSize());
+                consumer.increaseAvailablePermits(consumer.getConnectionHandler().cnx(), conf.getReceiverQueueSize());
                 receiveMessageFromConsumer(consumer);
             });
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -76,7 +76,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
         CompletableFuture<Message<T>> future = super.internalReceiveAsync();
         if (!future.isDone()) {
             // We expect the message to be not in the queue yet
-            sendFlowPermitsToBroker(cnx(), 1);
+            increaseAvailablePermits(cnx());
         }
 
         return future;
@@ -95,7 +95,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
             waitingOnReceiveForZeroQueueSize = true;
             synchronized (this) {
                 if (isConnected()) {
-                    sendFlowPermitsToBroker(cnx(), 1);
+                    increaseAvailablePermits(cnx());
                 }
             }
             do {
@@ -135,7 +135,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
         if (waitingOnReceiveForZeroQueueSize
                 || currentQueueSize > 0
                 || (listener != null && !waitingOnListenerForZeroQueueSize)) {
-            sendFlowPermitsToBroker(cnx, 1);
+            increaseAvailablePermits(cnx);
         }
     }
 


### PR DESCRIPTION
### Motivation

Consumers whose `pause()` method is called are expected not to fetch any more new messages from the broker until `resume()` is called. However, when the topic is unloaded or the broker is restarted, the consumer receives new messages.

While the consumer is paused, no flow permits are sent to the broker when the `increaseAvailablePermits()` method is called.
https://github.com/apache/pulsar/blob/dea574b3c6af7ea8eaa4904d8d6ed1044df00642/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L1527-L1538

However, if the `sendFlowPermitsToBroker()` method is called directly, flow permits will be sent even while the consumer is paused. When a reconnection occurs, `sendFlowPermitsToBroker()` is called instead of `increaseAvailablePermits()`.
https://github.com/apache/pulsar/blob/dea574b3c6af7ea8eaa4904d8d6ed1044df00642/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L850-L856

### Modifications

Fixed consumer classes to always use `increaseAvailablePermits()` instead of `sendFlowPermitsToBroker()`.