### PR TITLE
Improve protobuf and grpc dependency management

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf3.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.11.4</protobuf3.version>
-    <protoc3.version>3.11.4</protoc3.version>
+    <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.18.0</grpc.version>
-    <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
+    <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
@@ -801,6 +801,14 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-protobuf-lite</artifactId>
         <version>${grpc.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf3.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf3.version}</version>
     </dependency>
 
     <dependency>

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuf3.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -136,7 +136,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf3.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pulsar-functions/proto/pom.xml
+++ b/pulsar-functions/proto/pom.xml
@@ -38,13 +38,11 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuf3.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>${protobuf3.version}</version>
         </dependency>
         
         <dependency>

--- a/pulsar-transaction/common/pom.xml
+++ b/pulsar-transaction/common/pom.xml
@@ -38,13 +38,11 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuf3.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>${protobuf3.version}</version>
         </dependency>
 
     </dependencies>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuf3.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation

For managing protobuf libraries there is a maven bom file available for protobuf. The benefit of using this is that it can be imported to the project's pom.xml dependency management to make sure that the versions of the various protobuf libraries are aligned and use the same version.

Besides starting to use protobuf-bom, it was noticed that there are separate settings for protobuf protoc version (`protoc3.version`) and the protoc grpc plugin versions (`protoc-gen-grpc-java.version`). These versions should match the protobuf and grpc versions. The PR also covers an improvement for that.

One motivation of this PR is to prepare for the grpc upgrade that was attempted by #8351 , but reverted. Before doing the grpc upgrade, it would be useful to improve the protobuf & grpc dependency management provided by this PR.

### Modifications

* Use protobuf-bom to manage protobuf library versions
* make `protoc3.version` match `protobuf3.version`
  * there should be no reason that these would be different
* make grpc's `protoc-gen-grpc-java.version` match `grpc.version`
  * there should be no reason that there would be different