### PR TITLE
Upgrade jetty to 9.4.33.v20201020

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -424,23 +424,23 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-http-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-io-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-security-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-server-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-util-9.4.31.v20200723.jar
-    - org.eclipse.jetty-jetty-xml-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.31.v20200723.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.31.v20200723.jar
+    - org.eclipse.jetty-jetty-client-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-xml-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.33.v20201020.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.33.v20201020.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ flexible messaging model and an intuitive client API.</description>
     <netty.version>4.1.51.Final</netty.version>
     <netty-tc-native.version>2.0.30.Final</netty-tc-native.version>
     <storm.version>2.0.0</storm.version>
-    <jetty.version>9.4.31.v20200723</jetty.version>
+    <jetty.version>9.4.33.v20201020</jetty.version>
     <jersey.version>2.31</jersey.version>
     <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -433,12 +433,12 @@ The Apache Software License, Version 2.0
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty
-    - jetty-http-9.4.31.v20200723.jar
-    - jetty-io-9.4.31.v20200723.jar
-    - jetty-security-9.4.31.v20200723.jar
-    - jetty-server-9.4.31.v20200723.jar
-    - jetty-servlet-9.4.31.v20200723.jar
-    - jetty-util-9.4.31.v20200723.jar
+    - jetty-http-9.4.33.v20201020.jar
+    - jetty-io-9.4.33.v20201020.jar
+    - jetty-security-9.4.33.v20201020.jar
+    - jetty-server-9.4.33.v20201020.jar
+    - jetty-servlet-9.4.33.v20201020.jar
+    - jetty-util-9.4.33.v20201020.jar
   * Java Native Access
     - jna-4.2.0.jar
     - jna-5.3.1.jar


### PR DESCRIPTION
Jetty versions 9.4.32.v20200930 and earlier have a security vulnerability, so upgraded to the latest stable version.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27216