### PR TITLE
[pulsar-broker] Fix: bookie-isolation placement-policy was not configuring rackaware policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -220,6 +220,10 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
             }
             bkConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, this.zkCache.get());
         }
+        if (conf.isBookkeeperClientRackawarePolicyEnabled() || conf.isBookkeeperClientRegionawarePolicyEnabled()) {
+            bkConf.setProperty(REPP_DNS_RESOLVER_CLASS, conf.getProperties().getProperty(REPP_DNS_RESOLVER_CLASS,
+                    ZkBookieRackAffinityMapping.class.getName()));
+        }
     }
 
     public void close() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -35,7 +35,6 @@ import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.Configuration;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;


### PR DESCRIPTION
### Motivation

BookieIsolation placement policy doesn't consider rackaware policy because it doesn't configure `dns_resolver_class` and because of that it doesn't select bookies by considering racks and it logs below message

```
21:48:09.331 [bookkeeper-ml-workers-OrderedExecutor-3-0] WARN  org.apache.bookkeeper.client.BookieWatcherImpl - New ensemble: [1.1.1.1:3181, 2.2.2.2:3181] is not adhering to Placement Policy. quarantinedBookies: []
```

### Modification
Configure `ZkBookieRackAffinityMapping` with BookieIsolation placement policy to apply rackaware policy.