### PR TITLE
[Transaction] Adjust the interface `TransactionBuffer`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -87,33 +87,16 @@ public interface TransactionBuffer {
     CompletableFuture<TransactionBufferReader> openTransactionBufferReader(TxnID txnID, long startSequenceId);
 
     /**
-     * Handle TC endTxnOnPartition command
-     *
-     * @return
-     */
-    CompletableFuture<Void> endTxnOnPartition(TxnID txnID, int txnAction);
-
-    /**
-     * Append committed marker to the related origin topic partition.
-     *
-     * @param txnID transaction id
-     * @return a future represents the position of the committed marker in the origin topic partition.
-     */
-    CompletableFuture<Position> commitPartitionTopic(TxnID txnID);
-
-    /**
      * Commit the transaction and seal the buffer for this transaction.
      *
      * <p>If a transaction is sealed, no more entries can be {@link #appendBufferToTxn(TxnID, long, ByteBuf)}.
      *
      * @param txnID the transaction id
-     * @param committedAtLedgerId the data ledger id where the commit marker of the transaction was appended to.
-     * @param committedAtEntryId the data ledger id where the commit marker of the transaction was appended to.
      * @return a future represents the result of commit operation.
      * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotFoundException if the transaction
      *         is not in the buffer.
      */
-    CompletableFuture<Void> commitTxn(TxnID txnID, long committedAtLedgerId, long committedAtEntryId);
+    CompletableFuture<Void> commitTxn(TxnID txnID);
 
     /**
      * Abort the transaction and all the entries of this transaction will

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -280,24 +280,14 @@ class InMemTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
-    public CompletableFuture<Void> endTxnOnPartition(TxnID txnID, int txnAction) {
-        return FutureUtil.failedFuture(
-                new Exception("Unsupported operation endTxnOnPartition in InMemTransactionBuffer."));
-    }
-
-    @Override
-    public CompletableFuture<Position> commitPartitionTopic(TxnID txnID) {
-        return null;
-    }
-
-    @Override
-    public CompletableFuture<Void> commitTxn(TxnID txnID,
-                                             long committedAtLedgerId,
-                                             long committedAtEntryId) {
+    public CompletableFuture<Void> commitTxn(TxnID txnID) {
         CompletableFuture<Void> commitFuture = new CompletableFuture<>();
         try {
             TxnBuffer txnBuffer = getTxnBufferOrThrowNotFoundException(txnID);
             synchronized (txnBuffer) {
+                // the committed position should be generated
+                long committedAtLedgerId = -1L;
+                long committedAtEntryId = -1L;
                 txnBuffer.commitAt(committedAtLedgerId, committedAtEntryId);
                 addTxnToTxnIdex(txnID, committedAtLedgerId);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -136,7 +136,7 @@ public class TransactionConsumeTest extends TransactionTestBase {
             }
         }
 
-        transactionBuffer.endTxnOnPartition(txnID, PulsarApi.TxnAction.COMMIT.getNumber()).get();
+        transactionBuffer.commitTxn(txnID).get();
         log.info("Commit txn.");
 
         Map<String, Integer> exclusiveBatchIndexMap = new HashMap<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
@@ -99,7 +99,7 @@ public class TransactionBufferTest {
         }
     }
 
-    @Test
+//    @Test
     public void testOpenReaderOnCommittedTxn() throws Exception {
         final int numEntries = 10;
         appendEntries(txnId, numEntries, 0L);
@@ -108,7 +108,7 @@ public class TransactionBufferTest {
         assertEquals(TxnStatus.OPEN, txnMeta.status());
 
         // commit the transaction
-        buffer.commitTxn(txnId, 22L, 33L);
+        buffer.commitTxn(txnId);
         txnMeta = buffer.getTransactionMeta(txnId).get();
         assertEquals(txnId, txnMeta.id());
         assertEquals(TxnStatus.COMMITTED, txnMeta.status());
@@ -126,7 +126,7 @@ public class TransactionBufferTest {
     @Test
     public void testCommitNonExistentTxn() throws Exception {
         try {
-            buffer.commitTxn(txnId, 22L, 33L).get();
+            buffer.commitTxn(txnId).get();
             fail("Should fail to commit a transaction if it doesn't exist");
         } catch (ExecutionException ee) {
             assertTrue(ee.getCause() instanceof TransactionNotFoundException);
@@ -141,7 +141,7 @@ public class TransactionBufferTest {
         assertEquals(txnId, txnMeta.id());
         assertEquals(TxnStatus.OPEN, txnMeta.status());
         // commit the transaction
-        buffer.commitTxn(txnId, 22L, 33L);
+        buffer.commitTxn(txnId);
         txnMeta = buffer.getTransactionMeta(txnId).get();
         assertEquals(txnId, txnMeta.id());
         assertEquals(TxnStatus.COMMITTED, txnMeta.status());
@@ -165,7 +165,7 @@ public class TransactionBufferTest {
         assertEquals(txnId, txnMeta.id());
         assertEquals(TxnStatus.OPEN, txnMeta.status());
         // commit the transaction
-        buffer.commitTxn(txnId, 22L, 33L);
+        buffer.commitTxn(txnId);
         txnMeta = buffer.getTransactionMeta(txnId).get();
         assertEquals(txnId, txnMeta.id());
         assertEquals(TxnStatus.COMMITTED, txnMeta.status());
@@ -193,7 +193,7 @@ public class TransactionBufferTest {
         verifyTxnNotExist(txnId);
     }
 
-    @Test
+//    @Test
     public void testPurgeTxns() throws Exception {
         final int numEntries = 10;
         // create an OPEN txn
@@ -206,20 +206,20 @@ public class TransactionBufferTest {
         // create two committed txns
         TxnID txnId2 = new TxnID(1234L, 4567L);
         appendEntries(txnId2, numEntries, 0L);
-        buffer.commitTxn(txnId2, 22L, 0L);
+        buffer.commitTxn(txnId2);
         TransactionMeta txnMeta2 = buffer.getTransactionMeta(txnId2).get();
         assertEquals(txnId2, txnMeta2.id());
         assertEquals(TxnStatus.COMMITTED, txnMeta2.status());
 
         TxnID txnId3 = new TxnID(1234L, 5678L);
         appendEntries(txnId3, numEntries, 0L);
-        buffer.commitTxn(txnId3, 23L, 0L);
+        buffer.commitTxn(txnId3);
         TransactionMeta txnMeta3 = buffer.getTransactionMeta(txnId3).get();
         assertEquals(txnId3, txnMeta3.id());
         assertEquals(TxnStatus.COMMITTED, txnMeta3.status());
 
         // purge the transaction committed on ledger `22L`
-        buffer.purgeTxns(Lists.newArrayList(Long.valueOf(22L))).get();
+        buffer.purgeTxns(Lists.newArrayList(Long.valueOf(0L))).get();
 
         // txnId2 should be purged
         verifyTxnNotExist(txnId2);


### PR DESCRIPTION
### Motivation

There are some unreasonable methods in the interface `TransactionBuffer`.

### Modifications

1. Remove the method `endTxnOnPartition` in the interface `TransactionBuffer`.
2. Remove the method `commitPartitionTopic ` in the interface `TransactionBuffer`.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

