### PR TITLE
[Issue 8345][Documentation] Improve retention policy documentation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -378,15 +378,16 @@ public class ManagedLedgerConfig {
     }
 
     /**
-     * Set the retention time for the ManagedLedger
+     * Set the retention time for the ManagedLedger.
      * <p>
-     * Retention time will prevent data from being deleted for at least the specified amount of time, even if no cursors
-     * are created, or if all the cursors have marked the data for deletion.
+     * Retention time and retention size ({@link #setRetentionSizeInMB(long)}) are together used to retain the
+     * ledger data when when there are no cursors or when all the cursors have marked the data for deletion.
+     * Data will be deleted in this case when both retention time and retention size settings don't prevent deleting
+     * the data marked for deletion.
      * <p>
-     * A retention time of 0 (the default), will to have no time based retention.
+     * A retention time of 0 (default) will make data to be deleted immediately.
      * <p>
-     * Specifying a negative retention time will make the data to be retained indefinitely, based on the
-     * {@link #setRetentionSizeInMB(long)} value.
+     * A retention time of -1 , means to have an unlimited retention time.
      *
      * @param retentionTime
      *            duration for which messages should be retained
@@ -409,12 +410,14 @@ public class ManagedLedgerConfig {
     /**
      * The retention size is used to set a maximum retention size quota on the ManagedLedger.
      * <p>
-     * This setting works in conjuction with {@link #setRetentionSizeInMB(long)} and places a max size for retention,
-     * after which the data is deleted.
+     * Retention size and retention time ({@link #setRetentionTime(int, TimeUnit)}) are together used to retain the
+     * ledger data when when there are no cursors or when all the cursors have marked the data for deletion.
+     * Data will be deleted in this case when both retention time and retention size settings don't prevent deleting
+     * the data marked for deletion.
      * <p>
-     * A retention size of 0, will make data to be deleted immediately.
+     * A retention size of 0 (default) will make data to be deleted immediately.
      * <p>
-     * A retention size of -1, means to have an unlimited retention size.
+     * A retention size of -1 , means to have an unlimited retention size.
      *
      * @param retentionSizeInMB
      *            quota for message retention

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
@@ -20,6 +20,12 @@ package org.apache.pulsar.common.policies.data;
 
 /**
  * Definition of the retention policy.
+ *
+ * When you set a retention policy you must set **both** a *size limit* and a *time limit*.
+ * In the case where you don't want to limit by either time or set, the value must be set to `-1`.
+ * Retention policy will be effectively disabled and it won't prevent the deletion of acknowledged
+ * messages when either size or time limit is set to `0`.
+ * Infinite retention can be achieved by setting both time and size limits to `-1`.
  */
 public class RetentionPolicies {
     private int retentionTimeInMinutes;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.common.policies.data;
 /**
  * Definition of the retention policy.
  *
- * When you set a retention policy you must set **both** a *size limit* and a *time limit*.
+ * <p>When you set a retention policy you must set **both** a *size limit* and a *time limit*.
  * In the case where you don't want to limit by either time or set, the value must be set to `-1`.
  * Retention policy will be effectively disabled and it won't prevent the deletion of acknowledged
  * messages when either size or time limit is set to `0`.

--- a/site2/docs/reference-terminology.md
+++ b/site2/docs/reference-terminology.md
@@ -88,7 +88,7 @@ A message that has been delivered to a consumer for processing but not yet confi
 
 #### Retention Policy
 
-Size and/or time limits that you can set on a [namespace](#namespace) to configure retention of [messages](#message)
+Size and time limits that you can set on a [namespace](#namespace) to configure retention of [messages](#message)
 that have already been [acknowledged](#acknowledgement-ack).
 
 #### Multi-Tenancy


### PR DESCRIPTION
Fixes #8345

### Motivation

See #8345, #655

### Modifications

Documentation has been improved to cover the fact that retention policy is always based on both time and size limit. To make either limit ignored, it can be set to `-1`. It's misleading in the current documentation to call this "infinite" limit since it simply ignores the limit when it's `-1`. Infinite retention can be achieved by specifying both limits to `-1`. 
If either limit is `0`, it will effectively disable the retention policy. This wasn't documented before at all. 

Javadoc for ManagedLedgerConfig was also improved as part of the documentation changes.