### PR TITLE
Use grpc-bom and make protoc-gen-grpc-java.version match grpc.version to fix grpc version incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <protobuf3.version>3.11.4</protobuf3.version>
     <protoc3.version>3.11.4</protoc3.version>
     <grpc.version>1.31.0</grpc.version>
-    <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
+    <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
@@ -787,20 +787,10 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>io.grpc</groupId>
-        <artifactId>grpc-core</artifactId>
+        <artifactId>grpc-bom</artifactId>
         <version>${grpc.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-stub</artifactId>
-        <version>${grpc.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-protobuf-lite</artifactId>
-        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- CI fails currently because of grpc version incompatibilities

Another PR job failed with this kind of exception:
```
13:11:31.285 [main] ERROR org.apache.bookkeeper.common.component.AbstractLifecycleComponent - Failed to start Component: storage-service
java.lang.NoSuchMethodError: io.grpc.internal.DnsNameResolverProvider.newNameResolver(Ljava/net/URI;Lio/grpc/Attributes;)Lio/grpc/internal/DnsNameResolver;
	at org.apache.bookkeeper.common.resolver.ServiceNameResolverProvider.newNameResolver(ServiceNameResolverProvider.java:95) ~[org.apache.bookkeeper-stream-storage-java-client-4.10.0.jar:4.10.0]
	at org.apache.bookkeeper.common.resolver.NameResolverProviderFactory.newNameResolver(NameResolverProviderFactory.java:45) ~[org.apache.bookkeeper-stream-storage-java-client-4.10.0.jar:4.10.0]
	at io.grpc.NameResolver$Factory.newNameResolver(NameResolver.java:207) ~[io.grpc-grpc-api-1.31.0.jar:1.31.0]
	at io.grpc.NameResolver$Factory.newNameResolver(NameResolver.java:235) ~[io.grpc-grpc-api-1.31.0.jar:1.31.0]
	at io.grpc.internal.ManagedChannelImpl.getNameResolver(ManagedChannelImpl.java:701) ~[io.grpc-grpc-core-1.31.0.jar:1.31.0]
	at io.grpc.internal.ManagedChannelImpl.<init>(ManagedChannelImpl.java:606) ~[io.grpc-grpc-core-1.31.0.jar:1.31.0]
```
in https://github.com/apache/pulsar/runs/1297863577?check_suite_focus=true

I'd assume that protoc-gen-grpc-java.version should match grpc.version . I also added a change in the PR to use the grpc-bom in dependencyManagement.