### PR TITLE
[python-client] expose batchingType interface

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -101,7 +101,7 @@ To install the Python bindings:
 
 import _pulsar
 
-from _pulsar import Result, CompressionType, ConsumerType, InitialPosition, PartitionsRoutingMode  # noqa: F401
+from _pulsar import Result, CompressionType, ConsumerType, InitialPosition, PartitionsRoutingMode, BatchingType  # noqa: F401
 
 from pulsar.functions.function import Function
 from pulsar.functions.context import Context
@@ -445,6 +445,7 @@ class Client:
                         batching_max_publish_delay_ms=10,
                         message_routing_mode=PartitionsRoutingMode.RoundRobinDistribution,
                         properties=None,
+                        batching_type=BatchingType.Default,
                         ):
         """
         Create a new producer on a given topic.
@@ -513,6 +514,7 @@ class Client:
         _check_type(int, batching_max_allowed_size_in_bytes, 'batching_max_allowed_size_in_bytes')
         _check_type(int, batching_max_publish_delay_ms, 'batching_max_publish_delay_ms')
         _check_type_or_none(dict, properties, 'properties')
+        _check_type(BatchingType, batching_type, 'batching_type')
 
         conf = _pulsar.ProducerConfiguration()
         conf.send_timeout_millis(send_timeout_millis)
@@ -525,6 +527,7 @@ class Client:
         conf.batching_max_allowed_size_in_bytes(batching_max_allowed_size_in_bytes)
         conf.batching_max_publish_delay_ms(batching_max_publish_delay_ms)
         conf.partitions_routing_mode(message_routing_mode)
+        conf.batching_type(batching_type)
         if producer_name:
             conf.producer_name(producer_name)
         if initial_sequence_id:

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -499,6 +499,20 @@ class Client:
         * `properties`:
           Sets the properties for the producer. The properties associated with a producer
           can be used for identify a producer at broker side.
+        * `batching_type`:
+          Sets the batching type for the producer.
+          There are two batching type: DefaultBatching and KeyBasedBatching.
+            - Default batching
+            incoming single messages:
+            (k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)
+            batched into single batch message:
+            [(k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)]
+
+            - KeyBasedBatching
+            incoming single messages:
+            (k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)
+            batched into single batch message:
+            [(k1, v1), (k1, v2), (k1, v3)], [(k2, v1), (k2, v2), (k2, v3)], [(k3, v1), (k3, v2), (k3, v3)]
         """
         _check_type(str, topic, 'topic')
         _check_type_or_none(str, producer_name, 'producer_name')

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -126,6 +126,8 @@ void export_config() {
             .def("batching_max_publish_delay_ms", &ProducerConfiguration::getBatchingMaxPublishDelayMs, return_value_policy<copy_const_reference>())
             .def("batching_max_publish_delay_ms", &ProducerConfiguration::setBatchingMaxPublishDelayMs, return_self<>())
             .def("property", &ProducerConfiguration::setProperty, return_self<>())
+            .def("batching_type", &ProducerConfiguration::setBatchingType, return_self<>())
+            .def("batching_type", &ProducerConfiguration::getBatchingType)
             ;
 
     class_<ConsumerConfiguration>("ConsumerConfiguration")

--- a/pulsar-client-cpp/python/src/enums.cc
+++ b/pulsar-client-cpp/python/src/enums.cc
@@ -100,4 +100,9 @@ void export_enums() {
             .value("Latest", InitialPositionLatest)
             .value("Earliest", InitialPositionEarliest)
             ;
+
+    enum_<ProducerConfiguration::BatchingType>("BatchingType", "Supported batching types")
+            .value("Default", ProducerConfiguration::DefaultBatching)
+            .value("KeyBased", ProducerConfiguration::KeyBasedBatching)
+            ;
 }

--- a/pulsar-client-cpp/python/test_producer.py
+++ b/pulsar-client-cpp/python/test_producer.py
@@ -31,7 +31,8 @@ producer = client.create_producer(
                     properties={
                         "producer-name": "test-producer-name",
                         "producer-id": "test-producer-id"
-                    }
+                    },
+                    batching_type=BatchingType.KeyBased
                 )
 
 for i in range(10):


### PR DESCRIPTION
Fix #8135 

### Changes
Expose the ProducerConfiguration::BatchingType and related setter/getter to Python client.