### PR TITLE
Try to fix flaky test in the InactiveTopicDeleteTest.java

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -133,6 +133,12 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     }
 
     @Override
+    public boolean cacheIsInitialized(TopicName topicName) {
+        return policyCacheInitMap.containsKey(topicName.getNamespaceObject())
+                && policyCacheInitMap.get(topicName.getNamespaceObject());
+    }
+
+    @Override
     public TopicPolicies getTopicPolicies(TopicName topicName) throws TopicPoliciesCacheNotInitException {
         if (policyCacheInitMap.containsKey(topicName.getNamespaceObject())
                 && !policyCacheInitMap.get(topicName.getNamespaceObject())) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -77,6 +77,13 @@ public interface TopicPoliciesService {
      */
     void start();
 
+    /**
+     * whether the cache has been initialized
+     * @param topicName
+     * @return
+     */
+    boolean cacheIsInitialized(TopicName topicName);
+
     void registerListener(TopicName topicName, TopicPolicyListener<TopicPolicies> listener);
 
     void unregisterListener(TopicName topicName, TopicPolicyListener<TopicPolicies> listener);
@@ -113,6 +120,11 @@ public interface TopicPoliciesService {
         @Override
         public void start() {
             //No-op
+        }
+
+        @Override
+        public boolean cacheIsInitialized(TopicName topicName) {
+            return false;
         }
 
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -329,7 +329,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         }
         assertEquals(admin.topics().getInactiveTopicPolicies(topicName), policies);
         admin.topics().removeInactiveTopicPolicies(topicName);
-        for (int i = 0; i <50; i++) {
+        for (int i = 0; i < 50; i++) {
             if (admin.topics().getInactiveTopicPolicies(topicName) == null) {
                 break;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Consumer;
 
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.testng.Assert;
@@ -305,8 +306,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         super.baseSetup();
         final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
-        //wait for init
-        Thread.sleep(3000);
+        pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe().close();
+        TopicName topic = TopicName.get(topicName);
+        while (!pulsar.getTopicPoliciesService().cacheIsInitialized(topic)) {
+            Thread.sleep(500);
+        }
 
         InactiveTopicPolicies inactiveTopicPolicies = admin.topics().getInactiveTopicPolicies(topicName);
         assertNull(inactiveTopicPolicies);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -204,9 +204,7 @@ public abstract class BaseResource {
         } else if (e instanceof WebApplicationException) {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
-                return new PulsarAdminException((WebApplicationException)e);
-                //ServerErrorException see = (ServerErrorException) e;
-                //return new ServerSideErrorException(see, e.getMessage());
+                return new PulsarAdminException((WebApplicationException) e);
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -205,6 +205,8 @@ public abstract class BaseResource {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
                 return new PulsarAdminException((WebApplicationException) e);
+                //ServerErrorException see = (ServerErrorException) e;
+                //return new ServerSideErrorException(see, e.getMessage());
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotAllowedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.client.admin.PulsarAdminException.ServerSideErrorException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -204,9 +205,8 @@ public abstract class BaseResource {
         } else if (e instanceof WebApplicationException) {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
-                return new PulsarAdminException((WebApplicationException) e);
-                //ServerErrorException see = (ServerErrorException) e;
-                //return new ServerSideErrorException(see, e.getMessage());
+                ServerErrorException see = (ServerErrorException) e;
+                return new ServerSideErrorException(see, e.getMessage());
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -43,7 +43,6 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotAllowedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
-import org.apache.pulsar.client.admin.PulsarAdminException.ServerSideErrorException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -205,8 +205,9 @@ public abstract class BaseResource {
         } else if (e instanceof WebApplicationException) {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
-                ServerErrorException see = (ServerErrorException) e;
-                return new ServerSideErrorException(see, e.getMessage());
+                return new PulsarAdminException((WebApplicationException) e);
+                //ServerErrorException see = (ServerErrorException) e;
+                //return new ServerSideErrorException(see, e.getMessage());
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -205,7 +205,7 @@ public abstract class BaseResource {
         } else if (e instanceof WebApplicationException) {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
-                return new PulsarAdminException((WebApplicationException) e);
+                return new PulsarAdminException((WebApplicationException)e);
                 //ServerErrorException see = (ServerErrorException) e;
                 //return new ServerSideErrorException(see, e.getMessage());
             } else if (e instanceof ClientErrorException) {


### PR DESCRIPTION
1）testTopicLevelInActiveTopicApi：The error is caused by `getInactiveTopicPolicies()`, due to the slow startup of the broker, the cache has not been initialized yet.

2)testTopicLevelInactivePolicyUpdateAndClean：We previously updated the event trigger timing of topic-policies. The update is triggered after the event is consumed. Therefore, it is not enough to judge that the policy in the cache is null. We need to sleep and wait for the event to be consumed.