### PR TITLE
fix pulsar service close exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -610,6 +610,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         // close replication clients
         replicationClients.forEach((cluster, client) -> {
             try {
+                log.info("[hangc-1] shutdown {}-{}", cluster, client);
                 client.shutdown();
             } catch (PulsarClientException e) {
                 log.warn("Error shutting down repl client for cluster {}", cluster, e);
@@ -619,6 +620,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         // close replication admins
         clusterAdmins.forEach((cluster, admin) -> {
             try {
+                log.info("[hangc-2] shutdown {}-{}", cluster, admin);
                 admin.close();
             } catch (Exception e) {
                 log.warn("Error shutting down repl admin for cluster {}", cluster, e);
@@ -633,13 +635,14 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             listenChannelTls.close();
         }
 
+        acceptorGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+
         if (interceptor != null) {
             interceptor.close();
             interceptor = null;
         }
 
-        acceptorGroup.shutdownGracefully();
-        workerGroup.shutdownGracefully();
         statsUpdater.shutdown();
         inactivityMonitor.shutdown();
         messageExpiryMonitor.shutdown();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -610,7 +610,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         // close replication clients
         replicationClients.forEach((cluster, client) -> {
             try {
-                log.info("[hangc-1] shutdown {}-{}", cluster, client);
                 client.shutdown();
             } catch (PulsarClientException e) {
                 log.warn("Error shutting down repl client for cluster {}", cluster, e);
@@ -620,7 +619,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         // close replication admins
         clusterAdmins.forEach((cluster, admin) -> {
             try {
-                log.info("[hangc-2] shutdown {}-{}", cluster, admin);
                 admin.close();
             } catch (Exception e) {
                 log.warn("Error shutting down repl admin for cluster {}", cluster, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -225,6 +225,7 @@ public class ServerCnx extends PulsarHandler {
                 producer.closeNow(true);
             }
         });
+
         consumers.values().forEach((consumerFuture) -> {
             Consumer consumer;
             if (consumerFuture.isDone() && !consumerFuture.isCompletedExceptionally()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.unsafeGetPartitionedTopicMetadataAsync;
+import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
 import static org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion.v5;
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
@@ -215,8 +216,9 @@ public class ServerCnx extends PulsarHandler {
         super.channelInactive(ctx);
         isActive = false;
         log.info("Closed connection from {}", remoteAddress);
-        if (getBrokerService().getInterceptor() != null) {
-            getBrokerService().getInterceptor().onConnectionClosed(this);
+        BrokerInterceptor brokerInterceptor = getBrokerService().getInterceptor();
+        if (brokerInterceptor != null) {
+            brokerInterceptor.onConnectionClosed(this);
         }
         // Connection is gone, close the producers immediately
         producers.values().forEach((producerFuture) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -215,7 +215,9 @@ public class ServerCnx extends PulsarHandler {
         super.channelInactive(ctx);
         isActive = false;
         log.info("Closed connection from {}", remoteAddress);
-        getBrokerService().getInterceptor().onConnectionClosed(this);
+        if (getBrokerService().getInterceptor() != null) {
+            getBrokerService().getInterceptor().onConnectionClosed(this);
+        }
         // Connection is gone, close the producers immediately
         producers.values().forEach((producerFuture) -> {
             if (producerFuture.isDone() && !producerFuture.isCompletedExceptionally()) {
@@ -223,7 +225,6 @@ public class ServerCnx extends PulsarHandler {
                 producer.closeNow(true);
             }
         });
-
         consumers.values().forEach((consumerFuture) -> {
             Consumer consumer;
             if (consumerFuture.isDone() && !consumerFuture.isCompletedExceptionally()) {


### PR DESCRIPTION
Fix #8196 

### Motivation
In BrokerService#close, it close interceptor first and close workerGroup in the second. However, in workerGroup.shutdownGracefully(), it will call ServerCnx#channelInactive method. The code with bug as follow.
```
getBrokerService().getInterceptor().onConnectionClosed(this);
```
It doesn't check whether `getBrokerService().getInterceptor()` is null and call `onConnectionClosed` may cause NullPointerException.

### Changes
1. In BrokerService#close, close workerGroup first and close interceptor in the second.
2. In ServerCnx#channelInactive, check `getBrokerService().getInterceptor()` whether is null before call onConnectionClosed method.