### PR TITLE
Support limit topic publish rate at the broker level

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -252,6 +252,14 @@ brokerPublisherThrottlingMaxMessageRate=0
 # (Disable byte rate limit with value 0)
 brokerPublisherThrottlingMaxByteRate=0
 
+# Max Rate(in 1 seconds) of Message allowed to publish for a topic if topic publish rate limiting enabled
+# (Disable byte rate limit with value 0)
+maxPublishRatePerTopicInMessages=0
+
+#Max Rate(in 1 seconds) of Byte allowed to publish for a topic if topic publish rate limiting enabled.
+# (Disable byte rate limit with value 0)
+maxPublishRatePerTopicInBytes=0
+
 # Too many subscribe requests from a consumer can cause broker rewinding consumer cursors and loading data from bookies,
 # hence causing high network bandwidth usage
 # When the positive value is set, broker will throttle the subscribe requests for one consumer.

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -237,6 +237,14 @@ brokerPublisherThrottlingMaxMessageRate=0
 # (Disable byte rate limit with value 0)
 brokerPublisherThrottlingMaxByteRate=0
 
+# Max Rate(in 1 seconds) of Message allowed to publish for a topic if topic publish rate limiting enabled
+# (Disable byte rate limit with value 0)
+maxPublishRatePerTopicInMessages=0
+
+#Max Rate(in 1 seconds) of Byte allowed to publish for a topic if topic publish rate limiting enabled.
+# (Disable byte rate limit with value 0)
+maxPublishRatePerTopicInBytes=0
+
 # Too many subscribe requests from a consumer can cause broker rewinding consumer cursors and loading data from bookies,
 # hence causing high network bandwidth usage
 # When the positive value is set, broker will throttle the subscribe requests for one consumer.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -501,6 +501,20 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + "when broker publish rate limiting enabled. (Disable byte rate limit with value 0)"
     )
     private long brokerPublisherThrottlingMaxByteRate = 0;
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Max Rate(in 1 seconds) of Message allowed to publish for a topic "
+            + "when topic publish rate limiting enabled. (Disable byte rate limit with value 0)"
+    )
+    private int maxPublishRatePerTopicInMessages = 0;
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Max Rate(in 1 seconds) of Byte allowed to publish for a topic "
+            + "when topic publish rate limiting enabled. (Disable byte rate limit with value 0)"
+    )
+    private long maxPublishRatePerTopicInBytes = 0;
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -488,6 +488,15 @@ public class Namespaces extends NamespacesBase {
         internalSetPublishRate(publishRate);
     }
 
