### PR TITLE
Modify the occasion of triggering listeners

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -113,16 +113,23 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             });
                     })
                 );
-                if (listeners.get(topicName) != null) {
-                    for (TopicPolicyListener<TopicPolicies> listener : listeners.get(topicName)) {
-                        listener.onUpdate(policies);
-                    }
-                }
             }
         });
-
-
         return result;
+    }
+
+    private void notifyListener(Message<PulsarEvent> msg) {
+        if (!EventType.TOPIC_POLICY.equals(msg.getValue().getEventType())) {
+            return;
+        }
+        TopicPoliciesEvent event = msg.getValue().getTopicPoliciesEvent();
+        TopicName topicName = TopicName.get(event.getDomain(), event.getTenant(), event.getNamespace(), event.getTopic());
+        if (listeners.get(topicName) != null) {
+            TopicPolicies policies = event.getPolicies();
+            for (TopicPolicyListener<TopicPolicies> listener : listeners.get(topicName)) {
+                listener.onUpdate(policies);
+            }
+        }
     }
 
     @Override
@@ -243,6 +250,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         reader.readNextAsync().whenComplete((msg, ex) -> {
             if (ex == null) {
                 refreshTopicPoliciesCache(msg);
+                notifyListener(msg);
                 readMorePolicies(reader);
             } else {
                 if (ex instanceof PulsarClientException.AlreadyClosedException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.common.naming.TopicName;
@@ -304,8 +305,11 @@ public class DispatchRateLimiter {
         final String path = path(POLICIES, namespace.toString());
         Optional<Policies> policies = Optional.empty();
         try {
-            policies = brokerService.pulsar().getConfigurationCache().policiesCache().getAsync(path)
-                    .get(brokerService.pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+            ConfigurationCacheService configurationCacheService = brokerService.pulsar().getConfigurationCache();
+            if (configurationCacheService != null) {
+                policies = configurationCacheService.policiesCache().getAsync(path)
+                        .get(brokerService.pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+            }
         } catch (Exception e) {
             log.warn("Failed to get message-rate for {} ", topicName, e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2432,7 +2432,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return Optional.ofNullable(brokerService.pulsar().getAdminClient().namespaces()
                     .getPolicies(TopicName.get(topic).getNamespace()));
         } catch (Exception e) {
-            log.error("get namespace policies fail", e);
+            log.warn("get namespace policies fail", e);
         }
         return Optional.empty();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2427,14 +2427,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
-    private Optional<Policies> getNamespacePolicies(){
-        try {
-            return Optional.ofNullable(brokerService.pulsar().getAdminClient().namespaces()
-                    .getPolicies(TopicName.get(topic).getNamespace()));
-        } catch (Exception e) {
-            log.warn("get namespace policies fail", e);
-        }
-        return Optional.empty();
+    private Optional<Policies> getNamespacePolicies() {
+        return DispatchRateLimiter.getPolicies(brokerService, topic);
     }
 
     private void initializeTopicDispatchRateLimiterIfNeeded(TopicPolicies policies) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -303,6 +303,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setSystemTopicEnabled(true);
         conf.setTopicLevelPoliciesEnabled(true);
         super.baseSetup();
+        //wait for init
+        Thread.sleep(2000);
         final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
 
@@ -314,8 +316,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         policies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_no_subscriptions);
         policies.setMaxInactiveDurationSeconds(10);
         admin.topics().setInactiveTopicPolicies(topicName, policies);
-        //wait for init
-        Thread.sleep(3000);
+        
         for (int i = 0; i < 50; i++) {
             if (admin.topics().getInactiveTopicPolicies(topicName) != null) {
                 break;


### PR DESCRIPTION
### Motivation
When we use `SystemTopicBasedTopicPoliciesService#updateTopicPoliciesAsync` to update Topic-level policies, `Listener.onUpdate()` will be triggered;
Now this approach will cause 2 problems:
1) Because `updateTopicPoliciesAsync` only sends the message to the system topic, it has not been consumed yet. Therefore, the policy data in the cache is still old. When listeners are triggered, they cannot get the policies directly through the cache. They have to modify the existing interface and pass the policies through parameters.
2) When the broker restarts, some topic-level policies will no longer take effect, because they rely on the `onUpdate` method to take effect

### Modifications
1)The trigger occasion of `listener.onUpdate` is changed to when the reader consumes the event
2)fix some npe

### Verifying this change

TopicPoliciesTest#testRestart