### PR TITLE
Fix message TTL on Key_Shared subscription and Fix ordering issue when replay messages.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -28,6 +28,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.stats.Rate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
     private final String topicName;
     private final Rate msgExpired;
     private final boolean autoSkipNonRecoverableData;
+    private final PersistentSubscription subscription;
 
     private static final int FALSE = 0;
     private static final int TRUE = 1;
@@ -48,14 +50,15 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
     private static final AtomicIntegerFieldUpdater<PersistentMessageExpiryMonitor> expirationCheckInProgressUpdater = AtomicIntegerFieldUpdater
             .newUpdater(PersistentMessageExpiryMonitor.class, "expirationCheckInProgress");
 
-    public PersistentMessageExpiryMonitor(String topicName, String subscriptionName, ManagedCursor cursor) {
+    public PersistentMessageExpiryMonitor(String topicName, String subscriptionName, ManagedCursor cursor, PersistentSubscription subscription) {
         this.topicName = topicName;
         this.cursor = cursor;
         this.subName = subscriptionName;
+        this.subscription = subscription;
         this.msgExpired = new Rate();
-        this.autoSkipNonRecoverableData = cursor.getManagedLedger() != null  // check to avoid test failures
-                ? cursor.getManagedLedger().getConfig().isAutoSkipNonRecoverableData()
-                : false;
+        // check to avoid test failures
+        this.autoSkipNonRecoverableData = this.cursor.getManagedLedger() != null
+                && this.cursor.getManagedLedger().getConfig().isAutoSkipNonRecoverableData();
     }
 
     public void expireMessages(int messageTTLInSeconds) {
@@ -64,7 +67,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
                     messageTTLInSeconds);
 
             cursor.asyncFindNewestMatching(ManagedCursor.FindPositionConstraint.SearchActiveEntries, entry -> {
-                MessageImpl msg = null;
+                MessageImpl<?> msg = null;
                 try {
                     msg = MessageImpl.deserialize(entry.getDataBuffer());
                     return msg.isExpired(messageTTLInSeconds);
@@ -102,7 +105,10 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
             long numMessagesExpired = (long) ctx - cursor.getNumberOfEntriesInBacklog(false);
             msgExpired.recordMultipleEvents(numMessagesExpired, 0 /* no value stats */);
             updateRates();
-
+            // If the subscription is a Key_Shared subscription, we should to trigger message dispatch.
+            if (subscription != null && subscription.getType() == PulsarApi.CommandSubscribe.SubType.Key_Shared) {
+                subscription.getDispatcher().acknowledgementWasProcessed();
+            }
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{}] Mark deleted {} messages", topicName, subName, numMessagesExpired);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -113,7 +113,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         this.ledger = cursor.getManagedLedger();
         this.cursor = cursor;
         this.topic = topic;
-        this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor);
+        this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor, null);
         HAVE_PENDING_READ_UPDATER.set(this, FALSE);
         PENDING_MESSAGES_UPDATER.set(this, 0);
 
@@ -196,7 +196,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         if (cursor != null) {
             log.info("[{}][{} -> {}] Using the exists cursor for replicator", topicName, localCluster, remoteCluster);
             if (expiryMonitor == null) {
-                this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor);
+                this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor, null);
             }
             return CompletableFuture.completedFuture(null);
         }
@@ -206,7 +206,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
             public void openCursorComplete(ManagedCursor cursor, Object ctx) {
                 log.info("[{}][{} -> {}] Open cursor succeed for replicator", topicName, localCluster, remoteCluster);
                 PersistentReplicator.this.cursor = cursor;
-                PersistentReplicator.this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor);
+                PersistentReplicator.this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, Codec.decode(cursor.getName()), cursor, null);
                 res.complete(null);
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -147,7 +147,7 @@ public class PersistentSubscription implements Subscription {
         this.topicName = topic.getName();
         this.subName = subscriptionName;
         this.fullName = MoreObjects.toStringHelper(this).add("topic", topicName).add("name", subName).toString();
-        this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, subscriptionName, cursor);
+        this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName, subscriptionName, cursor, this);
         this.setReplicated(replicated);
         IS_FENCED_UPDATER.set(this, FALSE);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -187,7 +187,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
                 });
         assertTrue(ex.get());
 
-        PersistentMessageExpiryMonitor monitor = new PersistentMessageExpiryMonitor("topicname", c1.getName(), c1);
+        PersistentMessageExpiryMonitor monitor = new PersistentMessageExpiryMonitor("topicname", c1.getName(), c1, null);
         monitor.findEntryFailed(new ManagedLedgerException.ConcurrentFindCursorPositionException("failed"),
                 Optional.empty(), null);
         Field field = monitor.getClass().getDeclaredField("expirationCheckInProgress");
