### PR TITLE
[pulsar-broker] Fix broker-ml bucket stats show high metrics rate

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -112,7 +112,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final long cacheEvictionTimeThresholdNanos;
     private final MetadataStore metadataStore;
 
-    private static final int StatsPeriodSeconds = 60;
+    public static final int StatsPeriodSeconds = 60;
 
     private static class PendingInitializeManagedLedger {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -171,7 +171,7 @@ abstract class AbstractMetrics {
     }
 
     protected void populateBucketEntries(Map<String, Double> map, String mkey, double[] boundaries,
-            long[] bucketValues) {
+            long[] bucketValues, int period) {
 
         // bucket values should be one more that the boundaries to have the last element as OVERFLOW
         if (bucketValues != null && bucketValues.length != boundaries.length + 1) {
@@ -191,7 +191,7 @@ abstract class AbstractMetrics {
                 bucketKey = String.format("%s_OVERFLOW", mkey);
             }
 
-            value = (bucketValues == null) ? 0.0D : (double) bucketValues[i];
+            value = (bucketValues == null) ? 0.0D : ((double) bucketValues[i] / (period > 0 ? period : 1));
 
             Double val = map.getOrDefault(bucketKey, 0.0);
             map.put(bucketKey, val + value);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
@@ -98,14 +99,14 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
 
                 // handle bucket entries initialization here
                 populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_AddEntryLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getAddEntryLatencyBuckets());
+                        ENTRY_LATENCY_BUCKETS_MS, lStats.getAddEntryLatencyBuckets(), ManagedLedgerFactoryImpl.StatsPeriodSeconds);
                 populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_LedgerAddEntryLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerAddEntryLatencyBuckets());
+                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerAddEntryLatencyBuckets(), ManagedLedgerFactoryImpl.StatsPeriodSeconds);
                 populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_LedgerSwitchLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerSwitchLatencyBuckets());
+                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerSwitchLatencyBuckets(), ManagedLedgerFactoryImpl.StatsPeriodSeconds);
 
                 populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_EntrySizeBuckets", ENTRY_SIZE_BUCKETS_BYTES,
-                        lStats.getEntrySizeBuckets());
+                        lStats.getEntrySizeBuckets(), ManagedLedgerFactoryImpl.StatsPeriodSeconds);
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_MarkDeleteRate", lStats.getMarkDeleteRate());
             }
 


### PR DESCRIPTION
### Motivation
Right now, all pulsar metrics related rates and latencies are measured per second. However, managed-ledger addEntry-latency bucket has per minute cumulative numbers which shows very high rate and not useful when user want to know latency per second. So, ml-stats samples should have lower rate period which should per second.

### Modification
Therefore, ml-stats latency rate will be represented per second instead a minute.