### PR TITLE
Consumer filtering

### DIFF
--- a/README_CONSUMER_FILTERS
+++ b/README_CONSUMER_FILTERS
@@ -1,0 +1,85 @@
+Enable broker side filtering of messages based on message properties. Consumers can specify message properties 
+as tags to filter on using consumer subscription (meta data) properties. Message properties which have a key 
+beginning with the string "tag" are matched by value against these consumer subscription properties with keys 
+starting with strings "anytag" or "alltag". The matching is by string equality of property values.
+
+An "anytag" matches successfully if any of the messages "tag" properities has the same property value 
+as the consumer property value. This allows "or" matching.
+
+e.g. Say a consumer subscribes with an "anyTag" property with "anyTag1" of "urgent" and another 
+with key "anyTag2" and value "compressed". Then a message with property "tag0" as key and "urgent" 
+as value will match as would a message with "tagA" / "compressed".
+
+To subscribe the consumer:
+
+Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                    .topic("sometopic")
+                    .property("anytag0", "urgent") // A filtering meta tag.
+                    .property("anytag1", "compressed") // Another filtering meta tag.
+                    .subscribe();
+                    
+To send a message with a tag that matches:
+
+Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                    .topic(topic)
+                    .create();
+
+producer.newMessage()
+                   .property("tag0", "urgent") // tag with a matching property value.
+                   .value("my-matching-message")
+                   .sendAsync();
+
+An "allTag" will only match if all other allTags in the consumer subscription meta data properties
+also can be match. This allows "and" matching of multiple values.
+
+e.g. Say a consumer subscribes with an "allTag" property with "allTag1" of "urgent" and another 
+with key "allTag2" and value "compressed". Then a message with property "tag0" as key and "urgent" 
+and property "tag1" of "compressed" as value will match while a message with "tag0" of "urgent" 
+and "tag1" of "uncompressed" property values will not.
+
+
+Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                    .topic("sometopic")
+                    .property("alltag0", "urgent") // A filtering meta tag.
+                    .property("alltag1", "compressed") // Additional filtering meta tag.
+                    .subscribe();
+
+will match on the following message:
+
+producer.newMessage()
+                   .property("tag0", "urgent") // A tag property value.
+                   .property("tag1", "compressed") // A second tag property value.
+                   .value("my-matching-message")
+                   .sendAsync();
+
+But the following will not match:
+
+producer.newMessage()
+                   .property("tag0", "urgent") // A tag property value.
+                   .property("tag1", "uncompressed") // A second tag property value.
+                   .value("my-not-matching-message")
+                   .sendAsync();
+
+producer.newMessage()
+                   .property("tag0", "urgent") // A tag property value.
+                   .value("my-other-not-matching-message")
+                   .sendAsync();
+                    
+If the consumer subscribes with both anyTags and allTags then at least one anyTag and all of the 
+allTags must match tags in the message (with overlap allowed) for the message to be passed by the 
+filter.
+
+The default implementation matches only on properties that have keys beginning with "tag" to help 
+avoid unintended matching. A new Java ConsumerFilter interface and factory allows other property 
+based filtering schemes to be implented and deployed.
+
+Appart from message tag properties starting with (lowercase) "tag" and consumer tag subscription 
+meta data properties starting with "anyTag" and "allTag" there are no other requirements or 
+conventions on tag naming and usage. For example, tags could use more meaningful keys such as 
+"tag_priority" and namespace tag values such as values "prority_urgent" and "priority_low". 
+
+Another possibliity is to use values such as "priority=ugent" and match by text on such 
+categories or classes (with keys just enumerating "tag0","tag1" etc as in examples above). 
+These suggestions are a convention only and not checked or enforced in any way. In the 
+examples above we have used "0" and "1" but other unique strings (such as "A","B" ..) 
+could have been used.

--- a/README_CONSUMER_FILTERS
+++ b/README_CONSUMER_FILTERS
@@ -1,21 +1,25 @@
-Enable broker side filtering of messages based on message properties. Consumers can specify message properties 
-as tags to filter on using consumer subscription (meta data) properties. Message properties which have a key 
-beginning with the string "tag" are matched by value against these consumer subscription properties with keys 
-starting with strings "anytag" or "alltag". The matching is by string equality of property values.
+Tag based Consumer Filtering
+----------------------------
 
-An "anytag" matches successfully if any of the messages "tag" properities has the same property value 
-as the consumer property value. This allows "or" matching.
+Enables broker side "tag" based filtering of messages on selected message properties by allowing consumers to 
+specify a subset of message properties as being “tags” to filter on, using existing consumer (meta data) 
+property API (and underlying protocol). Message properties which have a key beginning with the string "tag" 
+are matched by value against the consumer subscription properties that are specified on subscription with 
+meta data string keys starting with either "anytag" or "alltag". What follows “tag”, “anytag”, “alltag” 
+textually is immaterial except to allow multiple key /  values to be enumerated (e.g. “tag1”, “tag2” etc).
 
