### PR TITLE
[Pulsar-Proxy] Fix request.getContentLength() to return 0 if it is less than 0

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -169,7 +169,7 @@ class AdminProxyHandler extends ProxyServlet {
         private final ByteArrayOutputStream bodyBuffer;
         protected ReplayableProxyContentProvider(HttpServletRequest request, HttpServletResponse response, Request proxyRequest, InputStream input) {
             super(request, response, proxyRequest, input);
-            bodyBuffer = new ByteArrayOutputStream(request.getContentLength());
+            bodyBuffer = new ByteArrayOutputStream(Math.max(request.getContentLength(), 0));
         }
 
         @Override

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AdminProxyHandlerTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.mockito.Mockito.*;
+
+import org.eclipse.jetty.client.api.Request;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AdminProxyHandlerTest {
+
+    @Test
+    public void replayableProxyContentProviderTest() throws Exception {
+
+        AdminProxyHandler adminProxyHandler = new AdminProxyHandler(mock(ProxyConfiguration.class),
+                mock(BrokerDiscoveryProvider.class));
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn(-1).when(request).getContentLength();
+
+        try {
+            AdminProxyHandler.ReplayableProxyContentProvider replayableProxyContentProvider = adminProxyHandler.new ReplayableProxyContentProvider(
+                    request, mock(HttpServletResponse.class), mock(Request.class), mock(InputStream.class));
+            Field field = replayableProxyContentProvider.getClass().getDeclaredField("bodyBuffer");
+            field.setAccessible(true);
+            Assert.assertEquals(((ByteArrayOutputStream) field.get(replayableProxyContentProvider)).size(), 0);
+        } catch (IllegalArgumentException e) {
+            Assert.fail("IllegalArgumentException should not be thrown");
+        }
+
+    }
+}


### PR DESCRIPTION
### Motivation

- "Negative initial size: -1" error occurs when submitting an HTTP request which has "Content-Type: application/json"  and no request body .

### Modifications

- Pass 0 to argument of ByteArrayOutputStream if request.getContentLength() returns a negative number.
- Add unit test.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - AdminProxyHandlerTest.java

example:
  - If request.getContentLength () returns -1, make sure bodyBuffer is 0.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)