### PR TITLE
Support limits the max namespaces per tenant

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -201,6 +201,9 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 # value will be used as the default
 defaultNumberOfNamespaceBundles=4
 
+#The maximum number of namespaces that each tenant can create
+maxNamespacePerTenant=0
+
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -203,7 +203,7 @@ defaultNumberOfNamespaceBundles=4
 
 # The maximum number of namespaces that each tenant can create
 # This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
-maxNamespacePerTenant=0
+maxNamespacesPerTenant=0
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -201,7 +201,8 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 # value will be used as the default
 defaultNumberOfNamespaceBundles=4
 
-#The maximum number of namespaces that each tenant can create
+# The maximum number of namespaces that each tenant can create
+# This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
 maxNamespacePerTenant=0
 
 # Enable check for minimum allowed client library version

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -186,7 +186,8 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 # value will be used as the default
 defaultNumberOfNamespaceBundles=4
 
-#The maximum number of namespaces that each tenant can create
+# The maximum number of namespaces that each tenant can create
+# This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
 maxNamespacePerTenant=0
 
 # Enable check for minimum allowed client library version

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -188,7 +188,7 @@ defaultNumberOfNamespaceBundles=4
 
 # The maximum number of namespaces that each tenant can create
 # This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded
-maxNamespacePerTenant=0
+maxNamespacesPerTenant=0
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -186,6 +186,9 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 # value will be used as the default
 defaultNumberOfNamespaceBundles=4
 
+#The maximum number of namespaces that each tenant can create
+maxNamespacePerTenant=0
+
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -427,7 +427,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_POLICIES, 
         dynamic = true,
-        doc = "The maximum number of namespaces that each tenant can create")
+        doc = "The maximum number of namespaces that each tenant can create."
+            + "This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded")
     private int maxNamespacePerTenant = 0;
 
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -423,6 +423,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "When a namespace is created without specifying the number of bundle, this"
             + " value will be used as the default")
     private int defaultNumberOfNamespaceBundles = 4;
+    
+    @FieldContext(
+        category = CATEGORY_POLICIES, 
+        dynamic = true,
+        doc = "The maximum number of namespaces that each tenant can create")
+    private int maxNamespacePerTenant = 0;
 
     @FieldContext(
         category = CATEGORY_SERVER,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -429,7 +429,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         dynamic = true,
         doc = "The maximum number of namespaces that each tenant can create."
             + "This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded")
