### PR TITLE
[Doc]--remove pulsarctl from pulsar docs

### DIFF
--- a/site2/docs/tiered-storage-aws.md
+++ b/site2/docs/tiered-storage-aws.md
@@ -188,7 +188,7 @@ Threshold value|Action
 
 Automatic offloading runs when a new segment is added to a topic log. If you set the threshold on a namespace, but few messages are being produced to the topic, offloader does not work until the current segment is full.
 
-You can configure the threshold size using CLI tools, such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin.
+You can configure the threshold size using CLI tools, such as pulsar-admin.
 
 The offload configurations in `broker.conf` and `standalone.conf` are used for the namespaces that do not have namespace level offload policies. Each namespace can have its own offload policy. If you want to set offload policy for each namespace, use the command [`pulsar-admin namespaces set-offload-policies options`](http://pulsar.apache.org/tools/pulsar-admin/2.6.0-SNAPSHOT/#-em-set-offload-policies-em-) command.
  
@@ -208,9 +208,9 @@ bin/pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namesp
 
 For individual topics, you can trigger AWS S3 offloader manually using one of the following methods:
 
-- Use REST endpoint 
+- Use REST endpoint.
 
-- Use CLI tools (such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin). 
+- Use CLI tools (such as pulsar-admin). 
 
     To trigger it via CLI tools, you need to specify the maximum amount of data (threshold) that should be retained on a Pulsar cluster for a topic. If the size of the topic data on the Pulsar cluster exceeds this threshold, segments from the topic are moved to AWS S3 until the threshold is no longer exceeded. Older segments are moved first.
 

--- a/site2/docs/tiered-storage-azure.md
+++ b/site2/docs/tiered-storage-azure.md
@@ -135,7 +135,7 @@ Threshold value|Action
 
 Automatic offloading runs when a new segment is added to a topic log. If you set the threshold on a namespace, but few messages are being produced to the topic, offloader does not work until the current segment is full.
 
-You can configure the threshold size using CLI tools, such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin.
+You can configure the threshold size using CLI tools, such as pulsar-admin.
 
 The offload configurations in `broker.conf` and `standalone.conf` are used for the namespaces that do not have namespace level offload policies. Each namespace can have its own offload policy. If you want to set offload policy for each namespace, use the command [`pulsar-admin namespaces set-offload-policies options`](http://pulsar.apache.org/tools/pulsar-admin/2.6.0-SNAPSHOT/#-em-set-offload-policies-em-) command.
  
@@ -155,9 +155,9 @@ bin/pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namesp
 
 For individual topics, you can trigger Azure BlobStore offloader manually using one of the following methods:
 
-- Use REST endpoint 
+- Use REST endpoint.
 
-- Use CLI tools (such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin). 
+- Use CLI tools (such as pulsar-admin). 
 
     To trigger it via CLI tools, you need to specify the maximum amount of data (threshold) that should be retained on a Pulsar cluster for a topic. If the size of the topic data on the Pulsar cluster exceeds this threshold, segments from the topic are moved to Azure BlobStore until the threshold is no longer exceeded. Older segments are moved first.
 

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -178,36 +178,36 @@ Threshold value|Action
 
 Automatic offload runs when a new segment is added to a topic log. If you set the threshold on a namespace, but few messages are being produced to the topic, offloader does not work until the current segment is full.
 
-You can configure the threshold size using CLI tools, such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin.
+You can configure the threshold size using CLI tools, such as pulsar-admin.
 
 #### Example
 
-This example sets the filesystem offloader threshold size to 10 MB using pulsarctl.
+This example sets the filesystem offloader threshold size to 10 MB using pulsar-admin.
 
 ```bash
-bin/pulsarctl namespaces set-offload-threshold --size 10M my-tenant/my-namespace
+pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
 > #### Tip
 >
-> For more information about the `pulsarctl namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-set-offload-threshold-em-). 
+> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#set-offload-threshold). 
 
 ### Configure filesystem offloader to run manually
 
 For individual topics, you can trigger filesystem offloader manually using one of the following methods:
 
-- Use REST endpoint 
+- Use REST endpoint.
 
-- Use CLI tools (such as pulsarctl or pulsar-admin). 
+- Use CLI tools (such as pulsar-admin). 
 
 To trigger via CLI tools, you need to specify the maximum amount of data (threshold) that should be retained on a Pulsar cluster for a topic. If the size of the topic data on the Pulsar cluster exceeds this threshold, segments from the topic are offloaded to the filesystem until the threshold is no longer exceeded. Older segments are offloaded first.
 
 #### Example
 
-- This example triggers the filesystem offloader to run manually using pulsarctl.
+- This example triggers the filesystem offloader to run manually using pulsar-admin.
 
     ```bash
-    bin/pulsarctl topic offload persistent://my-tenant/my-namespace/topic1 10M
+    pulsar-admin topics offload --size-threshold 10M persistent://tmy-tenant/my-namespace/topic1
     ``` 
 
     **Output**
@@ -218,12 +218,12 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
 
     > #### Tip
     >
-    > For more information about the `pulsarctl topic offload options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-offload-em-). 
+    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload). 
 
-- This example checks filesystem offloader status using pulsarctl.
+- This example checks filesystem offloader status using pulsar-admin.
 
     ```bash
-    bin/pulsarctl topic offload-status persistent://my-tenant/my-namespace/topic1
+    pulsar-admin topics offload-status persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -235,7 +235,7 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
     To wait for the filesystem to complete the job, add the `-w` flag.
 
     ```bash
-    bin/pulsarctl topic offload-status -w persistent://my-tenant/my-namespace/topic1
+    pulsar-admin topics offload-status -w persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -244,10 +244,10 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
     Offload was a success
     ```
 
-    If there is an error in the offloading operation, the error is propagated to the `pulsarctl topic offload-status` command.
+    If there is an error in the offloading operation, the error is propagated to the `pulsar-admin topics offload-status` command.
 
     ```bash
-    bin/pulsarctl topic offload-status persistent://my-tenant/my-namespace/topic1
+    pulsar-admin topics offload-status persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -261,7 +261,7 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
 
     > #### Tip
     >
-    > For more information about the `pulsarctl topic offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-offload-status-em-). 
+    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload-status). 
 
 ## Tutorial
 

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -190,7 +190,7 @@ pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 
 > #### Tip
 >
-> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#set-offload-threshold). 
+> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload#set-offload-threshold). 
 
 ### Configure filesystem offloader to run manually
 
@@ -218,7 +218,7 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
 
     > #### Tip
     >
-    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload). 
+    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
 - This example checks filesystem offloader status using pulsar-admin.
 
@@ -261,7 +261,7 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
 
     > #### Tip
     >
-    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload-status). 
+    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
 ## Tutorial
 

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -190,7 +190,7 @@ pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 
 > #### Tip
 >
-> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload#set-offload-threshold). 
+> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
 ### Configure filesystem offloader to run manually
 

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -207,7 +207,7 @@ To trigger via CLI tools, you need to specify the maximum amount of data (thresh
 - This example triggers the filesystem offloader to run manually using pulsar-admin.
 
     ```bash
-    pulsar-admin topics offload --size-threshold 10M persistent://tmy-tenant/my-namespace/topic1
+    pulsar-admin topics offload --size-threshold 10M persistent://my-tenant/my-namespace/topic1
     ``` 
 
     **Output**

--- a/site2/docs/tiered-storage-gcs.md
+++ b/site2/docs/tiered-storage-gcs.md
@@ -181,38 +181,38 @@ Threshold value|Action
 
 Automatic offloading runs when a new segment is added to a topic log. If you set the threshold on a namespace, but few messages are being produced to the topic, offloader does not work until the current segment is full.
 
-You can configure the threshold size using CLI tools, such as [pulsarctl](https://streamnative.io/docs/v1.0.0/manage-and-monitor/pulsarctl/overview/) or pulsar-admin.
+You can configure the threshold size using CLI tools, such as pulsar-admin.
 
 The offload configurations in `broker.conf` and `standalone.conf` are used for the namespaces that do not have namespace level offload policies. Each namespace can have its own offload policy. If you want to set offload policy for each namespace, use the command [`pulsar-admin namespaces set-offload-policies options`](http://pulsar.apache.org/tools/pulsar-admin/2.6.0-SNAPSHOT/#-em-set-offload-policies-em-) command.
 
 #### Example
 
-This example sets the GCS offloader threshold size to 10 MB using pulsarctl.
+This example sets the GCS offloader threshold size to 10 MB using pulsar-admin.
 
 ```bash
-bin/pulsarctl namespaces set-offload-threshold --size 10M my-tenant/my-namespace
+pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
 > #### Tip
 >
-> For more information about the `pulsarctl namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-set-offload-threshold-em-). 
+> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#set-offload-threshold). 
 
 ### Configure GCS offloader to run manually
 
 For individual topics, you can trigger GCS offloader manually using one of the following methods:
 
-- Use REST endpoint 
+- Use REST endpoint.
 
-- Use CLI tools (such as pulsarctl or pulsar-admin). 
+- Use CLI tools (such as pulsar-admin). 
 
     To trigger the GCS via CLI tools, you need to specify the maximum amount of data (threshold) that should be retained on a Pulsar cluster for a topic. If the size of the topic data on the Pulsar cluster exceeds this threshold, segments from the topic are moved to GCS until the threshold is no longer exceeded. Older segments are moved first.
 
 #### Example
 
-- This example triggers the GCS offloader to run manually using pulsarctl with the command `pulsarctl topic offload (topic-name) (threshold)`.
+- This example triggers the GCS offloader to run manually using pulsar-admin with the command `pulsar-admin topics offload (topic-name) (threshold)`.
 
     ```bash
-    bin/pulsarctl topics offload persistent://my-tenant/my-namespace/topic1 10M
+    pulsar-admin topics offload persistent://my-tenant/my-namespace/topic1 10M
     ``` 
 
     **Output**
@@ -223,12 +223,12 @@ For individual topics, you can trigger GCS offloader manually using one of the f
 
     > #### Tip
     >
-    > For more information about the `pulsarctl topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-offload-em-). 
+    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here]((https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload). 
 
-- This example checks the GCS offloader status using pulsarctl with the command `pulsarctl topic offload-status options`.
+- This example checks the GCS offloader status using pulsar-admin with the command `pulsar-admin topics offload-status options`.
 
     ```bash
-    bin/pulsarctl topics offload-status persistent://my-tenant/my-namespace/topic1
+    pulsar-admin topics offload-status persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -240,7 +240,7 @@ For individual topics, you can trigger GCS offloader manually using one of the f
     To wait for GCS to complete the job, add the `-w` flag.
 
     ```bash
-    bin/pulsarctl topics offload-status -w persistent://my-tenant/my-namespace/topic1
+    pulsar-admin topics offload-status -w persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -249,10 +249,10 @@ For individual topics, you can trigger GCS offloader manually using one of the f
     Offload was a success
     ```
 
-    If there is an error in offloading, the error is propagated to the `pulsarctl topic offload-status` command.
+    If there is an error in offloading, the error is propagated to the `pulsar-admin topics offload-status` command.
 
     ```bash
-    bin/pulsarctl topic offload-status persistent://my-tenant/my-namespace/topic1
+   pulsar-admin topics offload-status persistent://my-tenant/my-namespace/topic1
     ```
 
     **Output**
@@ -266,7 +266,7 @@ For individual topics, you can trigger GCS offloader manually using one of the f
 
     > #### Tip
     >
-    > For more information about the `pulsarctl topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://streamnative.io/docs/pulsarctl/v0.4.0/#-em-offload-status-em-). 
+    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload-status). 
 
 ## Tutorial
 

--- a/site2/docs/tiered-storage-gcs.md
+++ b/site2/docs/tiered-storage-gcs.md
@@ -223,7 +223,7 @@ For individual topics, you can trigger GCS offloader manually using one of the f
 
     > #### Tip
     >
-    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here]((https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload). 
+    > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here]((reference-pulsar-admin.md#offload). 
 
 - This example checks the GCS offloader status using pulsar-admin with the command `pulsar-admin topics offload-status options`.
 
@@ -266,7 +266,7 @@ For individual topics, you can trigger GCS offloader manually using one of the f
 
     > #### Tip
     >
-    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#offload-status). 
+    > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
 ## Tutorial
 

--- a/site2/docs/tiered-storage-gcs.md
+++ b/site2/docs/tiered-storage-gcs.md
@@ -195,7 +195,7 @@ pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 
 > #### Tip
 >
-> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](https://pulsar.apache.org/docs/en/next/pulsar-admin/#set-offload-threshold). 
+> For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
 ### Configure GCS offloader to run manually
 


### PR DESCRIPTION


Fixes #8400 

### Motivation

pulsarctl is not supported for pulsar docs. Therefore, remove pulsarctl commands and code examples

### Modifications

use pulsar-admin commands and code examples to replace pulsarctl commands and code examples.



