### PR TITLE
Update deps, allow to run tests with forkCount=1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.10.0</log4j2.version>
+    <log4j2.version>2.13.3</log4j2.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.11.1</jackson.version>
@@ -187,10 +187,10 @@ flexible messaging model and an intuitive client API.</description>
     <disruptor.version>3.4.0</disruptor.version>
     <testcontainers.version>1.14.3</testcontainers.version>
     <kerby.version>1.1.1</kerby.version>
-    <testng.version>6.14.3</testng.version>
-    <mockito.version>2.28.2</mockito.version>
-    <powermock.version>2.0.2</powermock.version>
-    <javassist.version>3.25.0-GA</javassist.version>
+    <testng.version>7.3.0</testng.version>
+    <mockito.version>3.0.0</mockito.version>
+    <powermock.version>2.0.9</powermock.version>
+    <javassist.version>3.27.0-GA</javassist.version>
     <failsafe.version>2.3.1</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <confluent.version>5.2.2</confluent.version>
@@ -202,7 +202,7 @@ flexible messaging model and an intuitive client API.</description>
     <aspectj-maven-plugin.version>1.11.1</aspectj-maven-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
     <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@ flexible messaging model and an intuitive client API.</description>
     <aspectj-maven-plugin.version>1.11.1</aspectj-maven-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
     <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.11.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.yaml</groupId>
+                <artifactId>*</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@ flexible messaging model and an intuitive client API.</description>
     <testng.version>7.3.0</testng.version>
     <mockito.version>3.0.0</mockito.version>
     <powermock.version>2.0.9</powermock.version>
-    <javassist.version>3.27.0-GA</javassist.version>
+    <javassist.version>3.25.0-GA</javassist.version>
     <failsafe.version>2.3.1</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <confluent.version>5.2.2</confluent.version>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -63,12 +63,14 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Base class for all tests that need a Pulsar instance without a ZK and BK cluster
  */
+@PowerMockIgnore(value = {"org.slf4j.*", "com.sun.org.apache.xerces.*" })
 public abstract class MockedPulsarServiceBaseTest {
 
     protected ServiceConfiguration conf;

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -554,7 +554,7 @@ public class CmdFunctionsTest {
         assertEquals(FN_NAME, creater.getFunctionName());
         assertEquals(INPUT_TOPIC_NAME, creater.getInputs());
         assertEquals(OUTPUT_TOPIC_NAME, creater.getOutput());
-        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 5.0);
+        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 5.0, 0);
         // Disk/Ram should be default
         assertEquals(creater.getFunctionConfig().getResources().getRam(), Long.valueOf(1073741824L));
         assertEquals(creater.getFunctionConfig().getResources().getDisk(), Long.valueOf(10737418240L));
@@ -582,7 +582,7 @@ public class CmdFunctionsTest {
         assertEquals(OUTPUT_TOPIC_NAME, creater.getOutput());
         assertEquals(creater.getFunctionConfig().getResources().getRam(), Long.valueOf(5656565656L));
         // cpu/disk should be default
-        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 1.0);
+        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 1.0, 0);
         assertEquals(creater.getFunctionConfig().getResources().getDisk(), Long.valueOf(10737418240L));
         verify(functions, times(1)).createFunctionWithUrl(any(FunctionConfig.class), anyString());
     }
@@ -609,7 +609,7 @@ public class CmdFunctionsTest {
         assertEquals(creater.getFunctionConfig().getResources().getDisk(), Long.valueOf(8080808080808080L));
         // cpu/Ram should be default
         assertEquals(creater.getFunctionConfig().getResources().getRam(), Long.valueOf(1073741824L));
-        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 1.0);
+        assertEquals(creater.getFunctionConfig().getResources().getCpu(), 1.0, 0);
         verify(functions, times(1)).createFunctionWithUrl(any(FunctionConfig.class), anyString());
     }
 
@@ -633,7 +633,7 @@ public class CmdFunctionsTest {
         assertEquals(FN_NAME, updater.getFunctionName());
         assertEquals(INPUT_TOPIC_NAME, updater.getInputs());
         assertEquals(OUTPUT_TOPIC_NAME, updater.getOutput());
-        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 5.0);
+        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 5.0, 0);
         // Disk/Ram should be default
         assertEquals(updater.getFunctionConfig().getResources().getRam(), Long.valueOf(1073741824L));
         assertEquals(updater.getFunctionConfig().getResources().getDisk(), Long.valueOf(10737418240L));
@@ -661,7 +661,7 @@ public class CmdFunctionsTest {
         assertEquals(OUTPUT_TOPIC_NAME, updater.getOutput());
         assertEquals(updater.getFunctionConfig().getResources().getRam(), Long.valueOf(5656565656L));
         // cpu/disk should be default
-        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0);
+        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0, 0);
         assertEquals(updater.getFunctionConfig().getResources().getDisk(), Long.valueOf(10737418240L));
         verify(functions, times(1)).updateFunctionWithUrl(any(FunctionConfig.class), anyString(), eq(new UpdateOptions()));
     }
@@ -688,7 +688,7 @@ public class CmdFunctionsTest {
         assertEquals(updater.getFunctionConfig().getResources().getDisk(), Long.valueOf(8080808080808080L));
         // cpu/Ram should be default
         assertEquals(updater.getFunctionConfig().getResources().getRam(), Long.valueOf(1073741824L));
-        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0);
+        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0, 0);
         verify(functions, times(1)).updateFunctionWithUrl(any(FunctionConfig.class), anyString(), eq(new UpdateOptions()));
     }
 
