### PR TITLE
[Issue 8547][java-client] new listener for end of topic events

### DIFF
--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/EndOfTopicMessageListener.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/EndOfTopicMessageListener.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.io.Serializable;
+
+/**
+ * A listener that will be called when the end of the topic has been reached.
+ */
+public interface EndOfTopicMessageListener<T> extends Serializable {
+
+    /**
+     * Get the notification when a topic is terminated.
+     *
+     * @param consumer
+     *            the Consumer object associated with the terminated topic
+     */
+    default void reachedEndOfTopic(Consumer consumer) {
+        // By default ignore the notification
+    }
+}

--- a/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
@@ -85,6 +85,7 @@
                     <include>org.apache.pulsar.client.api.Consumer</include>
                     <include>org.apache.pulsar.client.api.Reader</include>
                     <include>org.apache.pulsar.client.api.MessageListener</include>
+                    <include>org.apache.pulsar.client.api.EndOfTopicMessageListener</include>
                     <include>org.apache.pulsar.client.api.ReaderListener</include>
                   </includes>
                 </relocation>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -248,12 +248,24 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *
      * <p>When a {@link MessageListener} is set, application will receive messages through it. Calls to
      * {@link Consumer#receive()} will not be allowed.
+     * Use {@Link endOfTopicMessageListener} for end of topic events only.
      *
      * @param messageListener
      *            the listener object
      * @return the consumer builder instance
      */
     ConsumerBuilder<T> messageListener(MessageListener<T> messageListener);
+
+  /**
+   * Sets a {@link EndOfTopicMessageListener} for the consumer
+   *
+   * <p>When a {@link endOfTopicMessageListener} is set, the application will receive the end of topic event through it.
+   *
+   * @param endOfTopicMessageListener
+   *            the listener object
+   * @return the consumer builder instance
+   */
+  ConsumerBuilder<T> endOfTopicMessageListener(EndOfTopicMessageListener<T> endOfTopicMessageListener);
 
     /**
      * Sets a {@link CryptoKeyReader}.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/EndOfTopicMessageListener.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/EndOfTopicMessageListener.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.io.Serializable;
+
+/**
+ * A listener that will be called when the end of the topic has been reached.
+ */
+public interface EndOfTopicMessageListener<T> extends Serializable {
+
+    /**
+     * Get the notification when a topic is terminated.
+     *
+     * @param consumer
+     *            the Consumer object associated with the terminated topic
+     */
+    default void reachedEndOfTopic(Consumer<T> consumer) {
+        // By default ignore the notification
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.EndOfTopicMessageListener;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -68,6 +69,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected final String consumerName;
     protected final CompletableFuture<Consumer<T>> subscribeFuture;
     protected final MessageListener<T> listener;
+    protected final EndOfTopicMessageListener<T> endOfTopicMessageListener;
     protected final ConsumerEventListener consumerEventListener;
     protected final ExecutorService listenerExecutor;
     final BlockingQueue<Message<T>> incomingMessages;
@@ -94,6 +96,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         this.consumerName = conf.getConsumerName() == null ? ConsumerName.generateRandomName() : conf.getConsumerName();
         this.subscribeFuture = subscribeFuture;
         this.listener = conf.getMessageListener();
+        this.endOfTopicMessageListener = conf.getEndOfTopicMessageListener();
         this.consumerEventListener = conf.getConsumerEventListener();
         // Always use growable queue since items can exceed the advertised size
         this.incomingMessages = new GrowableArrayBlockingQueue<>();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.MessageCrypto;
 import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.EndOfTopicMessageListener;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
@@ -225,6 +226,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     public ConsumerBuilder<T> messageListener(@NonNull MessageListener<T> messageListener) {
         conf.setMessageListener(messageListener);
         return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> endOfTopicMessageListener(@NonNull EndOfTopicMessageListener<T> endOfTopicMessageListener) {
+      conf.setEndOfTopicMessageListener(endOfTopicMessageListener);
+      return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2220,6 +2220,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             // Propagate notification to listener
             listener.reachedEndOfTopic(this);
         }
+        if(endOfTopicMessageListener != null) {
+          listenerExecutor.execute(() -> {
+              endOfTopicMessageListener.reachedEndOfTopic(this);
+            });
+        }
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.MessageCrypto;
 import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.EndOfTopicMessageListener;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -65,6 +66,9 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     @JsonIgnore
     private MessageListener<T> messageListener;
+
+    @JsonIgnore
+    private EndOfTopicMessageListener<T> endOfTopicMessageListener;
 
     @JsonIgnore
     private ConsumerEventListener consumerEventListener;


### PR DESCRIPTION
Fixes #8547


### Motivation

I am using the java client and calling `consumer.receive()` or `consumer.receiveAsync()` to get messages. This is incompatible with the end of topic listener.
Here I create a new listener `EndOfTopicListener` that can be used without having to receive messages, unlike the existing `MessageListener`.

### Modifications

I allow passing a `endOfTopicMessageListener` to the consumerBuilder, and pass the data along to the consumer implementation which will call the listener accordingly.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: **yes**  it adds a  `ConsumerBuilder<T> endOfTopicMessageListener(EndOfTopicMessageListener<T> endOfTopicMessageListener);`

  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
