### PR TITLE
[Issue 8311][pulsar-client-go] Fix memory leak in cgo golang client

### DIFF
--- a/pulsar-client-go/pulsar/c_go_pulsar.h
+++ b/pulsar-client-go/pulsar/c_go_pulsar.h
@@ -61,7 +61,7 @@ static inline void _pulsar_producer_close_async(pulsar_producer_t *producer, voi
     pulsar_producer_close_async(producer, pulsarProducerCloseCallbackProxy, ctx);
 }
 
-void pulsarProducerSendCallbackProxy(pulsar_result result, pulsar_message_id_t *message, void *ctx);
+void pulsarProducerSendCallbackProxy(pulsar_result result, pulsar_message_id_t *messageId, void *ctx);
 
 void pulsarProducerSendCallbackProxyWithMsgID(pulsar_result result, pulsar_message_id_t *messageId, void *ctx);
 

--- a/pulsar-client-go/pulsar/c_producer.go
+++ b/pulsar-client-go/pulsar/c_producer.go
@@ -298,7 +298,6 @@ func pulsarProducerSendCallbackProxyWithMsgID(res C.pulsar_result, messageId *C.
 		sendCallback.callback(getMessageId(messageId), newError(res, "Failed to send message"))
 	} else {
 		sendCallback.callback(getMessageId(messageId), nil)
-		C.pulsar_message_id_free(messageId)
 	}
 }
 

--- a/pulsar-client-go/pulsar/c_producer.go
+++ b/pulsar-client-go/pulsar/c_producer.go
@@ -268,7 +268,6 @@ func (p *producer) SendAndGetMsgID(ctx context.Context, msg ProducerMessage) (Me
 	}
 }
 
-
 type sendCallback struct {
 	message  ProducerMessage
 	callback func(ProducerMessage, error)
@@ -287,6 +286,7 @@ func pulsarProducerSendCallbackProxy(res C.pulsar_result, messageId *C.pulsar_me
 		sendCallback.callback(sendCallback.message, newError(res, "Failed to send message"))
 	} else {
 		sendCallback.callback(sendCallback.message, nil)
+		C.pulsar_message_id_free(messageId)
 	}
 }
 
@@ -298,6 +298,7 @@ func pulsarProducerSendCallbackProxyWithMsgID(res C.pulsar_result, messageId *C.
 		sendCallback.callback(getMessageId(messageId), newError(res, "Failed to send message"))
 	} else {
 		sendCallback.callback(getMessageId(messageId), nil)
+		C.pulsar_message_id_free(messageId)
 	}
 }
 


### PR DESCRIPTION
Fixes #8311.

### Motivation

In the C/C++ glue code, file *c_Producer.cc* function *handle_producer_send()*, a new `pulsar_message_id_t` is created. This needs to be freed at some point.

Because of issues with legacy C clients, it is not possible to call *delete* from inside `c_Producer.cc` ([see here](https://github.com/apache/pulsar/pull/8312#issuecomment-712984933)). Instead, the client must call *pulsar_message_id_free()*.

Previously, the cgo interface was not freeing this message ID, which caused a memory leak on every message sent.

### Modifications

This PR adds the missing calls to *pulsar_message_id_free()*. The calls are added in the cgo layer, in *pulsarProducerSendCallbackProxy()* and *pulsarProducerSendCallbackProxyWithMsgID()*.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I have manually checked (using valgrind) that this fixes the leak I was previously seeing.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
