### PR TITLE
[C++] Client back-pressure is done on batches rather than number of messages

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Message.h
+++ b/pulsar-client-cpp/include/pulsar/Message.h
@@ -175,6 +175,7 @@ class PULSAR_PUBLIC Message {
     friend class BatchAcknowledgementTracker;
     friend class PulsarWrapper;
     friend class MessageBatch;
+    friend struct OpSendMsg;
 
     friend PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, const StringMap& map);
     friend PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, const Message& msg);

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -45,7 +45,9 @@ struct OpSendMsg {
           sequenceId_(sequenceId),
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)) {}
 
-    uint32_t num_messages_in_batch() const { return msg_.impl_->metadata.num_messages_in_batch(); }
+    uint32_t num_messages_in_batch() const {
+        return msg_.impl_->metadata.num_messages_in_batch();
+    }
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -45,9 +45,7 @@ struct OpSendMsg {
           sequenceId_(sequenceId),
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)) {}
 
-    uint32_t num_messages_in_batch() const {
-        return msg_.impl_->metadata.num_messages_in_batch();
-    }
+    uint32_t num_messages_in_batch() const { return msg_.impl_->metadata.num_messages_in_batch(); }
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -24,6 +24,7 @@
 #include <boost/date_time/posix_time/ptime.hpp>
 
 #include "TimeUtils.h"
+#include "MessageImpl.h"
 
 namespace pulsar {
 
@@ -43,6 +44,10 @@ struct OpSendMsg {
           producerId_(producerId),
           sequenceId_(sequenceId),
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)) {}
+
+    uint32_t num_messages_in_batch() const {
+        return msg_.impl_->metadata.num_messages_in_batch();
+    }
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -462,7 +462,7 @@ PendingFailures ProducerImpl::batchMessageAndSend(const FlushCallback& flushCall
                 // A spot has been reserved for this batch, but the batch failed to be pushed to the queue, so
                 // we need to release the spot manually
                 LOG_ERROR("batchMessageAndSend | Failed to createOpSendMsg: " << result);
-                pendingMessagesQueue_.release(opSendMsg.num_messages_in_batch());
+                pendingMessagesQueue_.release(1);
                 failures.add(std::bind(opSendMsg.sendCallback_, result, MessageId{}));
             }
         } else if (numBatches > 1) {
@@ -476,7 +476,7 @@ PendingFailures ProducerImpl::batchMessageAndSend(const FlushCallback& flushCall
                     // queue, so we need to release the spot manually
                     LOG_ERROR("batchMessageAndSend | Failed to createOpSendMsgs[" << i
                                                                                   << "]: " << results[i]);
-                    pendingMessagesQueue_.release(opSendMsgs[i].num_messages_in_batch());
+                    pendingMessagesQueue_.release(1);
                     failures.add(std::bind(opSendMsgs[i].sendCallback_, results[i], MessageId{}));
                 }
             }

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -1009,7 +1009,7 @@ TEST(BatchMessageTest, testSendCallback) {
     producerConfig.setBatchingEnabled(true);
     producerConfig.setBatchingMaxMessages(numMessagesOfBatch);
     producerConfig.setBatchingMaxPublishDelayMs(1000);  // 1 s, it's long enough for 3 messages batched
-    producerConfig.setMaxPendingMessages(2);            // only 1 spot is actually used
+    producerConfig.setMaxPendingMessages(5);
 
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConfig, producer));

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -1050,7 +1050,6 @@ TEST(BatchMessageTest, testSendCallback) {
     client.close();
 }
 
-
 TEST(BatchMessageTest, testProducerQueueWithBatches) {
     std::string testName = std::to_string(epochTime) + "testProducerQueueWithBatches";
 
@@ -1076,9 +1075,7 @@ TEST(BatchMessageTest, testProducerQueueWithBatches) {
     int rejectedMessges = 0;
     for (int i = 0; i < 20; i++) {
         std::string messageContent = prefix + std::to_string(i);
-        Message msg = MessageBuilder()
-            .setContent("hello")
-            .build();
+        Message msg = MessageBuilder().setContent("hello").build();
 
         producer.sendAsync(msg, [&rejectedMessges](Result result, const MessageId& id) {
             if (result == ResultProducerQueueIsFull) {

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -1049,3 +1049,43 @@ TEST(BatchMessageTest, testSendCallback) {
     producer.close();
     client.close();
 }
+
+
+TEST(BatchMessageTest, testProducerQueueWithBatches) {
+    std::string testName = std::to_string(epochTime) + "testProducerQueueWithBatches";
+
+    ClientConfiguration clientConf;
+    clientConf.setStatsIntervalInSeconds(0);
+
+    Client client(lookupUrl, clientConf);
+    std::string topicName = "persistent://public/default/" + testName;
+
+    // Enable batching on producer side
+    ProducerConfiguration conf;
+    conf.setBlockIfQueueFull(false);
+    conf.setMaxPendingMessages(10);
+    conf.setBatchingMaxMessages(10000);
+    conf.setBatchingMaxPublishDelayMs(1000);
+    conf.setBatchingEnabled(true);
+
+    Producer producer;
+    Result result = client.createProducer(topicName, conf, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    std::string prefix = "msg-batch-test-produce-timeout-";
+    int rejectedMessges = 0;
+    for (int i = 0; i < 20; i++) {
+        std::string messageContent = prefix + std::to_string(i);
+        Message msg = MessageBuilder()
+            .setContent("hello")
+            .build();
+
+        producer.sendAsync(msg, [&rejectedMessges](Result result, const MessageId& id) {
+            if (result == ResultProducerQueueIsFull) {
+                ++rejectedMessges;
+            }
+        });
+    }
+
+    ASSERT_EQ(rejectedMessges, 10);
+}

--- a/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
+++ b/pulsar-client-cpp/tests/KeyBasedBatchingTest.cc
@@ -66,10 +66,9 @@ class KeyBasedBatchingTest : public ::testing::Test {
 TEST_F(KeyBasedBatchingTest, testFlush) {
     initTopicName("Flush");
     // no limits for batching
-    initProducer(createDefaultProducerConfig()
-                     .setBatchingMaxMessages(static_cast<unsigned int>(-1))  // no limits for batching
-                     // only 2+1=3 spots are needed because there're at most only 2 batches to send
-                     .setMaxPendingMessages(3));
+    initProducer(createDefaultProducerConfig().setBatchingMaxMessages(
+        static_cast<unsigned int>(-1))  // no limits for batching
+    );
 
     constexpr int numMessages = 100;
     const std::string keys[] = {"A", "B"};


### PR DESCRIPTION
### Motivation

C++ client can end up using a huge amount of memory under certain conditions: 
 * Batching enabled
 * Number of messages per batch high
 * Several partitions

### Modifications

We need to use messages rather than batches for the sizing of the pending messages queue and back-pressure. Same as how it happens in Java and Go client implementations. Otherwise, the batching size becomes a multiplier of these settings. 

