### PR TITLE
Optimize batch source discovery and task ack

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -460,7 +460,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
     }
 
-    private Record readInput() {
+    private Record readInput() throws Exception {
         Record record;
         if (!(this.source instanceof PulsarSource)) {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
@@ -469,8 +469,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             record = this.source.read();
         } catch (Exception e) {
             stats.incrSourceExceptions(e);
-            log.info("Encountered exception in source read: ", e);
-            throw new RuntimeException(e);
+            log.error("Encountered exception in source read", e);
+            throw e;
         } finally {
             Thread.currentThread().setContextClassLoader(instanceClassLoader);
         }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutor.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutor.java
@@ -155,7 +155,7 @@ public class BatchSourceExecutor<T> implements Source<T> {
     } else {
       discoverInProgress = true;
     }
-    // Run this code asynchronous so it does block processing of the tasks
+    // Run this code asynchronous so it doesn't block processing of the tasks
     CompletableFuture.runAsync(() -> {
       try {
         batchSource.discover(task -> taskEater(discoveredEvent, task));

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutorTest.java
@@ -21,25 +21,28 @@ package org.apache.pulsar.functions.source.batch;
 
 import com.google.gson.Gson;
 import lombok.Getter;
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.io.BatchSourceConfig;
 import org.apache.pulsar.functions.api.Record;
-
 import org.apache.pulsar.io.core.BatchPushSource;
 import org.apache.pulsar.io.core.BatchSource;
 import org.apache.pulsar.io.core.BatchSourceTriggerer;
 import org.apache.pulsar.io.core.SourceContext;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
 /**
@@ -49,13 +52,13 @@ public class BatchSourceExecutorTest {
 
   public static class TestBatchSource implements BatchSource<String> {
     @Getter
-    private static int prepareCount;
+    public static int prepareCount;
     @Getter
-    private static int discoverCount;
+    public static int discoverCount;
     @Getter
-    private static int recordCount;
+    public static int recordCount;
     @Getter
-    private static int closeCount;
+    public static int closeCount;
     private Record record = Mockito.mock(Record.class);
     public TestBatchSource() { }
 
@@ -93,15 +96,22 @@ public class BatchSourceExecutorTest {
     }
   }
 
+  public static class TestBatchSourceFailDiscovery extends TestBatchSource {
+    @Override
+    public void discover(Consumer<byte[]> taskEater) throws Exception {
+      throw new Exception("test");
+    }
+  }
+
   public static class TestBatchPushSource extends BatchPushSource<String> {
     @Getter
-    private static int prepareCount;
+    public static int prepareCount;
     @Getter
-    private static int discoverCount;
+    public static int discoverCount;
     @Getter
-    private static int recordCount;
+    public static int recordCount;
     @Getter
-    private static int closeCount;
+    public static int closeCount;
     private Record record = Mockito.mock(Record.class);
     public TestBatchPushSource() { }
 
@@ -135,7 +145,10 @@ public class BatchSourceExecutorTest {
     }
   }
 
+  public static LinkedBlockingQueue<String> triggerQueue = new LinkedBlockingQueue<>();
+  public static LinkedBlockingQueue<String> completedQueue = new LinkedBlockingQueue<>();
   public static class TestDiscoveryTriggerer implements BatchSourceTriggerer {
+    @Getter
     private Consumer<String> trigger;
     private Thread thread;
 
@@ -150,12 +163,12 @@ public class BatchSourceExecutorTest {
 
     @Override
     public void start(Consumer<String> trigger) {
+
       this.trigger = trigger;
       thread = new Thread(() -> {
         while(true) {
           try {
-            Thread.sleep(100);
-            trigger.accept("Triggered");
+            trigger.accept(triggerQueue.take());
           } catch (InterruptedException e) {
             break;
           }
@@ -186,7 +199,6 @@ public class BatchSourceExecutorTest {
   private ConsumerBuilder consumerBuilder;
   private org.apache.pulsar.client.api.Consumer<byte[]> consumer;
   private TypedMessageBuilder<byte[]> messageBuilder;
-  private CyclicBarrier discoveryBarrier;
   private Message<byte[]> discoveredTask;
 
   private static Map<String, Object> createConfig(String className, BatchSourceConfig batchConfig) {
@@ -208,6 +220,14 @@ public class BatchSourceExecutorTest {
 
   @BeforeMethod
   public void setUp() throws Exception {
+    TestBatchSource.closeCount = 0;
+    TestBatchSource.discoverCount = 0;
+    TestBatchSource.prepareCount = 0;
+    TestBatchSource.recordCount = 0;
+    TestBatchPushSource.closeCount = 0;
+    TestBatchPushSource.discoverCount = 0;
+    TestBatchPushSource.prepareCount = 0;
+    TestBatchPushSource.recordCount = 0;
     testBatchSource = new TestBatchSource();
     testBatchPushSource = new TestBatchPushSource();
     batchSourceExecutor = new BatchSourceExecutor<>();
@@ -225,9 +245,12 @@ public class BatchSourceExecutorTest {
     Mockito.doReturn(consumerBuilder).when(consumerBuilder).properties(Mockito.anyMap());
     Mockito.doReturn(consumerBuilder).when(consumerBuilder).topic(Mockito.any());
     discoveredTask = Mockito.mock(Message.class);
+    Mockito.doReturn(MessageId.latest).when(discoveredTask).getMessageId();
     consumer = Mockito.mock(org.apache.pulsar.client.api.Consumer.class);
     Mockito.doReturn(discoveredTask).when(consumer).receive();
+    Mockito.doReturn(discoveredTask).when(consumer).receive(Mockito.anyInt(), Mockito.any());
     Mockito.doReturn(CompletableFuture.completedFuture(consumer)).when(consumerBuilder).subscribeAsync();
+    Mockito.doReturn(CompletableFuture.completedFuture(null)).when(consumer).acknowledgeAsync(Mockito.any(MessageId.class));
     Mockito.doReturn(consumerBuilder).when(context).newConsumerBuilder(Schema.BYTES);
     messageBuilder = Mockito.mock(TypedMessageBuilder.class);
     Mockito.doReturn(messageBuilder).when(messageBuilder).value(Mockito.any());
@@ -235,16 +258,13 @@ public class BatchSourceExecutorTest {
     Mockito.doReturn(messageBuilder).when(context).newOutputMessage(Mockito.anyString(), Mockito.any());
 
     // Discovery
-    discoveryBarrier = new CyclicBarrier(2);
-    Mockito.doAnswer(new Answer<MessageId>() {
-      @Override public MessageId answer(InvocationOnMock invocation) {
-        try {
-          discoveryBarrier.await();
-        } catch (Exception e) {
-          throw new RuntimeException();
-        }
-        return null;
+    Mockito.doAnswer((Answer<MessageId>) invocation -> {
+      try {
+        completedQueue.put("done");
+      } catch (Exception e) {
+        throw new RuntimeException();
       }
+      return null;
     }).when(messageBuilder).send();
   }
 
@@ -333,43 +353,53 @@ public class BatchSourceExecutorTest {
     batchSourceExecutor.open(pushConfig, context);
   }
 
-  @Test
+  @Test (timeOut = 5000)
   public void testLifeCycle() throws Exception {
     batchSourceExecutor.open(config, context);
-    Assert.assertTrue(testBatchSource.getDiscoverCount() < 1);
-    discoveryBarrier.await();
-    Assert.assertTrue(testBatchSource.getDiscoverCount() >= 1);
-    Assert.assertTrue(testBatchSource.getDiscoverCount() <= 2);
+    Assert.assertEquals(testBatchSource.getDiscoverCount(), 0);
+    triggerQueue.put("trigger");
+    completedQueue.take();
+    Assert.assertEquals(testBatchSource.getDiscoverCount(), 1);
     for (int i = 0; i < 5; ++i) {
       batchSourceExecutor.read();
     }
     Assert.assertEquals(testBatchSource.getRecordCount(), 6);
-    Assert.assertTrue(testBatchSource.getDiscoverCount() >= 1);
-    Assert.assertTrue(testBatchSource.getDiscoverCount() <= 2);
-    discoveryBarrier.await();
-    Assert.assertTrue(testBatchSource.getDiscoverCount() >= 2);
-    Assert.assertTrue(testBatchSource.getDiscoverCount() <= 3);
+    Assert.assertEquals(testBatchSource.getDiscoverCount(), 1);
+    triggerQueue.put("trigger");
+    completedQueue.take();
+    Assert.assertTrue(testBatchSource.getDiscoverCount() == 2);
     batchSourceExecutor.close();
     Assert.assertEquals(testBatchSource.getCloseCount(), 1);
   }
 
-  @Test
+  @Test (timeOut = 5000)
   public void testPushLifeCycle() throws Exception {
     batchSourceExecutor.open(pushConfig, context);
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() < 1);
-    discoveryBarrier.await();
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() >= 1);
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() <= 2);
+    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 0);
+    triggerQueue.put("trigger");
+    completedQueue.take();
+    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 1);
     for (int i = 0; i < 5; ++i) {
       batchSourceExecutor.read();
     }
     Assert.assertEquals(testBatchPushSource.getRecordCount(), 5);
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() >= 1);
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() <= 2);
-    discoveryBarrier.await();
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() >= 2);
-    Assert.assertTrue(testBatchPushSource.getDiscoverCount() <= 3);
+    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 1);
+    triggerQueue.put("trigger");
+    completedQueue.take();
+    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 2);
     batchSourceExecutor.close();
     Assert.assertEquals(testBatchPushSource.getCloseCount(), 1);
+  }
+
+
+  @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = "test", timeOut = 1000)
+  public void testDiscoveryPhaseError() throws Exception {
+    config = createConfig(TestBatchSourceFailDiscovery.class.getName(), testBatchConfig);
+    batchSourceExecutor.open(config, context);
+    triggerQueue.put("trigger");
+    while (true) {
+      batchSourceExecutor.read();
+      Thread.sleep(100);
+    }
   }
 }


### PR DESCRIPTION

### Motivation

Currently, the discovery phase has to finish before tasks can start to process.  The discovery does not need to finish before tasks can start to be processed.  

Task message are also acknowledge synchronously which is not necessary 

### Modifications

Make discovery phase run asynchronously. 

Change to async ack for task message  

