### PR TITLE
Fix Double-Checked locking not using volatile

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesService {
 
     private final PulsarService pulsarService;
-    private NamespaceEventsSystemTopicFactory namespaceEventsSystemTopicFactory;
+    private volatile NamespaceEventsSystemTopicFactory namespaceEventsSystemTopicFactory;
 
     private final Map<TopicName, TopicPolicies> policiesCache = new ConcurrentHashMap<>();
 


### PR DESCRIPTION






```java
private void createSystemTopicFactoryIfNeeded() {
        if (namespaceEventsSystemTopicFactory == null) {
            synchronized (this) {
                if (namespaceEventsSystemTopicFactory == null) {
                    try {
                        namespaceEventsSystemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarService.getClient());
                    } catch (PulsarServerException e) {
                        log.error("Create namespace event system topic factory error.", e);
                    }
                }
            }
        }
    }
```

The creation of `namespaceEventsSystemTopicFactory` uses double-check locking, but does not add volatile