### PR TITLE
[Issue 8354][pulsar-io] Upgrade spring framework version to patch CVE-2020-5421

### DIFF
--- a/pulsar-io/batch-discovery-triggerers/pom.xml
+++ b/pulsar-io/batch-discovery-triggerers/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.2.5.RELEASE</version>
+      <version>5.2.9.RELEASE</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Fixes #8354 

### Motivation

QiAnXinCodeSafe bot found vulnerability CVE-2020-5421 in the pulsar-io module.

### Modifications

Recommendation was to upgrade the springframework dependency.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? Minor upgrade of dependency.
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
