### PR TITLE
[Issue 8382][Pulsar Function] Enable e2e encryption for Pulsar Function

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -52,6 +52,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.functions.Utils;
@@ -219,6 +220,8 @@ public class CmdFunctions extends CmdBase {
 
         @Parameter(names = {"-o", "--output"}, description = "The output topic of a Pulsar Function (If none is specified, no output is written)")
         protected String output;
+        @Parameter(names = "--producer-config", description = "The custom producer configuration (as a JSON string)" )
+        protected String producerConfig;
         // for backwards compatibility purposes
         @Parameter(names = "--logTopic", description = "The topic to which the logs of a Pulsar Function are produced", hidden = true)
         protected String DEPRECATED_logTopic;
@@ -390,6 +393,10 @@ public class CmdFunctions extends CmdBase {
             }
             if (null != output) {
                 functionConfig.setOutput(output);
+            }
+            if (null != producerConfig) {
+                Type type = new TypeToken<ProducerConfig>() {}.getType();
+                functionConfig.setProducerConfig(new Gson().fromJson(producerConfig, type));
             }
             if (null != logTopic) {
                 functionConfig.setLogTopic(logTopic);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.text.WordUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptions;
 import org.apache.pulsar.common.io.ConnectorDefinition;
@@ -270,6 +271,8 @@ public class CmdSources extends CmdBase {
         protected String DEPRECATED_destinationTopicName;
         @Parameter(names = "--destination-topic-name", description = "The Pulsar topic to which data is sent")
         protected String destinationTopicName;
+        @Parameter(names = "--producer-config", description = "The custom producer configuration (as a JSON string)")
+        protected String producerConfig;
 
         @Parameter(names = "--deserializationClassName", description = "The SerDe classname for the source", hidden = true)
         protected String DEPRECATED_deserializationClassName;
@@ -345,6 +348,10 @@ public class CmdSources extends CmdBase {
             }
             if (null != destinationTopicName) {
                 sourceConfig.setTopicName(destinationTopicName);
+            }
+            if (null != producerConfig) {
+                Type type = new TypeToken<ProducerConfig>() {}.getType();
+                sourceConfig.setProducerConfig(new Gson().fromJson(producerConfig, type));
             }
             if (null != deserializationClassName) {
                 sourceConfig.setSerdeClassName(deserializationClassName);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -45,6 +45,7 @@ public class ConsumerConfig {
     @Builder.Default
     private Map<String, String> consumerProperties = new HashMap<>();
     private Integer receiverQueueSize;
+    private CryptoConfig cryptoConfig;
 
     public ConsumerConfig(String schemaType) {
         this.schemaType = schemaType;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java
@@ -1,0 +1,30 @@
+package org.apache.pulsar.common.functions;
+
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
+
+/**
+ * Configuration of the producer inside the function.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class CryptoConfig {
+    private String cryptoKeyReaderClassName;
+    private Map<String, Object> cryptoKeyReaderConfig;
+
+    private String[] encryptionKeys;
+    private ProducerCryptoFailureAction producerCryptoFailureAction;
+
+    private ConsumerCryptoFailureAction consumerCryptoFailureAction;
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java
@@ -1,5 +1,23 @@
-package org.apache.pulsar.common.functions;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+package org.apache.pulsar.common.functions;
 
 import java.util.Map;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ProducerConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ProducerConfig.java
@@ -36,4 +36,5 @@ public class ProducerConfig {
     private Integer maxPendingMessages;
     private Integer maxPendingMessagesAcrossPartitions;
     private Boolean useThreadLocalProducers;
+    private CryptoConfig cryptoConfig;
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
@@ -88,7 +88,7 @@ public class Reflections {
         } catch (NoSuchMethodException e) {
             throw new RuntimeException("User class must have a no-arg constructor", e);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("User class must a public constructor", e);
+            throw new RuntimeException("User class must have a public constructor", e);
         } catch (InvocationTargetException e) {
             throw new RuntimeException("User class constructor throws exception", e);
         }

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -78,6 +78,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-messagecrypto-bc</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <exclusions>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -391,11 +391,13 @@ public class PulsarSink<T> implements Sink<T> {
     @SuppressWarnings("unchecked")
     @VisibleForTesting
     Crypto initializeCrypto() throws ClassNotFoundException {
-        CryptoConfig cryptoConfig = pulsarSinkConfig.getProducerConfig().getCryptoConfig();
-
-        if (cryptoConfig == null || isEmpty(cryptoConfig.getCryptoKeyReaderClassName())) {
+        if (pulsarSinkConfig.getProducerConfig() == null
+                || pulsarSinkConfig.getProducerConfig().getCryptoConfig() == null
+                || isEmpty(pulsarSinkConfig.getProducerConfig().getCryptoConfig().getCryptoKeyReaderClassName())) {
             return null;
         }
+
+        CryptoConfig cryptoConfig = pulsarSinkConfig.getProducerConfig().getCryptoConfig();
 
         // add provider only if it's not in the JVM
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -398,9 +398,9 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         // add provider only if it's not in the JVM
-//        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-//            Security.addProvider(new BouncyCastleProvider());
-//        }
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
 
         Crypto.CryptoBuilder bldr = Crypto.builder()
                 .failureAction(cryptoConfig.getProducerCryptoFailureAction())

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -19,21 +19,28 @@
 package org.apache.pulsar.functions.sink;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.Builder;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.functions.ConsumerConfig;
+import org.apache.pulsar.common.functions.CryptoConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.FunctionResultRouter;
@@ -42,9 +49,12 @@ import org.apache.pulsar.functions.instance.stats.ComponentStatsManager;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.functions.source.TopicSchema;
 import org.apache.pulsar.common.util.Reflections;
+import org.apache.pulsar.functions.utils.CryptoUtils;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -54,6 +64,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
 
 @Slf4j
 public class PulsarSink<T> implements Sink<T> {
@@ -81,9 +93,11 @@ public class PulsarSink<T> implements Sink<T> {
     private abstract class PulsarSinkProcessorBase implements PulsarSinkProcessor<T> {
         protected Map<String, Producer<T>> publishProducers = new ConcurrentHashMap<>();
         protected Schema schema;
+        protected  Crypto crypto;
 
-        protected PulsarSinkProcessorBase(Schema schema) {
+        protected PulsarSinkProcessorBase(Schema schema, Crypto crypto) {
             this.schema = schema;
+            this.crypto = crypto;
         }
 
         public Producer<T> createProducer(PulsarClient client, String topic, String producerName, Schema<T> schema)
@@ -103,15 +117,23 @@ public class PulsarSink<T> implements Sink<T> {
             if (producerName != null) {
                 builder.producerName(producerName);
             }
-            if (pulsarSinkConfig.getProducerSpec() != null) {
-                if (pulsarSinkConfig.getProducerSpec().getMaxPendingMessages() != 0) {
-                    builder.maxPendingMessages(pulsarSinkConfig.getProducerSpec().getMaxPendingMessages());
+            if (pulsarSinkConfig.getProducerConfig() != null) {
+                ProducerConfig producerConfig = pulsarSinkConfig.getProducerConfig();
+                if (producerConfig.getMaxPendingMessages() != 0) {
+                    builder.maxPendingMessages(producerConfig.getMaxPendingMessages());
                 }
-                if (pulsarSinkConfig.getProducerSpec().getMaxPendingMessagesAcrossPartitions() != 0) {
-                    builder.maxPendingMessagesAcrossPartitions(pulsarSinkConfig.getProducerSpec().getMaxPendingMessagesAcrossPartitions());
+                if (producerConfig.getMaxPendingMessagesAcrossPartitions() != 0) {
+                    builder.maxPendingMessagesAcrossPartitions(producerConfig.getMaxPendingMessagesAcrossPartitions());
+                }
+                if (producerConfig.getCryptoConfig() != null) {
+                    CryptoConfig cryptoConfig = producerConfig.getCryptoConfig();
+                    builder.cryptoKeyReader(crypto.keyReader);
+                    builder.cryptoFailureAction(crypto.failureAction);
+                    for (String encryptionKeyName : crypto.getEncryptionKeys()) {
+                        builder.addEncryptionKey(encryptionKeyName);
+                    }
                 }
             }
-
             return builder.properties(properties).create();
         }
 
@@ -175,8 +197,8 @@ public class PulsarSink<T> implements Sink<T> {
 
     @VisibleForTesting
     class PulsarSinkAtMostOnceProcessor extends PulsarSinkProcessorBase {
-        public PulsarSinkAtMostOnceProcessor(Schema schema) {
-            super(schema);
+        public PulsarSinkAtMostOnceProcessor(Schema schema, Crypto crypto) {
+            super(schema, crypto);
             // initialize default topic
             try {
                 publishProducers.put(pulsarSinkConfig.getTopic(),
@@ -211,8 +233,8 @@ public class PulsarSink<T> implements Sink<T> {
 
     @VisibleForTesting
     class PulsarSinkAtLeastOnceProcessor extends PulsarSinkAtMostOnceProcessor {
-        public PulsarSinkAtLeastOnceProcessor(Schema schema) {
-            super(schema);
+        public PulsarSinkAtLeastOnceProcessor(Schema schema, Crypto crypto) {
+            super(schema, crypto);
         }
 
         @Override
@@ -226,8 +248,8 @@ public class PulsarSink<T> implements Sink<T> {
     @VisibleForTesting
     class PulsarSinkEffectivelyOnceProcessor extends PulsarSinkProcessorBase {
 
-        public PulsarSinkEffectivelyOnceProcessor(Schema schema) {
-            super(schema);
+        public PulsarSinkEffectivelyOnceProcessor(Schema schema, Crypto crypto) {
+            super(schema, crypto);
         }
 
         @Override
@@ -284,16 +306,21 @@ public class PulsarSink<T> implements Sink<T> {
             return;
         }
 
+        Crypto crypto = initializeCrypto();
+        if (crypto == null) {
+            log.info("crypto key reader is not provided, not enabling end to end encryption");
+        }
+
         FunctionConfig.ProcessingGuarantees processingGuarantees = this.pulsarSinkConfig.getProcessingGuarantees();
         switch (processingGuarantees) {
             case ATMOST_ONCE:
-                this.pulsarSinkProcessor = new PulsarSinkAtMostOnceProcessor(schema);
+                this.pulsarSinkProcessor = new PulsarSinkAtMostOnceProcessor(schema, crypto);
                 break;
             case ATLEAST_ONCE:
-                this.pulsarSinkProcessor = new PulsarSinkAtLeastOnceProcessor(schema);
+                this.pulsarSinkProcessor = new PulsarSinkAtLeastOnceProcessor(schema, crypto);
                 break;
             case EFFECTIVELY_ONCE:
-                this.pulsarSinkProcessor = new PulsarSinkEffectivelyOnceProcessor(schema);
+                this.pulsarSinkProcessor = new PulsarSinkEffectivelyOnceProcessor(schema, crypto);
                 break;
         }
     }
@@ -359,5 +386,37 @@ public class PulsarSink<T> implements Sink<T> {
             return (Schema<T>) topicSchema.getSchema(pulsarSinkConfig.getTopic(), typeArg,
                     consumerConfig, false, functionClassLoader);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @VisibleForTesting
+    Crypto initializeCrypto() throws ClassNotFoundException {
+        CryptoConfig cryptoConfig = pulsarSinkConfig.getProducerConfig().getCryptoConfig();
+
+        if (cryptoConfig == null || isEmpty(cryptoConfig.getCryptoKeyReaderClassName())) {
+            return null;
+        }
+
+        // add provider only if it's not in the JVM
+//        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+//            Security.addProvider(new BouncyCastleProvider());
+//        }
+
+        Crypto.CryptoBuilder bldr = Crypto.builder()
+                .failureAction(cryptoConfig.getProducerCryptoFailureAction())
+                .encryptionKeys(cryptoConfig.getEncryptionKeys());
+
+        bldr.keyReader(CryptoUtils.getCryptoKeyReaderInstance(
+                cryptoConfig.getCryptoKeyReaderClassName(), cryptoConfig.getCryptoKeyReaderConfig(), functionClassLoader));
+
+        return bldr.build();
+    }
+
+    @Data
+    @Builder
+    private static class Crypto {
+        private CryptoKeyReader keyReader;
+        private ProducerCryptoFailureAction failureAction;
+        private String[] encryptionKeys;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSinkConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSinkConfig.java
@@ -22,7 +22,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.pulsar.common.functions.FunctionConfig;
-import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.common.functions.ProducerConfig;
 
 import java.util.Map;
 
@@ -37,5 +37,5 @@ public class PulsarSinkConfig {
     private Map<String, String> schemaProperties;
     private String typeClassName;
     private boolean forwardSourceMessageProperty;
-    private Function.ProducerSpec producerSpec;
+    private ProducerConfig producerConfig;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.security.Security;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -35,8 +36,10 @@ import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.util.Reflections;
+import org.apache.pulsar.functions.utils.CryptoUtils;
 import org.apache.pulsar.io.core.PushSource;
 import org.apache.pulsar.io.core.SourceContext;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 @Slf4j
 public class PulsarSource<T> extends PushSource<T> implements MessageListener<T> {
@@ -71,8 +74,6 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                     topic, conf.getSchema(), conf.getSchema().getSchemaInfo());
 
             ConsumerBuilder<T> cb = pulsarClient.newConsumer(conf.getSchema())
-                    // consume message even if can't decrypt and deliver it along with encryption-ctx
-                    .cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
                     .subscriptionName(pulsarSourceConfig.getSubscriptionName())
                     .subscriptionInitialPosition(pulsarSourceConfig.getSubscriptionPosition())
                     .subscriptionType(pulsarSourceConfig.getSubscriptionType());
@@ -90,6 +91,12 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             }
             if (conf.getReceiverQueueSize() != null) {
                 cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
+            }
+            if (conf.getCryptoKeyReader() != null) {
+                cb = cb.cryptoKeyReader(conf.getCryptoKeyReader());
+            }
+            if (conf.getConsumerCryptoFailureAction() != null) {
+                cb = cb.cryptoFailureAction(conf.getConsumerCryptoFailureAction());
             }
             cb = cb.properties(properties);
             if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
@@ -166,18 +173,32 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
         // Check new config with schema types or classnames
         pulsarSourceConfig.getTopicSchema().forEach((topic, conf) -> {
+            ConsumerConfig.ConsumerConfigBuilder<T> consumerConfBuilder =  ConsumerConfig.<T> builder().
+                    isRegexPattern(conf.isRegexPattern()).
+                    receiverQueueSize(conf.getReceiverQueueSize()).
+                    consumerProperties(conf.getConsumerProperties());
+
             Schema<T> schema;
             if (conf.getSerdeClassName() != null && !conf.getSerdeClassName().isEmpty()) {
                 schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf.getSerdeClassName(), true);
             } else {
                 schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf, true);
             }
-            configs.put(topic,
-                    ConsumerConfig.<T> builder().
-                            schema(schema).
-                            isRegexPattern(conf.isRegexPattern()).
-                            receiverQueueSize(conf.getReceiverQueueSize()).
-                            consumerProperties(conf.getConsumerProperties()).build());
+            consumerConfBuilder.schema(schema);
+
+            if (conf.getCryptoConfig() != null) {
+                // add provider only if it's not in the JVM
+//                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+//                    Security.addProvider(new BouncyCastleProvider());
+//                }
+
+                consumerConfBuilder.consumerCryptoFailureAction(conf.getCryptoConfig().getConsumerCryptoFailureAction());
+                consumerConfBuilder.cryptoKeyReader(CryptoUtils.getCryptoKeyReaderInstance(
+                        conf.getCryptoConfig().getCryptoKeyReaderClassName(),
+                        conf.getCryptoConfig().getCryptoKeyReaderConfig(), functionClassLoader));
+            }
+
+            configs.put(topic, consumerConfBuilder.build());
         });
 
         return configs;
@@ -198,6 +219,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
         private boolean isRegexPattern;
         private Integer receiverQueueSize;
         private Map<String, String> consumerProperties;
+        private CryptoKeyReader cryptoKeyReader;
+        private ConsumerCryptoFailureAction consumerCryptoFailureAction;
     }
-
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -188,9 +188,9 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
             if (conf.getCryptoConfig() != null) {
                 // add provider only if it's not in the JVM
-//                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-//                    Security.addProvider(new BouncyCastleProvider());
-//                }
+                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                    Security.addProvider(new BouncyCastleProvider());
+                }
 
                 consumerConfBuilder.consumerCryptoFailureAction(conf.getCryptoConfig().getConsumerCryptoFailureAction());
                 consumerConfBuilder.cryptoKeyReader(CryptoUtils.getCryptoKeyReaderInstance(

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConfig.java
@@ -28,6 +28,7 @@ import lombok.Data;
 
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.functions.CryptoConfig;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
@@ -1,0 +1,51 @@
+package org.apache.pulsar.functions.api.examples;
+
+import lombok.Data;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.EncryptionKeyInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+@Data
+public class RawFileKeyReader implements CryptoKeyReader {
+
+    private final String publicKeyFile;
+    private final String privateKeyFile;
+
+    public RawFileKeyReader(String pubKeyFile, String privKeyFile) {
+        publicKeyFile = pubKeyFile;
+        privateKeyFile = privKeyFile;
+    }
+
+    public RawFileKeyReader(Map<String, Object> conf) {
+        publicKeyFile = (String) conf.get("PUBLIC");
+        privateKeyFile = (String) conf.get("PRIVATE");
+    }
+
+    @Override
+    public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
+        EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+        try {
+            keyInfo.setKey(Files.readAllBytes(Paths.get(publicKeyFile)));
+        } catch (IOException e) {
+            System.out.println("ERROR: Failed to read public key from file " + publicKeyFile);
+            e.printStackTrace();
+        }
+        return keyInfo;
+    }
+
+    @Override
+    public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> keyMeta) {
+        EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+        try {
+            keyInfo.setKey(Files.readAllBytes(Paths.get(privateKeyFile)));
+        } catch (IOException e) {
+            System.out.println("ERROR: Failed to read private key from file " + privateKeyFile);
+            e.printStackTrace();
+        }
+        return keyInfo;
+    }
+}

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pulsar.functions.api.examples;
 
 import lombok.Data;
@@ -9,6 +28,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 
+/**
+ * Example function that provide a constructor with map<string, object> argument
+ * to initialize the CryptoKeyReader class used by pulsar function
+ */
 @Data
 public class RawFileKeyReader implements CryptoKeyReader {
 

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -100,12 +100,38 @@ message ConsumerSpec {
     ReceiverQueueSize receiverQueueSize = 4;
     map<string, string> schemaProperties = 5;
     map<string, string> consumerProperties = 6;
+    CryptoSpec cryptoSpec = 7;
 }
 
 message ProducerSpec {
     int32 maxPendingMessages = 1;
     int32 maxPendingMessagesAcrossPartitions = 2;
     bool useThreadLocalProducers = 3;
+    CryptoSpec cryptoSpec = 4;
+}
+
+message CryptoSpec {
+    enum FailureAction {
+        FAIL = 0;
+
+        DISCARD = 1;
+        CONSUME = 2;
+
+        SEND = 10;
+    }
+
+    string cryptoKeyReaderClassName = 1;
+    string cryptoKeyReaderConfig = 2;
+
+    // key names used by producer to encrypt data
+    repeated string producerEncryptionKeyName = 3;
+    // define the action if producer fail to encrypt data
+    // one of FAIL, SEND
+    FailureAction producerCryptoFailureAction = 4;
+
+    // define the action if consumer fail to decrypt data
+    // one of FAIL, DISCARD, CONSUME
+    FailureAction consumerCryptoFailureAction = 5;
 }
 
 message SourceSpec {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/CryptoUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/CryptoUtils.java
@@ -1,0 +1,135 @@
+package org.apache.pulsar.functions.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
+import org.apache.pulsar.common.functions.CryptoConfig;
+import org.apache.pulsar.common.util.ClassLoaderUtils;
+import org.apache.pulsar.functions.proto.Function;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
+public final class CryptoUtils {
+
+    public static Function.CryptoSpec convert(CryptoConfig config) {
+        Function.CryptoSpec.Builder bldr = Function.CryptoSpec.newBuilder()
+                .setCryptoKeyReaderClassName(config.getCryptoKeyReaderClassName());
+
+        if (config.getCryptoKeyReaderConfig() != null) {
+            Type type = new TypeToken<Map<String, Object>>() {
+            }.getType();
+            String readerConfigString = new Gson().toJson(config.getCryptoKeyReaderConfig(), type);
+            bldr.setCryptoKeyReaderConfig(readerConfigString);
+        }
+
+        if (config.getEncryptionKeys() != null && config.getEncryptionKeys().length > 0) {
+            bldr.addAllProducerEncryptionKeyName(Arrays.asList(config.getEncryptionKeys()));
+        }
+
+        if (config.getProducerCryptoFailureAction() != null) {
+            bldr.setProducerCryptoFailureAction(getProtoFailureAction(config.getProducerCryptoFailureAction()));
+        }
+
+        if (config.getConsumerCryptoFailureAction() != null) {
+            bldr.setConsumerCryptoFailureAction(getProtoFailureAction(config.getConsumerCryptoFailureAction()));
+        }
+
+        return bldr.build();
+    }
+
+    public static CryptoConfig convertFromSpec(Function.CryptoSpec spec) {
+        if (spec == null || isEmpty(spec.getCryptoKeyReaderClassName())) {
+            return null;
+        }
+
+        CryptoConfig.CryptoConfigBuilder bldr = CryptoConfig.builder();
+
+        Type type = new TypeToken<Map<String, Object>>() {
+        }.getType();
+        Map<String, Object> cryptoReaderConfig = new Gson().fromJson(spec.getCryptoKeyReaderConfig(), type);
+
+        bldr.cryptoKeyReaderClassName(spec.getCryptoKeyReaderClassName())
+                .cryptoKeyReaderConfig(cryptoReaderConfig)
+                .consumerCryptoFailureAction(getConsumerCryptoFailureAction(spec.getConsumerCryptoFailureAction()))
+                .producerCryptoFailureAction(getProducerCryptoFailureAction(spec.getProducerCryptoFailureAction()))
+                .encryptionKeys(spec.getProducerEncryptionKeyNameList().toArray(new String[0]));
+
+        return bldr.build();
+    }
+
+    public static CryptoKeyReader getCryptoKeyReaderInstance(String className, Map<String, Object> configs, ClassLoader classLoader) {
+        Class<?> cryptoClass;
+        try {
+            cryptoClass = ClassLoaderUtils.loadClass(className, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    String.format("Failed to load crypto key reader class %sx", className));
+        }
+
+        try {
+            Constructor<?> ctor = cryptoClass.getConstructor(java.util.Map.class);
+            return (CryptoKeyReader) ctor.newInstance(configs);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Key reader class does not have constructor accepts map", e);
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to create instance for key reader class", e);
+        }
+    }
+
+    public static ProducerCryptoFailureAction getProducerCryptoFailureAction(Function.CryptoSpec.FailureAction action) {
+        switch (action) {
+            case FAIL:
+                return ProducerCryptoFailureAction.FAIL;
+            case SEND:
+                return ProducerCryptoFailureAction.SEND;
+            default:
+                throw new RuntimeException("Unknown producer protobuf failure action " + action.getValueDescriptor().getName());
+        }
+    }
+
+    public static ConsumerCryptoFailureAction getConsumerCryptoFailureAction(Function.CryptoSpec.FailureAction action) {
+        switch (action) {
+            case FAIL:
+                return ConsumerCryptoFailureAction.FAIL;
+            case DISCARD:
+                return ConsumerCryptoFailureAction.DISCARD;
+            case CONSUME:
+                return ConsumerCryptoFailureAction.CONSUME;
+            default:
+                throw new RuntimeException("Unknown consumer protobuf failure action " + action.getValueDescriptor().getName());
+        }
+    }
+
+    public static Function.CryptoSpec.FailureAction getProtoFailureAction(ProducerCryptoFailureAction action) {
+        switch (action) {
+            case FAIL:
+                return Function.CryptoSpec.FailureAction.FAIL;
+            case SEND:
+                return Function.CryptoSpec.FailureAction.SEND;
+            default:
+                throw new RuntimeException("Unknown producer crypto failure action " + action);
+        }
+    }
+
+    public static Function.CryptoSpec.FailureAction getProtoFailureAction(ConsumerCryptoFailureAction action) {
+        switch (action) {
+            case FAIL:
+                return Function.CryptoSpec.FailureAction.FAIL;
+            case DISCARD:
+                return Function.CryptoSpec.FailureAction.DISCARD;
+            case CONSUME:
+                return Function.CryptoSpec.FailureAction.CONSUME;
+            default:
+                throw new RuntimeException("Unknown consumer crypto failure action " + action);
+        }
+    }
+
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/CryptoUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/CryptoUtils.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pulsar.functions.utils;
 
 import java.lang.reflect.Constructor;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -433,7 +433,7 @@ public class SourceConfigUtils {
             ValidatorUtils.validateSchema(sourceConfig.getSchemaType(), typeArg, classLoader, false);
         }
 
-        if (sourceConfig.getProducerConfig().getCryptoConfig() != null) {
+        if (sourceConfig.getProducerConfig() != null && sourceConfig.getProducerConfig().getCryptoConfig() != null) {
             ValidatorUtils.validateCryptoKeyReader(sourceConfig.getProducerConfig().getCryptoConfig(), classLoader, true);
         }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.pulsar.functions.utils.FunctionCommon.convertProcessingGuarantee;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getSourceType;
 
@@ -148,15 +149,19 @@ public class SourceConfigUtils {
         }
 
         if (sourceConfig.getProducerConfig() != null) {
+            ProducerConfig conf = sourceConfig.getProducerConfig();
             Function.ProducerSpec.Builder pbldr = Function.ProducerSpec.newBuilder();
-            if (sourceConfig.getProducerConfig().getMaxPendingMessages() != null) {
-                pbldr.setMaxPendingMessages(sourceConfig.getProducerConfig().getMaxPendingMessages());
+            if (conf.getMaxPendingMessages() != null) {
+                pbldr.setMaxPendingMessages(conf.getMaxPendingMessages());
             }
-            if (sourceConfig.getProducerConfig().getMaxPendingMessagesAcrossPartitions() != null) {
-                pbldr.setMaxPendingMessagesAcrossPartitions(sourceConfig.getProducerConfig().getMaxPendingMessagesAcrossPartitions());
+            if (conf.getMaxPendingMessagesAcrossPartitions() != null) {
+                pbldr.setMaxPendingMessagesAcrossPartitions(conf.getMaxPendingMessagesAcrossPartitions());
             }
-            if (sourceConfig.getProducerConfig().getUseThreadLocalProducers() != null) {
-                pbldr.setUseThreadLocalProducers(sourceConfig.getProducerConfig().getUseThreadLocalProducers());
+            if (conf.getUseThreadLocalProducers() != null) {
+                pbldr.setUseThreadLocalProducers(conf.getUseThreadLocalProducers());
+            }
+            if (conf.getCryptoConfig() != null) {
+                pbldr.setCryptoSpec(CryptoUtils.convert(conf.getCryptoConfig()));
             }
             sinkSpecBuilder.setProducerSpec(pbldr.build());
         }
@@ -231,14 +236,18 @@ public class SourceConfigUtils {
             sourceConfig.setSerdeClassName(sinkSpec.getSerDeClassName());
         }
         if (sinkSpec.getProducerSpec() != null) {
+            Function.ProducerSpec spec = sinkSpec.getProducerSpec();
             ProducerConfig producerConfig = new ProducerConfig();
-            if (sinkSpec.getProducerSpec().getMaxPendingMessages() != 0) {
-                producerConfig.setMaxPendingMessages(sinkSpec.getProducerSpec().getMaxPendingMessages());
+            if (spec.getMaxPendingMessages() != 0) {
+                producerConfig.setMaxPendingMessages(spec.getMaxPendingMessages());
             }
-            if (sinkSpec.getProducerSpec().getMaxPendingMessagesAcrossPartitions() != 0) {
-                producerConfig.setMaxPendingMessagesAcrossPartitions(sinkSpec.getProducerSpec().getMaxPendingMessagesAcrossPartitions());
+            if (spec.getMaxPendingMessagesAcrossPartitions() != 0) {
+                producerConfig.setMaxPendingMessagesAcrossPartitions(spec.getMaxPendingMessagesAcrossPartitions());
             }
-            producerConfig.setUseThreadLocalProducers(sinkSpec.getProducerSpec().getUseThreadLocalProducers());
+            if (spec.hasCryptoSpec()) {
+                producerConfig.setCryptoConfig(CryptoUtils.convertFromSpec(spec.getCryptoSpec()));
+            }
+            producerConfig.setUseThreadLocalProducers(spec.getUseThreadLocalProducers());
             sourceConfig.setProducerConfig(producerConfig);
         }
         if (functionDetails.hasResources()) {
@@ -422,6 +431,10 @@ public class SourceConfigUtils {
         }
         if (!StringUtils.isEmpty(sourceConfig.getSchemaType())) {
             ValidatorUtils.validateSchema(sourceConfig.getSchemaType(), typeArg, classLoader, false);
+        }
+
+        if (sourceConfig.getProducerConfig().getCryptoConfig() != null) {
+            ValidatorUtils.validateCryptoKeyReader(sourceConfig.getProducerConfig().getCryptoConfig(), classLoader, true);
         }
 
         if (typeArg.equals(TypeResolver.Unknown.class)) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ValidatorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ValidatorUtils.java
@@ -21,7 +21,10 @@ package org.apache.pulsar.functions.utils;
 
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.typetools.TypeResolver;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.functions.CryptoConfig;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.ClassLoaderUtils;
 import org.apache.pulsar.common.util.Reflections;
@@ -29,6 +32,10 @@ import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.Source;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -56,6 +63,35 @@ public class ValidatorUtils {
         } catch (IllegalArgumentException e) {
             // schemaType is not referring to builtin type
             return null;
+        }
+    }
+
+
+    public static void validateCryptoKeyReader(CryptoConfig conf, ClassLoader classLoader, boolean isProducer) {
+        if (isEmpty(conf.getCryptoKeyReaderClassName())) return;
+
+        Class<?> cryptoClass;
+        try {
+            cryptoClass = ClassLoaderUtils.loadClass(conf.getCryptoKeyReaderClassName(), classLoader);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            throw new IllegalArgumentException(
+                    String.format("The crypto key reader class %s does not exist", conf.getCryptoKeyReaderClassName()));
+        }
+        ClassLoaderUtils.implementsClass(conf.getCryptoKeyReaderClassName(), CryptoKeyReader.class, classLoader);
+
+        try {
+            cryptoClass.getConstructor(Map.class);
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalArgumentException(
+                    String.format("The crypto key reader class %s does not implement the desired constructor.",
+                            conf.getCryptoKeyReaderClassName()));
+
+        } catch (SecurityException e) {
+            throw new IllegalArgumentException("Failed to access crypto key reader class", e);
+        }
+
+        if (isProducer && (conf.getEncryptionKeys() == null || conf.getEncryptionKeys().length == 0)) {
+            throw new IllegalArgumentException("Missing encryption key name for producer crypto key reader");
         }
     }
 
@@ -133,6 +169,7 @@ public class ValidatorUtils {
             }
         }
     }
+
 
     public static void validateFunctionClassTypes(ClassLoader classLoader, Function.FunctionDetails.Builder functionDetailsBuilder) {
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #8382 


### Motivation

Add the e2e encryption support for Pulsar Functions

### Modifications

- Add `CryptoConfig` the encapsulate all the crypto related configs set by user
- Add `CryptoSpec` to `Function` protobuf to container crypto information internally
- Add `CryptoUtils` to help create instance, convert between `CryptoConfig` and `CryptoSpec`
- Add crypto validation method in `ValidatorUtils` to ensure the provided `CryptoKeyReader` Class has a ctor with `Map` arg
- Updated the cli to allow user set crypto for consumer/producer when submitting the function
- Update `PulsarSource`, `PulsarSink` to use the crypto config if provided

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): Added `pulsar-client-messagecrypto-bc` into `puslar-function instance`
  - The admin cli options: Added `--producer-config` to allow setting crypto related configs.

### Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? not documented
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation: [#8431](https://github.com/apache/pulsar/issues/8431)

Now user can enable e2e encryption as follows:
```bash
./bin/pulsar-admin functions create --jar pulsar-functions/java-examples/target/pulsar-functions-api-examples.jar \
--classname org.apache.pulsar.functions.api.examples.ExclamationFunction  \
--inputs "persistent://public/default/input" --output persistent://public/default/output --producer-config '{"cryptoConfig": {"cryptoKeyReaderClassName": "org.apache.pulsar.functions.api.examples.RawFileKeyReader", "cryptoKeyReaderConfig": {"PUBLIC": "/Users/nlu/workspace/stream-native/pulsar/keys/test_ecdsa_pubkey.pem", "PRIVATE":"/Users/nlu/workspace/stream-native/pulsar/keys/test_ecdsa_privkey.pem"}, "producerCryptoFailureAction": "FAIL", "encryptionKeys":["myapp1"]}}'
```

```bash
./bin/pulsar-admin functions create --jar pulsar-functions/java-examples/target/pulsar-functions-api-examples.jar \
--classname org.apache.pulsar.functions.api.examples.ExclamationFunction  \
--input-specs '{"persistent://public/default/output": {"cryptoConfig": {"cryptoKeyReaderClassName": "org.apache.pulsar.functions.api.examples.RawFileKeyReader", "cryptoKeyReaderConfig": {"PUBLIC": "/Users/nlu/workspace/stream-native/pulsar/keys/test_ecdsa_pubkey.pem", "PRIVATE":"/Users/nlu/workspace/stream-native/pulsar/keys/test_ecdsa_privkey_2.pem"}, "consumerCryptoFailureAction": "FAIL"}}}' \
--output persistent://public/default/output-2 
```

One requirement is the provided `cryptoKeyReaderClass` must has a constructor with `Map<String, Object>` parameter for initialization. And the argument is provided via `cryptoKeyReaderConfig` in the cli