### PR TITLE
Upgrade Testcontainers to 1.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
     <disruptor.version>3.4.0</disruptor.version>
-    <testcontainers.version>1.11.2</testcontainers.version>
+    <testcontainers.version>1.14.3</testcontainers.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>6.14.3</testng.version>
     <mockito.version>2.28.2</mockito.version>


### PR DESCRIPTION
### Motivation

The current Testcontainers version in 1.11.2 . A lot of improvements have been made in Testcontainers since 1.11.2 was released. The newest version is 1.14.3. 

### Modifications

Testcontainers version upgraded to 1.14.3 (latest stable version)