### PR TITLE
expose ensemblePlacementPolicy in bookkeeper.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -238,6 +238,23 @@ autoRecoveryDaemonEnabled=true
 lostBookieRecoveryDelay=0
 
 #############################################################################
+## Placement settings
+#############################################################################
+
+# the following settings take effects when `autoRecoveryDaemonEnabled` is true.
+
+# The ensemble placement policy used for re-replicating entries.
+#
+# Options:
+#   - org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
+#   - org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
+#
+# Default value:
+#   org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
+#
+# ensemblePlacementPolicy=org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
+
+#############################################################################
 ## Netty server settings
 #############################################################################
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -652,11 +652,15 @@ bookkeeperGetBookieInfoRetryIntervalSeconds=60
 
 # Enable rack-aware bookie selection policy. BK will chose bookies from different racks when
 # forming a new bookie ensemble
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
 bookkeeperClientRackawarePolicyEnabled=true
 
 # Enable region-aware bookie selection policy. BK will chose bookies from
 # different regions and racks when forming a new bookie ensemble
 # If enabled, the value of bookkeeperClientRackawarePolicyEnabled is ignored
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
 bookkeeperClientRegionawarePolicyEnabled=false
 
 # Minimum number of racks per write quorum. BK rack-aware bookie selection policy will try to
@@ -739,7 +743,7 @@ managedLedgerDefaultWriteQuorum=2
 # Number of guaranteed copies (acks to wait before write is complete)
 managedLedgerDefaultAckQuorum=2
 
-# Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
+# Default type of checksum to use when writing to BoakKeeper. Default is "CRC32C"
 # Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).
 managedLedgerDigestType=CRC32C
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -743,7 +743,7 @@ managedLedgerDefaultWriteQuorum=2
 # Number of guaranteed copies (acks to wait before write is complete)
 managedLedgerDefaultAckQuorum=2
 
-# Default type of checksum to use when writing to BoakKeeper. Default is "CRC32C"
+# Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
 # Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).
 managedLedgerDigestType=CRC32C
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -434,11 +434,15 @@ bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
 
 # Enable rack-aware bookie selection policy. BK will chose bookies from different racks when
 # forming a new bookie ensemble
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
 bookkeeperClientRackawarePolicyEnabled=true
 
 # Enable region-aware bookie selection policy. BK will chose bookies from
 # different regions and racks when forming a new bookie ensemble.
 # If enabled, the value of bookkeeperClientRackawarePolicyEnabled is ignored
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
 bookkeeperClientRegionawarePolicyEnabled=false
 
 # Minimum number of racks per write quorum. BK rack-aware bookie selection policy will try to


### PR DESCRIPTION
Fix #8171 

### Changes
expose ensemblePlacementPolicy in bookkeeper.conf, makes it can be configured sync with broker ensemble placement policy and applied to bookkeeper auto recovery.

@sijie  Please take a look, thanks.