### PR TITLE
[Issue 8012][pulsar_functions] For the Kubernetes function worker runtime, allow customization of the pulsar function "jobName"

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
@@ -50,6 +50,7 @@ public class BasicKubernetesManifestCustomizer implements KubernetesManifestCust
     @NoArgsConstructor
     static private class RuntimeOpts {
         private String jobNamespace;
+        private String jobName;
         private Map<String, String> extraLabels;
         private Map<String, String> extraAnnotations;
         private Map<String, String> nodeSelectorLabels;
@@ -70,7 +71,17 @@ public class BasicKubernetesManifestCustomizer implements KubernetesManifestCust
             return currentNamespace;
         }
     }
-
+    
+    @Override
+    public String customizeName(Function.FunctionDetails funcDetails, String currentName) {
+        RuntimeOpts opts = getOptsFromDetails(funcDetails);
+        if (!StringUtils.isEmpty(opts.getJobName())) {
+            return opts.getJobName();
+        } else {
+            return currentName;
+        }
+    }
+    
     @Override
     public V1Service customizeService(Function.FunctionDetails funcDetails, V1Service service) {
         RuntimeOpts opts = getOptsFromDetails(funcDetails);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesManifestCustomizer.java
@@ -36,4 +36,8 @@ public interface KubernetesManifestCustomizer extends RuntimeCustomizer {
     default String customizeNamespace(Function.FunctionDetails funcDetails, String currentNamespace) {
         return currentNamespace;
     }
+    
+    default String customizeName(Function.FunctionDetails funcDetails, String currentName) {
+        return currentName;
+    }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -130,6 +130,7 @@ public class KubernetesRuntime implements Runtime {
     private InstanceControlGrpc.InstanceControlFutureStub[] stub;
     private InstanceConfig instanceConfig;
     private final String jobNamespace;
+    private final String jobName;
     private final Map<String, String> customLabels;
     private final Map<String, String> functionDockerImages;
     private final String pulsarDockerImageName;
@@ -154,6 +155,7 @@ public class KubernetesRuntime implements Runtime {
     KubernetesRuntime(AppsV1Api appsClient,
                       CoreV1Api coreClient,
                       String jobNamespace,
+                      String jobName,
                       Map<String, String> customLabels,
                       Boolean installUserCodeDependencies,
                       String pythonDependencyRepository,
@@ -189,6 +191,7 @@ public class KubernetesRuntime implements Runtime {
         this.coreClient = coreClient;
         this.instanceConfig = instanceConfig;
         this.jobNamespace = jobNamespace;
+        this.jobName = jobName;
         this.customLabels = customLabels;
         this.functionDockerImages = functionDockerImages;
         this.pulsarDockerImageName = pulsarDockerImageName;
@@ -259,7 +262,7 @@ public class KubernetesRuntime implements Runtime {
                         narExtractionDirectory,
                         functinoInstanceClassPath));
 
-        doChecks(instanceConfig.getFunctionDetails());
+        doChecks(instanceConfig.getFunctionDetails(), this.jobName);
     }
 
     /**
@@ -294,7 +297,7 @@ public class KubernetesRuntime implements Runtime {
             channel = new ManagedChannel[instanceConfig.getFunctionDetails().getParallelism()];
             stub = new InstanceControlGrpc.InstanceControlFutureStub[instanceConfig.getFunctionDetails().getParallelism()];
 
-            String jobName = createJobName(instanceConfig.getFunctionDetails());
+            String jobName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
             for (int i = 0; i < instanceConfig.getFunctionDetails().getParallelism(); ++i) {
                 String address = getServiceUrl(jobName, jobNamespace, i);
                 channel[i] = ManagedChannelBuilder.forAddress(address, grpcPort)
@@ -460,7 +463,7 @@ public class KubernetesRuntime implements Runtime {
 
     @VisibleForTesting
     V1Service createService() {
-        final String jobName = createJobName(instanceConfig.getFunctionDetails());
+        final String jobName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
 
         final V1Service service = new V1Service();
 
@@ -545,7 +548,7 @@ public class KubernetesRuntime implements Runtime {
 
 
     public void deleteStatefulSet() throws InterruptedException {
-        String statefulSetName = createJobName(instanceConfig.getFunctionDetails());
+        String statefulSetName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
         final V1DeleteOptions options = new V1DeleteOptions();
         options.setGracePeriodSeconds(5L);
         options.setPropagationPolicy("Foreground");
@@ -700,7 +703,7 @@ public class KubernetesRuntime implements Runtime {
         options.setGracePeriodSeconds(0L);
         options.setPropagationPolicy("Foreground");
         String fqfn = FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails());
-        String serviceName = createJobName(instanceConfig.getFunctionDetails());
+        String serviceName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
 
         Actions.Action deleteService = Actions.Action.builder()
                 .actionName(String.format("Deleting service for function %s", fqfn))
@@ -861,7 +864,7 @@ public class KubernetesRuntime implements Runtime {
 
     @VisibleForTesting
     V1StatefulSet createStatefulSet() {
-        final String jobName = createJobName(instanceConfig.getFunctionDetails());
+        final String jobName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
 
         final V1StatefulSet statefulSet = new V1StatefulSet();
 
@@ -1082,40 +1085,48 @@ public class KubernetesRuntime implements Runtime {
         return ports;
     }
 
-    public static String createJobName(Function.FunctionDetails functionDetails) {
-        return createJobName(functionDetails.getTenant(),
+    public static String createJobName(Function.FunctionDetails functionDetails, String jobName) {
+        return jobName == null ? createJobName(functionDetails.getTenant(),
                 functionDetails.getNamespace(),
-                functionDetails.getName());
+                functionDetails.getName()) : createJobName(jobName);
     }
 
     private static String toValidPodName(String ori) {
         return ori.toLowerCase().replaceAll("[^a-z0-9-\\.]", "-");
     }
-
-    private static String createJobName(String tenant, String namespace, String functionName) {
-        final String jobNameContent = String.format("%s-%s-%s", tenant, namespace,functionName);
-        final String jobName = "pf-" + jobNameContent;
-        final String convertedJobName = toValidPodName(jobName);
+    
+    private static String validateName(String jobName) {
+    	final String convertedJobName = toValidPodName(jobName);
         if (jobName.equals(convertedJobName)) {
             return jobName;
         }
         // toValidPodName may cause naming collisions, add a short hash here to avoid it
-        final String shortHash = DigestUtils.sha1Hex(jobNameContent).toLowerCase().substring(0, 8);
+        final String shortHash = DigestUtils.sha1Hex(jobName.replaceFirst("pf-", "")).toLowerCase().substring(0, 8);
         return convertedJobName + "-" + shortHash;
+    }
+    
+    private static String createJobName(String jobName) {
+    	return validateName(jobName);
+    }
+    
+    private static String createJobName(String tenant, String namespace, String functionName) {
+        final String jobName = "pf-" + String.format("%s-%s-%s", tenant, namespace, functionName);
+        return validateName(jobName);
     }
 
     private static String getServiceUrl(String jobName, String jobNamespace, int instanceId) {
         return String.format("%s-%d.%s.%s.svc.cluster.local", jobName, instanceId, jobName, jobNamespace);
     }
 
-    public static void doChecks(Function.FunctionDetails functionDetails) {
-        final String jobName = createJobName(functionDetails);
+    public static void doChecks(Function.FunctionDetails functionDetails, String overridenJobName) {
+        final String jobName = createJobName(functionDetails, overridenJobName);
         if (!jobName.equals(jobName.toLowerCase())) {
             throw new RuntimeException("Kubernetes does not allow upper case jobNames.");
         }
         final Matcher matcher = VALID_POD_NAME_REGEX.matcher(jobName);
         if (!matcher.matches()) {
-            throw new RuntimeException("Kubernetes only admits lower case and numbers.");
+            throw new RuntimeException("Kubernetes only admits lower case and numbers. " +
+            		"(jobName=" + jobName + ")");
         }
         if (jobName.length() > maxJobNameSize) {
             throw new RuntimeException("Kubernetes job name size should be less than " + maxJobNameSize);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
@@ -39,6 +39,11 @@ public class KubernetesRuntimeFactoryConfig {
     )
     protected String jobNamespace;
     @FieldContext(
+            doc = "The Kubernetes pod name to run the function instances. It is set to"
+                + "`pf-<tenant>-<namespace>-<function_name>-<random_uuid(8)>` if this setting is left to be empty"
+        )
+    protected String jobName;
+    @FieldContext(
         doc = "The docker image used to run function instance. By default it is `apachepulsar/pulsar`"
     )
     protected String pulsarDockerImageName;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
@@ -105,7 +105,7 @@ public class KubernetesRuntimeFactoryTest {
         }
 
         @Override
-        public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, FunctionDetails functionDetails) {
+        public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, String jobName, FunctionDetails functionDetails) {
 
         }
     }
@@ -152,6 +152,7 @@ public class KubernetesRuntimeFactoryTest {
         KubernetesRuntimeFactoryConfig kubernetesRuntimeFactoryConfig = new KubernetesRuntimeFactoryConfig();
         kubernetesRuntimeFactoryConfig.setK8Uri(null);
         kubernetesRuntimeFactoryConfig.setJobNamespace(null);
+        kubernetesRuntimeFactoryConfig.setJobName(null);
         kubernetesRuntimeFactoryConfig.setPulsarDockerImageName(null);
         kubernetesRuntimeFactoryConfig.setFunctionDockerImages(null);
         kubernetesRuntimeFactoryConfig.setImagePullPolicy(null);
@@ -375,6 +376,7 @@ public class KubernetesRuntimeFactoryTest {
         KubernetesRuntimeFactoryConfig kubernetesRuntimeFactoryConfig = new KubernetesRuntimeFactoryConfig();
         kubernetesRuntimeFactoryConfig.setK8Uri("test_k8uri");
         kubernetesRuntimeFactoryConfig.setJobNamespace("test_jobNamespace");
+        kubernetesRuntimeFactoryConfig.setJobName("test_jobName");
         kubernetesRuntimeFactoryConfig.setPulsarDockerImageName("test_dockerImage");
         kubernetesRuntimeFactoryConfig.setFunctionDockerImages(imageNames);
         kubernetesRuntimeFactoryConfig.setImagePullPolicy("test_imagePullPolicy");

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -97,7 +97,7 @@ public class ProcessRuntimeTest {
         }
 
         @Override
-        public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, FunctionDetails functionDetails) {
+        public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, String jobName, FunctionDetails functionDetails) {
 
         }
     }

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfigurator.java
@@ -107,7 +107,7 @@ public class KubernetesSecretsProviderConfigurator implements SecretsProviderCon
 
     // The secret object should be of type Map<String, String> and it should contain "id" and "key"
     @Override
-    public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, Function.FunctionDetails functionDetails) {
+    public void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, String jobName, Function.FunctionDetails functionDetails) {
         if (!StringUtils.isEmpty(functionDetails.getSecretsMap())) {
             Type type = new TypeToken<Map<String, Object>>() {
             }.getType();

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/SecretsProviderConfigurator.java
@@ -69,6 +69,6 @@ public interface SecretsProviderConfigurator {
     /**
      * Do config checks to see whether the secrets provided are conforming.
      */
-    default void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, Function.FunctionDetails functionDetails) {}
+    default void doAdmissionChecks(AppsV1Api appsV1Api, CoreV1Api coreV1Api, String jobNamespace, String jobName, Function.FunctionDetails functionDetails) {}
 
 }

--- a/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
+++ b/pulsar-functions/secrets/src/test/java/org/apache/pulsar/functions/secretsproviderconfigurator/KubernetesSecretsProviderConfiguratorTest.java
@@ -38,7 +38,7 @@ public class KubernetesSecretsProviderConfiguratorTest {
             HashMap<String, Object> map = new HashMap<String, Object>();
             map.put("secretname", "randomsecret");
             Function.FunctionDetails functionDetails = Function.FunctionDetails.newBuilder().setSecretsMap(new Gson().toJson(map)).build();
-            provider.doAdmissionChecks(null, null, null, functionDetails);
+            provider.doAdmissionChecks(null, null, null, null, functionDetails);
             Assert.fail("Non conforming secret object should not validate");
         } catch (Exception e) {
         }
@@ -48,7 +48,7 @@ public class KubernetesSecretsProviderConfiguratorTest {
             map1.put("secretname", "secretvalue");
             map.put("secretname", map1);
             Function.FunctionDetails functionDetails = Function.FunctionDetails.newBuilder().setSecretsMap(new Gson().toJson(map)).build();
-            provider.doAdmissionChecks(null, null, null, functionDetails);
+            provider.doAdmissionChecks(null, null, null, null, functionDetails);
             Assert.fail("Non conforming secret object should not validate");
         } catch (Exception e) {
         }
@@ -59,7 +59,7 @@ public class KubernetesSecretsProviderConfiguratorTest {
             map1.put("key", "secretvalue");
             map.put("secretname", map1);
             Function.FunctionDetails functionDetails = Function.FunctionDetails.newBuilder().setSecretsMap(new Gson().toJson(map)).build();
-            provider.doAdmissionChecks(null, null, null, functionDetails);
+            provider.doAdmissionChecks(null, null, null, null, functionDetails);
         } catch (Exception e) {
             Assert.fail("Conforming secret object should validate");
         }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -871,6 +871,7 @@ public class FunctionRuntimeManagerTest {
                 = new WorkerConfig.KubernetesContainerFactory();
         kubernetesContainerFactory.setK8Uri("k8Uri");
         kubernetesContainerFactory.setJobNamespace("jobNamespace");
+        kubernetesContainerFactory.setJobName("jobName");
         kubernetesContainerFactory.setPulsarDockerImageName("pulsarDockerImageName");
         kubernetesContainerFactory.setImagePullPolicy("imagePullPolicy");
         kubernetesContainerFactory.setPulsarRootDir("pulsarRootDir");


### PR DESCRIPTION
Fixes #8012 

### Motivation

Currently (as of 2.6.x), the Pulsar KubernetesRuntime class hardcodes the jobName (the name assigned to the StatefulSet used to create the function pods) to the format "pf-[tenant]-[namespace]-[function][-optional 8 char hash]." While the intent of this name format was no doubt both to provide a human readable name for the k8s objects and ensure uniqueness within k8s, we've found it -- when combined with the 55 character size restriction imposed by KubernetesRuntime -- to be unnecessarily limiting. In our environment, we ensure that Pulsar functions under a particular Pulsar tenant deploy into a kubernetes namespace dedicated to that tenant; hence, for us the [tenant] portion of the function name is redundant. Further, the "pf-" prefix is unnecessary, as we're able to distinguish the function pods from other pods based on the function name alone. These issues may seem minor, but they consume precious characters against the 55 character max!

### Modifications

Updated Kubernetes runtime and factory classes under pulsar/pulsar-functions to add "jobName" to customRuntimeOptions just like jobNamespace for setting the k8s namespace.

### Verifying this change

- [X ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Updated/extended src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java to contain news tests for overridden job Name (jobName). 
- Updated other tests to account for new parameters for checks but does not change any functionality in the tests.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (yes)

It does not change the endpoint for creating functions but it does change the available string (json) that can be submitted for 'customRuntimeOptions: string'.  Like 'jobNamespace: <name>' you may add 'jobName: <name>' to the json string for changing the k8s pod name for the function.

Example: 

curl -v --form "functionConfig={\"tenant\": \"public\", \"namespace\": \"default\", \"name\": \"exclamation\", \"className\": \"org.apache.pulsar.functions.api.examples.ExclamationFunction\", \"inputs\": [\"persistent://public/default/in-content\"], \"output\": \"persistent://public/default/out-content\", \"customRuntimeOptions\": \"{\\\"jobNamespace\\\": \\\"pulsar\\\", **\\\"jobName\\\": \\\"test123\\\**"}\", \"jar\": \"api-examples.jar\"};type=application/json" --form data=@/pulsar/examples/api-examples.jar http://pulsar-broker.pulsar.svc.cluster.local:8080/admin/v3/functions/public/default/exclamation

  - The admin cli options: (yes)

Same as above.  Adds an available option for creating functions 'customRuntimeOptions'.

Example: 

./bin/pulsar-admin functions create --custom-runtime-options '{"jobNamespace": "pulsar", **"jobName": "test123"**}' --auto-ack false --classname org.apache.pulsar.functions.api.examples.ExclamationFunction -i persistent://public/default/in-content -o persistent://public/default/out-content --jar /pulsar/examples/api-examples.jar --name exclamation

  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)

   Probably should be added to functions-runtime.md for 2.7.0 ... hopefully (like 'jobNamespace' under 'customRuntimeOptions')