-e.g. Say a consumer subscribes with an "anyTag" property with "anyTag1" of "urgent" and another 
-with key "anyTag2" and value "compressed". Then a message with property "tag0" as key and "urgent" 
-as value will match as would a message with "tagA" / "compressed".
+An "anytag" matches successfully if any of the messages "tag" properties has the same property value as the 
+consumer property value. This allows "or" matching.
+e.g. Say a consumer subscribes with an "anytag" property with "anytag1" of "urgent" and another with key 
+"anytag2" and value "compressed". Then a message with property "tag0" as key and "urgent" as value will match 
+as would a message with "tagA" / "compressed".
 
 To subscribe the consumer:
 
 Consumer<String> consumer = client.newConsumer(Schema.STRING)
-                    .topic("sometopic")
-                    .property("anytag0", "urgent") // A filtering meta tag.
-                    .property("anytag1", "compressed") // Another filtering meta tag.
+                     .topic("sometopic")
+                    .property("anytag0", "urgent") // A filtering meta data tag.
+                    .property("anytag1", "compressed") // Another filtering meta data tag.
                     .subscribe();
                     
 To send a message with a tag that matches:
@@ -23,27 +27,24 @@ To send a message with a tag that matches:
 Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                     .topic(topic)
                     .create();
-
 producer.newMessage()
                    .property("tag0", "urgent") // tag with a matching property value.
                    .value("my-matching-message")
                    .sendAsync();
-
-An "allTag" will only match if all other allTags in the consumer subscription meta data properties
-also can be match. This allows "and" matching of multiple values.
-
-e.g. Say a consumer subscribes with an "allTag" property with "allTag1" of "urgent" and another 
-with key "allTag2" and value "compressed". Then a message with property "tag0" as key and "urgent" 
-and property "tag1" of "compressed" as value will match while a message with "tag0" of "urgent" 
-and "tag1" of "uncompressed" property values will not.
-
+                   
+An "alltag" will only match if all other alltags in the consumer subscription meta data properties also 
+can be matched. This allows "and" matching of multiple values.
+e.g. Say a consumer subscribes with an "alltag" property with "alltag1" of "urgent" and another with key 
+"alltag2" and value "compressed". Then a message with property "tag0" as key and "urgent" and property 
+"tag1" of "compressed" as value will match while a message with "tag0" of "urgent" and "tag1" of 
+"uncompressed" property values will not.
 
 Consumer<String> consumer = client.newConsumer(Schema.STRING)
                     .topic("sometopic")
                     .property("alltag0", "urgent") // A filtering meta tag.
                     .property("alltag1", "compressed") // Additional filtering meta tag.
                     .subscribe();
-
+                    
 will match on the following message:
 
 producer.newMessage()
@@ -51,7 +52,7 @@ producer.newMessage()
                    .property("tag1", "compressed") // A second tag property value.
                    .value("my-matching-message")
                    .sendAsync();
-
+                   
 But the following will not match:
 
 producer.newMessage()
@@ -59,27 +60,22 @@ producer.newMessage()
                    .property("tag1", "uncompressed") // A second tag property value.
                    .value("my-not-matching-message")
                    .sendAsync();
-
+                   
 producer.newMessage()
                    .property("tag0", "urgent") // A tag property value.
                    .value("my-other-not-matching-message")
-                   .sendAsync();
-                    
-If the consumer subscribes with both anyTags and allTags then at least one anyTag and all of the 
-allTags must match tags in the message (with overlap allowed) for the message to be passed by the 
-filter.
-
-The default implementation matches only on properties that have keys beginning with "tag" to help 
-avoid unintended matching. A new Java ConsumerFilter interface and factory allows other property 
-based filtering schemes to be implented and deployed.
-
-Appart from message tag properties starting with (lowercase) "tag" and consumer tag subscription 
-meta data properties starting with "anyTag" and "allTag" there are no other requirements or 
-conventions on tag naming and usage. For example, tags could use more meaningful keys such as 
-"tag_priority" and namespace tag values such as values "prority_urgent" and "priority_low". 
-
-Another possibliity is to use values such as "priority=ugent" and match by text on such 
-categories or classes (with keys just enumerating "tag0","tag1" etc as in examples above). 
-These suggestions are a convention only and not checked or enforced in any way. In the 
-examples above we have used "0" and "1" but other unique strings (such as "A","B" ..) 
-could have been used.
+                   .sendAsync();   
+                   
+If the consumer subscribes with both anytags and alltags then at least one anytag and all of the alltags 
+must match tags in the message (with overlap allowed) for the message to be passed by the filter.
+The default implementation matches only on properties that have keys beginning with "tag" to help avoid 
+unintended matching. A new Java ConsumerFilter interface and factory allows other property-based filtering 
+schemes to be implemented and deployed.
+Apart from message tag properties starting with (lowercase) "tag" and consumer tag subscription meta data 
+properties starting with "anytag" and "alltag" there are no other requirements or conventions on tag naming 
+and usage. For example, tags could use more meaningful keys such as "tag_priority" and namespace tag values 
+such as values "prority_urgent" and "priority_low". 
+Another possibility is to use values such as "priority=urgent" and match by text on such categories or classes 
+(with keys just enumerating "tag0","tag1" etc as in examples above). 
+These suggestions are a convention only and not checked or enforced in any way. In the examples above we have 
+used "0" and "1" but other unique strings (such as "A","B" etc) could have been used.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -675,6 +675,18 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int numWorkerThreadsForNonPersistentTopic = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Enable broker to filter messages for consumer subscriptions"
+    )
+    private boolean enableConsumerFilters = true;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Consumer filter implementation"
+    )
+    private String consumerFilterClass = "";
+
+    @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Enable broker to load persistent topics"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -92,6 +92,8 @@ public class Consumer {
     private long lastAckedTimestamp;
     private Rate chuckedMessageRate;
 
