### PR TITLE
sync license-maven-plugin version

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -62,7 +62,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>3.0.rc1</version>
+        <version>3.0</version>
         <configuration>
           <header>../src/license-header.txt</header>
         </configuration>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>3.0.rc1</version>
+                <version>3.0</version>
                 <configuration>
                     <header>../../src/license-header.txt</header>
                 </configuration>


### PR DESCRIPTION
### Motivation

license-maven-plugin version is 3.0 in the root pom.xml file. sync the version otherwise in my local environment it failed with

```
Cannot resolve plugin com.mycila:license-maven-plugin:3.0.rc1
```

### Modifications

sync version of license-maven-plugin in `buildtools/pom.xml` and `pulsar-sql/presto-distribution/pom.xml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no affect

### Documentation

no affect
