### PR TITLE
[Issue 8293][managed-ledger] Fix race condition in updating readPosition in ManagedCursorImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1534,18 +1534,21 @@ public class ManagedCursorImpl implements ManagedCursor {
         markDeletePosition = newMarkDeletePosition;
         individualDeletedMessages.removeAtMost(markDeletePosition.getLedgerId(), markDeletePosition.getEntryId());
 
-        if (readPosition.compareTo(newMarkDeletePosition) <= 0) {
-            // If the position that is mark-deleted is past the read position, it
-            // means that the client has skipped some entries. We need to move
-            // read position forward
-            PositionImpl oldReadPosition = readPosition;
-            readPosition = ledger.getNextValidPosition(newMarkDeletePosition);
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Moved read position from: {} to: {}, and new mark-delete position {}", ledger.getName(),
-                        oldReadPosition, readPosition, markDeletePosition);
+        READ_POSITION_UPDATER.updateAndGet(this, currentReadPosition -> {
+            if (currentReadPosition.compareTo(markDeletePosition) <= 0) {
+                // If the position that is mark-deleted is past the read position, it
+                // means that the client has skipped some entries. We need to move
+                // read position forward
+                PositionImpl newReadPosition = ledger.getNextValidPosition(markDeletePosition);
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Moved read position from: {} to: {}, and new mark-delete position {}", ledger.getName(),
+                            currentReadPosition, newReadPosition, markDeletePosition);
+                }
+                return newReadPosition;
+            } else {
+                return currentReadPosition;
             }
-        }
+        });
 
         return newMarkDeletePosition;
     }


### PR DESCRIPTION
Fixes #8293

### Motivation

Regarding the race condition in #8229, it seems that `ManagedCursorImpl.readPosition` could get out of sync from `OpReadEntry.readPosition` if `ManagedCursorImpl.readPosition` gets updated after the `OpReadEntry` has been created since `OpReadEntry`'s `readPosition` gets initialized from `ManagedCursorImpl.readPosition`.

The race condition seems to happen in this code in the `setAcknowledgePosition` method:
https://github.com/apache/pulsar/blob/825fdd4222dd65ef3099f1a975a1555226297379/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1512-L1523

The intent of this change is to properly handle concurrent updates when updating `readPosition` in `setAcknowledgePosition` method.


### Modifications

The update of `readPosition` uses `READ_POSITION_UPDATER.updateAndGet` to handle concurrent updates to `readPosition` in `setAcknowledgePosition` method. 

### Verifying this change

There are currently no separate tests to verify this change.