+    private final ConsumerFilter consumerFilter;
+
     // Represents how many messages we can safely send to the consumer without
     // overflowing its receiving queue. The consumer will use Flow commands to
     // increase its availability
@@ -179,6 +181,8 @@ public class Consumer {
             // We don't need to keep track of pending acks if the subscription is not shared
             this.pendingAcks = null;
         }
+
+        consumerFilter = ConsumerFilterFactory.createConsumerFilter(this.cnx.getBrokerService().getPulsar().getConfiguration());
     }
 
     public SubType subType() {
@@ -201,11 +205,11 @@ public class Consumer {
 
         if (log.isDebugEnabled()) {
             log.debug("notify consumer {} - that [{}] for subscription {} has new active consumer : {}",
-                consumerId, topicName, subscription.getName(), activeConsumer);
+                    consumerId, topicName, subscription.getName(), activeConsumer);
         }
         cnx.ctx().writeAndFlush(
-            Commands.newActiveConsumerChange(consumerId, this == activeConsumer),
-            cnx.ctx().voidPromise());
+                Commands.newActiveConsumerChange(consumerId, this == activeConsumer),
+                cnx.ctx().voidPromise());
     }
 
     public boolean readCompacted() {
@@ -218,10 +222,10 @@ public class Consumer {
      *
      * @return a SendMessageInfo object that contains the detail of what was sent to consumer
      */
-
     public ChannelPromise sendMessages(final List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
                int totalMessages, long totalBytes, long totalChunkedMessages, RedeliveryTracker redeliveryTracker) {
         this.lastConsumedTimestamp = System.currentTimeMillis();
+
         final ChannelHandlerContext ctx = cnx.ctx();
         final ChannelPromise writePromise = ctx.newPromise();
 
@@ -248,6 +252,7 @@ public class Consumer {
                     int batchSize = batchSizes.getBatchSize(i);
                     pendingAcks.put(entry.getLedgerId(), entry.getEntryId(), batchSize, 0);
                 }
+
             }
         }
 
@@ -287,10 +292,10 @@ public class Consumer {
 
                 MessageIdData.Builder messageIdBuilder = MessageIdData.newBuilder();
                 MessageIdData messageId = messageIdBuilder
-                    .setLedgerId(entry.getLedgerId())
-                    .setEntryId(entry.getEntryId())
-                    .setPartition(partitionIdx)
-                    .build();
+                        .setLedgerId(entry.getLedgerId())
+                        .setEntryId(entry.getEntryId())
+                        .setPartition(partitionIdx)
+                        .build();
 
                 ByteBuf metadataAndPayload = entry.getDataBuffer();
                 // increment ref-count of data and release at the end of process: so, we can get chance to call entry.release
@@ -390,6 +395,7 @@ public class Consumer {
     CompletableFuture<Void> messageAcked(CommandAck ack) {
         this.lastAckedTimestamp = System.currentTimeMillis();
         Map<String,Long> properties = Collections.emptyMap();
+
         if (ack.getPropertiesCount() > 0) {
             properties = ack.getPropertiesList().stream()
                 .collect(Collectors.toMap(PulsarApi.KeyLongValue::getKey,
@@ -489,8 +495,7 @@ public class Consumer {
      * Triggers dispatcher to dispatch {@code blockedPermits} number of messages and adds same number of permits to
      * {@code messagePermits} as it maintains count of actual dispatched message-permits.
      *
-     * @param consumer:
-     *            Consumer whose blockedPermits needs to be dispatched
+     * @param consumer: Consumer whose blockedPermits needs to be dispatched
      */
     void flowConsumerBlockedPermits(Consumer consumer) {
         int additionalNumberOfPermits = PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.getAndSet(consumer, 0);
@@ -608,9 +613,8 @@ public class Consumer {
     /**
      * first try to remove ack-position from the current_consumer's pendingAcks.
      * if ack-message doesn't present into current_consumer's pendingAcks
-     *  a. try to remove from other connected subscribed consumers (It happens when client
+     * a. try to remove from other connected subscribed consumers (It happens when client
      * tries to acknowledge message through different consumer under the same subscription)
-     *
      *
      * @param position
      */
@@ -723,6 +727,18 @@ public class Consumer {
 
     public Subscription getSubscription() {
         return subscription;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void initFiltering() {
+        consumerFilter.initFiltering(this.getMetadata());
+    }
+
+    public ConsumerFilter getConsumerFilter() {
+        return consumerFilter;
     }
 
     private int addAndGetUnAckedMsgs(Consumer consumer, int ackedMessages) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerFilter.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import java.util.Map;
+import java.util.List;
+
+/**
+ * ConsumerFilter - broker side filtering on consumer subscriptions.
+ */
+public interface ConsumerFilter {
+
+    /**
+     * Initialize consumer filtering.
+     * @param metadata the consumer metadata.
+     */
+    void initFiltering(Map<String, String> metadata);
+
+    /**
+     * Check is filtering.
+     * @return true if filtering otherwise false.
+     */
+    boolean isFiltering();
+
+    /**
+     * Filter based on the given list of key value pairs.
+     * @param properties the key value properties to filter by.
+     * @param payload the message data buffer.
+     * @return true if the filter matches otherwise false.
+     */
+    default boolean filter(List<PulsarApi.KeyValue> properties, ByteBuf payload) {
+        return true;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerFilterFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerFilterFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.broker.ServiceConfiguration;
+
+/**
+ * Factory for consumer filters.
+ */
+public class ConsumerFilterFactory {
+
+    /**
+     * Create a filter for a consumer.
+     * @param serviceConfiguration the service configuration which configures filtering.
+     * @return a consumer filter as configured in the service configuration.
+     */
+    public static ConsumerFilter createConsumerFilter(ServiceConfiguration serviceConfiguration) throws BrokerServiceException {
+        if (!serviceConfiguration.isEnableConsumerFilters()) {
+            return new ConsumerNullFilter();
+        }
+        String consumerFilterClass = serviceConfiguration.getConsumerFilterClass();
+        if (consumerFilterClass != null && !consumerFilterClass.isEmpty()) {
+            try {
+                ConsumerFilter consumerFilter = (ConsumerFilter) Class.forName(consumerFilterClass).newInstance();
+            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                throw new BrokerServiceException("Could not create consumer filter", e);
+            }
+        }
+        return new ConsumerTagFilter();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNullFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNullFilter.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.Map;
+
+/**
+ * Non filtering consumer filter.
+ */
+public class ConsumerNullFilter implements ConsumerFilter {
+
+    public ConsumerNullFilter() {
+    }
+
+    public void initFiltering(Map<String, String> metadata) {
+        // NOOP
+    }
+
+    /**
+     * Not filtering.
+     * @return false
+     */
+    public boolean isFiltering() {
+        return false;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerTagFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerTagFilter.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TagConsumerFilter - consumer filtering based on tags. Tags are consumer properties with a key
+ *  starting with "anytag" or "alltag" and the property as value to match for.
+ *  (e.g. "anTag" or "allTag" or "anyTag0", "anyTag1" etc or "allTag0", "allTag1", "allTag2" etc.)
+ *  Messages are to be checked for properties with keys starting with "tag" as prefix
+ *  (e.g. "tag" or "tag0", "tag1", etc.)
+ *  A message is only to be passed if at least one "anyTag" is matched by value against
+ *  these message properties (if there are anyTags specified) and all the "allTags" are matched
+ *  (if there are some allTags specified).
+ */
+public class ConsumerTagFilter implements ConsumerFilter {
+
+    private ArrayList<String> anyTags = null;
+    private ArrayList<String> allTags = null;
+
+    private boolean initFilter = false;
+
+    public ConsumerTagFilter() {
+    }
+
+    /**
+     * Inititialize for filtering by collecting filtering tags from the properties.
+     * Involves breaking out all consumer properties that are tags into separate lists.
+     * If both lists are null then there are no consumer tags to filter messages by.
+     *
+     * @param metadata the consumer metadata properties.
+     */
+    public synchronized void initFiltering(Map<String, String> metadata) {
+        if (initFilter)
+            return;
+
+        ArrayList<String> anyTags = null;
+        ArrayList<String> allTags = null;
+
+        for (Map.Entry<String, String> kv : metadata.entrySet()) {
+            if (kv.getKey().startsWith("anytag")) {
+                if (anyTags == null)
+                    anyTags = new ArrayList<>();
+                if (!anyTags.contains(kv.getValue()))
+                    anyTags.add(kv.getValue());
+            }
+            if (kv.getKey().startsWith("alltag")) {
+                if (allTags == null)
+                    allTags = new ArrayList<>();
+                if (!allTags.contains(kv.getValue()))
+                    allTags.add(kv.getValue());
+            }
+        }
+        if (allTags != null) {
+            this.allTags = allTags;
+        }
+        if (anyTags != null) {
+            this.anyTags = anyTags;
+        }
+        initFilter = true;
+    }
+
+    /**
+     * Check if filtering.
+     * @return true if there are tags to filter by; otherwise false.
+     */
+    public boolean isFiltering() {
+        return anyTags != null || allTags != null;
+    }
+
+    /**
+     * Filter by given list of message properties.
+     * @param properties the message properties to filter by.
+     * @param payload the message data buffer.
+     * @return true if the message properties contain proterties with "tag" as key prefix
+     * and values matching at least one of the filter's anyTag (if any) and all of the allTags.
+     */
+    @Override
+    public boolean filter(List<PulsarApi.KeyValue> properties, ByteBuf payload) {
+
+        if (false && payload != null) {
+            byte[] data = new byte[payload.readableBytes()];
+            int readIdx = payload.readerIndex();
+            payload.readBytes(data);
+            payload.readerIndex(readIdx);
+            String msg = new String(data);
+            System.out.println("ConsumerFiler message: " + msg);
+        }
+
+        boolean anyMatch = false;
+        HashSet<String> allMatch = null;
+        for (PulsarApi.KeyValue kv : properties) {
+            // System.out.println("msg prop key=" + kv.getKey() + " value=" + kv.getValue());
+            if (kv.getKey().startsWith("tag")) {
+                if (anyTags != null && anyTags.contains(kv.getValue())) {
+                    // System.out.println("anymatch");
+                    anyMatch = true;
+                    if (allTags == null)
+                        break;
+                }
+                if (allTags != null && allTags.contains(kv.getValue())) {
+                    if (allMatch == null)
+                        allMatch = new HashSet<String>();
+                    allMatch.add(kv.getValue());
+                }
+            }
+        }
+        // Match if we have at least one anyTag (if any anyTags) and all the allTags required.
+        return (anyTags == null || anyMatch) &&
+                ((allMatch == null ? 0 : allMatch.size()) == (allTags == null ? 0 : allTags.size()));
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -193,7 +193,7 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
         if (consumer != null) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
-            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo, null, null, false);
+            filterEntriesForConsumer(consumer, entries, batchSizes, sendMessageInfo, null, null, false);
             consumer.sendMessages(entries, batchSizes, null, sendMessageInfo.getTotalMessages(),
                     sendMessageInfo.getTotalBytes(), sendMessageInfo.getTotalChunkedMessages(), getRedeliveryTracker());
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -66,7 +66,7 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
         if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0 && currentConsumer.isWritable()) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
-            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo, null, null, false);
+            filterEntriesForConsumer(currentConsumer, entries, batchSizes, sendMessageInfo, null, null, false);
             currentConsumer.sendMessages(entries, batchSizes, null, sendMessageInfo.getTotalMessages(),
                     sendMessageInfo.getTotalBytes(), sendMessageInfo.getTotalChunkedMessages(), getRedeliveryTracker());
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
@@ -99,7 +99,7 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
 
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entriesForConsumer.size());
-            filterEntriesForConsumer(entriesForConsumer, batchSizes, sendMessageInfo, null, null, false);
+            filterEntriesForConsumer(consumer, entriesForConsumer, batchSizes, sendMessageInfo, null, null, false);
             consumer.sendMessages(entriesForConsumer, batchSizes, null, sendMessageInfo.getTotalMessages(),
                     sendMessageInfo.getTotalBytes(), sendMessageInfo.getTotalChunkedMessages(), getRedeliveryTracker());
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -sendMessageInfo.getTotalMessages());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -514,7 +514,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
                 EntryBatchSizes batchSizes = EntryBatchSizes.get(entriesForThisConsumer.size());
                 EntryBatchIndexesAcks batchIndexesAcks = EntryBatchIndexesAcks.get(entriesForThisConsumer.size());
-                filterEntriesForConsumer(entriesForThisConsumer, batchSizes, sendMessageInfo, batchIndexesAcks, cursor,
+                filterEntriesForConsumer(c, entriesForThisConsumer, batchSizes, sendMessageInfo, batchIndexesAcks, cursor,
                         readType == ReadType.Replay);
 
                 c.sendMessages(entriesForThisConsumer, batchSizes, batchIndexesAcks, sendMessageInfo.getTotalMessages(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -245,7 +245,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchIndexesAcks batchIndexesAcks = EntryBatchIndexesAcks.get(entries.size());
-            filterEntriesForConsumer(entries, batchSizes, sendMessageInfo, batchIndexesAcks, cursor, isReplayRead);
+            filterEntriesForConsumer(currentConsumer, entries, batchSizes, sendMessageInfo, batchIndexesAcks, cursor, isReplayRead);
 
             int totalMessages = sendMessageInfo.getTotalMessages();
             long totalBytes = sendMessageInfo.getTotalBytes();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -200,9 +200,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 }
 
                 SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+
                 EntryBatchSizes batchSizes = EntryBatchSizes.get(messagesForC);
+
                 EntryBatchIndexesAcks batchIndexesAcks = EntryBatchIndexesAcks.get(messagesForC);
-                filterEntriesForConsumer(entriesWithSameKey, batchSizes, sendMessageInfo, batchIndexesAcks, cursor,
+                filterEntriesForConsumer(consumer, entriesWithSameKey, batchSizes, sendMessageInfo, batchIndexesAcks, cursor,
                         readType == ReadType.Replay);
 
                 consumer.sendMessages(entriesWithSameKey, batchSizes, batchIndexesAcks, sendMessageInfo.getTotalMessages(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerFilterTest.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.buffer.ByteBuf;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Consumer tag filtering tests.
+ */
+@Test
+public class ConsumerFilterTest {
+
+    private ByteBuf nullByteBuf = null;
+
+    @Test(timeOut = 30000)
+    public void testNullFilter() throws Exception {
+        ConsumerFilter consumerFilter = new ConsumerNullFilter();
+        List<PulsarApi.KeyValue> messageProperties = new ArrayList<>();
+
+        // Anything should match with no filter.
+        boolean match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+    }
+
+    @Test(timeOut = 30000)
+    public void testAnyTag() throws Exception {
+        ConsumerFilter consumerFilter = new ConsumerTagFilter();
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("anytag0", "abc");
+        consumerFilter.initFiltering(metadata);
+
+        List<PulsarApi.KeyValue> messageProperties = new ArrayList<>();
+
+        // No tags should not match.
+        boolean match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        // Wrong tag should not match.
+        PulsarApi.KeyValue prop1 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag0")
+                .setValue("123")
+                .build();
+        messageProperties.add(prop1);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        messageProperties.clear();
+
+        // This tag should match.
+        PulsarApi.KeyValue prop2 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag1")
+                .setValue("abc")
+                .build();
+        messageProperties.add(prop2);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+
+        messageProperties.clear();
+
+        // One of 3 tag should match.
+        PulsarApi.KeyValue prop3 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag2")
+                .setValue("123")
+                .build();
+
+        messageProperties.add(prop3);
+        messageProperties.add(prop2);
+        messageProperties.add(prop1);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+    }
+
+    @Test(timeOut = 30000)
+    public void testAllTag() throws Exception {
+        ConsumerFilter consumerFilter = new ConsumerTagFilter();
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("alltag0", "abc");
+        consumerFilter.initFiltering(metadata);
+
+        List<PulsarApi.KeyValue> messageProperties = new ArrayList<>();
+
+        // No tags should not match.
+        boolean match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        // Wrong tag should not match.
+        PulsarApi.KeyValue prop1 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag0")
+                .setValue("123")
+                .build();
+        messageProperties.add(prop1);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        messageProperties.clear();
+
+        // This tag should match.
+        PulsarApi.KeyValue prop2 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag0")
+                .setValue("abc")
+                .build();
+        messageProperties.add(prop2);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+    }
+
+    @Test(timeOut = 30000)
+    public void testAllTags() throws Exception {
+        ConsumerFilter consumerFilter = new ConsumerTagFilter();
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("alltag0", "abc");
+        metadata.put("alltag1", "xyz");
+        consumerFilter.initFiltering(metadata);
+
+        List<PulsarApi.KeyValue> messageProperties = new ArrayList<>();
+
+        // One tag should not match.
+        PulsarApi.KeyValue prop1 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag0")
+                .setValue("abc")
+                .build();
+        messageProperties.add(prop1);
+
+        boolean match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        // Two tags that should match.
+        PulsarApi.KeyValue prop2 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag1")
+                .setValue("xyz")
+                .build();
+        messageProperties.add(prop2);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+    }
+
+    @Test(timeOut = 30000)
+    public void testAnyAllTags() throws Exception {
+        ConsumerFilter consumerFilter = new ConsumerTagFilter();
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("anytag0", "123");
+        metadata.put("alltag0", "abc");
+        metadata.put("alltag1", "xyz");
+        consumerFilter.initFiltering(metadata);
+
+        List<PulsarApi.KeyValue> messageProperties = new ArrayList<>();
+
+        // One tag should not match.
+        PulsarApi.KeyValue prop1 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag0")
+                .setValue("123")
+                .build();
+        messageProperties.add(prop1);
+
+        boolean match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        // Two tags that should not match.
+        PulsarApi.KeyValue prop2 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag1")
+                .setValue("abc")
+                .build();
+        messageProperties.add(prop2);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertFalse(match);
+
+        // Three tags that should match.
+        PulsarApi.KeyValue prop3 = PulsarApi.KeyValue.newBuilder()
+                .setKey("tag1")
+                .setValue("xyz")
+                .build();
+        messageProperties.add(prop3);
+
+        match = consumerFilter.filter(messageProperties, nullByteBuf);
+        assertTrue(match);
+    }
+}
+

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -101,6 +101,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
         consumerMock = mock(Consumer.class);
         channelMock = mock(ChannelPromise.class);
         doReturn("consumer1").when(consumerMock).consumerName();
+        doReturn(new ConsumerNullFilter()).when(consumerMock).getConsumerFilter();
         doReturn(1000).when(consumerMock).getAvailablePermits();
         doReturn(true).when(consumerMock).isWritable();
         doReturn(channelMock).when(consumerMock).sendMessages(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerFilteringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerFilteringTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class ConsumerFilteringTest extends ProducerConsumerBase {
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setManagedLedgerCacheEvictionFrequency(0.1);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    private int messages = 100;
+
+    private static boolean once = false;
+    private static boolean once2 = false;
+
+    @Test
+    public void testConsumerFilterAnyRatioBatched() throws PulsarClientException {
+        if (once)
+            return;
+        once = true;
+        testConsumerFilterAnyRatio(true);
+    }
+
+    @Test
+    public void testConsumerFilterAnyRatioNoBatching() throws PulsarClientException {
+        if (once2)
+            return;
+        once2 = true;
+        testConsumerFilterAnyRatio(false);
+    }
+
+    private void testConsumerFilterAnyRatio(boolean batching) throws PulsarClientException {
+        testConsumerFilterAnyRatio(0, batching);
+        testConsumerFilterAnyRatio(1, batching);
+        testConsumerFilterAnyRatio(2, batching);
+        testConsumerFilterAnyRatio(10, batching);
+        testConsumerFilterAnyRatio(this.messages, batching);
+    }
+
+    private void  testConsumerFilterAnyRatio(int filterRatio, boolean batching) throws PulsarClientException {
+
+        if (!conf.isEnableConsumerFilters())
+            return;
+
+        String topic = "persistent://my-property/my-ns/consumer-filter";
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("s1")
+                .property("anytag", "abc")
+                .subscribe();
+
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .enableBatching(batching)
+                //.batchingMaxMessages(5)
+                //.batchingMaxPublishDelay(1, TimeUnit.SECONDS)
+                .create();
+
+        try {
+            for (int i = 0; i < this.messages; i++) {
+                String tag = filterRatio == 0 ? "xyz" : i % filterRatio == 0 ? "abc" : "xyz";
+                producer.newMessage()
+                        .property("tag", tag)
+                        .value("my-message-" + i + "-eom")
+                        .sendAsync();
+            }
+
+            int messageReceived = 0;
+
+            while (true) {
+                Message<String> message = consumer.receive(1, TimeUnit.SECONDS);
+                if (message == null)
+                    break;
+                assertEquals(message.getProperty("tag"), "abc");
+                assertTrue(message.getValue().startsWith("my-message-"));
+                assertTrue(message.getValue().endsWith("eom"));
+
+                messageReceived++;
+                consumer.acknowledge(message);
+
+                System.out.println("received " + messageReceived + " from " + this.messages);
+                assertEquals(messageReceived, filterRatio == 0 ? 0 : this.messages / filterRatio);
+            }
+        } finally {
+            producer.close();
+            consumer.close();
+        }
+    }
+}
+


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #3302 (a request for consumer filtering in the Pulsar broker)

### Motivation

At Software AG, we have prototyped property (key / value) based message filtering on consumer subscriptions in the Pulsar broker. This feature was also requested as Issue 3302 but the mitigation suggestion of using Pulsar Functions, which imply management and runtime overheads and an extra topic, or the alternative of publishing to multiple (sub)topics are not always adequate mitigations to lack of simple consumer subscription filtering.

In Pulsar, consumers receive all messages published on a topic, even if only interested in messages with certain properties. Always delivering all messages and having the consumer client application filter means all messages must be sent over the network, processed and acknowledged remotely. Other message brokers and messaging standards (such as Java's JMS message selectors) typically allow a filter to be specified on client subscription, allowing the message broker to filter on behalf of the client subscriber and deliver a subset of the messages over the wire.
In some cases, a separate topic can be used for each subscription filter, but if there are a very large number of possible filters then capacity as well as the management and processing overheads of topics (or any Pulsar Functions) are an issue. It therefore seems sensible to extend consumer subscriptions to perform an additional level of selection that is not directly driven by the publisher and does not require additional Functions and/or topics to be created for consumers.

Our proposal is to allow the publisher to "tag" messages with one or more additional message properties that can be used to selectively filter by. The consumer (on subscription) should be able to specify which tags to filter on, specified by special consumer “meta data” (using the meta data key value pairs in consumer properties).

The implementation is itself configurable, allowing both for no filtering and for alternative property-based schemes to be implemented and configured in Pulsar brokers, using a new configuration time "ConsumerFilter" dynamic factory mechanism. Our default "tag" based scheme, is explicit about which properties are used for filtering so as to more safely use existing message properties and consumer meta data. Two types of meta data tags are provided to allow both simple AND (all match) as well as OR (any match) filter expressions on message properties.

Our implemented design enables broker side "tag" based filtering of messages on selected message properties by allowing consumers to specify a subset of message properties as being “tags” to filter on, using existing consumer (meta data) property API (and underlying protocol). Message properties which have a key beginning with the string "tag" are matched by value against the consumer subscription properties that are specified on subscription with meta data string keys starting with either "anytag" or "alltag". What follows “tag”, “anytag”, “alltag” textually is immaterial except to allow multiple key /  values to be enumerated (e.g. “tag1”, “tag2” etc).

An "anytag" matches successfully if any of the messages "tag" properties has the same property value as the consumer property value. This allows "or" matching.

e.g. Say a consumer subscribes with an "anytag" property with "anytag1" of "urgent" and another with key "anytag2" and value "compressed". Then a message with property "tag0" as key and "urgent" as value will match as would a message with "tagA" / "compressed".

To subscribe the consumer:
Consumer<String> consumer = client.newConsumer(Schema.STRING)
                     .topic("sometopic")
                    .property("anytag0", "urgent") // A filtering meta data tag.
                    .property("anytag1", "compressed") // Another filtering meta data tag.
                    .subscribe();
To send a message with a tag that matches:
Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                    .topic(topic)
                    .create();
producer.newMessage()
                   .property("tag0", "urgent") // tag with a matching property value.
                   .value("my-matching-message")
                   .sendAsync();

An "alltag" will only match if all other alltags in the consumer subscription meta data properties also can be matched. This allows "and" matching of multiple values.
e.g. Say a consumer subscribes with an "alltag" property with "alltag1" of "urgent" and another with key "alltag2" and value "compressed". Then a message with property "tag0" as key and "urgent" and property "tag1" of "compressed" as value will match while a message with "tag0" of "urgent" and "tag1" of "uncompressed" property values will not.

Consumer<String> consumer = client.newConsumer(Schema.STRING)
                    .topic("sometopic")
                    .property("alltag0", "urgent") // A filtering meta tag.
                    .property("alltag1", "compressed") // Additional filtering meta tag.
                    .subscribe();
will match on the following message:
producer.newMessage()
                   .property("tag0", "urgent") // A tag property value.
                   .property("tag1", "compressed") // A second tag property value.
                   .value("my-matching-message")
                   .sendAsync();
But the following will not match:
producer.newMessage()
                   .property("tag0", "urgent") // A tag property value.
                   .property("tag1", "uncompressed") // A second tag property value.
                   .value("my-not-matching-message")
                   .sendAsync();
producer.newMessage()
                   .property("tag0", "urgent") // A tag property value.
                   .value("my-other-not-matching-message")
                   .sendAsync();   

If the consumer subscribes with both anytags and alltags then at least one anytag and all of the alltags must match tags in the message (with overlap allowed) for the message to be passed by the filter.
The default implementation matches only on properties that have keys beginning with "tag" to help avoid unintended matching. A new Java ConsumerFilter interface and factory allows other property-based filtering schemes to be implemented and deployed.

Apart from message tag properties starting with (lowercase) "tag" and consumer tag subscription meta data properties starting with "anytag" and "alltag" there are no other requirements or conventions on tag naming and usage. For example, tags could use more meaningful keys such as "tag_priority" and namespace tag values such as values "prority_urgent" and "priority_low". 
Another possibility is to use values such as "priority=urgent" and match by text on such categories or classes (with keys just enumerating "tag0","tag1" etc as in examples above). 
These suggestions are a convention only and not checked or enforced in any way. In the examples above we have used "0" and "1" but other unique strings (such as "A","B" etc) could have been used.

### Modifications

A new interface "ConsumerFilter" (org/apache/pulsar/broker/service/ConsumerFilter.java) with a factory (ConsumerFilterFactory.java) configured via settings in org/apache/pulsar/broker/ServiceConfiguration.java allows consumer filtering to be configured was added. Our suggested default implementation of this interface (behaviour described in detail above) is defined by the "ConsumerTagFilter" class.

In order to minimise code changes we've limited our modifications mainly to two existing classes. The consumer abstract base class org.apache.pulsar.broker.AbstractBaseDispacher is modified to use the above interface to filter both batches and single messages (conditionally only if consumer filtering is enabled) in method filterEntriesForConsumer(), keeping this method's code as similar as possible to the current implementation.

For filtering entries in a batch, we duplicated an existing method in org.apache.pulsar.client.impl.RawBatchConverted and adapted it for our needs. The new static "filter" method in this class was kept as similar as possible to the "rebatchMessage" it was based on. It's expected that on average most messages will be both batched and filtered out (on average if a filter is in effect) and we've therefore not attempted to optimise other code paths. Non-filtered usage should not be impacted except for a simple check.

A handful of other code files changes in the persistent and nonpersistent sub modules of
org.apache.pulsar.broker.service are just single point modifications to pass the consumer object through so that the consumer meta data properties are available for use in filtering.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

The org.apache.pulsar.broker.service.ConsumerFilterTest unit test tests the ConsumerFilter implementations.
Both "anytag" and "alltags" combinations are tested by simple combinations of these meta data properties.
A more comprehensive ProducerConsumerBase sub-class test
(org.apache.pulsar.client.api.ConsumerFilteringTest) tests sending and receiving messages with variations on the percentage of messages with tag properties that should match the subscription filter. All and no matches as well as 10% and 1% expected matches are tested.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
No
  - The public API: (yes / no)
Yes,
Change to semantics of key/value meta data supplied by Consumer. API signature unchanged.

  - The schema: (yes / no / don't know)
No
  - The default values of configurations: (yes / no)
Yes, if enabled by default. Code switchable.
  - The wire protocol: (yes / no)
No
  - The rest endpoints: (yes / no)
No
  - The admin cli options: (yes / no)
No
  - Anything that affects deployment: (yes / no / don't know)
No

### Documentation

Please see README_CONSUMER_FILTER in PR.

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
