### PR TITLE
[C++] Client is allocating buffer bigger than needed

### DIFF
--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -675,7 +675,7 @@ uint64_t Commands::serializeSingleMessageInBatchWithPayload(const Message& msg, 
                   << batchPayLoad.writableBytes() << "] can't accomodate new payload [" << requiredSpace
                   << "] - expanding the batchPayload buffer");
         SharedBuffer buffer = SharedBuffer::allocate(batchPayLoad.readableBytes() +
-                                                     std::max(requiredSpace, maxMessageSizeInBytes));
+                                                     std::min(requiredSpace, maxMessageSizeInBytes));
         // Adding batch created so far
         buffer.write(batchPayLoad.data(), batchPayLoad.readableBytes());
         batchPayLoad = buffer;

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -674,8 +674,7 @@ uint64_t Commands::serializeSingleMessageInBatchWithPayload(const Message& msg, 
         LOG_DEBUG("remaining size of batchPayLoad buffer ["
                   << batchPayLoad.writableBytes() << "] can't accomodate new payload [" << requiredSpace
                   << "] - expanding the batchPayload buffer");
-        SharedBuffer buffer = SharedBuffer::allocate(batchPayLoad.readableBytes() +
-                                                     std::min(requiredSpace, maxMessageSizeInBytes));
+        SharedBuffer buffer = SharedBuffer::allocate(batchPayLoad.readableBytes() + requiredSpace);
         // Adding batch created so far
         buffer.write(batchPayLoad.data(), batchPayLoad.readableBytes());
         batchPayLoad = buffer;


### PR DESCRIPTION
### Motivation

The C++ client is using a huge amount of memory (eg: ~10GB) when it's partitioned from brokers and it's using a topic with many partitions. This is kind also present when the producer queue sizes are kind of small. 

The reason is that the buffer size for the batch is always allocated with 5MB capacity, even though we're going to need much less memory per each batch. 