### PR TITLE
Revert jersey version to 2.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@ flexible messaging model and an intuitive client API.</description>
     <netty-tc-native.version>2.0.30.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
     <jetty.version>9.4.31.v20200723</jetty.version>
-    <jersey.version>2.31</jersey.version>
+    <jersey.version>2.27</jersey.version>
     <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>


### PR DESCRIPTION
### Motivation

Revert jersey version to 2.27 to avoid `java.lang.NoClassDefFoundError: org/apache/pulsar/shade/javax/annotation/Priority` in branch-2.6

