### PR TITLE
[Issue 8311][pulsar-client-cpp] In C shim, free message ID pointer after hitting callback

### DIFF
--- a/pulsar-client-cpp/lib/c/c_Producer.cc
+++ b/pulsar-client-cpp/lib/c/c_Producer.cc
@@ -42,6 +42,7 @@ static void handle_producer_send(pulsar::Result result, pulsar::MessageId messag
         pulsar_message_id_t *c_message_id = new pulsar_message_id_t;
         c_message_id->messageId = messageId;
         callback(pulsar_result_Ok, c_message_id, ctx);
+        delete c_message_id;
     } else {
         callback((pulsar_result)result, NULL, ctx);
     }

--- a/pulsar-client-cpp/lib/c/c_Producer.cc
+++ b/pulsar-client-cpp/lib/c/c_Producer.cc
@@ -39,10 +39,9 @@ pulsar_result pulsar_producer_send(pulsar_producer_t *producer, pulsar_message_t
 static void handle_producer_send(pulsar::Result result, pulsar::MessageId messageId,
                                  pulsar_send_callback callback, void *ctx) {
     if (result == pulsar::ResultOk) {
-        pulsar_message_id_t *c_message_id = new pulsar_message_id_t;
-        c_message_id->messageId = messageId;
-        callback(pulsar_result_Ok, c_message_id, ctx);
-        delete c_message_id;
+        pulsar_message_id_t c_message_id;
+        c_message_id.messageId = messageId;
+        callback(pulsar_result_Ok, &c_message_id, ctx);
     } else {
         callback((pulsar_result)result, NULL, ctx);
     }


### PR DESCRIPTION
Fixes #8311

### Motivation

The C/C++ glue code in *c_Producer.cc:handle_producer_send()* has a memory leak. Specifically, a `pulsar_message_id_t` is created but never freed. This leaks one object for every asynchronous message send, which adds up to a big problem if sending lots of messages.

### Modifications

After calling the C callback, `delete` the memory allocated for the `pulsar_message_id_t`.

### Verifying this change

I have manually verified that this change fixes the leak, using _valgrind_.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
