### PR TITLE
[Transaction] Support produce batch transaction messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -178,7 +178,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         for (int i = 0; i < txn1MessageCnt; i++) {
             message = consumer.receive();
             Assert.assertNotNull(message);
-            log.info("receive msgId: {}, msg: {}", message.getMessageId(), new String(message.getData(), UTF_8));
             receiveCnt ++;
         }
         Assert.assertEquals(txn1MessageCnt, receiveCnt);
@@ -193,7 +192,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         for (int i = 0; i < txn2MessageCnt; i++) {
             message = consumer.receive();
             Assert.assertNotNull(message);
-            log.info("receive second msgId: {}, msg: {}", message.getMessageId(), new String(message.getData(), UTF_8));
             receiveCnt ++;
         }
         Assert.assertEquals(txn2MessageCnt, receiveCnt);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -129,6 +129,11 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         produceCommitTest(false);
     }
 
+    @Test
+    public void batchProduceCommitTest() throws Exception {
+        produceCommitTest(true);
+    }
+
     private void produceCommitTest(boolean enableBatch) throws Exception {
         @Cleanup
         MultiTopicsConsumerImpl<byte[]> consumer = (MultiTopicsConsumerImpl<byte[]>) pulsarClient
@@ -149,12 +154,16 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Transaction txn1 = getTxn();
         Transaction txn2 = getTxn();
 
-        int messageCnt = 20;
+        int txn1MessageCnt = 0;
+        int txn2MessageCnt = 0;
+        int messageCnt = 1000;
         for (int i = 0; i < messageCnt; i++) {
-            if (i % 2 == 0) {
+            if (i % 5 == 0) {
                 producer.newMessage(txn1).value(("Hello Txn - " + i).getBytes(UTF_8)).sendAsync();
+                txn1MessageCnt ++;
             } else {
                 producer.newMessage(txn2).value(("Hello Txn - " + i).getBytes(UTF_8)).sendAsync();
+                txn2MessageCnt ++;
             }
         }
 
@@ -166,13 +175,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // txn1 messages could be received after txn1 committed
         int receiveCnt = 0;
-        for (int i = 0; i < messageCnt / 2; i++) {
+        for (int i = 0; i < txn1MessageCnt; i++) {
             message = consumer.receive();
             Assert.assertNotNull(message);
             log.info("receive msgId: {}, msg: {}", message.getMessageId(), new String(message.getData(), UTF_8));
             receiveCnt ++;
         }
-        Assert.assertEquals(messageCnt / 2, receiveCnt);
+        Assert.assertEquals(txn1MessageCnt, receiveCnt);
 
         message = consumer.receive(5, TimeUnit.SECONDS);
         Assert.assertNull(message);
@@ -181,13 +190,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // txn2 messages could be received after txn2 committed
         receiveCnt = 0;
-        for (int i = 0; i < messageCnt / 2; i++) {
+        for (int i = 0; i < txn2MessageCnt; i++) {
             message = consumer.receive();
             Assert.assertNotNull(message);
             log.info("receive second msgId: {}, msg: {}", message.getMessageId(), new String(message.getData(), UTF_8));
             receiveCnt ++;
         }
-        Assert.assertEquals(messageCnt / 2, receiveCnt);
+        Assert.assertEquals(txn2MessageCnt, receiveCnt);
 
         message = consumer.receive(5, TimeUnit.SECONDS);
         Assert.assertNull(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -91,40 +91,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
     }
 
     @Test
-    public void produceTest() throws Exception {
-        String topic = NAMESPACE1 + "/txn-test";
-
-        @Cleanup
-        Consumer<byte[]> consumer = pulsarClient
-                .newConsumer()
-                .topic(topic)
-                .subscriptionName("test")
-                .subscribe();
-
-        @Cleanup
-        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient
-                .newProducer()
-                .topic(topic)
-                .enableBatching(false)
-                .sendTimeout(0, TimeUnit.SECONDS)
-                .create();
-
-        Transaction txn = getTxn();
-
-        for (int i = 0; i < 10; i++) {
-            producer.newMessage(txn).value("Hello".getBytes()).sendAsync();
-        }
-
-        txn.commit().get();
-
-        for (int i = 0; i < 10; i++) {
-            Message<byte[]> message = consumer.receive();
-            log.info("receive msg: {}", new String(message.getData()));
-        }
-
-    }
-
-    @Test
     public void noBatchProduceCommitTest() throws Exception {
         produceCommitTest(false);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  * Batch message container framework.
  */
+@Slf4j
 public abstract class AbstractBatchMessageContainer implements BatchMessageContainerBase {
 
     protected PulsarApi.CompressionType compressionType;
@@ -40,6 +42,9 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected int maxBytesInBatch;
     protected int numMessagesInBatch = 0;
     protected long currentBatchSizeBytes = 0;
+
+    protected long currentTxnidMostBits = -1L;
+    protected long currentTxnidLeastBits = -1L;
 
     protected static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
 
@@ -92,5 +97,19 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         this.compressor = CompressionCodecProvider.getCompressionCodec(compressionType);
         this.maxNumMessagesInBatch = producer.getConfiguration().getBatchingMaxMessages();
         this.maxBytesInBatch = producer.getConfiguration().getBatchingMaxBytes();
+    }
+
+    @Override
+    public boolean hasSameTxn(MessageImpl<?> msg) {
+        if (!msg.getMessageBuilder().hasTxnidMostBits() || !msg.getMessageBuilder().hasTxnidLeastBits()) {
+            return true;
+        }
+        if (currentTxnidMostBits == -1 || currentTxnidLeastBits == -1) {
+            currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();
+            currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
+            return true;
+        }
+        return currentTxnidMostBits == msg.getMessageBuilder().getTxnidMostBits()
+                && currentTxnidLeastBits == msg.getMessageBuilder().getTxnidLeastBits();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerBase.java
@@ -75,4 +75,12 @@ public interface BatchMessageContainerBase extends BatchMessageContainer {
      * @throws IOException
      */
     OpSendMsg createOpSendMsg() throws IOException;
+
+    /**
+     * Check whether the added message belong to the same txn with batch message container.
+     *
+     * @param msg added message
+     * @return belong to the same txn or not
+     */
+    boolean hasSameTxn(MessageImpl<?> msg);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -671,7 +671,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private boolean canAddToCurrentBatch(MessageImpl<?> msg) {
         return batchMessageContainer.haveEnoughSpace(msg)
-               && (!isMultiSchemaEnabled(false) || batchMessageContainer.hasSameSchema(msg));
+               && (!isMultiSchemaEnabled(false) || batchMessageContainer.hasSameSchema(msg))
+                && batchMessageContainer.hasSameTxn(msg);
     }
 
     private void doBatchSendAndAdd(MessageImpl<?> msg, SendCallback callback, ByteBuf payload) {


### PR DESCRIPTION
### Motivation

Currently, Pulsar only supports produce transaction messages in no batch mode.

### Modifications

Add transaction id in the batch message container, if the newly added message has a different transaction id with the container, it will be added in the next batch.

### Verifying this change

add a new unit test.

**org.apache.pulsar.client.impl.TransactionEndToEndTest#batchProduceCommitTest**

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
