### PR TITLE
fix peek message not supported for partitioned topic with topicname

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -563,5 +563,6 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
                 .peekMessages(topic, "sub1", 5);
 
         Assert.assertEquals(messages.size(), 5);
+        producer.close();
     }
 }


### PR DESCRIPTION
Fix #8174 

### Motivation
To Reproduce
Steps to reproduce the behavior:
```shell
bin/pulsar-admin topics create-partitioned-topic persistent://public/default/test-v1
pulsar-admin topics create-subscription -s sub persistent://public/default/test-v1
pulsar-admin topics peek-messages -s sub persitent://public/default/test-v1
```
Throw exception:
```
Peek messages on a partitioned topic is not allowed
```

The reseason is in PersistentTopicsBase.java#internalPeekNthMessage method, it check the partition number for the given topicName. The `persitent://public/default/test-v1` is not partitioned and the partition size > 0 in the following check, so throw `METHOD_NOT_ALLOWED` exception.
```Java  
if (!topicName.isPartitioned() && getPartitionedTopicMetadata(topicName, authoritative, false).partitions > 0) {
            throw new RestException(Status.METHOD_NOT_ALLOWED, "Peek messages on a partitioned topic is not allowed");
}
```

### Changes
Using the partition name instead of topicName in this case.
Please take a look @sijie @codelipenghui @tuteng 