### PR TITLE
Support limits the max tenants of the Pulsar cluster

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -83,6 +83,7 @@ isRunningStandalone=
 clusterName=
 
 # The maximum number of tenants that each pulsar cluster can create
+# This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
 maxTenants=0
 
 # Enable cluster's failure-domain which can distribute brokers into logical region

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -82,6 +82,9 @@ isRunningStandalone=
 # Name of the cluster to which this broker belongs to
 clusterName=
 
+# The maximum number of tenants that each pulsar cluster can create
+maxTenants=0
+
 # Enable cluster's failure-domain which can distribute brokers into logical region
 failureDomainsEnabled=false
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -67,6 +67,9 @@ isRunningStandalone=
 # Name of the cluster to which this broker belongs to
 clusterName={{ cluster_name }}
 
+# The maximum number of tenants that each pulsar cluster can create
+maxTenants=0
+
 # Enable cluster's failure-domain which can distribute brokers into logical region
 failureDomainsEnabled=false
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -68,6 +68,7 @@ isRunningStandalone=
 clusterName={{ cluster_name }}
 
 # The maximum number of tenants that each pulsar cluster can create
+# This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
 maxTenants=0
 
 # Enable cluster's failure-domain which can distribute brokers into logical region

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -239,6 +239,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
+        doc = "The maximum number of tenants that each pulsar cluster can create"
+    )
+    private int maxTenants = 0;
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
         doc = "Enable cluster's failure-domain which can distribute brokers into logical region"
     )
     private boolean failureDomainsEnabled = false;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -239,7 +239,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
-        doc = "The maximum number of tenants that each pulsar cluster can create"
+        doc = "The maximum number of tenants that each pulsar cluster can create." 
+                + "This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded."
     )
     private int maxTenants = 0;
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -107,7 +107,8 @@ public class TenantsBase extends AdminResource {
             NamedEntity.checkName(tenant);
             List<String> tenants = globalZk().getChildren(path(POLICIES), false);
             int maxTenants = pulsar().getConfiguration().getMaxTenants();
-            //Not precise control without lock
+            //Due to the cost of distributed locks, no locks are added here. 
+            //In a concurrent scenario, the threshold will be exceeded.
             if (maxTenants > 0 && tenants != null && tenants.size() >= maxTenants) {
                 throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -106,8 +106,9 @@ public class TenantsBase extends AdminResource {
         try {
             NamedEntity.checkName(tenant);
             List<String> tenants = globalZk().getChildren(path(POLICIES), false);
+            int maxTenants = pulsar().getConfiguration().getMaxTenants();
             //No locks for precise control
-            if (tenants != null && tenants.size() >= pulsar().getConfiguration().getMaxTenants()) {
+            if (maxTenants > 0 && tenants != null && tenants.size() >= maxTenants) {
                 throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
             }
             zkCreate(path(POLICIES, tenant), jsonMapper().writeValueAsBytes(config));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -105,12 +105,15 @@ public class TenantsBase extends AdminResource {
 
         try {
             NamedEntity.checkName(tenant);
-            List<String> tenants = globalZk().getChildren(path(POLICIES), false);
+            
             int maxTenants = pulsar().getConfiguration().getMaxTenants();
             //Due to the cost of distributed locks, no locks are added here. 
             //In a concurrent scenario, the threshold will be exceeded.
-            if (maxTenants > 0 && tenants != null && tenants.size() >= maxTenants) {
-                throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
+            if (maxTenants > 0) {
+                List<String> tenants = globalZk().getChildren(path(POLICIES), false);
+                if (tenants != null && tenants.size() >= maxTenants) {
+                    throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
+                }
             }
             zkCreate(path(POLICIES, tenant), jsonMapper().writeValueAsBytes(config));
             log.info("[{}] Created tenant {}", clientAppId(), tenant);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -107,7 +107,7 @@ public class TenantsBase extends AdminResource {
             NamedEntity.checkName(tenant);
             List<String> tenants = globalZk().getChildren(path(POLICIES), false);
             int maxTenants = pulsar().getConfiguration().getMaxTenants();
-            //No locks for precise control
+            //Not precise control without lock
             if (maxTenants > 0 && tenants != null && tenants.size() >= maxTenants) {
                 throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -105,6 +105,11 @@ public class TenantsBase extends AdminResource {
 
         try {
             NamedEntity.checkName(tenant);
+            List<String> tenants = globalZk().getChildren(path(POLICIES), false);
+            //No locks for precise control
+            if (tenants != null && tenants.size() >= pulsar().getConfiguration().getMaxTenants()) {
+                throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
+            }
             zkCreate(path(POLICIES, tenant), jsonMapper().writeValueAsBytes(config));
             log.info("[{}] Created tenant {}", clientAppId(), tenant);
         } catch (KeeperException.NodeExistsException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import com.google.common.collect.Sets;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TenantTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testMaxTenant() throws Exception {
+        conf.setMaxTenants(2);
+        super.internalSetup();
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant("testTenant1", tenantInfo);
+        admin.tenants().createTenant("testTenant2", tenantInfo);
+        try {
+            admin.tenants().createTenant("testTenant3", tenantInfo);
+        } catch (PulsarAdminException e) {
+            Assert.assertEquals(e.getStatusCode(), 412);
+            Assert.assertEquals(e.getHttpError(), "Exceed the maximum number of tenants");
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
@@ -74,31 +74,4 @@ public class TenantTest extends MockedPulsarServiceBaseTest {
         }
     }
     
-    @Test
-    public void testExceedMaxTenant() throws Exception {
-        conf.setMaxTenants(2);
-        super.internalSetup();
-        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
-        TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
-        ExecutorService executor = new ThreadPoolExecutor(10, 10, 30
-                , TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
-                new DefaultThreadFactory("testExceedMaxTenant"));
-        CountDownLatch countDownLatch = new CountDownLatch(10);
-        AtomicInteger counter = new AtomicInteger(0);
-        for (int i = 0; i < 10; i++) {
-            executor.execute(() -> {
-                try {
-                    admin.tenants().createTenant("tenant" + UUID.randomUUID(), tenantInfo);
-                    counter.getAndIncrement();
-                } catch (PulsarAdminException ignored) {
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-        countDownLatch.await();
-        Assert.assertTrue(counter.get() > 2);
-        executor.shutdownNow();
-    }
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.api;
 
 import com.google.common.collect.Sets;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -28,14 +27,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TenantTest extends MockedPulsarServiceBaseTest {
 
@@ -66,6 +57,7 @@ public class TenantTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(e.getHttpError(), "Exceed the maximum number of tenants");
         }
         //unlimited
+        super.internalCleanup();
         conf.setMaxTenants(0);
         super.internalSetup();
         admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
@@ -56,6 +56,13 @@ public class TenantTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(e.getStatusCode(), 412);
             Assert.assertEquals(e.getHttpError(), "Exceed the maximum number of tenants");
         }
+        //unlimited
+        conf.setMaxTenants(0);
+        super.internalSetup();
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        for (int i = 0; i < 10; i++) {
+            admin.tenants().createTenant("testTenant-unlimited" + i, tenantInfo);
+        }
     }
 
 }


### PR DESCRIPTION

Fixes #8223

### Motivation
Support limits the max tenants of the Pulsar cluster. When the tenants reach the max tenants of the cluster, the broker should reject the new tenant request.

### Modifications
Add maxTenants=0 in the broker.conf and don't limit by default.

### Verifying this change
TenantTest#testMaxTenant