### PR TITLE
Upgrade solr version to 8.6.3

### DIFF
--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <solr.version>8.6.0</solr.version>
+        <solr.version>8.6.3</solr.version>
     </properties>
 
     <artifactId>pulsar-io-solr</artifactId>


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


Fixes #8324 


### Motivation

In Apache Solr 8.6.0, there are the following security issues:

- CVE-2020-13957

Recommended upgrade version：8.6.3

### Modifications

- Upgrade solr version to `8.6.3`

