### PR TITLE
Support exclude the message when reset cursor by message ID

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2006,7 +2006,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalResetCursorOnPosition(AsyncResponse asyncResponse, String subName, boolean authoritative,
-            MessageIdImpl messageId, boolean isExclusive) {
+            MessageIdImpl messageId, boolean isExcluded) {
         if (topicName.isGlobal()) {
             try {
                 validateGlobalNamespaceOwnership(namespaceName);
@@ -2039,7 +2039,7 @@ public class PersistentTopicsBase extends AdminResource {
                 PersistentSubscription sub = topic.getSubscription(subName);
                 Preconditions.checkNotNull(sub);
                 PositionImpl position = PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId());
-                position = isExclusive ? position.getNext() : position;
+                position = isExcluded ? position.getNext() : position;
                 sub.resetCursor(position).thenRun(() -> {
                     log.info("[{}][{}] successfully reset cursor on subscription {} to position {}", clientAppId(),
                             topicName, subName, messageId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2006,7 +2006,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalResetCursorOnPosition(AsyncResponse asyncResponse, String subName, boolean authoritative,
-            MessageIdImpl messageId) {
+            MessageIdImpl messageId, boolean isExclusive) {
         if (topicName.isGlobal()) {
             try {
                 validateGlobalNamespaceOwnership(namespaceName);
@@ -2038,7 +2038,9 @@ public class PersistentTopicsBase extends AdminResource {
             try {
                 PersistentSubscription sub = topic.getSubscription(subName);
                 Preconditions.checkNotNull(sub);
-                sub.resetCursor(PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId())).thenRun(() -> {
+                PositionImpl position = PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId());
+                position = isExclusive ? position.getNext() : position;
+                sub.resetCursor(position).thenRun(() -> {
                     log.info("[{}][{}] successfully reset cursor on subscription {} to position {}", clientAppId(),
                             topicName, subName, messageId);
                     asyncResponse.resume(Response.noContent().build());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -512,7 +512,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative, MessageIdImpl messageId) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalResetCursorOnPosition(asyncResponse, decode(encodedSubName), authoritative, messageId);
+            internalResetCursorOnPosition(asyncResponse, decode(encodedSubName), authoritative, messageId, false);
         } catch (Exception e) {
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1219,7 +1219,43 @@ public class PersistentTopics extends PersistentTopicsBase {
             MessageIdImpl messageId) {
         try {
             validateTopicName(tenant, namespace, encodedTopic);
-            internalResetCursorOnPosition(asyncResponse, decode(encodedSubName), authoritative, messageId);
+            internalResetCursorOnPosition(asyncResponse, decode(encodedSubName), authoritative, messageId, false);
+        } catch (Exception e) {
+            resumeAsyncResponseExceptionally(asyncResponse, e);
+        }
+    }
+    
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/subscription/{subName}/resetCursorExclusive")
+    @ApiOperation(value = "Reset subscription to message position closest to given position, " +
+            "and start consume messages from the next position of the reset position.", notes = "It fence cursor and disconnects all active consumers before reseting cursor.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or" +
+                    "subscriber is not authorized to access this operation"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic/Subscription does not exist"),
+            @ApiResponse(code = 405, message = "Not supported for partitioned topics"),
+            @ApiResponse(code = 412, message = "Unable to find position for position specified"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration") })
+    public void resetCursorOnPositionExclusive(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(name = "subName", value = "Subscription to reset position on", required = true)
+            @PathParam("subName") String encodedSubName,
+            @ApiParam(value = "Is authentication required to perform this operation")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(name = "messageId", value = "messageId to reset back to (ledgerId:entryId)")
+            MessageIdImpl messageId) {
+        try {
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalResetCursorOnPosition(asyncResponse, decode(encodedSubName), authoritative, messageId, true);
         } catch (Exception e) {
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3468,4 +3468,47 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }).start();
         countDownLatch3.await();
     }
+
+    @Test(timeOut = 20000)
+    public void testResetPosition() throws Exception {
+        final String topicName = "persistent://my-property/my-ns/testResetPosition";
+        final String subName = "my-sub";
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(false).topic(topicName).create();
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName).subscriptionName(subName).subscribe();
+        for (int i = 0; i < 50; i++) {
+            producer.send("msg" + i);
+        }
+        Message<String> lastMsg = null;
+        for (int i = 0; i < 10; i++) {
+            lastMsg = consumer.receive();
+            assertNotNull(lastMsg);
+            consumer.acknowledge(lastMsg);
+        }
+        MessageIdImpl lastMessageId = (MessageIdImpl)lastMsg.getMessageId();
+        consumer.close();
+
+        admin.topics().resetCursor(topicName, subName, lastMsg.getMessageId());
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        Message<String> message = consumer2.receive(1, TimeUnit.SECONDS);
+        assertEquals(message.getMessageId(), lastMsg.getMessageId());
+        consumer2.close();
+
+        admin.topics().resetCursorExclusive(topicName, subName, lastMsg.getMessageId());
+        Consumer<String> consumer3 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        message = consumer3.receive(1, TimeUnit.SECONDS);
+        assertNotEquals(message.getMessageId(), lastMsg.getMessageId());
+        MessageIdImpl messageId = (MessageIdImpl)message.getMessageId();
+        assertEquals(messageId.getEntryId() - 1, lastMessageId.getEntryId());
+        consumer3.close();
+
+        admin.topics().resetCursorExclusiveAsync(topicName, subName, lastMsg.getMessageId()).get(3,TimeUnit.SECONDS);
+        Consumer<String> consumer4 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        message = consumer4.receive(1, TimeUnit.SECONDS);
+        assertNotEquals(message.getMessageId(), lastMsg.getMessageId());
+        messageId = (MessageIdImpl)message.getMessageId();
+        assertEquals(messageId.getEntryId() - 1, lastMessageId.getEntryId());
+        consumer4.close();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3495,7 +3495,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(message.getMessageId(), lastMsg.getMessageId());
         consumer2.close();
 
-        admin.topics().resetCursorExclusive(topicName, subName, lastMsg.getMessageId());
+        admin.topics().resetCursor(topicName, subName, lastMsg.getMessageId(), true);
         Consumer<String> consumer3 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
         message = consumer3.receive(1, TimeUnit.SECONDS);
         assertNotEquals(message.getMessageId(), lastMsg.getMessageId());
@@ -3503,12 +3503,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(messageId.getEntryId() - 1, lastMessageId.getEntryId());
         consumer3.close();
 
-        admin.topics().resetCursorExclusiveAsync(topicName, subName, lastMsg.getMessageId()).get(3,TimeUnit.SECONDS);
+        admin.topics().resetCursorAsync(topicName, subName, lastMsg.getMessageId(), true).get(3, TimeUnit.SECONDS);
         Consumer<String> consumer4 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
         message = consumer4.receive(1, TimeUnit.SECONDS);
         assertNotEquals(message.getMessageId(), lastMsg.getMessageId());
         messageId = (MessageIdImpl)message.getMessageId();
         assertEquals(messageId.getEntryId() - 1, lastMessageId.getEntryId());
         consumer4.close();
+
+        admin.topics().resetCursorAsync(topicName, subName, lastMsg.getMessageId()).get(3, TimeUnit.SECONDS);
+        Consumer<String> consumer5 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        message = consumer5.receive(1, TimeUnit.SECONDS);
+        assertEquals(message.getMessageId(), lastMsg.getMessageId());
+        consumer5.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3488,6 +3488,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
         MessageIdImpl lastMessageId = (MessageIdImpl)lastMsg.getMessageId();
         consumer.close();
+        producer.close();
 
         admin.topics().resetCursor(topicName, subName, lastMsg.getMessageId());
         Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1304,6 +1304,17 @@ public interface Topics {
 
     /**
      * Reset cursor position on a topic subscription.
+     * <p/>
+     * and start consume messages from the next position of the reset position.
+     * @param topic
+     * @param subName
+     * @param messageId
+     * @throws PulsarAdminException
+     */
+    void resetCursorExclusive(String topic, String subName, MessageId messageId) throws PulsarAdminException;
+
+    /**
+     * Reset cursor position on a topic subscription.
      *
      * @param topic
      *            topic name
@@ -1313,6 +1324,17 @@ public interface Topics {
      *            reset subscription to position closest to time in ms since epoch
      */
     CompletableFuture<Void> resetCursorAsync(String topic, String subName, long timestamp);
+
+    /**
+     * Reset cursor position on a topic subscription.
+     * <p/>
+     * and start consume messages from the next position of the reset position.
+     * @param topic
+     * @param subName
+     * @param messageId
+     * @return
+     */
+    CompletableFuture<Void> resetCursorExclusiveAsync(String topic, String subName, MessageId messageId);
 
     /**
      * Reset cursor position on a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1309,9 +1309,10 @@ public interface Topics {
      * @param topic
      * @param subName
      * @param messageId
+     * @param isExcluded
      * @throws PulsarAdminException
      */
-    void resetCursorExclusive(String topic, String subName, MessageId messageId) throws PulsarAdminException;
+    void resetCursor(String topic, String subName, MessageId messageId, boolean isExcluded) throws PulsarAdminException;
 
     /**
      * Reset cursor position on a topic subscription.
@@ -1332,9 +1333,10 @@ public interface Topics {
      * @param topic
      * @param subName
      * @param messageId
+     * @param isExcluded
      * @return
      */
-    CompletableFuture<Void> resetCursorExclusiveAsync(String topic, String subName, MessageId messageId);
+    CompletableFuture<Void> resetCursorAsync(String topic, String subName, MessageId messageId, boolean isExcluded);
 
     /**
      * Reset cursor position on a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1147,7 +1147,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public void resetCursor(String topic, String subName, MessageId messageId, boolean isExcluded) throws PulsarAdminException {
+    public void resetCursor(String topic, String subName, MessageId messageId
+            , boolean isExcluded) throws PulsarAdminException {
         try {
             resetCursorAsync(topic, subName, messageId, true).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
@@ -1168,7 +1169,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<Void> resetCursorAsync(String topic, String subName, MessageId messageId, boolean isExcluded) {
+    public CompletableFuture<Void> resetCursorAsync(String topic, String subName
+            , MessageId messageId, boolean isExcluded) {
         TopicName tn = validateTopic(topic);
         String encodedSubName = Codec.encode(subName);
         final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetcursor");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1150,7 +1150,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public void resetCursor(String topic, String subName, MessageId messageId
             , boolean isExcluded) throws PulsarAdminException {
         try {
-            resetCursorAsync(topic, subName, messageId, true).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+            resetCursorAsync(topic, subName, messageId, isExcluded).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.ResetCursorData;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata;
@@ -1132,23 +1133,30 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void resetCursor(String topic, String subName, MessageId messageId) throws PulsarAdminException {
         try {
-            TopicName tn = validateTopic(topic);
-            String encodedSubName = Codec.encode(subName);
-            WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetcursor");
-            request(path).post(Entity.entity(messageId, MediaType.APPLICATION_JSON),
-                            ErrorData.class);
+            resetCursorAsync(topic, subName, messageId).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
         } catch (Exception e) {
             throw getApiException(e);
         }
     }
+
     @Override
-    public void resetCursorExclusive(String topic, String subName, MessageId messageId) throws PulsarAdminException {
+    public void resetCursor(String topic, String subName, MessageId messageId, boolean isExcluded) throws PulsarAdminException {
         try {
-            TopicName tn = validateTopic(topic);
-            String encodedSubName = Codec.encode(subName);
-            WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetCursorExclusive");
-            request(path).post(Entity.entity(messageId, MediaType.APPLICATION_JSON),
-                            ErrorData.class);
+            resetCursorAsync(topic, subName, messageId, true).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
         } catch (Exception e) {
             throw getApiException(e);
         }
@@ -1156,17 +1164,17 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<Void> resetCursorAsync(String topic, String subName, MessageId messageId) {
+        return resetCursorAsync(topic, subName, messageId, false);
+    }
+
+    @Override
+    public CompletableFuture<Void> resetCursorAsync(String topic, String subName, MessageId messageId, boolean isExcluded) {
         TopicName tn = validateTopic(topic);
         String encodedSubName = Codec.encode(subName);
         final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetcursor");
-        return asyncPostRequest(path, Entity.entity(messageId, MediaType.APPLICATION_JSON));
-    }
-    @Override
-    public CompletableFuture<Void> resetCursorExclusiveAsync(String topic, String subName, MessageId messageId) {
-        TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetCursorExclusive");
-        return asyncPostRequest(path, Entity.entity(messageId, MediaType.APPLICATION_JSON));
+        ResetCursorData resetCursorData = new ResetCursorData(messageId);
+        resetCursorData.setExcluded(isExcluded);
+        return asyncPostRequest(path, Entity.entity(resetCursorData, MediaType.APPLICATION_JSON));
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1141,12 +1141,31 @@ public class TopicsImpl extends BaseResource implements Topics {
             throw getApiException(e);
         }
     }
+    @Override
+    public void resetCursorExclusive(String topic, String subName, MessageId messageId) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            String encodedSubName = Codec.encode(subName);
+            WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetCursorExclusive");
+            request(path).post(Entity.entity(messageId, MediaType.APPLICATION_JSON),
+                            ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
 
     @Override
     public CompletableFuture<Void> resetCursorAsync(String topic, String subName, MessageId messageId) {
         TopicName tn = validateTopic(topic);
         String encodedSubName = Codec.encode(subName);
         final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetcursor");
+        return asyncPostRequest(path, Entity.entity(messageId, MediaType.APPLICATION_JSON));
+    }
+    @Override
+    public CompletableFuture<Void> resetCursorExclusiveAsync(String topic, String subName, MessageId messageId) {
+        TopicName tn = validateTopic(topic);
+        String encodedSubName = Codec.encode(subName);
+        final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetCursorExclusive");
         return asyncPostRequest(path, Entity.entity(messageId, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -53,6 +53,7 @@ import org.apache.pulsar.client.admin.Tenants;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -789,6 +790,12 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("last-message-id persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getLastMessageId(eq("persistent://myprop/clust/ns1/ds1"));
+
+        //cmd with option cannot be executed repeatedly
+        cmdTopics = new CmdTopics(admin);
+        cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds2 -s sub1 -m 1:1 -e"));
+        verify(mockTopics).resetCursorExclusive(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
+                , eq(new MessageIdImpl(1, 1, -1)));
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -791,11 +791,11 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("last-message-id persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getLastMessageId(eq("persistent://myprop/clust/ns1/ds1"));
 
-        //cmd with option cannot be executed repeatedly
+        //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(admin);
         cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds2 -s sub1 -m 1:1 -e"));
-        verify(mockTopics).resetCursorExclusive(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
-                , eq(new MessageIdImpl(1, 1, -1)));
+        verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
+                , eq(new MessageIdImpl(1, 1, -1)), eq(true));
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -650,7 +650,7 @@ public class CmdTopics extends CmdBase {
             if (isNotBlank(resetMessageIdStr)) {
                 MessageId messageId = validateMessageIdString(resetMessageIdStr);
                 if (excludeResetPosition) {
-                    topics.resetCursorExclusive(persistentTopic, subName, messageId);
+                    topics.resetCursor(persistentTopic, subName, messageId, true);
                 } else {
                     topics.resetCursor(persistentTopic, subName, messageId);
                 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -640,12 +640,20 @@ public class CmdTopics extends CmdBase {
                 "-m" }, description = "messageId to reset back to (ledgerId:entryId)", required = false)
         private String resetMessageIdStr;
 
+        @Parameter(names = { "-e", "--exclude-reset-position" },
+                description = "Exclude the reset position, start consume messages from the next position.", required = false)
+        private boolean excludeResetPosition = false;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             if (isNotBlank(resetMessageIdStr)) {
                 MessageId messageId = validateMessageIdString(resetMessageIdStr);
-                topics.resetCursor(persistentTopic, subName, messageId);
+                if (excludeResetPosition) {
+                    topics.resetCursorExclusive(persistentTopic, subName, messageId);
+                } else {
+                    topics.resetCursor(persistentTopic, subName, messageId);
+                }
             } else if (isNotBlank(resetTimeStr)) {
                 long resetTimeInMillis = TimeUnit.SECONDS
                         .toMillis(RelativeTimeUtil.parseRelativeTimeInSeconds(resetTimeStr));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ResetCursorData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ResetCursorData.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.api.MessageId;
+
+@Data
+@NoArgsConstructor
+public class ResetCursorData {
+    protected long ledgerId;
+    protected long entryId;
+    protected int partitionIndex = -1;
+    protected boolean isExcluded = false;
+
+    public ResetCursorData(long ledgerId, long entryId) {
+        this.ledgerId = ledgerId;
+        this.entryId = entryId;
+    }
+
+    public ResetCursorData(long ledgerId, long entryId, boolean isExcluded) {
+        this.ledgerId = ledgerId;
+        this.entryId = entryId;
+        this.isExcluded = isExcluded;
+    }
+
+    public ResetCursorData(MessageId messageId) {
+        if (messageId instanceof MessageIdImpl) {
+            MessageIdImpl messageIdImpl = (MessageIdImpl) messageId;
+            this.ledgerId = messageIdImpl.getLedgerId();
+            this.entryId = messageIdImpl.getEntryId();
+        } else if (messageId instanceof TopicMessageIdImpl) {
+            throw new IllegalArgumentException("Not supported operation on partitioned-topic");
+        }
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_2.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_2.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.backwardscompatibility;
+
+
+import org.apache.pulsar.tests.integration.topologies.ClientTestBase;
+import org.testng.annotations.Test;
+
+public class ClientTest2_2 extends PulsarStandaloneTestSuite2_2 {
+
+    private final ClientTestBase clientTestBase = new ClientTestBase();
+
+    @Test(dataProvider = "StandaloneServiceUrlAndHttpUrl")
+    public void testResetCursorCompatibility(String serviceUrl, String httpServiceUrl) throws Exception {
+        String topicName = generateTopicName("test-reset-cursor-compatibility", true);
+        clientTestBase.resetCursorCompatibility(serviceUrl, httpServiceUrl, topicName);
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_3.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_3.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.backwardscompatibility;
+
+
+import org.apache.pulsar.tests.integration.topologies.ClientTestBase;
+import org.testng.annotations.Test;
+
+public class ClientTest2_3 extends PulsarStandaloneTestSuite2_3 {
+
+    private final ClientTestBase clientTestBase = new ClientTestBase();
+
+    @Test(dataProvider = "StandaloneServiceUrlAndHttpUrl")
+    public void testResetCursorCompatibility(String serviceUrl, String httpServiceUrl) throws Exception {
+        String topicName = generateTopicName("test-reset-cursor-compatibility", true);
+        clientTestBase.resetCursorCompatibility(serviceUrl, httpServiceUrl, topicName);
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_4.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_4.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.backwardscompatibility;
+
+
+import org.apache.pulsar.tests.integration.topologies.ClientTestBase;
+import org.testng.annotations.Test;
+
+public class ClientTest2_4 extends PulsarStandaloneTestSuite2_4 {
+
+    private final ClientTestBase clientTestBase = new ClientTestBase();
+
+    @Test(dataProvider = "StandaloneServiceUrlAndHttpUrl")
+    public void testResetCursorCompatibility(String serviceUrl, String httpServiceUrl) throws Exception {
+        String topicName = generateTopicName("test-reset-cursor-compatibility", true);
+        clientTestBase.resetCursorCompatibility(serviceUrl, httpServiceUrl, topicName);
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_5.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest2_5.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.backwardscompatibility;
+
+
+import org.apache.pulsar.tests.integration.topologies.ClientTestBase;
+import org.testng.annotations.Test;
+
+public class ClientTest2_5 extends PulsarStandaloneTestSuite2_5 {
+
+    private final ClientTestBase clientTestBase = new ClientTestBase();
+
+    @Test(dataProvider = "StandaloneServiceUrlAndHttpUrl")
+    public void testResetCursorCompatibility(String serviceUrl, String httpServiceUrl) throws Exception {
+        String topicName = generateTopicName("test-reset-cursor-compatibility", true);
+        clientTestBase.resetCursorCompatibility(serviceUrl, httpServiceUrl, topicName);
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
@@ -63,4 +63,9 @@ public class PersistentTopicMessagingTest extends TopicMessagingBase {
     public void testPartitionedTopicMessagingWithKeyShared(String serviceUrl) throws Exception {
         partitionedTopicSendAndReceiveWithKeyShared(serviceUrl, true);
     }
+
+    @Test(dataProvider = "ServiceUrls")
+    public void testResetCursorCompatibility(String serviceUrl) throws Exception {
+        resetCursorCompatibility(serviceUrl, true);
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
@@ -66,6 +66,6 @@ public class PersistentTopicMessagingTest extends TopicMessagingBase {
 
     @Test(dataProvider = "ServiceUrls")
     public void testResetCursorCompatibility(String serviceUrl) throws Exception {
-        resetCursorCompatibility(serviceUrl, true);
+        resetCursorCompatibility(serviceUrl);
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/PersistentTopicMessagingTest.java
@@ -64,8 +64,4 @@ public class PersistentTopicMessagingTest extends TopicMessagingBase {
         partitionedTopicSendAndReceiveWithKeyShared(serviceUrl, true);
     }
 
-    @Test(dataProvider = "ServiceUrls")
-    public void testResetCursorCompatibility(String serviceUrl) throws Exception {
-        resetCursorCompatibility(serviceUrl);
-    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
@@ -451,7 +451,9 @@ public class TopicMessagingBase extends MessagingBase {
                 .serviceUrl(serviceUrl)
                 .build();
         @Cleanup
-        final PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(serviceUrl).build();
+        final PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
+                .build();
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .enableBatching(false).topic(topicName).create();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
@@ -443,8 +443,8 @@ public class TopicMessagingBase extends MessagingBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    protected void resetCursorCompatibility(String serviceUrl, boolean isPersistent) throws Exception {
-        final String topicName = getNonPartitionedTopic("test-reset-cursor-compatibility", isPersistent);
+    protected void resetCursorCompatibility(String serviceUrl) throws Exception {
+        final String topicName = getNonPartitionedTopic("test-reset-cursor-compatibility", true);
         final String subName = "my-sub";
         @Cleanup
         final PulsarClient pulsarClient = PulsarClient.builder()

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/TopicMessagingBase.java
@@ -443,45 +443,4 @@ public class TopicMessagingBase extends MessagingBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    protected void resetCursorCompatibility(String serviceUrl) throws Exception {
-        final String topicName = getNonPartitionedTopic("test-reset-cursor-compatibility", true);
-        final String subName = "my-sub";
-        @Cleanup
-        final PulsarClient pulsarClient = PulsarClient.builder()
-                .serviceUrl(serviceUrl)
-                .build();
-        @Cleanup
-        final PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
-                .build();
-        @Cleanup
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
-                .enableBatching(false).topic(topicName).create();
-        @Cleanup
-        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
-                .topic(topicName).subscriptionName(subName).subscribe();
-        for (int i = 0; i < 50; i++) {
-            producer.send("msg" + i);
-        }
-        Message<String> lastMsg = null;
-        for (int i = 0; i < 10; i++) {
-            lastMsg = consumer.receive();
-            assertNotNull(lastMsg);
-            consumer.acknowledge(lastMsg);
-        }
-
-        admin.topics().resetCursor(topicName, subName, lastMsg.getMessageId());
-        @Cleanup
-        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
-        Message<String> message = consumer2.receive(1, TimeUnit.SECONDS);
-        assertEquals(message.getMessageId(), lastMsg.getMessageId());
-
-        admin.topics().resetCursorAsync(topicName, subName, lastMsg.getMessageId()).get(3, TimeUnit.SECONDS);
-        @Cleanup
-        Consumer<String> consumer3 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
-        message = consumer3.receive(1, TimeUnit.SECONDS);
-        assertEquals(message.getMessageId(), lastMsg.getMessageId());
-
-    }
-
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/ClientTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/ClientTestBase.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.topologies;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class ClientTestBase {
+
+    public void resetCursorCompatibility(String serviceUrl, String serviceHttpUrl, String topicName) throws Exception {
+        final String subName = "my-sub";
+        @Cleanup
+        final PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl(serviceUrl)
+                .build();
+        @Cleanup
+        final PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(serviceHttpUrl)
+                .build();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(false).topic(topicName).create();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName).subscriptionName(subName).subscribe();
+        for (int i = 0; i < 50; i++) {
+            producer.send("msg" + i);
+        }
+        Message<String> lastMsg = null;
+        for (int i = 0; i < 10; i++) {
+            lastMsg = consumer.receive();
+            assertNotNull(lastMsg);
+            consumer.acknowledge(lastMsg);
+        }
+
+        admin.topics().resetCursor(topicName, subName, lastMsg.getMessageId());
+        @Cleanup
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        Message<String> message = consumer2.receive(1, TimeUnit.SECONDS);
+        assertEquals(message.getMessageId(), lastMsg.getMessageId());
+
+        admin.topics().resetCursorAsync(topicName, subName, lastMsg.getMessageId()).get(3, TimeUnit.SECONDS);
+        @Cleanup
+        Consumer<String> consumer3 = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName).subscribe();
+        message = consumer3.receive(1, TimeUnit.SECONDS);
+        assertEquals(message.getMessageId(), lastMsg.getMessageId());
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -53,6 +53,16 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
         };
     }
 
+    @DataProvider(name = "StandaloneServiceUrlAndHttpUrl")
+    public static Object[][] serviceUrlAndHttpUrl() {
+        return new Object[][] {
+                {
+                        container.getPlainTextServiceUrl(),
+                        container.getHttpServiceUrl(),
+                }
+        };
+    }
+
     protected static Network network;
     protected static StandaloneContainer container;
 

--- a/tests/integration/src/test/resources/pulsar-backwards-compatibility.xml
+++ b/tests/integration/src/test/resources/pulsar-backwards-compatibility.xml
@@ -25,6 +25,11 @@
             <class name="org.apache.pulsar.tests.integration.backwardscompatibility.SmokeTest2_2" />
             <class name="org.apache.pulsar.tests.integration.backwardscompatibility.SmokeTest2_3" />
             <class name="org.apache.pulsar.tests.integration.backwardscompatibility.SmokeTest2_4" />
+            <class name="org.apache.pulsar.tests.integration.backwardscompatibility.SmokeTest2_5" />
+            <class name="org.apache.pulsar.tests.integration.backwardscompatibility.ClientTest2_2" />
+            <class name="org.apache.pulsar.tests.integration.backwardscompatibility.ClientTest2_3" />
+            <class name="org.apache.pulsar.tests.integration.backwardscompatibility.ClientTest2_4" />
+            <class name="org.apache.pulsar.tests.integration.backwardscompatibility.ClientTest2_5" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Fixes #8259
### Motivation
Currently, when reset the cursor to a position, the broker will set the mark delete position to the previous position of the reset position. For some usecase, we don't want to consume the reset position again, so it's better to provide a way to reset the cursor to a specific position and exclude this position. So that the consumers under the subscription can start consume messages from the next position of the reset position.

### Modifications
Add a new API to exclude the message when reset cursor by message ID

### Verifying this change
SimpleProducerConsumerTest#testResetPosition