### PR TITLE
Added REST handler for broker ready probe

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -587,8 +587,6 @@ public class PulsarService implements AutoCloseable {
                 this.protocolHandlers.newChannelInitializers();
             this.brokerService.startProtocolHandlers(protocolHandlerChannelInitializers);
 
-            state = State.Started;
-
             acquireSLANamespace();
 
             // start function worker service if necessary
@@ -603,6 +601,8 @@ public class PulsarService implements AutoCloseable {
 
             LOG.info("messaging service is ready, {}, cluster={}, configs={}", bootstrapMessage,
                     config.getClusterName(), ReflectionToStringBuilder.toString(config));
+
+            state = State.Started;
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             throw new PulsarServerException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.PulsarService.State;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -152,7 +153,7 @@ public class BrokersBase extends AdminResource {
         validateSuperUserAccess();
         deleteDynamicConfigurationOnZk(configName);
     }
-    
+
     @GET
     @Path("/configuration/values")
     @ApiOperation(value = "Get value of all dynamic configurations' value overridden on local config")
@@ -277,6 +278,20 @@ public class BrokersBase extends AdminResource {
     }
 
     @GET
+    @Path("/ready")
+    @ApiOperation(value = "Check if the broker is fully initialized")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Broker is ready"),
+            @ApiResponse(code = 500, message = "Broker is not ready") })
+    public void isReady(@Suspended AsyncResponse asyncResponse) {
+        if (pulsar().getState() == State.Started) {
+            asyncResponse.resume(Response.ok("ok").build());
+        } else {
+            asyncResponse.resume(Response.serverError().build());
+        }
+    }
+
+    @GET
     @Path("/health")
     @ApiOperation(value = "Run a healthcheck against the broker")
     @ApiResponses(value = {
@@ -378,7 +393,7 @@ public class BrokersBase extends AdminResource {
                         });
             });
     }
-    
+
     private synchronized void deleteDynamicConfigurationOnZk(String configName) {
         try {
             if (BrokerService.isDynamicConfiguration(configName)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -274,6 +274,20 @@ public class WebServiceTest {
         assertEquals(res3.getStatusCode(), 200);
     }
 
+    @Test
+    public void testBrokerReady() throws Exception {
+        setupEnv(true, "1.0", true, false, false, false, -1);
+
+        String url = pulsar.getWebServiceAddress() + "/admin/v2/brokers/ready";
+
+        @Cleanup
+        AsyncHttpClient client = new DefaultAsyncHttpClient();
+
+        Response res = client.prepareGet(url).execute().get();
+        assertEquals(res.getStatusCode(), 200);
+        assertEquals(res.getResponseBody(), "ok");
+    }
+
     private String makeHttpRequest(boolean useTls, boolean useAuth) throws Exception {
         InputStream response = null;
         try {


### PR DESCRIPTION
### Motivation

There's no way to determine if a broker is 100% ready to accept requests (eg: lookup requests). We need to have a precise method to determine the readiness of a broker so that it can be used by deployment tools (eg: kubernetes probes) to delay all traffic we're ready.