### PR TITLE
[Issue 7050][python] Limit enum34 installation via environment markers

### DIFF
--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -22,7 +22,6 @@ from distutils.core import Extension
 from distutils.util import strtobool
 from os import environ
 import subprocess
-import sys
 
 from distutils.command import build_ext
 
@@ -57,11 +56,6 @@ NAME = get_name()
 print(VERSION)
 print(NAME)
 
-if sys.version_info[0] == 2:
-    PY2 = True
-else:
-    PY2 = False
-
 # This is a workaround to have setuptools to include
 # the already compiled _pulsar.so library
 class my_build_ext(build_ext.build_ext):
@@ -83,16 +77,13 @@ dependencies = [
     'protobuf>=3.6.1',
     'six',
     'certifi',
+    'enum34>=1.1.9; python_version < "3.4"',
 
     # functions dependencies
     "apache-bookkeeper-client>=4.9.2",
     "prometheus_client",
     "ratelimit"
 ]
-
-if PY2:
-    # Python 2 compat dependencies
-    dependencies += ['enum34>=1.1.9']
 
 setup(
     name=NAME,


### PR DESCRIPTION
Fixes #7050 

### Motivation

To prevent installing enum34 on systems where it is not needed, declare the dependency with environment markers. Installing certain versions of enum34 on systems where it is not needed at all, might result in compile time issues. This is the recommended approach discussed here:
https://github.com/python-poetry/poetry/issues/1122

### Modifications

* `setup.py`: use environment markers for enum34 instead of custom logic that is not preserved in pypi metadata for the wheel

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as all python tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - *Anything that affects deployment*: don't know

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? Only packaging change
