### PR TITLE
PLSR-1240 upgrade GRPC to 1.31 to avoid deadlock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ flexible messaging model and an intuitive client API.</description>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.11.4</protobuf3.version>
     <protoc3.version>3.11.4</protoc3.version>
-    <grpc.version>1.18.0</grpc.version>
+    <grpc.version>1.31.0</grpc.version>
     <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>


### PR DESCRIPTION
### Motivation
Current version of gRPC is deadlocks as explained below.
This deadlock is currently only appearing in state store but might affect pulsar in general as well.

```
Found one Java-level deadlock:
"io-read-scheduler-OrderedScheduler-0-0":
waiting to lock monitor 0x00007f10e804e100 (object 0x00000000e3b8e0a8, a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessClientStream),
which is held by "grpc-default-executor-17"
"grpc-default-executor-17":
waiting to lock monitor 0x00007f107000ca00 (object 0x00000000e3b8e1d8, a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessServerStream),
which is held by "io-read-scheduler-OrderedScheduler-0-0"
Java stack information for the threads listed above:
===================================================
"io-read-scheduler-OrderedScheduler-0-0":
at io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessClientStream.request(InProcessTransport.java:639)
waiting to lock <0x00000000e3b8e0a8> (a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessClientStream)
at io.grpc.internal.ForwardingClientStream.request(ForwardingClientStream.java:32)
at io.grpc.internal.ClientCallImpl.request(ClientCallImpl.java:369)
at io.grpc.PartialForwardingClientCall.request(PartialForwardingClientCall.java:34)
at io.grpc.ForwardingClientCall.request(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.request(ForwardingClientCall.java:44)
at io.grpc.PartialForwardingClientCall.request(PartialForwardingClientCall.java:34)
at io.grpc.ForwardingClientCall.request(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.request(ForwardingClientCall.java:44)
at io.grpc.PartialForwardingClientCall.request(PartialForwardingClientCall.java:34)
at io.grpc.ForwardingClientCall.request(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.request(ForwardingClientCall.java:44)
at org.apache.bookkeeper.common.grpc.proxy.ProxyCall$ResponseProxy.onMessage(ProxyCall.java:112)
locked <0x00000000e3b8dfd8> (a org.apache.bookkeeper.common.grpc.proxy.ProxyCall$ResponseProxy)
at io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
at io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:519)
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
at io.grpc.internal.SerializeReentrantCallsDirectExecutor.execute(SerializeReentrantCallsDirectExecutor.java:49)
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.messagesAvailable(ClientCallImpl.java:536)
at io.grpc.internal.ForwardingClientStreamListener.messagesAvailable(ForwardingClientStreamListener.java:44)
at io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessServerStream.writeMessage(InProcessTransport.java:455)
locked <0x00000000e3b8e1d8> (a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessServerStream)
at io.grpc.internal.ServerCallImpl.sendMessage(ServerCallImpl.java:139)
at io.grpc.ForwardingServerCall.sendMessage(ForwardingServerCall.java:32)
at org.apache.bookkeeper.common.grpc.stats.MonitoringServerCall.sendMessage(MonitoringServerCall.java:47)
at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onNext(ServerCalls.java:344)
at org.apache.bookkeeper.stream.storage.impl.grpc.handler.ResponseHandler.accept(ResponseHandler.java:49)
at org.apache.bookkeeper.stream.storage.impl.grpc.handler.ResponseHandler.accept(ResponseHandler.java:29)
at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.8/CompletableFuture.java:859)
at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@11.0.8/CompletableFuture.java:837)
at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.8/CompletableFuture.java:506)
at java.util.concurrent.CompletableFuture.complete(java.base@11.0.8/CompletableFuture.java:2073)
at org.apache.bookkeeper.statelib.impl.journal.AbstractStateStoreWithJournal.lambda$executeIO$16(AbstractStateStoreWithJournal.java:472)
at org.apache.bookkeeper.statelib.impl.journal.AbstractStateStoreWithJournal$$Lambda$294/0x00000008404b7040.run(Unknown Source)
at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.8/Executors.java:515)
at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.8/Executors.java:515)
at java.util.concurrent.FutureTask.run(java.base@11.0.8/FutureTask.java:264)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@11.0.8/ScheduledThreadPoolExecutor.java:304)
at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.8/ThreadPoolExecutor.java:1128)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.8/ThreadPoolExecutor.java:628)
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.lang.Thread.run(java.base@11.0.8/Thread.java:834)
"grpc-default-executor-17":
at io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessServerStream.isReady(InProcessTransport.java:466)
waiting to lock <0x00000000e3b8e1d8> (a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessServerStream)
at io.grpc.internal.ServerCallImpl.isReady(ServerCallImpl.java:167)
at io.grpc.PartialForwardingServerCall.isReady(PartialForwardingServerCall.java:43)
at io.grpc.ForwardingServerCall.isReady(ForwardingServerCall.java:22)
at io.grpc.ForwardingServerCall$SimpleForwardingServerCall.isReady(ForwardingServerCall.java:39)
at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:173)
at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:711)
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
at io.grpc.internal.SerializeReentrantCallsDirectExecutor.execute(SerializeReentrantCallsDirectExecutor.java:49)
at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener.halfClosed(ServerImpl.java:722)
at io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessClientStream.halfClose(InProcessTransport.java:745)
locked <0x00000000e3b8e0a8> (a io.grpc.inprocess.InProcessTransport$InProcessStream$InProcessClientStream)
at io.grpc.internal.ForwardingClientStream.halfClose(ForwardingClientStream.java:67)
at io.grpc.internal.ClientCallImpl.halfClose(ClientCallImpl.java:408)
at io.grpc.PartialForwardingClientCall.halfClose(PartialForwardingClientCall.java:44)
at io.grpc.ForwardingClientCall.halfClose(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.halfClose(ForwardingClientCall.java:44)
at io.grpc.PartialForwardingClientCall.halfClose(PartialForwardingClientCall.java:44)
at io.grpc.ForwardingClientCall.halfClose(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.halfClose(ForwardingClientCall.java:44)
at io.grpc.PartialForwardingClientCall.halfClose(PartialForwardingClientCall.java:44)
at io.grpc.ForwardingClientCall.halfClose(ForwardingClientCall.java:22)
at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.halfClose(ForwardingClientCall.java:44)
at org.apache.bookkeeper.common.grpc.proxy.ProxyCall$RequestProxy.onHalfClose(ProxyCall.java:68)
at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:711)
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.8/ThreadPoolExecutor.java:1128)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.8/ThreadPoolExecutor.java:628)
at java.lang.Thread.run(java.base@11.0.8/Thread.java:834)
Found 1 deadlock.

```
### Solution
Verified that with gRPC-1.31 issue is fixed.