### PR TITLE
[pulsar-broker]Fix zk cache expiration check

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -396,7 +396,7 @@ public abstract class ZooKeeperCache implements Watcher {
         if (result != null && result.isDone()) {
             Pair<Entry<Object, Stat>, Long> entryPair = result.getNow(null);
             if (entryPair != null && entryPair.getRight() != null) {
-                if ((System.nanoTime() - entryPair.getRight()) > TimeUnit.SECONDS.toMillis(cacheExpirySeconds)) {
+                if ((System.nanoTime() - entryPair.getRight()) > TimeUnit.SECONDS.toNanos(cacheExpirySeconds)) {
                     this.zkSession.get().getData(path, this, (rc, path1, ctx, content, stat) -> {
                         if (rc != Code.OK.intValue()) {
                             log.warn("Failed to refresh zookeeper-cache for {} due to {}", path, rc);


### PR DESCRIPTION
### Motivation
Currently, zk cache is refreshed every time because the units of comparison are different(ns and ms).
We should check the zk cache expiration time in the same unit.