### PR TITLE
Upgrade hdfs2 version to 2.8.5

### DIFF
--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -48,7 +48,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>2.8.2</version>
+  		<version>2.8.5</version>
   	</dependency>
     <dependency>
        <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


Fixes #8305 


### Motivation

In Apache Hadoop 2.8.2, there are the following security issues:

- CVE-2018-1296
- CVE-2018-8009

Recommended upgrade version：2.8.5

### Modifications

- Upgrade hdfs2 version to `2.8.5`

