### PR TITLE
fix examples/spark compile failed under jdk10

### DIFF
--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -48,6 +48,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala-library.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@ flexible messaging model and an intuitive client API.</description>
     <presto.version>332</presto.version>
     <flink.version>1.6.0</flink.version>
     <scala.binary.version>2.11</scala.binary.version>
+    <scala-library.version>2.11.12</scala-library.version>
     <debezium.version>1.0.0.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>


### PR DESCRIPTION
Fix #8193 

### Changes
1. update scala-library version from `2.10.6` to `2.11.12`