### PR TITLE
[ISSUE 8159]Add a new state for namespace-level TTL

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -502,7 +502,7 @@ public abstract class AdminResource extends PulsarWebResource {
             policies.clusterSubscribeRate.put(cluster, subscribeRate());
         }
 
-        if (policies.message_ttl_in_seconds <= 0) {
+        if (policies.message_ttl_in_seconds == null) {
             policies.message_ttl_in_seconds = config.getTtlDurationDefaultInSeconds();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -797,11 +797,11 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected void internalSetNamespaceMessageTTL(int messageTTL) {
+    protected void internalSetNamespaceMessageTTL(Integer messageTTL) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.TTL, PolicyOperation.WRITE);
         validatePoliciesReadOnlyAccess();
 
-        if (messageTTL < 0) {
+        if (messageTTL != null && messageTTL < 0) {
             throw new RestException(Status.PRECONDITION_FAILED, "Invalid value for message TTL");
         }
 
@@ -2402,7 +2402,7 @@ public abstract class NamespacesBase extends AdminResource {
         // Validate cluster names and permissions
         policies.replication_clusters.forEach(cluster -> validateClusterForTenant(ns.getTenant(), cluster));
 
-        if (policies.message_ttl_in_seconds < 0) {
+        if (policies.message_ttl_in_seconds != null && policies.message_ttl_in_seconds < 0) {
             throw new RestException(Status.PRECONDITION_FAILED, "Invalid value for message TTL");
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -295,6 +295,17 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceMessageTTL(messageTTL);
     }
 
+    @DELETE
+    @Path("/{tenant}/{namespace}/messageTTL")
+    @ApiOperation(value = "Set message TTL in seconds for namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 412, message = "Invalid TTL") })
+    public void removeNamespaceMessageTTL(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace) {
+        validateNamespaceName(tenant, namespace);
+        internalSetNamespaceMessageTTL(null);
+    }
+
     @GET
     @Path("/{tenant}/{namespace}/subscriptionExpirationTime")
     @ApiOperation(value = "Get the subscription expiration time for the namespace")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -678,6 +678,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
         policies.max_unacked_messages_per_subscription = 200000;
         policies.max_unacked_messages_per_consumer = 50000;
+        policies.message_ttl_in_seconds = pulsar.getConfiguration().getTtlDurationDefaultInSeconds();
 
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
         assertEquals(admin.namespaces().getPermissions("prop-xyz/ns1"), policies.auth_policies.namespace_auth);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -167,6 +167,11 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(500);
         Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 0);
         Assert.assertEquals((int)method.invoke(persistentTopic), 0);
+
+        admin.namespaces().removeNamespaceMessageTTL(myNamespace);
+        Thread.sleep(500);
+        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 3600);
+        Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -21,20 +21,18 @@ package org.apache.pulsar.broker.admin;
 import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.service.BacklogQuotaManager;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
 
 @Slf4j
 public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
@@ -52,6 +50,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         this.conf.setSystemTopicEnabled(true);
         this.conf.setTopicLevelPoliciesEnabled(true);
+        this.conf.setTtlDurationDefaultInSeconds(3600);
         super.internalSetup();
 
         admin.clusters().createCluster("test", new ClusterData(pulsar.getWebServiceAddress()));
@@ -145,6 +144,29 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 405);
         }
+    }
+
+    @Test(timeOut = 20000)
+    public void testDifferentLevelPolicyPriority() throws Exception {
+        final String topicName = testTopic + UUID.randomUUID();
+        admin.topics().createNonPartitionedTopic(topicName);
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        Method method = PersistentTopic.class.getDeclaredMethod("getMessageTTL");
+        method.setAccessible(true);
+
+        int namespaceMessageTTL = admin.namespaces().getNamespaceMessageTTL(myNamespace);
+        Assert.assertEquals(namespaceMessageTTL, 3600);
+        Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
+
+        admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
+        Thread.sleep(500);
+        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 10);
+        Assert.assertEquals((int)method.invoke(persistentTopic), 10);
+
+        admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
+        Thread.sleep(500);
+        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 0);
+        Assert.assertEquals((int)method.invoke(persistentTopic), 0);
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -638,6 +638,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.topicDispatchRate.put("test", ConfigHelper.topicDispatchRate(conf));
         policies.subscriptionDispatchRate.put("test", ConfigHelper.subscriptionDispatchRate(conf));
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
+        policies.message_ttl_in_seconds = pulsar.getConfiguration().getTtlDurationDefaultInSeconds();
 
         policies.max_unacked_messages_per_subscription = 200000;
         policies.max_unacked_messages_per_consumer = 50000;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -849,6 +849,20 @@ public interface Namespaces {
     CompletableFuture<Void> setNamespaceMessageTTLAsync(String namespace, int ttlInSeconds);
 
     /**
+     * Remove the messages Time to Live for all the topics within a namespace.
+     * @param namespace
+     * @throws PulsarAdminException
+     */
+    void removeNamespaceMessageTTL(String namespace) throws PulsarAdminException;
+
+    /**
+     * Remove the messages Time to Live for all the topics within a namespace asynchronously.
+     * @param namespace
+     * @return
+     */
+    CompletableFuture<Void> removeNamespaceMessageTTLAsync(String namespace);
+
+    /**
      * Get the subscription expiration time for a namespace.
      * <p/>
      * Response example:

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -641,6 +641,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
+    public void removeNamespaceMessageTTL(String namespace) throws PulsarAdminException {
+        try {
+            removeNamespaceMessageTTLAsync(namespace)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeNamespaceMessageTTLAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "messageTTL");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
     public int getSubscriptionExpirationTime(String namespace) throws PulsarAdminException {
         try {
             return getSubscriptionExpirationTimeAsync(namespace).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -544,6 +544,9 @@ public class PulsarAdminToolTest {
 
         namespaces.run(split("get-offload-policies myprop/clust/ns1"));
         verify(mockNamespaces).getOffloadPolicies("myprop/clust/ns1");
+
+        namespaces.run(split("remove-message-ttl myprop/clust/ns1"));
+        verify(mockNamespaces).removeNamespaceMessageTTL("myprop/clust/ns1");
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -306,6 +306,18 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Remove Message TTL for a namespace")
+    private class RemoveMessageTTL extends CliCommand {
+        @Parameter(description = "tenant/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            admin.namespaces().removeNamespaceMessageTTL(namespace);
+        }
+    }
+
     @Parameters(commandDescription = "Set subscription expiration time for a namespace")
     private class SetSubscriptionExpirationTime extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
@@ -1710,6 +1722,7 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("get-message-ttl", new GetMessageTTL());
         jcommander.addCommand("set-message-ttl", new SetMessageTTL());
+        jcommander.addCommand("remove-message-ttl", new RemoveMessageTTL());
 
         jcommander.addCommand("get-subscription-expiration-time", new GetSubscriptionExpirationTime());
         jcommander.addCommand("set-subscription-expiration-time", new SetSubscriptionExpirationTime());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -58,7 +58,7 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public Map<String, Integer> latency_stats_sample_rate = Maps.newHashMap();
     @SuppressWarnings("checkstyle:MemberName")
-    public int message_ttl_in_seconds = 0;
+    public Integer message_ttl_in_seconds = null;
     @SuppressWarnings("checkstyle:MemberName")
     public int subscription_expiration_time_minutes = 0;
     @SuppressWarnings("checkstyle:MemberName")

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
@@ -76,11 +76,11 @@ public class PoliciesDataTest {
     public void bundlesPolicies() throws JsonGenerationException, JsonMappingException, IOException {
         ObjectMapper jsonMapper = ObjectMapperFactory.create();
         String oldJsonPolicy = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{}},\"replication_clusters\":[],"
-                + "\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":0}";
+                + "\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":null}";
         Policies policies = jsonMapper.readValue(oldJsonPolicy.getBytes(), Policies.class);
         assertEquals(policies, new Policies());
         String newJsonPolicy = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{}},\"replication_clusters\":[],\"bundles\":null,"
-                + "\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":0}";
+                + "\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":null}";
         OldPolicies oldPolicies = jsonMapper.readValue(newJsonPolicy.getBytes(), OldPolicies.class);
         assertEquals(oldPolicies, new OldPolicies());
     }

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/DeserializersTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/DeserializersTest.java
@@ -49,7 +49,7 @@ public class DeserializersTest {
     public void testSimplePolicyDeserialize() throws Exception {
         String key = "test_key";
         String jsonPolicy = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{}},\"replication_clusters\":[],"
-                + "\"bundles_activated\":true,\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":0}";
+                + "\"bundles_activated\":true,\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{},\"message_ttl_in_seconds\":null}";
         byte[] content = jsonPolicy.getBytes(StandardCharsets.UTF_8);
         Policies result = Deserializers.POLICY_DESERIALIZER.deserialize(key, content);
         assertEquals(result, new Policies());


### PR DESCRIPTION
Fixes #8159 

### Motivation
When the namespace-level TTL is set to 0, it means 2 states:
1) TTL check is disabled 
2) The namespace-level setting does not exist, return to the broker-level setting
These two states are in conflict. We don't know if it is disabled or using broker-level configuration.

### Modifications
We should set a state separately for the case where the namespace-level configuration does not exist.
The TTL of the namespace-level can be set to null, which means it does not exist. It is consistent with topic-level TTL.

### Verifying this change


