### PR TITLE
Support limit max subscriptions per topic

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -361,6 +361,11 @@ maxProducersPerTopic=0
 # Using a value of 0, is disabling maxConsumersPerTopic-limit check.
 maxConsumersPerTopic=0
 
+# Max number of subscriptions allowed to subscribe to topic. Once this limit reaches, broker will reject
+# new subscription until the number of subscribed subscriptions decrease.
+# Using a value of 0, is disabling maxSubscriptionsPerTopic limit check.
+maxSubscriptionsPerTopic=0
+
 # Max number of consumers allowed to connect to subscription. Once this limit reaches, Broker will reject new consumers
 # until the number of connected consumers decrease.
 # Using a value of 0, is disabling maxConsumersPerSubscription-limit check.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -242,6 +242,11 @@ maxProducersPerTopic=0
 # Using a value of 0, is disabling maxConsumersPerTopic-limit check.
 maxConsumersPerTopic=0
 
+# Max number of subscriptions allowed to subscribe to topic. Once this limit reaches, broker will reject
+# new subscription until the number of subscribed subscriptions decrease.
+# Using a value of 0, is disabling maxSubscriptionsPerTopic limit check.
+maxSubscriptionsPerTopic=0
+
 # Max number of consumers allowed to connect to subscription. Once this limit reaches, Broker will reject new consumers
 # until the number of connected consumers decrease.
 # Using a value of 0, is disabling maxConsumersPerSubscription-limit check.

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -346,6 +346,11 @@ maxProducersPerTopic=0
 # Using a value of 0, is disabling maxConsumersPerTopic-limit check.
 maxConsumersPerTopic=0
 
+# Max number of subscriptions allowed to subscribe to topic. Once this limit reaches, broker will reject
+# new subscription until the number of subscribed subscriptions decrease.
+# Using a value of 0, is disabling maxSubscriptionsPerTopic limit check.
+maxSubscriptionsPerTopic=0
+
 # Max number of consumers allowed to connect to subscription. Once this limit reaches, Broker will reject new consumers
 # until the number of connected consumers decrease.
 # Using a value of 0, is disabling maxConsumersPerSubscription-limit check.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -699,6 +699,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
+        doc = "Max number of subscriptions allowed to subscribe to topic. \n\nOnce this limit reaches, "
+                + " broker will reject new subscription until the number of subscribed subscriptions decrease.\n"
+                + " Using a value of 0, is disabling maxSubscriptionsPerTopic limit check."
+    )
+    private int maxSubscriptionsPerTopic = 0;
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
         doc = "Max number of consumers allowed to connect to subscription. \n\nOnce this limit reaches,"
             + " Broker will reject new consumers until the number of connected consumers decrease."
             + " Using a value of 0, is disabling maxConsumersPerSubscription-limit check.")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -46,9 +46,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.BiFunction;
 
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.core.StreamingOutput;
-
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
@@ -88,10 +85,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.TopicTerminatedEx
 import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
-import org.apache.pulsar.broker.service.PrecisPublishLimiter;
 import org.apache.pulsar.broker.service.Producer;
-import org.apache.pulsar.broker.service.PublishRateLimiter;
-import org.apache.pulsar.broker.service.PublishRateLimiterImpl;
 import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.StreamingStats;
@@ -121,7 +115,6 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.LedgerInfo;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.PublisherStats;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
@@ -134,7 +127,6 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.RateLimiter;
 import org.apache.pulsar.common.util.RestException;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.compaction.CompactedTopic;
@@ -2519,7 +2511,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private boolean checkMaxSubscriptionsPerTopicExceed() {
         final int maxSubscriptionsPerTopic = brokerService.pulsar().getConfig().getMaxSubscriptionsPerTopic();
         if (maxSubscriptionsPerTopic > 0) {
-            if (subscriptions != null && subscriptions.size() > maxSubscriptionsPerTopic) {
+            if (subscriptions != null && subscriptions.size() >= maxSubscriptionsPerTopic) {
                 return true;
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1333,7 +1333,12 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         conf.setMaxSubscriptionsPerTopic(2);
         super.internalSetup();
 
-        final String topic = "persistent://prop-xyz/ns1/max-subscriptions-per-topic";
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant("testTenant", tenantInfo);
+        admin.namespaces().createNamespace("testTenant/ns1", Sets.newHashSet("test"));
+
+        final String topic = "persistent://testTenant/ns1/max-subscriptions-per-topic";
 
         admin.topics().createPartitionedTopic(topic, 3);
         Producer producer = pulsarClient.newProducer().topic(topic).create();
@@ -1344,14 +1349,19 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.topics().createSubscription(topic, "test-sub2", MessageId.earliest);
         try {
             admin.topics().createSubscription(topic, "test-sub3", MessageId.earliest);
+            Assert.fail();
         } catch (PulsarAdminException e) {
-            Assert.assertEquals(e.getStatusCode(), 412);
-            Assert.assertEquals(e.getHttpError(), "Exceed the maximum number of subscriptions of the topic: " + topic);
+            log.info("create subscription failed. Exception: ", e);
         }
 
         super.internalCleanup();
         conf.setMaxSubscriptionsPerTopic(0);
         super.internalSetup();
+
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        admin.tenants().createTenant("testTenant", tenantInfo);
+        admin.namespaces().createNamespace("testTenant/ns1", Sets.newHashSet("test"));
+
         admin.topics().createPartitionedTopic(topic, 3);
         producer = pulsarClient.newProducer().topic(topic).create();
         producer.close();
@@ -1363,6 +1373,11 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
         conf.setMaxSubscriptionsPerTopic(2);
         super.internalSetup();
+
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+        admin.tenants().createTenant("testTenant", tenantInfo);
+        admin.namespaces().createNamespace("testTenant/ns1", Sets.newHashSet("test"));
+
         admin.topics().createPartitionedTopic(topic, 3);
         producer = pulsarClient.newProducer().topic(topic).create();
         producer.close();


### PR DESCRIPTION
Fix #8226 

### Motivation
Support limits the max subscriptions per topic of the Pulsar cluster. When the subscriptions reach the max subscriptions of the topic, the broker should reject the new subscription request and reject the consumer to subscribe to this topic.

### Modifications
1. Add maxSubscriptionsPerTopic=0 in the broker.conf and don't limit by default.
2. add limit max subscriptions per topic

### Verifying this change
AdminApiTest2#testMaxSubscriptionsPerTopic