### PR TITLE
fix peek messages failed with subscriptionName not exist

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2952,6 +2952,10 @@ public class PersistentTopicsBase extends AdminResource {
     private Subscription getSubscriptionReference(String subName, PersistentTopic topic) {
         try {
             Subscription sub = topic.getSubscription(subName);
+            if (sub == null) {
+                sub = topic.createSubscription(subName, InitialPosition.Earliest, false).get();
+            }
+
             return Preconditions.checkNotNull(sub);
         } catch (Exception e) {
             throw new RestException(Status.NOT_FOUND, "Subscription not found");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response.Status;
 import org.apache.pulsar.broker.admin.v2.NonPersistentTopics;
 import org.apache.pulsar.broker.admin.v2.PersistentTopics;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -32,8 +31,10 @@ import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -66,7 +67,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -510,6 +510,33 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+    }
+
+    @Test
+    public void testPeekWithSubscriptionNameNotExist() throws Exception {
+        final String topicName = "testTopic";
+        final String topic = TopicName.get(
+                TopicDomain.persistent.value(),
+                testTenant,
+                testNamespace,
+                topicName).toString();
+        final String subscriptionName = "sub";
+
+        admin.topics().createPartitionedTopic(topic, 3);
+
+        final String partitionedTopic = topic + "-partition-0";
+
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        for (int i = 0; i < 100; ++i) {
+            producer.send("test" + i);
+        }
+
+        List<Message<byte[]>> messages = admin.topics()
+                .peekMessages(partitionedTopic, subscriptionName, 5);
+
+        Assert.assertEquals(messages.size(), 5);
+
+        producer.close();
     }
 
     @Test()


### PR DESCRIPTION
### Motivation
When peek message with not exist subscriptionName, it will get the following exception:
```shell
$bin/pulsar-admin topics peek-messages -s test persistent://public/default/test-v1-partition-2

22:11:29.237 [AsyncHttpClient-7-1] WARN  org.apache.pulsar.client.admin.internal.TopicsImpl - Exception 'Subscription not found' occurred while trying to peek Messages.
```

### Changes
When the given subscriptionName not exist, create a new subscription with given subscriptionName and earliest initial position.