### PR TITLE
Add nettyMaxFrameSizeBytes setting to standalone.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -285,7 +285,7 @@ serverTcpNoDelay=true
 # The Recv ByteBuf allocator max buf size.
 # byteBufAllocatorSizeMax=1048576
 
-# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 1G.
+# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 5MB.
 nettyMaxFrameSizeBytes=5253120
 
 #############################################################################

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -778,6 +778,9 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 
 ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
 
+# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 5MB.
+nettyMaxFrameSizeBytes=5253120
+
 # Size of Write Cache. Memory is allocated from JVM direct memory.
 # Write cache is used to buffer entries before flushing into the entry log
 # For good performance, it should be big enough to hold a substantial amount

--- a/deployment/terraform-ansible/templates/bookkeeper.conf
+++ b/deployment/terraform-ansible/templates/bookkeeper.conf
@@ -268,7 +268,7 @@ serverTcpNoDelay=true
 # The Recv ByteBuf allocator max buf size.
 # byteBufAllocatorSizeMax=1048576
 
-# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 1G.
+# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 5MB.
 nettyMaxFrameSizeBytes=5253120
 
 #############################################################################

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -89,7 +89,7 @@ BookKeeper is a replicated log storage system that Pulsar uses for durable stora
 |serverSockKeepalive|This setting is used to send keep-alive messages on connection-oriented sockets.|true|
 |serverTcpLinger|The socket linger timeout on close. When enabled, a close or shutdown will not return until all queued messages for the socket have been successfully sent or the linger timeout has been reached. Otherwise, the call returns immediately and the closing is done in the background.|0|
 |byteBufAllocatorSizeMax|The maximum buf size of the received ByteBuf allocator.|1048576|
-|nettyMaxFrameSizeBytes|The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 1G.|5253120|
+|nettyMaxFrameSizeBytes|The maximum netty frame size in bytes. Any message received larger than this will be rejected.|5253120|
 |openFileLimit|Max number of ledger index files could be opened in bookie server If number of ledger index files reaches this limitation, bookie server started to swap some ledgers from memory to disk. Too frequent swap will affect performance. You can tune this number to gain performance according your requirements.|0|
 |pageSize|Size of a index page in ledger cache, in bytes A larger index page can improve performance writing page to disk, which is efficient when you have small number of ledgers and these ledgers have similar number of entries. If you have large number of ledgers and each ledger has fewer entries, smaller index page would improve memory usage.|8192|
 |pageLimit|How many index pages provided in ledger cache If number of index pages reaches this limitation, bookie server starts to swap some ledgers from memory to disk. You can increment this value when you found swap became more frequent. But make sure pageLimit*pageSize should not more than JVM max memory limitation, otherwise you would got OutOfMemoryException. In general, incrementing pageLimit, using smaller index page would gain better performance in lager number of ledgers with fewer entries case If pageLimit is -1, bookie server will use 1/3 of JVM memory to compute the limitation of number of index pages.|0|
@@ -129,7 +129,6 @@ BookKeeper is a replicated log storage system that Pulsar uses for durable stora
 |dbStorage_rocksDB_numLevels||-1|
 |dbStorage_rocksDB_numFilesInLevel0||4|
 |dbStorage_rocksDB_maxSizeInLevel1MB||256|
-| nettyMaxFrameSizeBytes | Set the maximum netty frame size in bytes. If the size of a received message is larger than the configured value, the message is rejected. | 1 GB |
 
 
 ## Broker


### PR DESCRIPTION
The `nettyMaxFrameSizeBytes` setting added to bookkeeper.conf in https://github.com/apache/pulsar/pull/7116  should also be added to standalone.conf. In addition, the comment was incorrect, so I fixed it. The default value should be 5MB instead of 1GB.
https://github.com/apache/bookkeeper/blob/4c6cf097d9b823c8e839e176a06266a58bcb7bf5/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java#L145-L146