### PR TITLE
[Go functions] Provide pre-start access to secrets and conf

### DIFF
--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -30,19 +30,18 @@ import (
 type FunctionContext struct {
 	instanceConf *instanceConf
 	userConfigs  map[string]interface{}
+	secrets      map[string]interface{}
 	logAppender  *LogAppender
 	record       pulsar.Message
 }
 
 func NewFuncContext() *FunctionContext {
 	instanceConf := newInstanceConf()
-	userConfigs := buildUserConfig(instanceConf.funcDetails.GetUserConfig())
-
-	fc := &FunctionContext{
+	return &FunctionContext{
 		instanceConf: instanceConf,
-		userConfigs:  userConfigs,
+		userConfigs:  buildInterfaceMap(instanceConf.funcDetails.GetUserConfig()),
+		secrets:      buildInterfaceMap(instanceConf.funcDetails.GetSecretsMap()),
 	}
-	return fc
 }
 
 func (c *FunctionContext) GetInstanceID() int {
@@ -119,6 +118,15 @@ func (c *FunctionContext) GetUserConfMap() map[string]interface{} {
 	return c.userConfigs
 }
 
+func (c *FunctionContext) GetSecretsMap() map[string]interface{} {
+	return c.secrets
+}
+
+func (c *FunctionContext) GetSecretsValue(key string) interface{} {
+	return c.secrets[key]
+}
+
+
 // SetCurrentRecord sets the current message into the function context
 // called for each message before executing a handler function
 func (c *FunctionContext) SetCurrentRecord(record pulsar.Message) {
@@ -151,7 +159,7 @@ func FromContext(ctx context.Context) (*FunctionContext, bool) {
 	return fc, ok
 }
 
-func buildUserConfig(data string) map[string]interface{} {
+func buildInterfaceMap(data string) map[string]interface{} {
 	m := make(map[string]interface{})
 
 	json.Unmarshal([]byte(data), &m)

--- a/pulsar-function-go/pf/function.go
+++ b/pulsar-function-go/pf/function.go
@@ -174,3 +174,13 @@ func Start(funcName interface{}) {
 		panic("start function failed, please check.")
 	}
 }
+
+// GetUserConfig provides a means to access the pulsar function's user config map before initializing the pulsar function
+func GetUserConfig() map[string]interface{} {
+	return NewFuncContext().userConfigs
+}
+
+// GetSecrets provides a means to access the pulsar function's secrets  map before initializing the pulsar function
+func GetSecrets() map[string]interface{} {
+	return NewFuncContext().secrets
+}


### PR DESCRIPTION
### Motivation
The pulsar go functions SDK has no access to user config outside of the function context, which is only accessible from inside the function handler itself (i.e. once processing has started). This is a somewhat awkward access method when it comes to user configuration values which might be used to initialize a persistent connection to a database or other service, since it would require a largely-superfluous check for the initialization and related configuration values in every run of the function, when it's only required once at startup.  In addition, secrets are passed into the function context, but are completely inaccessible both inside and outside of the function, so support for these has been added to.

### Modifications

Two global methods have been provided to access the user config map and the secrets map, and transport of the secrets from the proto into the function context have been added.

### Verifying this change
This change is predicated on the changes (#8132)  made towards solving #8216, and will need to be tested in conjunction with them, however a very similar example should suffice:

```go
package main

import (
	"context"
	"fmt"

	log "github.com/apache/pulsar/pulsar-function-go/logutil"
	"github.com/apache/pulsar/pulsar-function-go/pf"
)

func contextFunc(ctx context.Context) {
	if fc, ok := pf.FromContext(ctx); ok {
		log.Infof("function ID is:%s, ", fc.GetFuncID())
		log.Infof("function version is:%s\n", fc.GetFuncVersion())
		for k := range fc.GetUserConfMap() {
			log.Infof("Config %q -> \"%v\"", k, fc.GetUserConfValue(k))
		}
		for k := range fc.GetSecretsMap() {
			log.Infof("Secret %q -> \"%v\"", k, fc.GetSecretsValue(k))
		}
	}
}

func main() {
	conf := pf.GetUserConfig()
	secrets := pf.GetSecrets()
	fmt.Println("***************************")
	fmt.Printf("got conf: %#v\n", conf)
	fmt.Printf("got secrets: %#v\n", secrets)
	fmt.Println("***************************")
	pf.Start(contextFunc)
}
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes)
    - Two new global methods are added to the Pulsar Functions for Go SDK, `GetUserConfig()` and `GetSecrets()`, as well as two new methods to `FunctionsContext`: `GetSecretsMap() map[string]interface{}` and `GetSecretsValue(key string) interface{}`
  - The schema: (no)
  - The default values of configurations: (yes / no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (don't know)

#### Public API
This adds two new global methods to the Pulsar Functions for Go SDK, in addition to two new methods on 
### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
    - godoc will suffice