### PR TITLE
Fixed direct memory leak in proxy with trace logging enabled

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
@@ -188,6 +188,8 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
             compBuf.addComponents(totalSizeBuf,buffer);
             compBuf.writerIndex(totalSizeBuf.capacity()+buffer.capacity());
 
+            messages.forEach(RawMessage::release);
+
             //next handler
             ctx.fireChannelRead(compBuf);
         }


### PR DESCRIPTION
### Motivation

Running the proxy with `proxyLogLevel=2` is triggering a memory leak and the proxy gets out of direct memory.