### PR TITLE
Transaction - fix TransactionBufferHandlerImpl thread leak in tests

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -367,6 +367,10 @@ public class PulsarService implements AutoCloseable {
                 protocolHandlers = null;
             }
 
+            if (transactionBufferClient != null) {
+                transactionBufferClient.close();
+            }
+
             state = State.Closed;
             isClosedCondition.signalAll();
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -67,4 +67,8 @@ public class TransactionBufferClientImpl implements TransactionBufferClient {
         return tbHandler.endTxnOnSubscription(topic, subscription, txnIdMostBits, txnIdLeastBits, PulsarApi.TxnAction.ABORT);
     }
 
+    @Override
+    public void close() {
+        tbHandler.close();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -312,4 +312,9 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler, T
             }
         };
     }
+
+    @Override
+    public void close() {
+        this.timer.stop();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.transaction.buffer;
 
 import com.google.common.collect.Sets;
-import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -32,7 +31,6 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.testng.annotations.AfterClass;
 
 public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
 
@@ -66,6 +65,13 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
                 .subscriptionName("test").subscribe();
         tbClient = TransactionBufferClientImpl.create(pulsarServices[0].getNamespaceService(),
                 ((PulsarClientImpl) pulsarClient).getCnxPool());
+    }
+
+    @AfterClass
+    public void shutdownClient() {
+        if (tbClient != null) {
+            tbClient.close();
+        }
     }
 
     @Override

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
@@ -82,4 +82,5 @@ public interface TransactionBufferClient {
                                                    long txnIdMostBits,
                                                    long txnIdLeastBits);
 
+    void close();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
@@ -66,4 +66,9 @@ public interface TransactionBufferHandler {
      * @param response response
      */
     void handleEndTxnOnSubscriptionResponse(long requestId, PulsarApi.CommandEndTxnOnSubscriptionResponse response);
+
+    /**
+     * Release resources.
+     */
+    void close();
 }


### PR DESCRIPTION
### Motivation
While running pulsar-broker tests I noticed that lots of threads named pulsar-transaction-buffer-client-timer-xxx are summing up, slowing consuming all of the resources of the host machine.
This change will be particularly helpful for CI and for downstream applications that start a PulsarBroken in unit tests. It is not a real problem in production as the server process is destroyed together with all of the internal threads.

### Modifications

Add "close" method to all relevant interfaces in order to allow PulsarService to shutdown the TransactionBufferHandlerImpl instance and the HashedWheelTimer inside.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
