### PR TITLE
Revert "PLSR-1240 upgrade GRPC to 1.31 to avoid deadlock"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ flexible messaging model and an intuitive client API.</description>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.11.4</protobuf3.version>
     <protoc3.version>3.11.4</protoc3.version>
-    <grpc.version>1.31.0</grpc.version>
+    <grpc.version>1.18.0</grpc.version>
     <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>


### PR DESCRIPTION
Reverts #8351 

- there are grpc/protobuf version compatibility issues and the master branch is currently broken

- tests weren't run when merging #8351 because of #8362

This reverts commit 647d3c22ee219e091fc29d809e8da982a25b6541.
