### PR TITLE
[pulsar-admin] Support delete schema ledgers when delete topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -374,11 +374,11 @@ public class PersistentTopicsBase extends AdminResource {
         grantPermissions(topicName.toString(), role, actions);
     }
 
-    protected void internalDeleteTopicForcefully(boolean authoritative) {
+    protected void internalDeleteTopicForcefully(boolean authoritative, boolean deleteSchema) {
         validateWriteOperationOnTopic(authoritative);
 
         try {
-            pulsar().getBrokerService().deleteTopic(topicName.toString(), true).get();
+            pulsar().getBrokerService().deleteTopic(topicName.toString(), true, deleteSchema).get();
         } catch (Exception e) {
             if (e.getCause() instanceof MetadataNotFoundException) {
                 log.info("[{}] Topic was already not existing {}", clientAppId(), topicName, e);
@@ -937,19 +937,19 @@ public class PersistentTopicsBase extends AdminResource {
         });
     }
 
-    protected void internalDeleteTopic(boolean authoritative, boolean force) {
+    protected void internalDeleteTopic(boolean authoritative, boolean force, boolean deleteSchema) {
         if (force) {
-            internalDeleteTopicForcefully(authoritative);
+            internalDeleteTopicForcefully(authoritative, deleteSchema);
         } else {
-            internalDeleteTopic(authoritative);
+            internalDeleteTopic(authoritative, deleteSchema);
         }
     }
 
-    protected void internalDeleteTopic(boolean authoritative) {
+    protected void internalDeleteTopic(boolean authoritative, boolean deleteSchema) {
         validateWriteOperationOnTopic(authoritative);
 
         try {
-            pulsar().getBrokerService().deleteTopic(topicName.toString(), false).get();
+            pulsar().getBrokerService().deleteTopic(topicName.toString(), false, deleteSchema).get();
             log.info("[{}] Successfully removed topic {}", clientAppId(), topicName);
         } catch (Exception e) {
             Throwable t = e.getCause();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -630,7 +630,8 @@ public class PersistentTopicsBase extends AdminResource {
         return metadata;
     }
 
-    protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse, boolean authoritative, boolean force) {
+    protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse, boolean authoritative,
+                                                  boolean force, boolean deleteSchema) {
         try {
             validateWriteOperationOnTopic(authoritative);
         } catch (WebApplicationException wae) {
@@ -652,8 +653,10 @@ public class PersistentTopicsBase extends AdminResource {
                 final AtomicInteger count = new AtomicInteger(numPartitions);
                 for (int i = 0; i < numPartitions; i++) {
                     TopicName topicNamePartition = topicName.getPartition(i);
+                    // Only delete schema for 1 partition because there's only 1 schema storage for all partitions
+                    boolean deleteSchemaForPartition = (deleteSchema && i == 0);
                     try {
-                        pulsar().getAdminClient().topics().deleteAsync(topicNamePartition.toString(), force)
+                        pulsar().getAdminClient().topics().deleteAsync(topicNamePartition.toString(), force, deleteSchema)
                                 .whenComplete((r, ex) -> {
                                     if (ex != null) {
                                         if (ex instanceof NotFoundException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -222,7 +222,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalDeletePartitionedTopic(asyncResponse, authoritative, force);
+            internalDeletePartitionedTopic(asyncResponse, authoritative, force, false);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -749,9 +749,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Stop all producer/consumer/replicator and delete topic forcefully", defaultValue = "false", type = "boolean")
             @QueryParam("force") @DefaultValue("false") boolean force,
             @ApiParam(value = "Is authentication required to perform this operation")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Delete the topic's schema storage")
+            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalDeleteTopic(authoritative, force);
+        internalDeleteTopic(authoritative, force, deleteSchema);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -686,10 +686,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Stop all producer/consumer/replicator and delete topic forcefully", defaultValue = "false", type = "boolean")
             @QueryParam("force") @DefaultValue("false") boolean force,
             @ApiParam(value = "Is authentication required to perform this operation")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Delete the topic's schema storage")
+            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
-            internalDeletePartitionedTopic(asyncResponse, authoritative, force);
+            internalDeletePartitionedTopic(asyncResponse, authoritative, force, deleteSchema);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -311,7 +311,10 @@ public abstract class AbstractTopic implements Topic {
         return schemaRegistryService.getSchema(id)
                 .thenCompose(schema -> {
                     if (schema != null) {
-                        return schemaRegistryService.deleteSchema(id, "");
+                        // It's different from `SchemasResource.deleteSchema` because when we delete a topic, the schema
+                        // history is meaningless. But when we delete a schema of a topic, a new schema could be
+                        // registered in the future.
+                        return schemaRegistryService.deleteSchemaStorage(id);
                     } else {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -314,6 +314,7 @@ public abstract class AbstractTopic implements Topic {
                         // It's different from `SchemasResource.deleteSchema` because when we delete a topic, the schema
                         // history is meaningless. But when we delete a schema of a topic, a new schema could be
                         // registered in the future.
+                        log.info("Delete schema storage of id: {}", id);
                         return schemaRegistryService.deleteSchemaStorage(id);
                     } else {
                         return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -146,6 +146,7 @@ import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FieldParser;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -744,6 +745,15 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             }
 
             return failedFuture(cause);
+        }
+    }
+
+    public CompletableFuture<SchemaVersion> deleteSchemaStorage(String topic) {
+        Optional<Topic> optTopic = getTopicReference(topic);
+        if (optTopic.isPresent()) {
+            return optTopic.get().deleteSchema();
+        } else {
+            return CompletableFuture.completedFuture(null);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -758,7 +758,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             if (forceDelete) {
                 if (deleteSchema) {
                     return t.deleteSchema().thenCompose(schemaVersion -> {
-                        log.info("Delete topic with schema version: {}", schemaVersion);
+                        log.info("Successfully delete topic {}'s schema of version {}", t.getName(), schemaVersion);
                         return t.deleteForcefully();
                     });
                 } else {
@@ -777,7 +777,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
             if (deleteSchema) {
                 return t.deleteSchema().thenCompose(schemaVersion -> {
-                    log.info("Delete topic with schema version: {}", schemaVersion);
+                    log.info("Successfully delete topic {}'s schema of version {}", t.getName(), schemaVersion);
                     return t.delete();
                 });
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -368,6 +368,11 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                                     log.warn("Failed to delete ledger {} of {}: {}", ledgerId, schemaId, rc);
                                 }
                                 if (numOfLedgerIds.decrementAndGet() == 0) {
+                                    try {
+                                        ZkUtils.deleteFullPathOptimistic(zooKeeper, getSchemaPath(schemaId), -1);
+                                    } catch (InterruptedException | KeeperException e) {
+                                        future.completeExceptionally(e);
+                                    }
                                     future.complete(version);
                                 }
                             }, null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -39,9 +39,11 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.validation.constraints.NotNull;
 
+import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -78,6 +80,9 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     private final ZooKeeperCache localZkCache;
     private final ServiceConfiguration config;
     private BookKeeper bookKeeper;
+
+    // schemaId => ledgers of the schemaId
+    private final Map<String, List<Long>> schemaLedgers = new ConcurrentHashMap<>();
 
     private final ConcurrentMap<String, CompletableFuture<StoredSchema>> readSchemaOperations = new ConcurrentHashMap<>();
 
@@ -350,7 +355,30 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
             if (isNull(schemaAndVersion)) {
                 return completedFuture(null);
             } else {
-                return putSchema(schemaId, new byte[]{}, new byte[]{});
+                // NOTE: putSchema is just for schema version, remove it if there's a better way to get schema version
+                return putSchema(schemaId, new byte[]{}, new byte[]{}).thenCompose(version -> {
+                    final List<Long> ledgerIds = schemaLedgers.get(schemaId);
+                    if (ledgerIds != null) {
+                        CompletableFuture<Long> future = new CompletableFuture<>();
+                        final AtomicInteger numOfLedgerIds = new AtomicInteger(ledgerIds.size());
+                        for (long ledgerId : ledgerIds) {
+                            bookKeeper.asyncDeleteLedger(ledgerId, (int rc, Object cnx) -> {
+                                if (rc != BKException.Code.OK) {
+                                    // It's not a serious error, we didn't need call future.completeExceptionally()
+                                    log.warn("Failed to delete ledger {} of {}: {}", ledgerId, schemaId, rc);
+                                }
+                                if (numOfLedgerIds.decrementAndGet() == 0) {
+                                    future.complete(version);
+                                }
+                            }, null);
+                        }
+                        return future;
+                    } else {
+                        // It should never reach here
+                        log.warn("No ledgers for schema id: {}", schemaId);
+                        return completedFuture(version);
+                    }
+                });
             }
         });
     }
@@ -512,6 +540,10 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                         if (rc != BKException.Code.OK) {
                             future.completeExceptionally(bkException("Failed to create ledger", rc, -1, -1));
                         } else {
+                            schemaLedgers.computeIfAbsent(
+                                    schemaId,
+                                    key -> Collections.synchronizedList(new ArrayList<>())
+                            ).add(handle.getId());
                             future.complete(handle);
                         }
                     }, null, metadata);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -78,6 +78,11 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
+    public CompletableFuture<SchemaVersion> deleteSchemaStorage(String schemaId) {
+        return completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema,
                                                    SchemaCompatibilityStrategy strategy) {
         return completedFuture(false);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -41,6 +41,8 @@ public interface SchemaRegistry extends AutoCloseable {
 
     CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user);
 
+    CompletableFuture<SchemaVersion> deleteSchemaStorage(String schemaId);
+
     CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema,
                                             SchemaCompatibilityStrategy strategy);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -176,6 +176,11 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     }
 
     @Override
+    public CompletableFuture<SchemaVersion> deleteSchemaStorage(String schemaId) {
+        return schemaStorage.delete(schemaId);
+    }
+
+    @Override
     public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
         return checkCompatible(schemaId, schema, strategy).thenApply(v -> true);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
@@ -102,6 +102,11 @@ public class SchemaRegistryServiceWithSchemaDataValidator implements SchemaRegis
     }
 
     @Override
+    public CompletableFuture<SchemaVersion> deleteSchemaStorage(String schemaId) {
+        return service.deleteSchemaStorage(schemaId);
+    }
+
+    @Override
     public CompletableFuture<Boolean> isCompatible(String schemaId, SchemaData schema, SchemaCompatibilityStrategy strategy) {
         try {
             SchemaDataValidator.validateSchemaData(schema);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -200,7 +200,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // 8) Delete the partitioned topic
         response = mock(AsyncResponse.class);
-        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, testLocalTopicName, true, true);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, testLocalTopicName, true, true, false);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
@@ -365,7 +365,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // 4) delete partitioned topic
         response = mock(AsyncResponse.class);
-        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, partitionTopicName, true, true);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, partitionTopicName, true, true, false);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -507,6 +507,8 @@ public interface Topics {
      *            Topic name
      * @param force
      *            Delete topic forcefully
+     * @param deleteSchema
+     *            Delete topic's schema storage
      *
      * @throws NotAuthorizedException
      *             Don't have admin permission
@@ -517,7 +519,14 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void delete(String topic, boolean force) throws PulsarAdminException;
+    void delete(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException;
+
+    /**
+     * @see Topics#delete(String, boolean, boolean)
+     */
+    default void delete(String topic, boolean force) throws PulsarAdminException {
+        delete(topic, force, false);
+    }
 
     /**
      * Delete a topic asynchronously.
@@ -531,10 +540,19 @@ public interface Topics {
      *            topic name
      * @param force
      *            Delete topic forcefully
+     * @param deleteSchema
+     *            Delete topic's schema storage
      *
      * @return a future that can be used to track when the topic is deleted
      */
-    CompletableFuture<Void> deleteAsync(String topic, boolean force);
+    CompletableFuture<Void> deleteAsync(String topic, boolean force, boolean deleteSchema);
+
+    /**
+     * @see Topics#deleteAsync(String, boolean, boolean)
+     */
+    default CompletableFuture<Void> deleteAsync(String topic, boolean force) {
+        return deleteAsync(topic, force, false);
+    }
 
     /**
      * Delete a topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -451,10 +451,19 @@ public interface Topics {
      *            Topic name
      * @param force
      *            Delete topic forcefully
+     * @param deleteSchema
+     *            Delete topic's schema storage
      *
      * @throws PulsarAdminException
      */
-    void deletePartitionedTopic(String topic, boolean force) throws PulsarAdminException;
+    void deletePartitionedTopic(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException;
+
+    /**
+     * @see Topics#deletePartitionedTopic(String, boolean, boolean)
+     */
+    default void deletePartitionedTopic(String topic, boolean force) throws PulsarAdminException {
+        deletePartitionedTopic(topic, force, false);
+    }
 
     /**
      * Delete a partitioned topic asynchronously.
@@ -466,10 +475,19 @@ public interface Topics {
      *            Topic name
      * @param force
      *            Delete topic forcefully
+     * @param deleteSchema
+     *            Delete topic's schema storage
      *
      * @return a future that can be used to track when the partitioned topic is deleted
      */
-    CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force);
+    CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force, boolean deleteSchema);
+
+    /**
+     * @see Topics#deletePartitionedTopic(String, boolean, boolean)
+     */
+    default CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force) {
+        return deletePartitionedTopicAsync(topic, force, false);
+    }
 
     /**
      * Delete a partitioned topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -470,9 +470,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public void deletePartitionedTopic(String topic, boolean force) throws PulsarAdminException {
+    public void deletePartitionedTopic(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
         try {
-            deletePartitionedTopicAsync(topic, force).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+            deletePartitionedTopicAsync(topic, force, deleteSchema).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
@@ -484,10 +484,11 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force) {
+    public CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force, boolean deleteSchema) {
         TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn, "partitions");
-        path = path.queryParam("force", force);
+        WebTarget path = topicPath(tn, "partitions") //
+                .queryParam("force", force) //
+                .queryParam("deleteSchema", force);
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -487,8 +487,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force, boolean deleteSchema) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitions") //
-                .queryParam("force", force) //
-                .queryParam("deleteSchema", force);
+                .queryParam("force", Boolean.toString(force)) //
+                .queryParam("deleteSchema", Boolean.toString(deleteSchema));
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -502,9 +502,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public void delete(String topic, boolean force) throws PulsarAdminException {
+    public void delete(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
         try {
-            deleteAsync(topic, force).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+            deleteAsync(topic, force, deleteSchema).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
@@ -516,10 +516,11 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<Void> deleteAsync(String topic, boolean force) {
+    public CompletableFuture<Void> deleteAsync(String topic, boolean force, boolean deleteSchema) {
         TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn);
-        path = path.queryParam("force", Boolean.toString(force));
+        WebTarget path = topicPath(tn) //
+                .queryParam("force", Boolean.toString(force)) //
+                .queryParam("deleteSchema", Boolean.toString(deleteSchema));
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -128,13 +128,14 @@ public class CmdClusters extends CmdBase {
             if (deleteAll) {
                 for (String tenant : admin.tenants().getTenants()) {
                     for (String namespace : admin.namespaces().getNamespaces(tenant)) {
-                        for (String topic : admin.topics().getList(namespace)) {
-                            admin.topics().delete(topic, true);
-                            // TODO: Delete all the ledgers of the SchemaStorage
-                            // admin.schemas().deleteSchema(topic) won't delete the schema's ledger. Instead a new ledger will be created.
-                            //       https://github.com/apache/pulsar/issues/8134
+                        // Partitioned topic's schema must be deleted by deletePartitionedTopic() but not delete() for each partition
+                        for (String topic : admin.topics().getPartitionedTopicList(namespace)) {
+                            admin.topics().deletePartitionedTopic(topic, true, true);
                         }
-                        admin.namespaces().deleteNamespace(namespace);
+                        for (String topic : admin.topics().getList(namespace)) {
+                            admin.topics().delete(topic, true, true);
+                        }
+                        admin.namespaces().deleteNamespace(namespace, true);
                     }
                     admin.tenants().deleteTenant(tenant);
                 }


### PR DESCRIPTION
Master Issue: #8134 

### Motivation

The REST APIs of `PersistentTopics#deleteTopic` and `PersistentTopics#deletePartitionedTopic` didn't support delete schema of topics, which may cause after topics were deleted, the schema ledgers still existed. And current implementation of delete schema is just add a empty schema ledger but not delete existed schema ledgers.

### Modifications

- Add a `deleteSchema` query param to REST APIs of deleting topics/partitioned topics;
- Add a map to record the created ledgers in `BookkeeperSchemaStorage`;
- Expose `deleteSchema` param in pulsar-admin APIs;
- Delete schema ledgers when delete the cluster with `-a` option.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

It has been tested in local environments:
1. Check the current count of ledgers;
2. Create a new partitioned topic or non-partitioned topic;
3. Create producers/consumers with schema to send and receive messages with the created topic;
4. Delete the topic with `deleteSchema=true` query param or call admin API that set `deleteSchema` to false;
5. Recheck the count of ledgers, make sure it's the same with step 1.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - **The rest endpoints**: (yes)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)