### PR TITLE
Fix link issue in Metrics in 2.6.x Pulsar docs

### DIFF
--- a/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
@@ -16,9 +16,9 @@ Pulsar exposes metrics in Prometheus format that can be collected and used for m
 * [ZooKeeper](#zookeeper)
 * [BookKeeper](#bookkeeper)
 * [Broker](#broker)
-* [Pulsar Functions](#pulsar functions)
+* [Pulsar Functions](#pulsar-functions)
 * [Proxy](#proxy)
-* [Pulsar SQL Worker](#Pulsar SQL Worker)
+* [Pulsar SQL Worker](#pulsar-sql-worker)
 
 ## Overview
 

--- a/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
@@ -16,9 +16,9 @@ Pulsar exposes metrics in Prometheus format that can be collected and used for m
 * [ZooKeeper](#zookeeper)
 * [BookKeeper](#bookkeeper)
 * [Broker](#broker)
-* [Pulsar Functions](#pulsar functions)
+* [Pulsar Functions](#pulsar-functions)
 * [Proxy](#proxy)
-* [Pulsar SQL Worker](#Pulsar SQL Worker)
+* [Pulsar SQL Worker](#pulsar-sql-worker)
 
 ## Overview
 

--- a/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
@@ -16,9 +16,9 @@ Pulsar exposes metrics in Prometheus format that can be collected and used for m
 * [ZooKeeper](#zookeeper)
 * [BookKeeper](#bookkeeper)
 * [Broker](#broker)
-* [Pulsar Functions](#pulsar functions)
+* [Pulsar Functions](#pulsar-functions)
 * [Proxy](#proxy)
-* [Pulsar SQL Worker](#Pulsar SQL Worker)
+* [Pulsar SQL Worker](#pulsar-sql-worker)
 
 ## Overview
 


### PR DESCRIPTION
Modification:
Fix the link issue in Metrics in version 2.6.x.

![image](https://user-images.githubusercontent.com/53718687/98289325-4c4ccb00-1fa8-11eb-93f1-fe32feedb6c2.png)
