### PR TITLE
[Pulsar-Broker] fetch list of topics under a namespace bundle

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -69,16 +69,18 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("deprecation")
 public class PersistentTopics extends PersistentTopicsBase {
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
+
     @GET
     @Path("/{property}/{cluster}/{namespace}")
     @ApiOperation(hidden = true, value = "Get the list of topics under a namespace.", response = String.class, responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace doesn't exist") })
     public void getList(@Suspended final AsyncResponse asyncResponse, @PathParam("property") String property,
-            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) {
+            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @QueryParam("bundle") String bundle) {
         try {
             validateNamespaceName(property, cluster, namespace);
-            asyncResponse.resume(internalGetList());
+            asyncResponse.resume(internalGetList(bundle));
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -93,10 +93,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Specify the tenant", required = true)
             @PathParam("tenant") String tenant,
             @ApiParam(value = "Specify the namespace", required = true)
-            @PathParam("namespace") String namespace) {
+            @PathParam("namespace") String namespace,
+            @QueryParam("bundle") String bundle) {
         try {
             validateNamespaceName(tenant, namespace);
-            asyncResponse.resume(internalGetList());
+            asyncResponse.resume(internalGetList(bundle));
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -717,7 +717,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                 CreateMode.PERSISTENT);
 
         AsyncResponse response = mock(AsyncResponse.class);
-        persistentTopics.getList(response, property, cluster, namespace);
+        persistentTopics.getList(response, property, cluster, namespace, null);
         verify(response, times(1)).resume(Lists.newArrayList());
         // create topic
         assertEquals(persistentTopics.getPartitionedTopicList(property, cluster, namespace), Lists.newArrayList());

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -687,7 +687,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1");
+        verify(mockTopics).getListInBundle("myprop/clust/ns1", null);
 
         cmdTopics.run(split("subscriptions persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getSubscriptions("persistent://myprop/clust/ns1/ds1");
@@ -834,7 +834,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
 
         topics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1");
+        verify(mockTopics).getListInBundle("myprop/clust/ns1", null);
 
         topics.run(split("subscriptions persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getSubscriptions("persistent://myprop/clust/ns1/ds1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -92,10 +92,13 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(description = "property/cluster/namespace\n", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-b", "--bundle" }, description = "list of topics under a bundle", required = false)
+        private String bundle;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(persistentTopics.getList(namespace));
+            print(persistentTopics.getListInBundle(namespace, bundle));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -187,10 +187,13 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "tenant/namespace\n", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = "--bundle", description = "list of topics under a bundle", required = false)
+        private String bundle;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(topics.getList(namespace));
+            print(topics.getListInBundle(namespace, bundle));
         }
     }
 


### PR DESCRIPTION
### Motivation
we need an api to get list of topics under a specific bundle which will be useful when broker is having load issue with specific topics/bundle and we can find out appropriate list of topics belong to the specific bundle.

### Modification
- added rest api param to get list of topics filtering by bundle
- add cli option to pass bundle with list-topics  command
