### PR TITLE
Add cherry-pick bot for the pulsar

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -46,6 +46,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master
 
+      # Just use a github user who has permission to create a branch on the apache/pulsar repo.
+      # We can consider creating a bot user to do this.
       - name: Cherry-pick prompt
         if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
         uses: apache/pulsar-test-infra/cherry-pick@master

--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -41,6 +41,28 @@ jobs:
 
       - name: Execute pulsarbot command
         id:   pulsarbot
+        if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/pulsarbot')
         env:
           GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master
+
+      - name: Cherry-pick prompt
+        if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+        uses: apache/pulsar-test-infra/cherry-pick@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
+        with:
+          type: prompt-comment
+          github_user: codelipenghui
+          github_email: 'penghui@apache.org'
+          github_repos: 'apache/pulsar'
+
+      - name: Cherry-pick
+        if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/pulsarbot cherry-pick')
+        uses: apache/pulsar-test-infra/cherry-pick@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
+        with:
+          github_user: codelipenghui
+          github_email: 'penghui@apache.org'
+          github_repos: 'apache/pulsar'


### PR DESCRIPTION
**Motivation**

We want to make the pulsar can cherry-pick automatically. This action will make a closed PR can cherry-pick by the command /pulsarbot cherry-pick to branch-X.Y.

When a PR is merged, the bot will say,

Hey. If you want to cherry-pick this pr to a target branch, please comments '/pulsarbot cherry-pick to branch-X.Y'.
Then you can comment /pulsarbot cherry-pick to branch-X.Y, the bot will open a new PR for cherry-picking the closed PR.

If we open a new PR to do the cherry-pick, we can also use the CI to check the branch.