-    private int maxNamespacePerTenant = 0;
+    private int maxNamespacesPerTenant = 0;
 
     @FieldContext(
         category = CATEGORY_SERVER,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -49,7 +49,6 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
@@ -133,11 +132,11 @@ public abstract class NamespacesBase extends AdminResource {
         validatePolicies(namespaceName, policies);
 
         try {
-            int maxNamespacePerTenant = pulsar().getConfiguration().getMaxNamespacePerTenant();
+            int maxNamespacesPerTenant = pulsar().getConfiguration().getMaxNamespacesPerTenant();
             //no distributed locks are added here.In a concurrent scenario, the threshold will be exceeded.
-            if (maxNamespacePerTenant > 0) {
+            if (maxNamespacesPerTenant > 0) {
                 List<String> namespaces = getListOfNamespaces(namespaceName.getTenant());
-                if (namespaces != null && namespaces.size() > maxNamespacePerTenant) {
+                if (namespaces != null && namespaces.size() > maxNamespacesPerTenant) {
                     throw new RestException(Status.PRECONDITION_FAILED,
                             "Exceed the maximum number of namespace in tenant :" + namespaceName.getTenant());
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -133,12 +133,14 @@ public abstract class NamespacesBase extends AdminResource {
         validatePolicies(namespaceName, policies);
 
         try {
-            List<String> namespaces = getListOfNamespaces(namespaceName.getTenant());
             int maxNamespacePerTenant = pulsar().getConfiguration().getMaxNamespacePerTenant();
             //no distributed locks are added here.In a concurrent scenario, the threshold will be exceeded.
-            if (maxNamespacePerTenant > 0 && namespaces != null && namespaces.size() > maxNamespacePerTenant) {
-                throw new RestException(Status.PRECONDITION_FAILED,
-                        "Exceed the maximum number of namespace in tenant :" + namespaceName.getTenant());
+            if (maxNamespacePerTenant > 0) {
+                List<String> namespaces = getListOfNamespaces(namespaceName.getTenant());
+                if (namespaces != null && namespaces.size() > maxNamespacePerTenant) {
+                    throw new RestException(Status.PRECONDITION_FAILED,
+                            "Exceed the maximum number of namespace in tenant :" + namespaceName.getTenant());
+                }
             }
             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -135,6 +135,7 @@ public abstract class NamespacesBase extends AdminResource {
         try {
             List<String> namespaces = getListOfNamespaces(namespaceName.getTenant());
             int maxNamespacePerTenant = pulsar().getConfiguration().getMaxNamespacePerTenant();
+            //no distributed locks are added here.In a concurrent scenario, the threshold will be exceeded.
             if (maxNamespacePerTenant > 0 && namespaces != null && namespaces.size() > maxNamespacePerTenant) {
                 throw new RestException(Status.PRECONDITION_FAILED,
                         "Exceed the maximum number of namespace in tenant :" + namespaceName.getTenant());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -133,6 +133,12 @@ public abstract class NamespacesBase extends AdminResource {
         validatePolicies(namespaceName, policies);
 
         try {
+            List<String> namespaces = getListOfNamespaces(namespaceName.getTenant());
+            int maxNamespacePerTenant = pulsar().getConfiguration().getMaxNamespacePerTenant();
+            if (maxNamespacePerTenant > 0 && namespaces != null && namespaces.size() > maxNamespacePerTenant) {
+                throw new RestException(Status.PRECONDITION_FAILED,
+                        "Exceed the maximum number of namespace in tenant :" + namespaceName.getTenant());
+            }
             policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
 
             zkCreateOptimistic(path(POLICIES, namespaceName.toString()), jsonMapper().writeValueAsBytes(policies));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1296,9 +1296,9 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testMaxNamespacePerTenant() throws Exception {
+    public void testMaxNamespacesPerTenant() throws Exception {
         super.internalCleanup();
-        conf.setMaxNamespacePerTenant(2);
+        conf.setMaxNamespacesPerTenant(2);
         super.internalSetup();
         admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
         TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
@@ -1314,7 +1314,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
         //unlimited
         super.internalCleanup();
-        conf.setMaxNamespacePerTenant(0);
+        conf.setMaxNamespacesPerTenant(0);
         super.internalSetup();
         admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
         admin.tenants().createTenant("testTenant", tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1294,4 +1294,33 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.clusters().updateCluster(clusterName, cluster);
         Assert.assertEquals(admin.clusters().getCluster(clusterName), cluster);
     }
+
+    @Test
+    public void testMaxNamespacePerTenant() throws Exception {
+        super.internalCleanup();
+        conf.setMaxNamespacePerTenant(2);
+        super.internalSetup();
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant("testTenant", tenantInfo);
+        admin.namespaces().createNamespace("testTenant/ns1", Sets.newHashSet("test"));
+        admin.namespaces().createNamespace("testTenant/ns2", Sets.newHashSet("test"));
+        try {
+            admin.namespaces().createNamespace("testTenant/ns3", Sets.newHashSet("test"));
+        } catch (PulsarAdminException e) {
+            Assert.assertEquals(e.getStatusCode(), 412);
+            Assert.assertEquals(e.getHttpError(), "Exceed the maximum number of namespace in tenant :testTenant");
+        }
+
+        //unlimited
+        super.internalCleanup();
+        conf.setMaxNamespacePerTenant(0);
+        super.internalSetup();
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        admin.tenants().createTenant("testTenant", tenantInfo);
+        for (int i = 0; i < 10; i++) {
+            admin.namespaces().createNamespace("testTenant/ns-" + i, Sets.newHashSet("test"));
+        }
+
+    }
 }


### PR DESCRIPTION
Fixes #8224
### Motivation
Support limits the max namespaces per tenant of the Pulsar cluster. When the namespaces reach the max namespaces of the tenant, the broker should reject the new namespace request.


### Modifications
Add maxNamespacePerTenant=0 in the broker.conf and don't limit by default.

### Verifying this change
AdminApiTest2#testMaxNamespacePerTenant
