### PR TITLE
[docs] Add config info in security jwt

### DIFF
--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -217,6 +217,12 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=
+brokerClientAuthenticationParameters=
+brokerClientTrustCertsFilePath=
+
 # If this flag is set then the broker authenticates the original Auth data
 # else it just accepts the originalPrincipal and authorizes it (if required).
 authenticateOriginalAuthData=true

--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -219,9 +219,11 @@ authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationPr
 
 # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
 brokerClientTlsEnabled=true
-brokerClientAuthenticationPlugin=
-brokerClientAuthenticationParameters=
-brokerClientTrustCertsFilePath=
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 
 # If this flag is set then the broker authenticates the original Auth data
 # else it just accepts the originalPrincipal and authorizes it (if required).

--- a/site2/website/versioned_docs/version-2.5.1/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-jwt.md
@@ -211,6 +211,14 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
+
 # If using secret key
 tokenSecretKey=file:///path/to/secret.key
 # The key can also be passed inline:

--- a/site2/website/versioned_docs/version-2.5.2/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.5.2/security-jwt.md
@@ -211,6 +211,14 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
+
 # If using secret key
 tokenSecretKey=file:///path/to/secret.key
 # The key can also be passed inline:

--- a/site2/website/versioned_docs/version-2.6.0/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.6.0/security-jwt.md
@@ -218,6 +218,14 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
+
 # If this flag is set then the broker authenticates the original Auth data
 # else it just accepts the originalPrincipal and authorizes it (if required).
 authenticateOriginalAuthData=true

--- a/site2/website/versioned_docs/version-2.6.1/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-jwt.md
@@ -218,6 +218,14 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
+
 # If this flag is set then the broker authenticates the original Auth data
 # else it just accepts the originalPrincipal and authorizes it (if required).
 authenticateOriginalAuthData=true

--- a/site2/website/versioned_docs/version-2.6.2/security-jwt.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-jwt.md
@@ -218,6 +218,14 @@ authenticationEnabled=true
 authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientTlsEnabled=true
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
+brokerClientAuthenticationParameters=token:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw
+# Or, alternatively, read token from file
+# brokerClientAuthenticationParameters=file:///path/to/proxy-token.txt
+brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
+
 # If this flag is set then the broker authenticates the original Auth data
 # else it just accepts the originalPrincipal and authorizes it (if required).
 authenticateOriginalAuthData=true


### PR DESCRIPTION
### Motivation

The configuration for broker to broker connection is missing when using JWT.

### Modifications

Add the configuration info and examples.