### PR TITLE
Support taking de-duplication snapshots based on time

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -194,6 +194,10 @@ brokerDeduplicationEnabled=false
 # persisted for deduplication purposes
 brokerDeduplicationMaxNumberOfProducers=10000
 
+# Interval to take deduplication snapshot in seconds.(disable with value 0)
+# It will run simultaneously with `brokerDeduplicationEntriesInterval`
+brokerDeduplicationSnapshotIntervalInSeconds=120
+
 # Number of entries after which a dedup info snapshot is taken.
 # A larger interval will lead to fewer snapshots being taken, though it would
 # increase the topic recovery time when the entries published after the

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -415,6 +415,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "Interval to take deduplication snapshot in seconds.(disable with value 0)"
+            + "It will run simultaneously with `brokerDeduplicationEntriesInterval`"
+    )
+    private int brokerDeduplicationSnapshotIntervalInSeconds = 120;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "Number of entries after which a dedup info snapshot is taken.\n\n"
             + "A bigger interval will lead to less snapshots being taken though it would"
             + " increase the topic recovery time, when the entries published after the"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -214,6 +214,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     private final ScheduledExecutorService ledgerFullMonitor;
     private ScheduledExecutorService topicPublishRateLimiterMonitor;
     private ScheduledExecutorService brokerPublishRateLimiterMonitor;
+    private final ScheduledExecutorService messageDeduplicationMonitor;
     protected volatile PublishRateLimiter brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
 
     private DistributedIdGenerator producerNameGenerator;
@@ -297,6 +298,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("consumed-Ledgers-monitor"));
         this.ledgerFullMonitor =
                 Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("ledger-full-monitor"));
+        this.messageDeduplicationMonitor =
+                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("message-deduplication-monitor"));
 
         this.backlogQuotaManager = new BacklogQuotaManager(pulsar);
         this.backlogQuotaChecker = Executors
@@ -442,6 +445,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         this.startBacklogQuotaChecker();
         this.updateBrokerPublisherThrottlingMaxRate();
         this.startCheckReplicationPolicies();
+        this.startMessageDeduplicationMonitor();
         // register listener to capture zk-latency
         ClientCnxnAspect.addListener(zkStatsListener);
         ClientCnxnAspect.registerExecutor(pulsar.getExecutor());
@@ -453,6 +457,14 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
         // Ensure the broker starts up with initial stats
         updateRates();
+    }
+
+    protected void startMessageDeduplicationMonitor() {
+        int interval = pulsar().getConfiguration().getBrokerDeduplicationSnapshotIntervalInSeconds();
+        if (interval > 0) {
+            inactivityMonitor.scheduleAtFixedRate(safeRun(() -> forEachTopic(Topic::checkMessageDeduplicationSnapshot))
+                    , interval, interval, TimeUnit.SECONDS);
+        }
     }
 
     protected void startInactivityMonitor() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -138,7 +138,7 @@ public interface Topic {
      */
     void checkBackloggedCursors();
 
-    void checkMessageDeduplicationSnapshot();
+    void checkDeduplicationSnapshot();
 
     void checkMessageExpiry();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -138,6 +138,8 @@ public interface Topic {
      */
     void checkBackloggedCursors();
 
+    void checkMessageDeduplicationSnapshot();
+
     void checkMessageExpiry();
 
     void checkMessageDeduplicationInfo();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -917,7 +917,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
-    public void checkMessageDeduplicationSnapshot() {
+    public void checkDeduplicationSnapshot() {
         // no-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -917,6 +917,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
+    public void checkMessageDeduplicationSnapshot() {
+        // no-op
+    }
+
+    @Override
     public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] isEncryptionRequired changes: {} -> {}", topic, isEncryptionRequired,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1832,7 +1832,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
-    public void checkMessageDeduplicationSnapshot() {
+    public void checkDeduplicationSnapshot() {
         producers.values().forEach(producers -> messageDeduplication.takeSnapshot(producers.getProducerName()));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1831,6 +1831,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
     }
 
+    @Override
+    public void checkMessageDeduplicationSnapshot() {
+        producers.values().forEach(producers -> messageDeduplication.takeSnapshot(producers.getProducerName()));
+    }
+
     /**
      * Check whether the topic should be retained (based on time), even tough there are no producers/consumers and it's
      * marked as inactive.


### PR DESCRIPTION

Master Issue: #8237

### Motivation
Currently we take de-duplication snapshots based on size. If the topic has relatively low traffic, the de-duplication cursor will not move. This can cause messages that are not able to be deleted based on the retention policy. We should add a policy to take de-duplication snapshots based on time.

### Modifications
add a monitor to take snapshot base on time

### Verifying this change
TopicDuplicationTest#testDuplicationSnapshot