### PR TITLE
Support taking de-duplication snapshots based on time

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -194,6 +194,12 @@ brokerDeduplicationEnabled=false
 # persisted for deduplication purposes
 brokerDeduplicationMaxNumberOfProducers=10000
 
+# How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)
+brokerDeduplicationSnapshotFrequencyInSeconds=10
+# If this time interval is exceeded, a snapshot will be taken.
+# It will run simultaneously with `brokerDeduplicationEntriesInterval`
+brokerDeduplicationSnapshotIntervalSeconds=120
+
 # Number of entries after which a dedup info snapshot is taken.
 # A larger interval will lead to fewer snapshots being taken, though it would
 # increase the topic recovery time when the entries published after the

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -415,6 +415,18 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)"
+    )
+    private int brokerDeduplicationSnapshotFrequencyInSeconds = 120;
+    @FieldContext(
+        category = CATEGORY_POLICIES,
+        doc = "If this time interval is exceeded, a snapshot will be taken."
+            + "It will run simultaneously with `brokerDeduplicationEntriesInterval`"
+    )
+    private Integer brokerDeduplicationSnapshotIntervalSeconds = 120;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "Number of entries after which a dedup info snapshot is taken.\n\n"
             + "A bigger interval will lead to less snapshots being taken though it would"
             + " increase the topic recovery time, when the entries published after the"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -461,7 +461,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     protected void startDeduplicationSnapshotMonitor() {
         int interval = pulsar().getConfiguration().getBrokerDeduplicationSnapshotFrequencyInSeconds();
-        if (interval > 0) {
+        if (interval > 0 && pulsar().getConfiguration().isBrokerDeduplicationEnabled()) {
             deduplicationSnapshotMonitor.scheduleAtFixedRate(safeRun(() -> forEachTopic(Topic::checkDeduplicationSnapshot))
                     , interval, interval, TimeUnit.SECONDS);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -138,6 +138,8 @@ public interface Topic {
      */
     void checkBackloggedCursors();
 
+    void checkDeduplicationSnapshot();
+
     void checkMessageExpiry();
 
     void checkMessageDeduplicationInfo();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -917,6 +917,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     }
 
     @Override
+    public void checkDeduplicationSnapshot() {
+        // no-op
+    }
+
+    @Override
     public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] isEncryptionRequired changes: {} -> {}", topic, isEncryptionRequired,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1833,7 +1833,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public void checkDeduplicationSnapshot() {
-        producers.values().forEach(producers -> messageDeduplication.takeSnapshot(producers.getProducerName()));
+        producers.values().forEach(producer -> messageDeduplication.takeSnapshot(producer.getProducerName()));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1831,6 +1831,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
     }
 
+    @Override
+    public void checkDeduplicationSnapshot() {
+        producers.values().forEach(producers -> messageDeduplication.takeSnapshot(producers.getProducerName()));
+    }
+
     /**
      * Check whether the topic should be retained (based on time), even tough there are no producers/consumers and it's
      * marked as inactive.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1833,7 +1833,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public void checkDeduplicationSnapshot() {
-        producers.values().forEach(producer -> messageDeduplication.takeSnapshot(producer.getProducerName()));
+        messageDeduplication.takeSnapshot();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
@@ -154,10 +154,15 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
     }
 
     private void testTakeSnapshot(boolean enabledSnapshot) throws Exception {
+        resetConfig();
+        conf.setBrokerDeduplicationEnabled(true);
         conf.setBrokerDeduplicationSnapshotFrequencyInSeconds(enabledSnapshot ? 1 : 0);
         conf.setBrokerDeduplicationSnapshotIntervalSeconds(1);
-        conf.setBrokerDeduplicationEntriesInterval(10000);
-        restartBroker();
+        conf.setBrokerDeduplicationEntriesInterval(20000);
+        super.internalCleanup();
+        super.internalSetup();
+        super.producerBaseSetup();
+
         final String topicName = testTopic + UUID.randomUUID().toString();
         final String producerName = "my-producer";
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
@@ -184,6 +184,24 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
             assertNotEquals(position, markDeletedPosition);
             assertNotEquals(markDeletedPosition.getEntryId(), -1);
         }
+
+        producer.newMessage().value("msg").send();
+        markDeletedPosition = (PositionImpl) managedCursor.getMarkDeletedPosition();
+        position = persistentTopic.getMessageDeduplication().lastPositionPersisted.get(producerName);
+        assertNotEquals(msgNum, markDeletedPosition.getEntryId());
+        assertNotNull(position);
+
+        Thread.sleep(2000);
+        markDeletedPosition = (PositionImpl) managedCursor.getMarkDeletedPosition();
+        position = persistentTopic.getMessageDeduplication().lastPositionPersisted.get(producerName);
+        if (enabledSnapshot) {
+            assertEquals(msgNum, markDeletedPosition.getEntryId());
+            assertNull(position);
+        } else {
+            assertNotEquals(msgNum, markDeletedPosition.getEntryId());
+            assertNotNull(position);
+        }
+
     }
 
     private void waitCacheInit(String topicName) throws Exception {


### PR DESCRIPTION
Master Issue: #8237

### Motivation
Currently we take de-duplication snapshots based on size. If the topic has relatively low traffic, the de-duplication cursor will not move. This can cause messages that are not able to be deleted based on the retention policy. We should add a policy to take de-duplication snapshots based on time.

### Modifications
add a monitor to take snapshot base on time

### Verifying this change
TopicDuplicationTest#testDuplicationSnapshot