@@ -237,7 +237,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         bkc.deleteLedger(ledgers.get(1).getLedgerId());
         bkc.deleteLedger(ledgers.get(2).getLedgerId());
 
-        PersistentMessageExpiryMonitor monitor = new PersistentMessageExpiryMonitor("topicname", c1.getName(), c1);
+        PersistentMessageExpiryMonitor monitor = new PersistentMessageExpiryMonitor("topicname", c1.getName(), c1, null);
         Position previousMarkDelete = null;
         for (int i = 0; i < totalEntries; i++) {
             monitor.expireMessages(1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -773,6 +774,85 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         }
 
         receiveAndCheckDistribution(Lists.newArrayList(consumer1, consumer2, consumer3));
+    }
+
+    @Test
+    public void testContinueDispatchMessagesWhenMessageTTL() throws Exception {
+        int defaultTTLSec = 3;
+        int totalMessages = 1000;
+        this.conf.setTtlDurationDefaultInSeconds(defaultTTLSec);
+        final String topic = "persistent://public/default/key_shared-" + UUID.randomUUID();
+        final String subName = "my-sub";
+
+        @Cleanup
+        Consumer<Integer> consumer1 = pulsarClient.newConsumer(Schema.INT32)
+                .topic(topic)
+                .subscriptionName(subName)
+                .receiverQueueSize(10)
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscribe();
+
+        @Cleanup
+        Producer<Integer> producer = pulsarClient.newProducer(Schema.INT32)
+                .topic(topic)
+                .create();
+
+        for (int i = 0; i < totalMessages; i++) {
+            producer.newMessage()
+                    .key(String.valueOf(random.nextInt(NUMBER_OF_KEYS)))
+                    .value(i)
+                    .send();
+        }
+
+        // don't ack the first message
+        consumer1.receive();
+        consumer1.acknowledge(consumer1.receive());
+
+        // The consumer1 and consumer2 should be stucked because of the mark delete position did not move forward.
+
+        @Cleanup
+        Consumer<Integer> consumer2 = pulsarClient.newConsumer(Schema.INT32)
+                .topic(topic)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscribe();
+
+        Message<Integer> received = null;
+        try {
+            received = consumer2.receive(1, TimeUnit.SECONDS);
+        } catch (PulsarClientException ignore) {
+        }
+        Assert.assertNull(received);
+
+        @Cleanup
+        Consumer<Integer> consumer3 = pulsarClient.newConsumer(Schema.INT32)
+                .topic(topic)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscribe();
+
+        try {
+            received = consumer3.receive(1, TimeUnit.SECONDS);
+        } catch (PulsarClientException ignore) {
+        }
+        Assert.assertNull(received);
+
+        Optional<Topic> topicRef = pulsar.getBrokerService().getTopic(topic, false).get();
+        assertTrue(topicRef.isPresent());
+        Thread.sleep((defaultTTLSec - 1) * 1000);
+        topicRef.get().checkMessageExpiry();
+
+        // The mark delete position is move forward, so the consumers should receive new messages now.
+        for (int i = 0; i < totalMessages; i++) {
+            producer.newMessage()
+                    .key(String.valueOf(random.nextInt(NUMBER_OF_KEYS)))
+                    .value(i)
+                    .send();
+        }
+
+        // Wait broker dispatch messages.
+        Assert.assertNotNull(consumer2.receive(1, TimeUnit.SECONDS));
+        Assert.assertNotNull(consumer3.receive(1, TimeUnit.SECONDS));
     }
 
     private Consumer<String> createFixedHashRangesConsumer(String topic, String subscription, Range... ranges) throws PulsarClientException {


### PR DESCRIPTION
Related to #8115 #7455

### Motivation

#### Fix message TTL on Key_Shared subscription.

The message TTL will move the mark delete position of the cursor. But did not trigger read entries for the Key_Shared subscription. This will lead to an earlier position which does not acked cause consumers under the Key_Shared subscription stucked even if users enable the message TTL.

#### Fix ordering issue when replaying messages in the Key_Shared subscription.
For example, we have 10 messages [0,1,2,3,4,5,6,7,8,9]
If the consumer0 get message 0 and 1, and does not acked message 0, then consumer1 joined,
when consumer1 get message 2,3, the broker will not dispatch messages to consumer1
because of the mark delete position did not move forward. So message 2,3 will stored in the redeliver tracker.
Now, consumer2 joined, it will read new messages from the cursor, so the recentJoinedPosition is 4 for consumer2
Because of there are messages that need to redeliver, so the broker will read the redelivery message first [2,3]
message [2,3] is lower than the recentJoinedPosition 4, so the message [2,3] will be dispatched to the consumer2
But the message [2,3] should not dispatch to consumer2.

### Verifying this change

1. To trigger message read operation when the TTL happens on Key_Shared subscription
2. Only dispatch the messages than lower than the min read position of recentJoined consumer.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
