### PR TITLE
Fix docker image permissions of /pulsar for OpenShift

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -60,6 +60,8 @@ RUN apt-get update \
      && apt install -y /pulsar/cpp-client/*.deb \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
+RUN chown -R 0:0 /pulsar \
+    && chmod -R g=u /pulsar
 
 VOLUME  ["/pulsar/conf", "/pulsar/data"]
 


### PR DESCRIPTION
### Motivation
On OpenShift the user id in the container is random. In this case, the `/pulsar` folder has problematic permissions. The `VOLUME` statement even locks these into place for derivative images.
e.g. as a random user the `/pulsar/conf` folder is read-only, while the pulsar helm chart assumes it to be present and writable.

### Modifications

Change ownership of everything in the `/pulsar` directory to be `root:root`, and make sure the owning group has the same rights as the owner.
This solves the problem, as OpenShift ensures the user in the container is a member of the `root` group.