@@ -715,7 +715,7 @@ public class CmdFunctionsTest {
         assertEquals(updater.getFunctionConfig().getResources().getDisk(), Long.valueOf(8080808080808080L));
         // cpu/Ram should be default
         assertEquals(updater.getFunctionConfig().getResources().getRam(), Long.valueOf(1073741824L));
-        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0);
+        assertEquals(updater.getFunctionConfig().getResources().getCpu(), 1.0, 0);
         UpdateOptions updateOptions = new UpdateOptions();
         updateOptions.setUpdateAuthData(true);
         verify(functions, times(1)).updateFunctionWithUrl(any(FunctionConfig.class), anyString(), eq(updateOptions));

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -549,7 +549,7 @@ public class FunctionConfigUtilsTest {
         assertEquals(functionConfig.getName(), name);
         assertEquals(functionConfig.getClassName(), classname);
         assertEquals(functionConfig.getLogTopic(), logTopic);
-        assertEquals(functionConfig.getResources().getCpu(), resources.getCpu());
+        assertEquals((Object) functionConfig.getResources().getCpu(), resources.getCpu());
         assertEquals(functionConfig.getResources().getDisk().longValue(), resources.getDisk());
         assertEquals(functionConfig.getResources().getRam().longValue(), resources.getRam());
         assertEquals(functionConfig.getOutput(), sinkSpec.getTopic());

--- a/tests/bc_2_0_0/src/test/resources/pulsar.xml
+++ b/tests/bc_2_0_0/src/test/resources/pulsar.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Standalone Tests" verbose="2" annotations="JDK">

--- a/tests/bc_2_0_1/src/test/resources/pulsar.xml
+++ b/tests/bc_2_0_1/src/test/resources/pulsar.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Standalone Tests" verbose="2" annotations="JDK">

--- a/tests/integration/src/test/resources/pulsar-backwards-compatibility.xml
+++ b/tests/integration/src/test/resources/pulsar-backwards-compatibility.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar Messaging Backwards Compatibility Tests" verbose="2" annotations="JDK">
     <test name="messaging-backwards-compatibility-suite" preserve-order="true">
         <classes>

--- a/tests/integration/src/test/resources/pulsar-cli-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-cli-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar CLI Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-cli-test-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-function-state.xml
+++ b/tests/integration/src/test/resources/pulsar-function-state.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar Function State Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-function-state-test-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-messaging.xml
+++ b/tests/integration/src/test/resources/pulsar-messaging.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar (Messaging) Integration Tests" verbose="2" annotations="JDK">
     <test name="messaging-test-suite" preserve-order="true">
         <classes>

--- a/tests/integration/src/test/resources/pulsar-process-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-process-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/pulsar-process.xml
+++ b/tests/integration/src/test/resources/pulsar-process.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar Function Process Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-function-process-test-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-schema-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-schema-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/pulsar-schema.xml
+++ b/tests/integration/src/test/resources/pulsar-schema.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar Schema Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-schema-test-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-sql-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-sql-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/pulsar-sql.xml
+++ b/tests/integration/src/test/resources/pulsar-sql.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar SQL Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-sql-test-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-standalone.xml
+++ b/tests/integration/src/test/resources/pulsar-standalone.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar Standalone Tests" verbose="2" annotations="JDK">
     <test name="pulsar-standalone-suite" preserve-order="true" >
         <classes>

--- a/tests/integration/src/test/resources/pulsar-thread-suite.xml
+++ b/tests/integration/src/test/resources/pulsar-thread-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/pulsar-thread.xml
+++ b/tests/integration/src/test/resources/pulsar-thread.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar (Thread Function Worker) Integration Tests" verbose="2" annotations="JDK">
     <test name="pulsar-thread-test-suite" preserve-order="true">
         <classes>

--- a/tests/integration/src/test/resources/pulsar.xml
+++ b/tests/integration/src/test/resources/pulsar.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/tiered-file-system-suite.xml
+++ b/tests/integration/src/test/resources/tiered-file-system-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar (Jcloud Tiered Storage)Test Suite" parallel="instances" thread-count="1">

--- a/tests/integration/src/test/resources/tiered-filesystem-storage.xml
+++ b/tests/integration/src/test/resources/tiered-filesystem-storage.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar (Filesystem Tiered Storage) Integration Tests" verbose="2" annotations="JDK">
     <test name="tiered-storage-filesystem-test-suite" preserve-order="true">
         <classes>

--- a/tests/integration/src/test/resources/tiered-jcloud-storage.xml
+++ b/tests/integration/src/test/resources/tiered-jcloud-storage.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Pulsar (Jcloud Tiered Storage) Integration Tests" verbose="2" annotations="JDK">
     <test name="tiered-storage-jcloud-test-suite" preserve-order="true">
         <classes>

--- a/tests/integration/src/test/resources/tiered-storage-jcloud-suite.xml
+++ b/tests/integration/src/test/resources/tiered-storage-jcloud-suite.xml
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- TODO: we have to put suite files in one file to avoid executing TESTNG test suites multiple times.
            see {@link https://github.com/cbeust/testng/issues/508} -->
 <suite name="Pulsar Test Suite" parallel="instances" thread-count="1">


### PR DESCRIPTION
# Motivation
In current master you cannot run the tests with "forkCount=1", this is very annoying as by default we are running all of the tests in parallel.
This change upgrades a few testing dependencies and fixes a problem with PowerMock + Testng + Log4j2 + forkCount=1

### Modifications
- Upgrade TestNG
- Upgrade PowerMock
- Upgrade Mockito

### Verifying this change

All tests should pass

This change is a trivial rework / code cleanup without any test coverage.
