### PR TITLE
[Websocket]Update produce request and acknowledge for WebSocket.

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAck.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAck.java
@@ -18,18 +18,39 @@
  */
 package org.apache.pulsar.websocket.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import static com.google.common.base.Joiner.on;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.pulsar.websocket.WebSocketError;
 
+/**
+ * Represent result of publishing a single message.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonInclude(Include.NON_NULL)
 public class ProducerAck {
+
+    // Message publishing result
     public String result;
+
+    // Error message if fail to publish a message.
     public String errorMsg;
+
     public String messageId;
+
     public String context;
+
+    // Indicating if error is retriable error.
+    public int errorCode;
+
+    // Version of schema used to encode the message.
+    public long schemaVersion;
 
     public ProducerAck(String messageId, String context) {
         this.result = "ok";

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAcks.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAcks.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.data;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * Represent results of publishing multiple messages.
+ */
+@Data
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProducerAcks {
+    List<ProducerAck> messagePublishResults;
+
+    // Version of schema used to encode messages.
+    long schemaVersion;
+}

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAcks.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerAcks.java
@@ -18,16 +18,16 @@
  */
 package org.apache.pulsar.websocket.data;
 
-import lombok.*;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represent results of publishing multiple messages.
  */
 @Data
-@Setter
-@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProducerAcks {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessage.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessage.java
@@ -21,11 +21,53 @@ package org.apache.pulsar.websocket.data;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Class represent single message to be published.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProducerMessage {
+    // Actual message payload.
     public String payload;
+
+    // Optional properties.
     public Map<String, String> properties;
+
+    // Request context
     public String context;
+
+    // Partition key.
     public String key;
+
+    // Clusters to replicate message to.
     public List<String> replicationClusters;
+
+    // Message event time.
     public String eventTime;
+
+    // Message sequenceId.
+    public long sequenceId;
+
+    // Whether to disable replication of the message.
+    public boolean disableReplication;
+
+    // Deliver the message only at or after the specified absolute timestamp.
+    public long deliverAt;
+
+    // Deliver the message only after the specified relative delay in milliseconds.
+    public long deliverAfterMs;
+
+    // Version of schema to use for the message.
+    public long schemaVersion;
+
+    // Base64 encoded serialized schema for key
+    public String keySchema;
+
+    // Base64 encoded serialized schema for payload
+    public String valueSchema;
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessages.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessages.java
@@ -20,14 +20,14 @@ package org.apache.pulsar.websocket.data;
 
 import java.util.List;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Class represent messages to be published.
  */
 @Data
-@Setter
-@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProducerMessages {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessages.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ProducerMessages.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.data;
+
+import java.util.List;
+
+import lombok.*;
+
+/**
+ * Class represent messages to be published.
+ */
+@Data
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProducerMessages {
+    // Version of schema used for messages.
+    private long schemaVersion;
+
+    // Base64 encoded serialized schema for key
+    private String keySchema;
+
+    // Base64 encoded serialized schema for value
+    private String valueSchema;
+
+    private String producerName;
+
+    private List<ProducerMessage> messages;
+}


### PR DESCRIPTION
### Motivation
Update produce request and acknowledge for WebSocket as it shares common struct with the produce req/ack we want to add for REST API, the change also make it possible to add schema support for Websocket producer later.

### Modifications
Add some more fields such as keySchema/valueSchema, schemaVersion deliverAt, deliverAfter so we can support more feature like schema for Websocket producer later.
Also added batch produce/ack request class to represent req/resp for multiple messages.


### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
