### PR TITLE
[go] Fix argument type of pulsarProducerSendCallbackProxy

### DIFF
--- a/pulsar-client-go/pulsar/c_go_pulsar.h
+++ b/pulsar-client-go/pulsar/c_go_pulsar.h
@@ -61,7 +61,7 @@ static inline void _pulsar_producer_close_async(pulsar_producer_t *producer, voi
     pulsar_producer_close_async(producer, pulsarProducerCloseCallbackProxy, ctx);
 }
 
-void pulsarProducerSendCallbackProxy(pulsar_result result, pulsar_message_t *message, void *ctx);
+void pulsarProducerSendCallbackProxy(pulsar_result result, pulsar_message_id_t *message, void *ctx);
 
 void pulsarProducerSendCallbackProxyWithMsgID(pulsar_result result, pulsar_message_id_t *messageId, void *ctx);
 

--- a/pulsar-client-go/pulsar/c_producer.go
+++ b/pulsar-client-go/pulsar/c_producer.go
@@ -280,7 +280,7 @@ type sendCallbackWithMsgID struct {
 }
 
 //export pulsarProducerSendCallbackProxy
-func pulsarProducerSendCallbackProxy(res C.pulsar_result, message *C.pulsar_message_t, ctx unsafe.Pointer) {
+func pulsarProducerSendCallbackProxy(res C.pulsar_result, messageId *C.pulsar_message_id_t, ctx unsafe.Pointer) {
 	sendCallback := restorePointer(ctx).(sendCallback)
 
 	if res != C.pulsar_result_Ok {


### PR DESCRIPTION
### Motivation

When installing or running Pulsar CGo client, we get the following warning:
```
../go/pkg/mod/github.com/apache/pulsar/pulsar-client-go@v0.0.0-20201001145619-e65875b99e39/pulsar/c_go_pulsar.h: In function '_pulsar_producer_send_async':
../go/pkg/mod/github.com/apache/pulsar/pulsar-client-go@v0.0.0-20201001145619-e65875b99e39/pulsar/c_go_pulsar.h:70:5: warning: passing argument 3 of 'pulsar_producer_send_async' from incompatible pointer type [-Wincompatible-pointer-types]
     pulsar_producer_send_async(producer, message, pulsarProducerSendCallbackProxy, ctx);
     ^
```
However, we can produce messages successfully.

### Modifications

The second argument of the callback function `pulsar_send_callback` must be `pulsar_message_id_t`, not `pulsar_message_t`.
https://github.com/apache/pulsar/blob/be6a102511560349701dbe6b83fabf831dc81340/pulsar-client-cpp/include/pulsar/c/producer.h#L80-L81
https://github.com/apache/pulsar/blob/be6a102511560349701dbe6b83fabf831dc81340/pulsar-client-cpp/include/pulsar/c/producer.h#L34