### PR TITLE
[pulsar-broker] Security-Recommendation: Remove verbose error message with system info for admin-api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -477,7 +477,7 @@ public abstract class PulsarWebResource {
     protected NamespaceBundle validateNamespaceBundleRange(NamespaceName fqnn, BundlesData bundles,
             String bundleRange) {
         try {
-            checkArgument(bundleRange.contains("_"), "Invalid bundle range");
+            checkArgument(bundleRange.contains("_"), "Invalid bundle range: " + bundleRange);
             String[] boundaries = bundleRange.split("_");
             Long lowerEndpoint = Long.decode(boundaries[0]);
             Long upperEndpoint = Long.decode(boundaries[1]);
@@ -489,6 +489,9 @@ public abstract class PulsarWebResource {
                     bundles);
             nsBundles.validateBundle(nsBundle);
             return nsBundle;
+        } catch (IllegalArgumentException e) {
+            log.error("[{}] Invalid bundle range {}/{}, {}", clientAppId(), fqnn.toString(), bundleRange, e.getMessage());
+            throw new RestException(Response.Status.PRECONDITION_FAILED, e.getMessage());
         } catch (Exception e) {
             log.error("[{}] Failed to validate namespace bundle {}/{}", clientAppId(), fqnn.toString(), bundleRange, e);
             throw new RestException(e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1339,6 +1339,16 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testInvalidBundleErrorResponse() throws Exception {
+        try {
+            admin.namespaces().deleteNamespaceBundle("prop-xyz/ns1", "invalid-bundle");
+            fail("should have failed due to invalid bundle");
+        } catch (PreconditionFailedException e) {
+            assertTrue(e.getMessage().startsWith("Invalid bundle range"));
+        }
+    }
+
+    @Test
     public void testMaxSubscriptionsPerTopic() throws Exception {
         super.internalCleanup();
         conf.setMaxSubscriptionsPerTopic(2);


### PR DESCRIPTION
### Motivation

one of the security-recommendation report has listed system internal info in error-response which should be fixed.

**url:** `curl -X DELETE -H 'Content-Type: application/json'  http://localhost:8080/admin/namespaces/sample/standalone/ns1/maxConsumerPerSubscription`
**Error-response:**
```
 --- An unexpected error occurred in the server ---

Message: Invalid bundle range

Stacktrace:

java.lang.IllegalArgumentException: Invalid bundle range
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at org.apache.pulsar.broker.web.PulsarWebResource.validateNamespaceBundleRange(PulsarWebResource.java:480)
	at org.apache.pulsar.broker.web.PulsarWebResource.validateNamespaceBundleOwnership(PulsarWebResource.java:522)
	at org.apache.pulsar.broker.admin.impl.NamespacesBase.internalDeleteNamespaceBundle(NamespacesBase.java:541)
	at org.apache.pulsar.broker.admin.impl.NamespacesBase.internalDeleteNamespaceBundle(NamespacesBase.java:488)
	at org.apache.pulsar.broker.admin.v1.Namespaces.deleteNamespaceBundle(Namespaces.java:229)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```

### Modification
Return informative response without system info

### Result
```
curl -X DELETE -H 'Content-Type: application/json'  http://localhost:8080/admin/namespaces/sample/standalone/ns1/my-range

{"reason":"Invalid bundle range: my-range"}
```