### PR TITLE
Fix flaky test in the InactiveTopicDeleteTest.java

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -297,14 +297,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 60000)
     public void testTopicLevelInActiveTopicApi() throws Exception {
-        super.resetConfig();
         conf.setSystemTopicEnabled(true);
         conf.setTopicLevelPoliciesEnabled(true);
         super.baseSetup();
-        //wait for init
-        Thread.sleep(2000);
         final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
 
@@ -336,7 +333,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testTopicLevelInactivePolicyUpdateAndClean() throws Exception {
         super.resetConfig();
         conf.setSystemTopicEnabled(true);


### PR DESCRIPTION
Fixes apache/pulsar#8390

Fix flaky test in the InactiveTopicDeleteTest.java

Since the test needs to start the broker, bookie, and zookeeper. So increase the test timeout to 60s.