### PR TITLE
Cancel producer sendtimeout task after creation failure

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1312,6 +1312,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         setState(State.Failed);
                         producerCreatedFuture.completeExceptionally(cause);
                         client.cleanupProducer(this);
+                        Timeout timeout = sendTimeout;
+                        if (timeout != null) {
+                            timeout.cancel();
+                            sendTimeout = null;
+                        }
                     }
 
                     return null;


### PR DESCRIPTION
### Motivation
SendTimeout task is being started in the ProducerImpl constructor though it is not being cancelled if the producer creation fails, leaving active ref to that object.
This problem looks like a problem similar to https://github.com/apache/pulsar/pull/5204.
