### PR TITLE
add bookie client quarantine ratio configuration for bookie client 4.11.1

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -683,6 +683,9 @@ bookkeeperClientHealthCheckIntervalSeconds=60
 bookkeeperClientHealthCheckErrorThresholdPerInterval=5
 bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
 
+#bookie quarantine ratio to avoid all clients quarantine the high pressure bookie servers at the same time
+bookkeeperClientQuarantineRatio=1.0
+
 # Specify options for the GetBookieInfo check. These settings can be useful
 # to help ensure the list of bookies is up to date on the brokers.
 bookkeeperGetBookieInfoIntervalSeconds=86400

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -443,6 +443,9 @@ bookkeeperClientHealthCheckIntervalSeconds=60
 bookkeeperClientHealthCheckErrorThresholdPerInterval=5
 bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
 
+#bookie quarantine ratio to avoid all clients quarantine the high pressure bookie servers at the same time
+bookkeeperClientQuarantineRatio=1.0
+
 # Enable rack-aware bookie selection policy. BK will chose bookies from different racks when
 # forming a new bookie ensemble
 # This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -641,6 +641,9 @@ bookkeeperClientHealthCheckIntervalSeconds=60
 bookkeeperClientHealthCheckErrorThresholdPerInterval=5
 bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
 
+#bookie quarantine ratio to avoid all clients quarantine the high pressure bookie servers at the same time
+bookkeeperClientQuarantineRatio=1.0
+
 # Specify options for the GetBookieInfo check. These settings can be useful
 # to help ensure the list of bookies is up to date on the brokers.
 bookkeeperGetBookieInfoIntervalSeconds=86400

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1087,6 +1087,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private long bookkeeperClientHealthCheckQuarantineTimeInSeconds = 1800;
     @FieldContext(
+            category = CATEGORY_STORAGE_BK,
+            doc = "bookie quarantine ratio to avoid all clients quarantine " +
+                    "the high pressure bookie servers at the same time"
+    )
+    private double bookkeeperClientQuarantineRatio = 1.0;
+    @FieldContext(
         category = CATEGORY_STORAGE_BK,
         doc = "Enable rack-aware bookie selection policy. \n\nBK will chose bookies from"
             + " different racks when forming a new bookie ensemble")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -130,6 +130,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
             bkConf.setBookieErrorThresholdPerInterval(conf.getBookkeeperClientHealthCheckErrorThresholdPerInterval());
             bkConf.setBookieQuarantineTime((int) conf.getBookkeeperClientHealthCheckQuarantineTimeInSeconds(),
                     TimeUnit.SECONDS);
+            bkConf.setBookieQuarantineRatio(conf.getBookkeeperClientQuarantineRatio());
         }
 
         bkConf.setReorderReadSequenceEnabled(conf.isBookkeeperClientReorderReadSequenceEnabled());


### PR DESCRIPTION
### Motivation
After bookie client upgraded to 4.11.1, it support configure bookie client quarantine ratio.
This feature introduced by https://github.com/apache/bookkeeper/pull/2327.

### Changes
Add `bookkeeperClientQuarantineRatio` configuration for broker.conf