+    @DELETE
+    @Path("/{property}/{namespace}/publishRate")
+    @ApiOperation(hidden = true, value = "Set publish-rate throttling for all topics of the namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void removePublishRate(@PathParam("property") String property, @PathParam("namespace") String namespace) {
+        validateNamespaceName(property, namespace);
+        internalRemovePublishRate();
+    }
+
     @GET
     @Path("/{property}/{namespace}/publishRate")
     @ApiOperation(hidden = true, value = "Get publish-rate configured for the namespace, -1 represents not configured yet")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -498,7 +498,7 @@ public abstract class AbstractTopic implements Topic {
                 : null;
 
         //both namespace-level and topic-level policy are not set, try to use broker-level policy
-        ServiceConfiguration serviceConfiguration = brokerService.getPulsar().getConfiguration();
+        ServiceConfiguration serviceConfiguration = brokerService.pulsar().getConfiguration();
         if (publishRate == null) {
             PublishRate brokerPublishRate = new PublishRate(serviceConfiguration.getMaxPublishRatePerTopicInMessages()
                     , serviceConfiguration.getMaxPublishRatePerTopicInBytes());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,8 +98,6 @@ public abstract class AbstractTopic implements Topic {
 
     protected boolean preciseTopicPublishRateLimitingEnable;
 
-    protected volatile PublishRate topicPolicyPublishRate = null;
-
     private LongAdder bytesInCounter = new LongAdder();
     private LongAdder msgInCounter = new LongAdder();
 
@@ -115,28 +114,17 @@ public abstract class AbstractTopic implements Topic {
         this.inactiveTopicPolicies.setMaxInactiveDurationSeconds(brokerService.pulsar().getConfiguration().getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds());
         this.inactiveTopicPolicies.setInactiveTopicDeleteMode(brokerService.pulsar().getConfiguration().getBrokerDeleteInactiveTopicsMode());
         this.lastActive = System.nanoTime();
-        ServiceConfiguration brokerConfig = brokerService.pulsar().getConfiguration();
-        if (brokerConfig.isSystemTopicEnabled() && brokerConfig.isSystemTopicEnabled()) {
-            topicPolicyPublishRate = Optional.ofNullable(getTopicPolicies(TopicName.get(topic)))
-                    .map(TopicPolicies::getPublishRate)
-                    .orElse(null);
-        }
-        if (topicPolicyPublishRate != null) {
-            // update topic level publish dispatcher
-            updateTopicPublishDispatcher();
-        } else {
-            Policies policies = null;
-            try {
-                policies = brokerService.pulsar().getConfigurationCache().policiesCache()
+        Policies policies = null;
+        try {
+            policies = brokerService.pulsar().getConfigurationCache().policiesCache()
                     .get(AdminResource.path(POLICIES, TopicName.get(topic).getNamespace()))
                     .orElseGet(() -> new Policies());
-            } catch (Exception e) {
-                log.warn("[{}] Error getting policies {} and publish throttling will be disabled", topic, e.getMessage());
-            }
-            this.preciseTopicPublishRateLimitingEnable =
-                brokerService.pulsar().getConfiguration().isPreciseTopicPublishRateLimiterEnable();
-            updatePublishDispatcher(policies);
+        } catch (Exception e) {
+            log.warn("[{}] Error getting policies {} and publish throttling will be disabled", topic, e.getMessage());
         }
+        this.preciseTopicPublishRateLimitingEnable =
+                brokerService.pulsar().getConfiguration().isPreciseTopicPublishRateLimiterEnable();
+        updatePublishDispatcher(policies);
     }
 
     protected boolean isProducersExceeded() {
@@ -495,16 +483,29 @@ public abstract class AbstractTopic implements Topic {
     }
 
     private void updatePublishDispatcher(Policies policies) {
-        // if topic level publish rate policy is set, skip update publish rate on namespace level
-        if (topicPolicyPublishRate != null) {
+        //if topic-level policy exists, try to use topic-level publish rate policy
+        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        if (topicPolicies != null && topicPolicies.isPublishRateSet()) {
             log.info("Using topic policy publish rate instead of namespace level topic publish rate on topic {}", this.topic);
+            updatePublishDispatcher(topicPolicies.getPublishRate());
             return;
         }
 
+        //topic-level policy is not set, try to use namespace-level rate policy
         final String clusterName = brokerService.pulsar().getConfiguration().getClusterName();
-        final PublishRate publishRate = policies != null && policies.publishMaxMessageRate != null
+        PublishRate publishRate = policies != null && policies.publishMaxMessageRate != null
                 ? policies.publishMaxMessageRate.get(clusterName)
                 : null;
+
+        //both namespace-level and topic-level policy are not set, try to use broker-level policy
+        ServiceConfiguration serviceConfiguration = brokerService.getPulsar().getConfiguration();
+        if (publishRate == null) {
+            PublishRate brokerPublishRate = new PublishRate(serviceConfiguration.getMaxPublishRatePerTopicInMessages()
+                    , serviceConfiguration.getMaxPublishRatePerTopicInBytes());
+            updatePublishDispatcher(brokerPublishRate);
+            return;
+        }
+
         if (publishRate != null
                 && (publishRate.publishThrottlingRateInByte > 0 || publishRate.publishThrottlingRateInMsg > 0)) {
             log.info("Enabling publish rate limiting {} on topic {}", publishRate, this.topic);
@@ -593,7 +594,7 @@ public abstract class AbstractTopic implements Topic {
     /**
      * update topic publish dispatcher for this topic.
      */
-    protected void updateTopicPublishDispatcher() {
+    protected void updatePublishDispatcher(PublishRate publishRate) {
         // noop
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2465,7 +2465,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     protected void updatePublishDispatcher(PublishRate publishRate) {
         if (publishRate != null && (publishRate.publishThrottlingRateInByte > 0
             || publishRate.publishThrottlingRateInMsg > 0)) {
-            log.info("Enabling topic policy publish rate limiting {} on topic {}", publishRate, this.topic);
+            log.info("Enabling publish rate limiting {} ", publishRate);
             if (!preciseTopicPublishRateLimitingEnable) {
                 this.brokerService.setupBrokerPublishRateLimiterMonitor();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2461,33 +2461,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return this;
     }
 
-    @Override
-    protected void updatePublishDispatcher(PublishRate publishRate) {
-        if (publishRate != null && (publishRate.publishThrottlingRateInByte > 0
-            || publishRate.publishThrottlingRateInMsg > 0)) {
-            log.info("Enabling publish rate limiting {} ", publishRate);
-            if (!preciseTopicPublishRateLimitingEnable) {
-                this.brokerService.setupBrokerPublishRateLimiterMonitor();
-            }
-
-            if (this.topicPublishRateLimiter == null
-                || this.topicPublishRateLimiter == PublishRateLimiter.DISABLED_RATE_LIMITER) {
-                // create new rateLimiter if rate-limiter is disabled
-                if (preciseTopicPublishRateLimitingEnable) {
-                    this.topicPublishRateLimiter = new PrecisPublishLimiter(publishRate, ()-> this.enableCnxAutoRead());
-                } else {
-                    this.topicPublishRateLimiter = new PublishRateLimiterImpl(publishRate);
-                }
-            } else {
-                this.topicPublishRateLimiter.update(publishRate);
-            }
-        } else {
-            log.info("Disabling publish throttling for {}", this.topic);
-            this.topicPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
-            enableProducerReadForPublishRateLimiting();
-        }
-    }
-
     private void registerTopicPolicyListener() {
         if (brokerService.pulsar().getConfig().isSystemTopicEnabled() &&
                 brokerService.pulsar().getConfig().isTopicLevelPoliciesEnabled()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -224,6 +224,18 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         producer4.close();
     }
 
+    @Test(timeOut = testTimeout)
+    public void testPubRateOnNonPersistent() throws Exception {
+        internalCleanup();
+        conf.setMaxPublishRatePerTopicInBytes(10000L);
+        conf.setMaxPublishRatePerTopicInMessages(100);
+        Thread.sleep(500);
+        isTcpLookup = true;
+        super.internalSetup();
+        super.producerBaseSetup();
+        testBinaryProtoToGetTopicsOfNamespaceNonPersistent();
+    }
+    
 	// verify consumer create success, and works well.
     @Test(timeOut = testTimeout)
     public void testBinaryProtoToGetTopicsOfNamespaceNonPersistent() throws Exception {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -1821,7 +1821,8 @@ public interface Namespaces {
     CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate);
 
     /**
-     * Remove message-publish-rate (topics under this namespace can publish this many messages per second) asynchronously.
+     * Remove message-publish-rate 
+     * (topics under this namespace can publish this many messages per second) asynchronously.
      *
      * @param namespace
      */

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -1821,9 +1821,9 @@ public interface Namespaces {
     CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate);
 
     /**
-     * Remove message-publish-rate 
-     * (topics under this namespace can publish this many messages per second) asynchronously.
-     *
+     * Remove message-publish-rate asynchronously.
+     * <p/>
+     * topics under this namespace can publish this many messages per second
      * @param namespace
      */
     CompletableFuture<Void> removePublishRateAsync(String namespace);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -1803,6 +1803,15 @@ public interface Namespaces {
     void setPublishRate(String namespace, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
+     * Remove message-publish-rate (topics under this namespace can publish this many messages per second).
+     *
+     * @param namespace
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removePublishRate(String namespace) throws PulsarAdminException;
+
+    /**
      * Set message-publish-rate (topics under this namespace can publish this many messages per second) asynchronously.
      *
      * @param namespace
@@ -1810,6 +1819,13 @@ public interface Namespaces {
      *            number of messages per second
      */
     CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate);
+
+    /**
+     * Remove message-publish-rate (topics under this namespace can publish this many messages per second) asynchronously.
+     *
+     * @param namespace
+     */
+    CompletableFuture<Void> removePublishRateAsync(String namespace);
 
     /**
      * Get message-publish-rate (topics under this namespace can publish this many messages per second).

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1335,10 +1335,31 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
+    public void removePublishRate(String namespace) throws PulsarAdminException {
+        try {
+            removePublishRateAsync(namespace).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
     public CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "publishRate");
         return asyncPostRequest(path, Entity.entity(publishMsgRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> removePublishRateAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "publishRate");
+        return asyncDeleteRequest(path);
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -503,6 +503,9 @@ public class PulsarAdminToolTest {
         namespaces.run(split("get-publish-rate myprop/clust/ns1"));
         verify(mockNamespaces).getPublishRate("myprop/clust/ns1");
 
+        namespaces.run(split("remove-publish-rate myprop/clust/ns1"));
+        verify(mockNamespaces).removePublishRate("myprop/clust/ns1");
+
         namespaces.run(split("set-subscribe-rate myprop/clust/ns1 -sr 2 -st 60"));
         verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", new SubscribeRate(2, 60));
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -782,6 +782,18 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Remove publish-rate for all topics of the namespace")
+    private class RemovePublishRate extends CliCommand {
+        @Parameter(description = "tenant/namespace\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            admin.namespaces().removePublishRate(namespace);
+        }
+    }
+
      @Parameters(commandDescription = "Get configured message-publish-rate for all topics of the namespace (Disabled if value < 0)")
     private class GetPublishRate extends CliCommand {
         @Parameter(description = "tenant/namespace\n", required = true)
@@ -1749,6 +1761,7 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("set-publish-rate", new SetPublishRate());
         jcommander.addCommand("get-publish-rate", new GetPublishRate());
+        jcommander.addCommand("remove-publish-rate", new RemovePublishRate());
 
         jcommander.addCommand("set-replicator-dispatch-rate", new SetReplicatorDispatchRate());
         jcommander.addCommand("get-replicator-dispatch-rate", new GetReplicatorDispatchRate());


### PR DESCRIPTION
Fixes #8222 

### Motivation
Currently, we can set up the publish rate limitation of the topic by user pulsar-admin. It's better to introduce a broker level setting as the default setting. The namespace level setting can rewrite the broker level setting.

### Modifications
1)Add `maxPublishRatePerTopicInMessages` and `maxPublishRatePerTopicInBytes` in the broker.conf
2)Add `RemovePublishRate` API for namespace
3)The priority of the policies is modified to topic-level > namespace-level > broker-level

### Verifying this change
TopicPoliciesTest#testPublishRateInDifferentLevelPolicy