### PR TITLE
[website] Update CFP dates for Pulsar Summit Asia 2020

### DIFF
--- a/site2/website/blog/2020-09-01-pulsar-summit-asia-2020-cfp.md
+++ b/site2/website/blog/2020-09-01-pulsar-summit-asia-2020-cfp.md
@@ -18,9 +18,9 @@ If you have questions about submitting a proposal, or want some feedback or advi
 
 ## Dates to remember
 - CFP opens: September 1, 2020
-- CFP closes: October 14, 2020 - 23:59 (CST: China Standard Time/UTC+8 time zone)
-- CFP notification: October 21, 2020
-- Schedule announcement: October 28, 2020
+- CFP closes: October 21, 2020 - 23:59 (CST: China Standard Time/UTC+8 time zone)
+- CFP notification: October 28, 2020
+- Schedule announcement: November 4, 2020
 
 ## Speaker benefits
 When your speaking proposal is approved, you will enjoy the following benefits:


### PR DESCRIPTION
### Motivation

Extend CFP for Pulsar Summit Asia 2020 for a week.

### Modifications
 
Update the schedule accordingly.