### PR TITLE
[Transaction] Register transaction metadata before send or ack messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
@@ -54,9 +54,9 @@ public class ConsumerAckResponseTest extends ProducerConsumerBase {
         super.producerBaseSetup();
         doReturn(1L).when(transaction).getTxnIdLeastBits();
         doReturn(1L).when(transaction).getTxnIdMostBits();
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        doReturn(completableFuture).when(transaction).registerAckOp(any());
-        doNothing().when(transaction).registerAckedTopic(any(), any());
+        CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
+        doNothing().when(transaction).registerAckOp(any());
+        doReturn(completableFuture).when(transaction).registerAckedTopic(any(), any());
 
         Thread.sleep(1000 * 3);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -487,9 +487,9 @@ public class TransactionEndToEndTest extends TransactionTestBase {
     private void markDeletePositionCheck(String topic, String subName, boolean equalsWithLastConfirm) throws Exception {
         for (int i = 0; i < TOPIC_PARTITION; i++) {
             PersistentTopicInternalStats stats = null;
+            String checkTopic = TopicName.get(topic).getPartition(i).toString();
             for (int j = 0; j < 10; j++) {
-                topic = TopicName.get(topic).getPartition(i).toString();
-                stats = admin.topics().getInternalStats(topic, false);
+                stats = admin.topics().getInternalStats(checkTopic, false);
                 if (stats.lastConfirmedEntry.equals(stats.cursors.get(subName).markDeletePosition)) {
                     break;
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -162,26 +162,34 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     }
 
     @Override
-    CompletableFuture<MessageId> internalSendAsync(Message<?> message, Transaction txn) {
+    CompletableFuture<MessageId> internalSendAsync(Message<?> message) {
+        return internalSendWithTxnAsync(message, null);
+    }
 
+    @Override
+    CompletableFuture<MessageId> internalSendWithTxnAsync(Message<?> message, Transaction txn) {
         switch (getState()) {
-        case Ready:
-        case Connecting:
-            break; // Ok
-        case Closing:
-        case Closed:
-            return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Producer already closed"));
-        case Terminated:
-            return FutureUtil.failedFuture(new PulsarClientException.TopicTerminatedException("Topic was terminated"));
-        case Failed:
-        case Uninitialized:
-            return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
+            case Ready:
+            case Connecting:
+                break; // Ok
+            case Closing:
+            case Closed:
+                return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Producer already closed"));
+            case Terminated:
+                return FutureUtil.failedFuture(new PulsarClientException.TopicTerminatedException("Topic was terminated"));
+            case Failed:
+            case Uninitialized:
+                return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
         }
 
         int partition = routerPolicy.choosePartition(message, topicMetadata);
         checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
                 "Illegal partition index chosen by the message routing policy: " + partition);
-        return producers.get(partition).internalSendAsync(message, txn);
+        if (txn != null) {
+            return producers.get(partition).internalSendWithTxnAsync(message, txn);
+        } else {
+            return producers.get(partition).internalSendAsync(message);
+        }
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -185,11 +185,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         int partition = routerPolicy.choosePartition(message, topicMetadata);
         checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
                 "Illegal partition index chosen by the message routing policy: " + partition);
-        if (txn != null) {
-            return producers.get(partition).internalSendWithTxnAsync(message, txn);
-        } else {
-            return producers.get(partition).internalSendAsync(message);
-        }
+        return producers.get(partition).internalSendWithTxnAsync(message, txn);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -73,7 +73,7 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
     }
 
     public CompletableFuture<MessageId> sendAsync(Message<?> message) {
-        return internalSendAsync(message, null);
+        return internalSendAsync(message);
     }
 
     @Override
@@ -100,12 +100,14 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
         return new TypedMessageBuilderImpl<>(this, schema, (TransactionImpl) txn);
     }
 
-    abstract CompletableFuture<MessageId> internalSendAsync(Message<?> message, Transaction txn);
+    abstract CompletableFuture<MessageId> internalSendAsync(Message<?> message);
+
+    abstract CompletableFuture<MessageId> internalSendWithTxnAsync(Message<?> message, Transaction txn);
 
     public MessageId send(Message<?> message) throws PulsarClientException {
         try {
             // enqueue the message to the buffer
-            CompletableFuture<MessageId> sendFuture = internalSendAsync(message, null);
+            CompletableFuture<MessageId> sendFuture = internalSendAsync(message);
 
             if (!sendFuture.isDone()) {
                 // the send request wasn't completed yet (e.g. not failing at enqueuing), then attempt to triggerFlush it out

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -347,7 +347,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     @Override
     CompletableFuture<MessageId> internalSendWithTxnAsync(Message<?> message, Transaction txn) {
-        return ((TransactionImpl) txn).registerProducedTopic(topic).thenCompose(ignored -> internalSendAsync(message));
+        if (txn == null) {
+            return internalSendAsync(message);
+        } else {
+            return ((TransactionImpl) txn).registerProducedTopic(topic)
+                        .thenCompose(ignored -> internalSendAsync(message));
+        }
     }
 
     public void sendAsync(Message<?> message, SendCallback callback) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -268,11 +268,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     @Override
-    CompletableFuture<MessageId> internalSendAsync(Message<?> message, Transaction txn) {
-        if (txn instanceof TransactionImpl) {
-            ((TransactionImpl) txn).registerProducedTopic(topic);
-        }
-
+    CompletableFuture<MessageId> internalSendAsync(Message<?> message) {
         CompletableFuture<MessageId> future = new CompletableFuture<>();
 
         MessageImpl<?> interceptorMessage = (MessageImpl) beforeSend(message);
@@ -347,6 +343,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
         });
         return future;
+    }
+
+    @Override
+    CompletableFuture<MessageId> internalSendWithTxnAsync(Message<?> message, Transaction txn) {
+        return ((TransactionImpl) txn).registerProducedTopic(topic).thenCompose(ignored -> internalSendAsync(message));
     }
 
     public void sendAsync(Message<?> message, SendCallback callback) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -93,13 +93,14 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     public CompletableFuture<MessageId> sendAsync() {
         Message<T> message = getMessage();
         final long sequenceId = message.getSequenceId();
-        CompletableFuture<MessageId> sendFuture = producer.internalSendAsync(message, txn);
+        CompletableFuture<MessageId> sendFuture;
         if (txn != null) {
-            // register the sendFuture as part of the transaction
-            return txn.registerSendOp(sequenceId, sendFuture);
+            sendFuture = producer.internalSendWithTxnAsync(message, txn);
+            txn.registerSendOp(sequenceId, sendFuture);
         } else {
-            return sendFuture;
+            sendFuture = producer.internalSendAsync(message);
         }
+        return sendFuture;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -92,11 +92,10 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     @Override
     public CompletableFuture<MessageId> sendAsync() {
         Message<T> message = getMessage();
-        final long sequenceId = message.getSequenceId();
         CompletableFuture<MessageId> sendFuture;
         if (txn != null) {
             sendFuture = producer.internalSendWithTxnAsync(message, txn);
-            txn.registerSendOp(sequenceId, sendFuture);
+            txn.registerSendOp(sendFuture);
         } else {
             sendFuture = producer.internalSendAsync(message);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -51,34 +51,19 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 @Getter
 public class TransactionImpl implements Transaction {
 
-    @Data
-    private static class TransactionalSendOp {
-        private final CompletableFuture<MessageId> sendFuture;
-        private final CompletableFuture<MessageId> transactionalSendFuture;
-    }
-
-    @Data
-    private static class TransactionalAckOp {
-        private final CompletableFuture<Void> ackFuture;
-        private final CompletableFuture<Void> transactionalAckFuture;
-    }
-
     private final PulsarClientImpl client;
     private final long transactionTimeoutMs;
     private final long txnIdLeastBits;
     private final long txnIdMostBits;
     private final AtomicLong sequenceId = new AtomicLong(0L);
-    private final LinkedHashMap<Long, TransactionalSendOp> sendOps;
+
     private final Set<String> producedTopics;
-    private final Set<TransactionalAckOp> ackOps;
     private final Set<String> ackedTopics;
     private final TransactionCoordinatorClientImpl tcClient;
     private Map<ConsumerImpl<?>, Integer> cumulativeAckConsumers;
 
     private final ArrayList<CompletableFuture<MessageId>> sendFutureList;
     private final ArrayList<CompletableFuture<Void>> ackFutureList;
-    private final ArrayList<CompletableFuture<Void>> registerSubscriptionFutureList;
-    private final ArrayList<MessageId> sendMessageIdList;
 
     TransactionImpl(PulsarClientImpl client,
                     long transactionTimeoutMs,
@@ -88,16 +73,13 @@ public class TransactionImpl implements Transaction {
         this.transactionTimeoutMs = transactionTimeoutMs;
         this.txnIdLeastBits = txnIdLeastBits;
         this.txnIdMostBits = txnIdMostBits;
-        this.sendOps = new LinkedHashMap<>();
+
         this.producedTopics = new HashSet<>();
-        this.ackOps = new HashSet<>();
         this.ackedTopics = new HashSet<>();
         this.tcClient = client.getTcClient();
 
-        sendFutureList = new ArrayList<>();
-        ackFutureList = new ArrayList<>();
-        registerSubscriptionFutureList = new ArrayList<>();
-        sendMessageIdList = new ArrayList<>();
+        this.sendFutureList = new ArrayList<>();
+        this.ackFutureList = new ArrayList<>();
     }
 
     public long nextSequenceId() {
@@ -117,20 +99,25 @@ public class TransactionImpl implements Transaction {
         return completableFuture;
     }
 
-    public synchronized CompletableFuture<MessageId> registerSendOp(long sequenceId,
-                                                                    CompletableFuture<MessageId> sendFuture) {
+    public synchronized void registerSendOp(CompletableFuture<MessageId> sendFuture) {
         sendFutureList.add(sendFuture);
-        return sendFuture;
     }
 
     // register the topics that will be modified by this transaction
-    public synchronized void registerAckedTopic(String topic, String subscription) {
+    public synchronized CompletableFuture<Void> registerAckedTopic(String topic, String subscription) {
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         if (ackedTopics.add(topic)) {
             // we need to issue the request to TC to register the acked topic
-            registerSubscriptionFutureList.add(
-                    tcClient.addSubscriptionToTxnAsync(new TxnID(txnIdMostBits, txnIdLeastBits), topic, subscription)
-            );
+            completableFuture = tcClient.addSubscriptionToTxnAsync(
+                    new TxnID(txnIdMostBits, txnIdLeastBits), topic, subscription);
+        } else {
+            completableFuture.complete(null);
         }
+        return completableFuture;
+    }
+
+    public synchronized void registerAckOp(CompletableFuture<Void> ackFuture) {
+        ackFutureList.add(ackFuture);
     }
 
     public synchronized void registerCumulativeAckConsumer(ConsumerImpl<?> consumer) {
@@ -140,13 +127,9 @@ public class TransactionImpl implements Transaction {
         cumulativeAckConsumers.put(consumer, 0);
     }
 
-    public synchronized CompletableFuture<Void> registerAckOp(CompletableFuture<Void> ackFuture) {
-        ackFutureList.add(ackFuture);
-        return ackFuture;
-    }
-
     @Override
     public CompletableFuture<Void> commit() {
+        List<MessageId> sendMessageIdList = new ArrayList<>(sendFutureList.size());
         CompletableFuture<Void> commitFuture = new CompletableFuture<>();
         allOpComplete().whenComplete((v, e) -> {
             if (e != null) {
@@ -170,7 +153,7 @@ public class TransactionImpl implements Transaction {
 
     @Override
     public CompletableFuture<Void> abort() {
-
+        List<MessageId> sendMessageIdList = new ArrayList<>(sendFutureList.size());
         CompletableFuture<Void> abortFuture = new CompletableFuture<>();
         allOpComplete().whenComplete((v, e) -> {
             if (e != null) {
@@ -205,7 +188,6 @@ public class TransactionImpl implements Transaction {
     private CompletableFuture<Void> allOpComplete() {
         List<CompletableFuture<?>> futureList = new ArrayList<>();
         futureList.addAll(sendFutureList);
-        futureList.addAll(registerSubscriptionFutureList);
         futureList.addAll(ackFutureList);
         return CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0]));
     }


### PR DESCRIPTION
Fixes https://github.com/streamnative/pulsar/issues/1659

### Motivation

The transaction metadata registration should be the precondition of send or ack transaction messages, this guarantees TC could notify all related topic partitions and subscriptions successfully.

### Modifications

1. Register topic partition info to TC before sending transaction messages.
2. Register subscription info to TC before ack transaction messages.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)