### PR TITLE
Update docs for Java Functions develop

### DIFF
--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -308,6 +308,8 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
+    <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.4.1/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.4.1/functions-develop.md
@@ -301,6 +301,7 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.4.2/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.4.2/functions-develop.md
@@ -301,6 +301,7 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.5.0/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.5.0/functions-develop.md
@@ -311,6 +311,7 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.5.1/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.5.1/functions-develop.md
@@ -311,6 +311,7 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.5.2/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.5.2/functions-develop.md
@@ -311,6 +311,7 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.6.0/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.6.0/functions-develop.md
@@ -311,6 +311,8 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
+    <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.6.1/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.6.1/functions-develop.md
@@ -307,6 +307,8 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
+    <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException;
 }
 ```
 

--- a/site2/website/versioned_docs/version-2.6.2/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.6.2/functions-develop.md
@@ -307,6 +307,8 @@ public interface Context {
     void recordMetric(String metricName, double value);
     <O> CompletableFuture<Void> publish(String topicName, O object, String schemaOrSerdeClassName);
     <O> CompletableFuture<Void> publish(String topicName, O object);
+    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
+    <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException;
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation


Currently, in Java Functions, the documentation of the context interface is missing as follows:

```
    <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException;
    <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException;
```

### Modifications

- Add the `newOutputMessage()` interface from 2.4.0
- Add the `newConsumerBuilder()` interface from 2.6.0
