### PR TITLE
Clear the recently joined consumers when there is only one consumer under the Key_Shared subscription.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -124,6 +124,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         selector.removeConsumer(consumer);
         if (recentlyJoinedConsumers != null) {
             recentlyJoinedConsumers.remove(consumer);
+            if (consumerList.size() == 1) {
+                recentlyJoinedConsumers.clear();
+            }
         }
     }
 


### PR DESCRIPTION

### Motivation

Clear the recently joined consumers when there is only one consumer under the Key_Shared subscription.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
