### PR TITLE
[docs] Sync K8S Helm content from 2.6.0 docs into 2.6.1 and 2.6.2

### DIFF
--- a/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
@@ -53,11 +53,21 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 ## Step 1: Install Pulsar Helm chart
 
+0. Add Pulsar charts repo.
+
+    ```bash
+    helm repo add apache https://pulsar.apache.org/charts
+    ```
+
+    ```bash
+    helm repo update
+    ```
+
 1. Clone the Pulsar Helm chart repository.
 
     ```bash
-    git clone https://github.com/apache/pulsar
-    cd deployment/kubernetes/helm/
+    git clone https://github.com/apache/pulsar-helm-chart
+    cd pulsar-helm-chart
     ```
 
 2. Run the script `prepare_helm_release.sh` to create secrets required for installing the Apache Pulsar Helm chart. The username `pulsar` and password `pulsar` are used for logging into the Grafana dashboard and Pulsar Manager.
@@ -66,8 +76,6 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ./scripts/pulsar/prepare_helm_release.sh \
         -n pulsar \
         -k pulsar-mini \
-        --control-center-admin pulsar \
-        --control-center-password pulsar \
         -c
     ```
 
@@ -76,7 +84,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
-        pulsar-mini pulsar
+        pulsar-mini apache/pulsar
     ```
 
 4. Check the status of all pods.
@@ -130,7 +138,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.
@@ -193,7 +201,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 You can use the Pulsar client to create producers and consumers to produce and consume messages.
 
-By default, the Pulsar Helm chart exposes the Pulsar cluster through a Kubernetes `LoadBalancer`. In Minikube, you can use the following command to check the proxy service.
+By default, the Pulsar Helm chart exposes the Pulsar cluster through a Kubernetes `LoadBalancer`. In Minikube, you can use the following command to get the IP address of the proxy service.
 
 ```bash
 kubectl get services -n pulsar | grep pulsar-mini-proxy
@@ -205,36 +213,19 @@ You will see a similar output as below.
 pulsar-mini-proxy            LoadBalancer   10.97.240.109    <pending>     80:32305/TCP,6650:31816/TCP   28m
 ```
 
-This output tells what are the node ports that Pulsar cluster's binary port and HTTP port are mapped to. The port after `80:` is the HTTP port while the port after `6650:` is the binary port.
+This output tells what are the node ports that Pulsar cluster's binary port and HTTP port are exposed to. The port after `80:` is the HTTP port while the port after `6650:` is the binary port.
 
-Then you can find the IP address and exposed ports of your Minikube server by running the following command.
-
-```bash
-minikube service pulsar-mini-proxy -n pulsar
-```
-
-**Output**
+Then you can find the IP address of your Minikube server by running the following command.
 
 ```bash
-|-----------|-------------------|-------------|-------------------------|
-| NAMESPACE |       NAME        | TARGET PORT |           URL           |
-|-----------|-------------------|-------------|-------------------------|
-| pulsar    | pulsar-mini-proxy | http/80     | http://172.17.0.4:32305 |
-|           |                   | pulsar/6650 | http://172.17.0.4:31816 |
-|-----------|-------------------|-------------|-------------------------|
-🏃  Starting tunnel for service pulsar-mini-proxy.
-|-----------|-------------------|-------------|------------------------|
-| NAMESPACE |       NAME        | TARGET PORT |          URL           |
-|-----------|-------------------|-------------|------------------------|
-| pulsar    | pulsar-mini-proxy |             | http://127.0.0.1:61853 |
-|           |                   |             | http://127.0.0.1:61854 |
-|-----------|-------------------|-------------|------------------------|
+minikube ip
 ```
 
-At this point, you can get the service URLs to connect to your Pulsar client. Here are URL examples:
+At this point, you can get the service URLs to connect to your Pulsar client.
+
 ```
-webServiceUrl=http://127.0.0.1:61853/
-brokerServiceUrl=pulsar://127.0.0.1:61854/
+webServiceUrl=http://$(minikube ip):<exposed-http-port>/
+brokerServiceUrl=pulsar://$(minikube ip):<exposed-binary-port>/
 ```
 
 Then you can proceed with the following steps:

--- a/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
@@ -53,11 +53,21 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 ## Step 1: Install Pulsar Helm chart
 
