### PR TITLE
Update Guava to version 30.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -336,7 +336,7 @@ The Apache Software License, Version 2.0
     - com.google.guava-guava-30.0-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
- * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.1.jar
+ * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.4.jar
  * Swagger
     - io.swagger-swagger-annotations-1.5.21.jar
@@ -448,7 +448,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.33.v20201020.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
- * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.1.3.jar
+ * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.3.4.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.12.0.jar
  * OkHttp
     - com.squareup.okhttp-okhttp-2.5.0.jar
@@ -529,10 +529,10 @@ MIT License
     - org.slf4j-slf4j-api-1.7.25.jar
     - org.slf4j-jcl-over-slf4j-1.7.25.jar
  * Animal Sniffer Annotations
-    - org.codehaus.mojo-animal-sniffer-annotations-1.14.jar
+    - org.codehaus.mojo-animal-sniffer-annotations-1.17.jar
  * The Checker Framework
  	- org.checkerframework-checker-compat-qual-2.5.2.jar
-    - org.checkerframework-checker-qual-2.0.0.jar
+    - org.checkerframework-checker-qual-3.5.0.jar
 
 Protocol Buffers License
  * Protocol Buffers

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -333,7 +333,7 @@ The Apache Software License, Version 2.0
     - io.sundr-sundr-codegen-0.21.0.jar
     - io.sundr-sundr-core-0.21.0.jar
  * Guava
-    - com.google.guava-guava-25.1-jre.jar
+    - com.google.guava-guava-30.0-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.3.0</hbase.version>
-    <guava.version>25.1-jre</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.14.0</prometheus-jmx.version>
     <confluent.version>5.3.2</confluent.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -221,7 +221,7 @@ The Apache Software License, Version 2.0
     - jackson-module-jaxb-annotations-2.11.1.jar
     - jackson-module-jsonSchema-2.11.1.jar
  * Guava
-    - guava-25.1-jre.jar
+    - guava-30.0-jre.jar
  * Google Guice
     - guice-4.2.3.jar
     - guice-multibindings-4.2.0.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -222,6 +222,8 @@ The Apache Software License, Version 2.0
     - jackson-module-jsonSchema-2.11.1.jar
  * Guava
     - guava-30.0-jre.jar
+    - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
+    - failureaccess-1.0.1.jar
  * Google Guice
     - guice-4.2.3.jar
     - guice-multibindings-4.2.0.jar
@@ -304,7 +306,7 @@ The Apache Software License, Version 2.0
     - httpclient-4.5.5.jar
     - httpcore-4.4.9.jar
   * Error Prone Annotations
-    - error_prone_annotations-2.1.3.jar
+    - error_prone_annotations-2.3.4.jar
   * Esri Geometry API For Java
     - esri-geometry-api-2.2.2.jar
   * Failsafe
@@ -312,7 +314,7 @@ The Apache Software License, Version 2.0
   * Fastutil
     - fastutil-8.3.0.jar
   * J2ObjC Annotations
-    - j2objc-annotations-1.1.jar
+    - j2objc-annotations-1.3.jar
   * JSON Web Token Support For The JVM
     - jjwt-0.9.0.jar
   * Jmxutils
@@ -482,8 +484,6 @@ BSD License
    - jline-terminal-jna-3.12.1.jar
 
 MIT License
- * Animal Sniffer Annotations
-   - animal-sniffer-annotations-1.14.jar
  * PCollections
    - pcollections-2.1.2.jar
  * SLF4J
@@ -496,7 +496,7 @@ MIT License
  * JUL to SLF4J Bridge
    - jul-to-slf4j-1.7.25.jar
  * Checker Qual
-   - checker-qual-2.0.0.jar
+   - checker-qual-3.5.0.jar
 
 CDDL - 1.0
  * OSGi Resource Locator

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -49,7 +49,7 @@
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
         <jackson.databind.version>2.11.1</jackson.databind.version>
         <maven.version>3.0.5</maven.version>
-        <guava.version>25.1-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <asynchttpclient.version>2.12.1</asynchttpclient.version>
     </properties>
 


### PR DESCRIPTION
### Motivation

Guava with version lower than 30.0 has vulnerability.
https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415

### Modifications

- Guava 25.1 -> 30.0