### PR TITLE
Add log level configuration in pulsar-client

### DIFF
--- a/bin/pulsar-client
+++ b/bin/pulsar-client
@@ -98,10 +98,12 @@ OPTS="$OPTS $PULSAR_EXTRA_OPTS"
 # log directory & file
 PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
 PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"Console"}
+PULSAR_LOG_LEVEL=${PULSAR_LOG_LEVEL:-"info"}
 
 #Configure log configuration system properties
 OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
 OPTS="$OPTS -Dpulsar.log.appender=$PULSAR_LOG_APPENDER"
+OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
 
 #Change to PULSAR_HOME to support relative paths
 cd "$PULSAR_HOME"


### PR DESCRIPTION
### Motivation
When using pulsar-client CLI, we have a lot of log4j logs useless for just sending/receiving messages.
It could great to not display these logs with just a env variable (like in pulsar-admin).

### Modifications
The log level can be configured with the system property `pulsar.log.level` for the Java application.
The modification is the ability to set this level using a env variable PULSAR_LOG_LEVEL (default: info).


### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
