### PR TITLE
[Doc]--add how pulsar CLI tools use OAuth2 authentication plugin to connect a cluster.

### DIFF
--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -44,9 +44,9 @@ The credentials file contains service account credentials used with the client a
 
 In the above example, the authentication type is set to `client_credentials` by default. And the fields "client_id" and "client_secret" are required.
 
-### Typical original Oauth2 request mapping
+### Typical original OAuth2 request mapping
 
-The following shows a typical original Oauth2 request, which is used to obtain the access token from the Oauth2 server.
+The following shows a typical original OAuth2 request, which is used to obtain the access token from the OAuth2 server.
 
 ```bash
 curl --request POST \
@@ -67,7 +67,7 @@ In the above example, the mapping relationship is shown as below.
 
 ## Client Configuration
 
-You can use the Oauth2 authentication provider with the following Pulsar clients.
+You can use the OAuth2 authentication provider with the following Pulsar clients.
 
 ### Java
 
@@ -151,3 +151,56 @@ params = '''
 
 client = Client("puslar://my-cluster:6650", authentication=AuthenticationOauth2(params))
 ```
+
+## CLI configuration
+
+This section describes how to use Pulsar CLI tools to connect a cluster through OAuth2 authentication plugin.
+
+### pulsar-admin
+
+This example shows how to use pulsar-admin to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-admin --admin-url https://streamnative.cloud:443 \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+tenants list
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-client
+
+This example shows how to use pulsar-client to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-client \
+--url SERVICE_URL \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+produce test-topic -m "test-message" -n 10
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-perf
+
+This example shows how to use pulsar-perf to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
+--auth_plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+-r 1000 -s 1024 test-topic
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
@@ -118,7 +118,7 @@ pulsar::Client client("pulsar://broker.example.com:6650/", config);
 ### Go client
 
 To enable OAuth2 authentication in Go client, you need to configure OAuth2 authentication.
-This example shows how to configure OAuth2 authentication in Go client. 
+This example shows how to configure OAuth2 authentication in Go client.   
 
 ```go
 oauth := pulsar.NewAuthenticationOAuth2(map[string]string{

--- a/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
@@ -45,9 +45,9 @@ The credentials file contains service account credentials used with the client a
 
 In the above example, the authentication type is set to `client_credentials` by default. And the fields "client_id" and "client_secret" are required.
 
-### Typical original Oauth2 request mapping
+### Typical original OAuth2 request mapping
 
-The following shows a typical original Oauth2 request, which is used to obtain the access token from the Oauth2 server.
+The following shows a typical original OAuth2 request, which is used to obtain the access token from the OAuth2 server.
 
 ```bash
 curl --request POST \
@@ -68,7 +68,7 @@ In the above example, the mapping relationship is shown as below.
 
 ## Client Configuration
 
-You can use the Oauth2 authentication provider with the following Pulsar clients.
+You can use the OAuth2 authentication provider with the following Pulsar clients.
 
 ### Java
 
@@ -133,3 +133,57 @@ client, err := pulsar.NewClient(pulsar.ClientOptions{
 		Authentication:   oauth,
 })
 ```
+
+
+## CLI configuration
+
+This section describes how to use Pulsar CLI tools to connect a cluster through OAuth2 authentication plugin.
+
+### pulsar-admin
+
+This example shows how to use pulsar-admin to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-admin --admin-url https://streamnative.cloud:443 \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+tenants list
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-client
+
+This example shows how to use pulsar-client to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-client \
+--url SERVICE_URL \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+produce test-topic -m "test-message" -n 10
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-perf
+
+This example shows how to use pulsar-perf to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
+--auth_plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+-r 1000 -s 1024 test-topic
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
@@ -45,9 +45,9 @@ The credentials file contains service account credentials used with the client a
 
 In the above example, the authentication type is set to `client_credentials` by default. And the fields "client_id" and "client_secret" are required.
 
-### Typical original Oauth2 request mapping
+### Typical original OAuth2 request mapping
 
-The following shows a typical original Oauth2 request, which is used to obtain the access token from the Oauth2 server.
+The following shows a typical original OAuth2 request, which is used to obtain the access token from the OAuth2 server.
 
 ```bash
 curl --request POST \
@@ -68,7 +68,7 @@ In the above example, the mapping relationship is shown as below.
 
 ## Client Configuration
 
-You can use the Oauth2 authentication provider with the following Pulsar clients.
+You can use the OAuth2 authentication provider with the following Pulsar clients.
 
 ### Java
 
@@ -133,3 +133,57 @@ client, err := pulsar.NewClient(pulsar.ClientOptions{
 		Authentication:   oauth,
 })
 ```
+
+
+## CLI configuration
+
+This section describes how to use Pulsar CLI tools to connect a cluster through OAuth2 authentication plugin.
+
+### pulsar-admin
+
+This example shows how to use pulsar-admin to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-admin --admin-url https://streamnative.cloud:443 \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+tenants list
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-client
+
+This example shows how to use pulsar-client to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-client \
+--url SERVICE_URL \
+--auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+produce test-topic -m "test-message" -n 10
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
+
+### pulsar-perf
+
+This example shows how to use pulsar-perf to connect to a cluster through OAuth2 authentication plugin.
+
+```shell script
+bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
+--auth_plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+--auth-params '{"privateKey":"file:///path/to/key/file.json",
+    "issuerUrl":"https://dev-kt-aa9ne.us.auth0.com",
+    "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/"}' \
+-r 1000 -s 1024 test-topic
+```
+
+Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).


### PR DESCRIPTION


Fixes #8466 


### Motivation

Add docs about how Pulsar CLI tools use OAuth2 authentication plugin.


### Modifications

Add docs about how pulsar-admin, pulsar-client, and pulsar-perf command use OAuth2 authentication plugin to connect to a cluster.

Affected releases: master, 2.6.1 and 2.6.2









