### PR TITLE
Close ZK connections at end of metadata setup

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -239,6 +239,9 @@ public class PulsarClusterMetadataSetup {
         // Create transaction coordinator assign partitioned topic
         createPartitionedTopic(configStoreZk, TopicName.TRANSACTION_COORDINATOR_ASSIGN, arguments.numTransactionCoordinators);
 
+        localZk.close();
+        configStoreZk.close();
+
         log.info("Cluster metadata for '{}' setup correctly", arguments.cluster);
     }
 


### PR DESCRIPTION
### Modifications

When deploying Pulsar in Kubernetes, the zookeeper-metadata job does not reach completed status with ZooKeeper TLS enabled. These changes close the ZooKeeper connections before exiting therefore the Kubernetes job is marked as completed.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: `yes`

### Documentation

  - Does this pull request introduce a new feature? no
