### PR TITLE
[pulsar-broker-admin] Fix: split bundle overwrites local-policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -888,12 +888,12 @@ public class NamespaceService {
 
         if (!policies.isPresent()) {
             // if policies is not present into localZk then create new policies
-            this.pulsar.getLocalZkCacheService().createPolicies(path, false)
+            policies = this.pulsar.getLocalZkCacheService().createPolicies(path, false)
                     .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
         }
 
         long version = nsBundles.getVersion();
-        LocalPolicies local = new LocalPolicies();
+        LocalPolicies local = policies.orElse(new LocalPolicies());
         local.bundles = getBundlesData(nsBundles);
         byte[] data = ObjectMapperFactory.getThreadLocal().writeValueAsBytes(local);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
@@ -19,10 +19,15 @@
 package org.apache.pulsar.broker.namespace;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -54,4 +59,24 @@ public class NamespaceCreateBundlesTest extends BrokerTestBase {
         assertEquals(policies.bundles.boundaries.size(), 17);
     }
 
+    @Test
+    public void testSplitBundleUpdatesLocalPoliciesWithoutOverwriting() throws Exception {
+        String namespaceName = "prop/" + UUID.randomUUID().toString();
+        String topicName = "persistent://" + namespaceName + "/my-topic5";
+
+        admin.namespaces().createNamespace(namespaceName);
+
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName).sendTimeout(1,
+                TimeUnit.SECONDS);
+
+        Producer<byte[]> producer = producerBuilder.create();
+
+        String bundle = admin.lookups().getBundleRange(topicName);
+        BookieAffinityGroupData bookieAffinityGroup = new BookieAffinityGroupData();
+        bookieAffinityGroup.bookkeeperAffinityGroupPrimary = "test";
+        admin.namespaces().setBookieAffinityGroup(namespaceName, bookieAffinityGroup);
+        admin.namespaces().splitNamespaceBundle(namespaceName, bundle, false, null);
+        assertNotNull(admin.namespaces().getBookieAffinityGroup(namespaceName));
+        producer.close();
+    }
 }


### PR DESCRIPTION
### Motivation
Namespace LocalPolicies contains bundle-data and bookie-isolation-policy. Split-bundle API overwrites local-policies because of that we lose configured bookie-isolation-policy on that cluster.

### Modification
Update LocalPolicies instead overwriting while bundle-split.