+0. Add Pulsar charts repo.
+
+    ```bash
+    helm repo add apache https://pulsar.apache.org/charts
+    ```
+
+    ```bash
+    helm repo update
+    ```
+
 1. Clone the Pulsar Helm chart repository.
 
     ```bash
-    git clone https://github.com/apache/pulsar
-    cd deployment/kubernetes/helm/
+    git clone https://github.com/apache/pulsar-helm-chart
+    cd pulsar-helm-chart
     ```
 
 2. Run the script `prepare_helm_release.sh` to create secrets required for installing the Apache Pulsar Helm chart. The username `pulsar` and password `pulsar` are used for logging into the Grafana dashboard and Pulsar Manager.
@@ -66,8 +76,6 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ./scripts/pulsar/prepare_helm_release.sh \
         -n pulsar \
         -k pulsar-mini \
-        --control-center-admin pulsar \
-        --control-center-password pulsar \
         -c
     ```
 
@@ -76,7 +84,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
-        pulsar-mini pulsar
+        pulsar-mini apache/pulsar
     ```
 
 4. Check the status of all pods.
@@ -130,7 +138,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 1. Enter the `toolset` container.
 
     ```bash
-    kubectl exec -it -n pulsar pulsar-mini-toolset-0 /bin/bash
+    kubectl exec -it -n pulsar pulsar-mini-toolset-0 -- /bin/bash
     ```
 
 2. In the `toolset` container, create a tenant named `apache`.
@@ -193,7 +201,7 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 You can use the Pulsar client to create producers and consumers to produce and consume messages.
 
-By default, the Pulsar Helm chart exposes the Pulsar cluster through a Kubernetes `LoadBalancer`. In Minikube, you can use the following command to check the proxy service.
+By default, the Pulsar Helm chart exposes the Pulsar cluster through a Kubernetes `LoadBalancer`. In Minikube, you can use the following command to get the IP address of the proxy service.
 
 ```bash
 kubectl get services -n pulsar | grep pulsar-mini-proxy
@@ -205,36 +213,19 @@ You will see a similar output as below.
 pulsar-mini-proxy            LoadBalancer   10.97.240.109    <pending>     80:32305/TCP,6650:31816/TCP   28m
 ```
 
-This output tells what are the node ports that Pulsar cluster's binary port and HTTP port are mapped to. The port after `80:` is the HTTP port while the port after `6650:` is the binary port.
+This output tells what are the node ports that Pulsar cluster's binary port and HTTP port are exposed to. The port after `80:` is the HTTP port while the port after `6650:` is the binary port.
 
-Then you can find the IP address and exposed ports of your Minikube server by running the following command.
-
-```bash
-minikube service pulsar-mini-proxy -n pulsar
-```
-
-**Output**
+Then you can find the IP address of your Minikube server by running the following command.
 
 ```bash
-|-----------|-------------------|-------------|-------------------------|
-| NAMESPACE |       NAME        | TARGET PORT |           URL           |
-|-----------|-------------------|-------------|-------------------------|
-| pulsar    | pulsar-mini-proxy | http/80     | http://172.17.0.4:32305 |
-|           |                   | pulsar/6650 | http://172.17.0.4:31816 |
-|-----------|-------------------|-------------|-------------------------|
-🏃  Starting tunnel for service pulsar-mini-proxy.
-|-----------|-------------------|-------------|------------------------|
-| NAMESPACE |       NAME        | TARGET PORT |          URL           |
-|-----------|-------------------|-------------|------------------------|
-| pulsar    | pulsar-mini-proxy |             | http://127.0.0.1:61853 |
-|           |                   |             | http://127.0.0.1:61854 |
-|-----------|-------------------|-------------|------------------------|
+minikube ip
 ```
 
-At this point, you can get the service URLs to connect to your Pulsar client. Here are URL examples:
+At this point, you can get the service URLs to connect to your Pulsar client.
+
 ```
-webServiceUrl=http://127.0.0.1:61853/
-brokerServiceUrl=pulsar://127.0.0.1:61854/
+webServiceUrl=http://$(minikube ip):<exposed-http-port>/
+brokerServiceUrl=pulsar://$(minikube ip):<exposed-binary-port>/
 ```
 
 Then you can proceed with the following steps:


### PR DESCRIPTION
### Motivation

The content in Kubernetes Helm in 2.6.0 is not synced in 2.6.1 and 2.6.2

### Modifications

Sync the content from 2.6.0 with that in 2.6.1 and 2.6.2.