### PR TITLE
Delete associated ledgers before deleting cluster metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -24,6 +24,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.pulsar.broker.service.schema.SchemaStorageFormat.SchemaLocator;
@@ -149,7 +150,9 @@ public class PulsarClusterMetadataTeardown {
     private static void deleteLedger(BookKeeper bookKeeper, long ledgerId) {
         try {
             bookKeeper.deleteLedger(ledgerId);
-            log.debug("Delete ledger id: {}", ledgerId);
+            if (log.isDebugEnabled()) {
+                log.debug("Delete ledger id: {}", ledgerId);
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (BKException e) {
@@ -180,7 +183,7 @@ public class PulsarClusterMetadataTeardown {
                                 return -1L;
                             }
                             // some cursor ledger id could also be set to -1 to mark deleted
-                        }).forEach(ledgerId -> deleteLedger(bookKeeper, ledgerId));
+                        }).filter(ledgerId -> ledgerId >= 0).forEach(ledgerId -> deleteLedger(bookKeeper, ledgerId));
                     } catch (InvalidProtocolBufferException e) {
                         log.warn("Invalid data format from {}: {}", topicRoot, e);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -133,6 +134,9 @@ public class PulsarClusterMetadataTeardown {
         try {
             return zooKeeper.getChildren(path, null);
         } catch (InterruptedException | KeeperException e) {
+            if (e instanceof KeeperException.NoNodeException) {
+                return new ArrayList<>();
+            }
             log.error("Failed to get children of {}: {}", path, e);
             throw new RuntimeException(e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -20,6 +20,13 @@ package org.apache.pulsar;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
+import org.apache.pulsar.broker.service.schema.SchemaStorageFormat.SchemaLocator;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.KeeperException;
@@ -28,7 +35,12 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 /**
  * Teardown the metadata for a existed Pulsar cluster
@@ -51,11 +63,14 @@ public class PulsarClusterMetadataTeardown {
         @Parameter(names = { "-cs", "--configuration-store" }, description = "Configuration Store connection string")
         private String configurationStore;
 
+        @Parameter(names = { "--bookkeeper-metadata-service-uri" }, description = "Metadata service uri of BookKeeper", required = true)
+        private String bkMetadataServiceUri;
+
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
     }
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, IOException, BKException {
         Arguments arguments = new Arguments();
         JCommander jcommander = new JCommander();
         try {
@@ -72,6 +87,21 @@ public class PulsarClusterMetadataTeardown {
 
         ZooKeeper localZk = initZk(arguments.zookeeper, arguments.zkSessionTimeoutMillis);
 
+        List<Long> ledgers = new ArrayList<>();
+        ledgers.addAll(getManagedLedgers(localZk));
+        ledgers.addAll(getSchemaLedgers(localZk));
+        BookKeeper bookKeeper = new BookKeeper(new ClientConfiguration().setMetadataServiceUri(arguments.bkMetadataServiceUri));
+        ledgers.forEach(ledger -> {
+            try {
+                bookKeeper.deleteLedger(ledger);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (BKException e) {
+                log.warn("Failed to delete ledger {}: {}", ledger, e);
+            }
+        });
+        bookKeeper.close();
+
         deleteZkNodeRecursively(localZk, "/bookies");
         deleteZkNodeRecursively(localZk, "/counters");
         deleteZkNodeRecursively(localZk, "/loadbalance");
@@ -84,8 +114,10 @@ public class PulsarClusterMetadataTeardown {
             // Should it be done by REST API before broker is down?
             ZooKeeper configStoreZk = initZk(arguments.configurationStore, arguments.zkSessionTimeoutMillis);
             deleteZkNodeRecursively(configStoreZk, "/admin/clusters/" + arguments.cluster);
+            configStoreZk.close();
         }
 
+        localZk.close();
         log.info("Cluster metadata for '{}' teardown.", arguments.cluster);
     }
 
@@ -105,6 +137,91 @@ public class PulsarClusterMetadataTeardown {
         } catch (KeeperException e) {
             log.warn("Failed to delete node {} from ZK [{}]: {}", path, zooKeeper, e);
         }
+    }
+
+    private static List<String> getChildren(ZooKeeper zooKeeper, String path) {
+        try {
+            return zooKeeper.getChildren(path, null);
+        } catch (InterruptedException | KeeperException e) {
+            log.error("Failed to get children of {}: {}", path, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static byte[] getData(ZooKeeper zooKeeper, String path) {
+        try {
+            return zooKeeper.getData(path, null, null);
+        } catch (KeeperException | InterruptedException e) {
+            log.error("Failed to get data from {}: {}", path, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static List<Long> getManagedLedgers(ZooKeeper zooKeeper) {
+        List<Long> ledgers = Collections.synchronizedList(new ArrayList<>());
+        final String managedLedgersRoot = "/managed-ledgers";
+        getChildren(zooKeeper, managedLedgersRoot).forEach(tenant -> {
+            final String tenantRoot = managedLedgersRoot + "/" + tenant;
+            getChildren(zooKeeper, tenantRoot).forEach(namespace -> {
+                final String namespaceRoot = String.join("/", tenantRoot, namespace, "persistent");
+                getChildren(zooKeeper, namespaceRoot).forEach(topic -> {
+                    final String topicRoot = namespaceRoot + "/" + topic;
+                    byte[] topicData = getData(zooKeeper, topicRoot);
+                    try {
+                        ManagedLedgerInfo ledgerInfo = ManagedLedgerInfo.parseFrom(topicData);
+                        List<Long> topicLedgers = ledgerInfo.getLedgerInfoList().stream()
+                                .map(ManagedLedgerInfo.LedgerInfo::getLedgerId)
+                                .collect(Collectors.toList());
+                        log.info("Detect topic ledgers: {} of {}", topicLedgers, topic);
+                        ledgers.addAll(topicLedgers);
+
+                        List<Long> cursorLedgers = getChildren(zooKeeper, topicRoot).stream().map(subscription -> {
+                            final String subscriptionRoot = topicRoot + "/" +subscription;
+                            try {
+                                return ManagedCursorInfo.parseFrom(getData(zooKeeper, subscriptionRoot)).getCursorsLedgerId();
+                            } catch (InvalidProtocolBufferException e) {
+                                log.warn("Invalid data format from {}: {}", subscriptionRoot, e);
+                                return null;
+                            }
+                            // some cursor ledger id could be set to -1 to mark deleted
+                        }).filter(ledgerId -> (ledgerId != null && ledgerId >= 0)).collect(Collectors.toList());
+                        if (!cursorLedgers.isEmpty()) {
+                            log.info("Detect cursor ledgers: {} of {}", cursorLedgers, topicRoot);
+                            ledgers.addAll(cursorLedgers);
+                        }
+                    } catch (InvalidProtocolBufferException e) {
+                        log.warn("Invalid data format from {}: {}", topicRoot, e);
+                    }
+                });
+            });
+        });
+        return ledgers;
+    }
+
+    public static List<Long> getSchemaLedgers(ZooKeeper zooKeeper) {
+        List<Long> ledgers = Collections.synchronizedList(new ArrayList<>());
+        final String schemaLedgersRoot = "/schemas";
+        getChildren(zooKeeper, schemaLedgersRoot).forEach(tenant -> {
+            final String tenantRoot = schemaLedgersRoot + "/" + tenant;
+            getChildren(zooKeeper, tenantRoot).forEach(namespace -> {
+                final String namespaceRoot = tenantRoot + "/" + namespace;
+                getChildren(zooKeeper, namespaceRoot).forEach(topic -> {
+                    final String topicRoot = namespaceRoot + "/" + topic;
+                    byte[] data = getData(zooKeeper, topicRoot);
+                    try {
+                        SchemaLocator locator = SchemaLocator.parseFrom(data);
+                        List<Long> schemaLedgers = locator.getIndexList().stream()
+                                .map(indexEntry -> indexEntry.getPosition().getLedgerId())
+                                .collect(Collectors.toList());
+                        log.info("Detect schema ledgers: {} of {}", schemaLedgers, topicRoot);
+                        ledgers.addAll(schemaLedgers);
+                    } catch (InvalidProtocolBufferException e) {
+                        log.warn("Invalid data format from {}: {}", topicRoot, e);
+                    }
+                });
+            });
+        });
+        return ledgers;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PulsarClusterMetadataTeardown.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -172,7 +172,7 @@ public class PulsarClusterMetadataTeardown {
                         List<Long> topicLedgers = ledgerInfo.getLedgerInfoList().stream()
                                 .map(ManagedLedgerInfo.LedgerInfo::getLedgerId)
                                 .collect(Collectors.toList());
-                        log.info("Detect topic ledgers: {} of {}", topicLedgers, topic);
+                        log.debug("Detect topic ledgers: {} of {}", topicLedgers, topic);
                         ledgers.addAll(topicLedgers);
 
                         List<Long> cursorLedgers = getChildren(zooKeeper, topicRoot).stream().map(subscription -> {
@@ -181,12 +181,12 @@ public class PulsarClusterMetadataTeardown {
                                 return ManagedCursorInfo.parseFrom(getData(zooKeeper, subscriptionRoot)).getCursorsLedgerId();
                             } catch (InvalidProtocolBufferException e) {
                                 log.warn("Invalid data format from {}: {}", subscriptionRoot, e);
-                                return null;
+                                return -1L;
                             }
-                            // some cursor ledger id could be set to -1 to mark deleted
-                        }).filter(ledgerId -> (ledgerId != null && ledgerId >= 0)).collect(Collectors.toList());
+                            // some cursor ledger id could also be set to -1 to mark deleted
+                        }).filter(ledgerId -> (ledgerId >= 0)).collect(Collectors.toList());
                         if (!cursorLedgers.isEmpty()) {
-                            log.info("Detect cursor ledgers: {} of {}", cursorLedgers, topicRoot);
+                            log.debug("Detect cursor ledgers: {} of {}", cursorLedgers, topicRoot);
                             ledgers.addAll(cursorLedgers);
                         }
                     } catch (InvalidProtocolBufferException e) {
@@ -213,7 +213,7 @@ public class PulsarClusterMetadataTeardown {
                         List<Long> schemaLedgers = locator.getIndexList().stream()
                                 .map(indexEntry -> indexEntry.getPosition().getLedgerId())
                                 .collect(Collectors.toList());
-                        log.info("Detect schema ledgers: {} of {}", schemaLedgers, topicRoot);
+                        log.debug("Detect schema ledgers: {} of {}", schemaLedgers, topicRoot);
                         ledgers.addAll(schemaLedgers);
                     } catch (InvalidProtocolBufferException e) {
                         log.warn("Invalid data format from {}: {}", topicRoot, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -69,6 +69,9 @@ public class PulsarClusterMetadataTeardown {
         private boolean help = false;
     }
 
+    public static String[] localZkNodes = {
+            "bookies", "counters", "loadbalance", "managed-ledgers", "namespace", "schemas", "stream" };
+
     public static void main(String[] args) throws Exception {
         Arguments arguments = new Arguments();
         JCommander jcommander = new JCommander();
@@ -98,13 +101,9 @@ public class PulsarClusterMetadataTeardown {
 
         ZooKeeper localZk = initZk(arguments.zookeeper, arguments.zkSessionTimeoutMillis);
 
-        deleteZkNodeRecursively(localZk, "/bookies");
-        deleteZkNodeRecursively(localZk, "/counters");
-        deleteZkNodeRecursively(localZk, "/loadbalance");
-        deleteZkNodeRecursively(localZk, "/managed-ledgers");
-        deleteZkNodeRecursively(localZk, "/namespace");
-        deleteZkNodeRecursively(localZk, "/schemas");
-        deleteZkNodeRecursively(localZk, "/stream");
+        for (String localZkNode : localZkNodes) {
+            deleteZkNodeRecursively(localZk, "/" + localZkNode);
+        }
 
         if (arguments.configurationStore != null && arguments.cluster != null) {
             // Should it be done by REST API before broker is down?

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-broker</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -52,6 +52,13 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/ClusterMetadataTearDownTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/ClusterMetadataTearDownTest.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.MetadataBookieDriver;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.pulsar.PulsarClusterMetadataTeardown;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.tests.integration.containers.ChaosContainer;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.zookeeper.ZooKeeper;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@Slf4j
+public class ClusterMetadataTearDownTest extends PulsarTestSuite {
+
+    private ZooKeeper localZk;
+    private ZooKeeper configStoreZk;
+
+    private String metadataServiceUri;
+    private MetadataBookieDriver driver;
+    private LedgerManager ledgerManager;
+
+    private PulsarClient client;
+    private PulsarAdmin admin;
+
+    @BeforeSuite
+    @Override
+    public void setupCluster() throws Exception {
+        super.setupCluster();
+        metadataServiceUri = "zk+null://" + pulsarCluster.getZKConnString() + "/ledgers";
+
+        final int sessionTimeoutMs = 30000;
+        localZk = PulsarClusterMetadataTeardown.initZk(pulsarCluster.getZKConnString(), sessionTimeoutMs);
+        configStoreZk = PulsarClusterMetadataTeardown.initZk(pulsarCluster.getCSConnString(), sessionTimeoutMs);
+
+        driver = MetadataDrivers.getBookieDriver(URI.create(metadataServiceUri));
+        driver.initialize(new ServerConfiguration().setMetadataServiceUri(metadataServiceUri), () -> {}, NullStatsLogger.INSTANCE);
+        ledgerManager = driver.getLedgerManagerFactory().newLedgerManager();
+
+        client = PulsarClient.builder().serviceUrl(pulsarCluster.getPlainTextServiceUrl()).build();
+        admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
+    }
+
+    @AfterSuite
+    @Override
+    public void tearDownCluster() {
+        try {
+            ledgerManager.close();
+        } catch (IOException e) {
+            log.warn("Failed to close ledger manager: ", e);
+        }
+        driver.close();
+        try {
+            configStoreZk.close();
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            localZk.close();
+        } catch (InterruptedException ignored) {
+        }
+        super.tearDownCluster();
+    }
+
+    @Test
+    public void testDeleteCluster() throws Exception {
+        assertEquals(getNumOfLedgers(), 0);
+        final String tenant = "my-tenant";
+        final String namespace = tenant + "/my-ns";
+
+        admin.tenants().createTenant(tenant,
+                new TenantInfo(new HashSet<>(), Collections.singleton(pulsarCluster.getClusterName())));
+        admin.namespaces().createNamespace(namespace);
+
+        String[] topics = { "topic-1", "topic-2", namespace + "/topic-1" };
+        for (String topic : topics) {
+            try (Producer<String> producer = client.newProducer(Schema.STRING).topic(topic).create()) {
+                producer.send("msg");
+            }
+            String[] subscriptions = { "sub-1", "sub-2" };
+            for (String subscription : subscriptions) {
+                try (Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                        .topic(topic)
+                        .subscriptionName(subscription)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                        .subscribe()) {
+                    Message<String> msg = consumer.receive(5, TimeUnit.SECONDS);
+                    consumer.acknowledge(msg);
+                }
+            }
+        }
+
+        final String partitionedTopic = namespace + "/par-topic";
+        admin.topics().createPartitionedTopic(partitionedTopic, 3);
+
+        // TODO: the schema ledgers of a partitioned topic cannot be deleted completely now,
+        //   so we create producers/consumers without schema here
+        try (Producer<byte[]> producer = client.newProducer().topic(partitionedTopic).create()) {
+            producer.send("msg".getBytes());
+            try (Consumer<byte[]> consumer = client.newConsumer()
+                    .topic(partitionedTopic)
+                    .subscriptionName("my-sub")
+                    .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                    .subscribe()) {
+                Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
+                consumer.acknowledge(msg);
+            }
+        }
+
+        pulsarCluster.getBrokers().forEach(ChaosContainer::stop);
+
+        assertTrue(getNumOfLedgers() > 0);
+        log.info("Before delete, cluster name: {}, num of ledgers: {}", pulsarCluster.getClusterName(), getNumOfLedgers());
+
+        String[] args = { "-zk", pulsarCluster.getZKConnString(),
+                "-cs", pulsarCluster.getCSConnString(),
+                "-c", pulsarCluster.getClusterName(),
+                "--bookkeeper-metadata-service-uri", metadataServiceUri };
+        PulsarClusterMetadataTeardown.main(args);
+
+
+        // 1. Check Bookie for number of ledgers
+        assertEquals(getNumOfLedgers(), 0);
+
+        // 2. Check ZooKeeper for relative nodes
+        final int zkOpTimeoutMs = 10000;
+        List<String> localZkNodes = ZkUtils.getChildrenInSingleNode(localZk, "/", zkOpTimeoutMs);
+        for (String node : PulsarClusterMetadataTeardown.localZkNodes) {
+            assertFalse(localZkNodes.contains(node));
+        }
+        List<String> clusterNodes = ZkUtils.getChildrenInSingleNode(configStoreZk, "/admin/clusters", zkOpTimeoutMs);
+        assertFalse(clusterNodes.contains(pulsarCluster.getClusterName()));
+    }
+
+    private long getNumOfLedgers() {
+        final AtomicInteger returnCode = new AtomicInteger(BKException.Code.OK);
+        final CountDownLatch processDone = new CountDownLatch(1);
+        final AtomicLong numOfLedgers = new AtomicLong(0L);
+
+        ledgerManager.asyncProcessLedgers((ledgerId, cb) -> numOfLedgers.incrementAndGet(), (rc, path, ctx) -> {
+            returnCode.set(rc);
+            processDone.countDown();
+        }, null, BKException.Code.OK, BKException.Code.ReadException);
+
+        try {
+            processDone.await(5, TimeUnit.SECONDS); // a timeout which is long enough
+        } catch (InterruptedException e) {
+            fail("asyncProcessLedgers failed", e);
+        }
+        return numOfLedgers.get();
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.tests.integration;
+package org.apache.pulsar.tests.integration.cli;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -200,6 +200,10 @@ public class PulsarCluster {
         return zkContainer.getContainerIpAddress() + ":" + zkContainer.getMappedPort(ZK_PORT);
     }
 
+    public String getCSConnString() {
+        return csContainer.getContainerIpAddress() + ":" + csContainer.getMappedPort(CS_PORT);
+    }
+
     public Network getNetwork() {
         return network;
     }

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -27,6 +27,7 @@
             <class name="org.apache.pulsar.tests.integration.compaction.TestCompaction" />
             <class name="org.apache.pulsar.tests.integration.cli.AdminMultiHostTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.FunctionsCLITest"/>
+            <class name="org.apache.pulsar.tests.integration.cli.ClusterMetadataTearDownTest"/>
         </classes>
     </test>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -22,12 +22,12 @@
 <suite name="Pulsar CLI Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-cli-test-suite" preserve-order="true" >
         <classes>
+            <class name="org.apache.pulsar.tests.integration.cli.ClusterMetadataTearDownTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.CLITest" />
             <class name="org.apache.pulsar.tests.integration.cli.HealthCheckTest" />
             <class name="org.apache.pulsar.tests.integration.compaction.TestCompaction" />
             <class name="org.apache.pulsar.tests.integration.cli.AdminMultiHostTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.FunctionsCLITest"/>
-            <class name="org.apache.pulsar.tests.integration.cli.ClusterMetadataTearDownTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Motivation

#8169 introduced a command tool to delete a cluster's metadata from ZK. This PR intends to delete the cluster's ledgers from BK.

### Modifications

- Retrieve ledger ids from related ZK nodes
- Add an optional argument to specify BK metadata service URI, then delete these ledgers if it's specified

### Verifying this change

- [ ] Make sure that the change passes the CI checks.