### PR TITLE
[Java Client] Disable batch receive timer for Readers

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -31,7 +31,10 @@ import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.common.naming.TopicName;
 
 public class ReaderImpl<T> implements Reader<T> {
-
+    private static final BatchReceivePolicy DISABLED_BATCH_RECEIVE_POLICY = BatchReceivePolicy.builder()
+            .timeout(0, TimeUnit.MILLISECONDS)
+            .maxNumMessages(1)
+            .build();
     private final ConsumerImpl<T> consumer;
 
     public ReaderImpl(PulsarClientImpl client, ReaderConfigurationData<T> readerConfiguration,
@@ -49,6 +52,10 @@ public class ReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setSubscriptionMode(SubscriptionMode.NonDurable);
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
+
+        // Reader doesn't need any batch receiving behaviours
+        // disable the batch receive timer for the ConsumerImpl instance wrapped by the ReaderImpl
+        consumerConfiguration.setBatchReceivePolicy(DISABLED_BATCH_RECEIVE_POLICY);
 
         if (readerConfiguration.getReaderName() != null) {
             consumerConfiguration.setConsumerName(readerConfiguration.getReaderName());


### PR DESCRIPTION
### Motivation

In the current implementation, each Reader implementation wraps a Consumer implementation. 
By default, the consumer implementation will use a BatchReceivePolicy that triggers a task every 100 milliseconds.
Since the Reader implementation doesn't use the batch receiving functionality, it's more efficient to disable the timer.

### Modifications

The the timeout is set to 0 for BatchReceivePolicy used for internal consumer of the Reader implementation.
This disables the timer that would get called every 100ms by default just for nothing.