### PR TITLE
Increasing timeout for pulsar client io threads to shutdown

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -320,7 +320,7 @@ public class ConnectionPool implements Closeable {
     @Override
     public void close() throws IOException {
         try {
-            eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).await();
+            eventLoopGroup.shutdownGracefully(0, 10, TimeUnit.SECONDS).await();
         } catch (InterruptedException e) {
             log.warn("EventLoopGroup shutdown was interrupted", e);
         }


### PR DESCRIPTION
### Motivation

We need to make a best effort to shutdown all threads when close() is on a pulsar client.  If threads spawned by a client are not shutdown when close() returns, this may lead to classloading exceptions/issues if pulsar JARs are unloaded afterwards like the case in a Flink job.

### Modifications

 Increase the wait time for IO threads in the pulsar client to shutdown.

