### PR TITLE
[Issue 8471] command getBrokersWithNamespaceIsolationPolicy, add test

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -595,6 +595,9 @@ public class ClustersBase extends AdminResource {
                             brokerIsolationData.namespaceRegex = Lists.newArrayList();
                         }
                         brokerIsolationData.namespaceRegex.addAll(policyData.namespaces);
+                        if (nsPolicyImpl.isPrimaryBroker(broker)) {
+                            brokerIsolationData.isPrimary = true;
+                        }
                     }
                 });
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -89,6 +89,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
 import org.apache.pulsar.common.policies.data.BrokerAssignment;
+import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
@@ -248,7 +249,9 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
             nsPolicyData1.namespaces = new ArrayList<String>();
             nsPolicyData1.namespaces.add("other/use/other.*");
             nsPolicyData1.primary = new ArrayList<String>();
-            nsPolicyData1.primary.add("prod1-broker[4-6].messaging.use.example.com");
+            // match all broker. make it easy to verify `getBrokersWithNamespaceIsolationPolicy` later
+            nsPolicyData1.primary.add(".*");
+
             nsPolicyData1.secondary = new ArrayList<String>();
             nsPolicyData1.secondary.add("prod1-broker.*.messaging.use.example.com");
             nsPolicyData1.auto_failover_policy = new AutoFailoverPolicyData();
@@ -277,6 +280,11 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
             Map<String, NamespaceIsolationData> policiesMap = admin.clusters().getNamespaceIsolationPolicies("use");
             assertEquals(policiesMap.get(policyName1), nsPolicyData1);
             assertEquals(policiesMap.get(policyName2), nsPolicyData2);
+
+            // verify local broker get matched.
+            List<BrokerNamespaceIsolationData> isoList = admin.clusters().getBrokersWithNamespaceIsolationPolicy("use");
+            assertEquals(isoList.size(), 1);
+            assertTrue(isoList.get(0).isPrimary);
 
             // verify update of primary
             nsPolicyData1.primary.remove(0);


### PR DESCRIPTION

Fixes #8471

### Motivation

command bin/pulsar-admin ns-isolation-policy brokers not handled the "isPrimary" parameter. and caused always "false" output.

### Modifications

fix command,
add test.

### Verifying this change
new added test passed