### PR TITLE
[broker] Close topics that remain fenced forcefully

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -453,7 +453,7 @@ systemTopicEnabled=false
 topicLevelPoliciesEnabled=false
 
 # If a topic remains fenced for this number of seconds, it will be closed forcefully.
-# If it is 0 or less, the fenced topic will not be closed.
+# If it is set to 0 or a negative number, the fenced topic will not be closed.
 topicFencingTimeoutSeconds=0
 
 ### --- Authentication --- ###

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -452,6 +452,10 @@ systemTopicEnabled=false
 # Please enable the system topic first.
 topicLevelPoliciesEnabled=false
 
+# If a topic remains fenced for this number of seconds, it will be closed forcefully.
+# If it is 0 or less, the fenced topic will not be closed.
+topicFencingTimeoutSeconds=0
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -365,6 +365,10 @@ systemTopicEnabled=false
 # Please enable the system topic first.
 topicLevelPoliciesEnabled=false
 
+# If a topic remains fenced for this number of seconds, it will be closed forcefully.
+# If it is 0 or less, the fenced topic will not be closed.
+topicFencingTimeoutSeconds=0
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -366,7 +366,7 @@ systemTopicEnabled=false
 topicLevelPoliciesEnabled=false
 
 # If a topic remains fenced for this number of seconds, it will be closed forcefully.
-# If it is 0 or less, the fenced topic will not be closed.
+# If it is set to 0 or a negative number, the fenced topic will not be closed.
 topicFencingTimeoutSeconds=0
 
 ### --- Authentication --- ###

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -827,6 +827,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private String zookeeperSessionExpiredPolicy = "shutdown";
 
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "If a topic remains fenced for this number of seconds, it will be closed forcefully.\n"
+                + " If it is 0 or less, the fenced topic will not be closed."
+    )
+    private int topicFencingTimeoutSeconds = 0;
 
     /**** --- Messaging Protocols --- ****/
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -830,7 +830,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "If a topic remains fenced for this number of seconds, it will be closed forcefully.\n"
-                + " If it is 0 or less, the fenced topic will not be closed."
+                + " If it is set to 0 or a negative number, the fenced topic will not be closed."
     )
     private int topicFencingTimeoutSeconds = 0;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2407,7 +2407,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
-    private synchronized void closeFencedTopicForcefully() {
+    private void closeFencedTopicForcefully() {
         if (isFenced) {
             final int timeout = brokerService.pulsar().getConfiguration().getTopicFencingTimeoutSeconds();
             if (isClosingOrDeleting) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -193,6 +194,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private volatile int maxUnackedMessagesOnSubscription = -1;
     private volatile boolean isClosingOrDeleting = false;
+
+    private ScheduledFuture<?> fencedTopicMonitoringTask = null;
 
     private static class TopicStatsHelper {
         public double averageMsgSize;
@@ -396,7 +399,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     // signal to managed ledger that we are ready to resume by creating a new ledger
                     ledger.readyToCreateNewLedger();
 
-                    isFenced = false;
+                    unfence();
                 }
 
             }
@@ -423,7 +426,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         } else {
 
             // fence topic when failed to write a message to BK
-            isFenced = true;
+            fence();
             // close all producers
             List<CompletableFuture<Void>> futures = Lists.newArrayList();
             producers.values().forEach(producer -> futures.add(producer.disconnect()));
@@ -2382,6 +2385,40 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public boolean isSystemTopic() {
         return false;
+    }
+
+    private synchronized void fence() {
+        isFenced = true;
+        ScheduledFuture<?> monitoringTask = this.fencedTopicMonitoringTask;
+        if (monitoringTask == null || monitoringTask.isDone()) {
+            final int timeout = brokerService.pulsar().getConfiguration().getTopicFencingTimeoutSeconds();
+            if (timeout > 0) {
+                this.fencedTopicMonitoringTask = brokerService.executor().schedule(this::closeFencedTopicForcefully,
+                        timeout, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private synchronized void unfence() {
+        isFenced = false;
+        ScheduledFuture<?> monitoringTask = this.fencedTopicMonitoringTask;
+        if (monitoringTask != null && !monitoringTask.isDone()) {
+            monitoringTask.cancel(false);
+        }
+    }
+
+    private synchronized void closeFencedTopicForcefully() {
+        if (isFenced) {
+            final int timeout = brokerService.pulsar().getConfiguration().getTopicFencingTimeoutSeconds();
+            if (isClosingOrDeleting) {
+                log.warn("[{}] Topic remained fenced for {} seconds and is already closed (pendingWriteOps: {})", topic,
+                        timeout, pendingWriteOps.get());
+            } else {
+                log.error("[{}] Topic remained fenced for {} seconds, so close it (pendingWriteOps: {})", topic,
+                        timeout, pendingWriteOps.get());
+                close();
+            }
+        }
     }
 
     private void fenceTopicToCloseOrDelete() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1747,6 +1748,43 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         verify(nonDeletableSubscription1, times(0)).delete();
         verify(deletableSubscription1, times(1)).delete();
         verify(nonDeletableSubscription2, times(0)).delete();
+    }
+
+    @Test
+    public void testTopicFencingTimeout() throws Exception {
+        ServiceConfiguration svcConfig = spy(new ServiceConfiguration());
+        doReturn(svcConfig).when(pulsar).getConfiguration();
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+
+        Method fence = PersistentTopic.class.getDeclaredMethod("fence");
+        fence.setAccessible(true);
+        Method unfence = PersistentTopic.class.getDeclaredMethod("unfence");
+        unfence.setAccessible(true);
+
+        Field fencedTopicMonitoringTaskField = PersistentTopic.class.getDeclaredField("fencedTopicMonitoringTask");
+        fencedTopicMonitoringTaskField.setAccessible(true);
+        Field isFencedField = AbstractTopic.class.getDeclaredField("isFenced");
+        isFencedField.setAccessible(true);
+        Field isClosingOrDeletingField = PersistentTopic.class.getDeclaredField("isClosingOrDeleting");
+        isClosingOrDeletingField.setAccessible(true);
+
+        doReturn(10).when(svcConfig).getTopicFencingTimeoutSeconds();
+        fence.invoke(topic);
+        unfence.invoke(topic);
+        ScheduledFuture<?> fencedTopicMonitoringTask = (ScheduledFuture<?>) fencedTopicMonitoringTaskField.get(topic);
+        assertTrue(fencedTopicMonitoringTask.isDone());
+        assertTrue(fencedTopicMonitoringTask.isCancelled());
+        assertFalse((boolean) isFencedField.get(topic));
+        assertFalse((boolean) isClosingOrDeletingField.get(topic));
+
+        doReturn(1).when(svcConfig).getTopicFencingTimeoutSeconds();
+        fence.invoke(topic);
+        Thread.sleep(2000);
+        fencedTopicMonitoringTask = (ScheduledFuture<?>) fencedTopicMonitoringTaskField.get(topic);
+        assertTrue(fencedTopicMonitoringTask.isDone());
+        assertFalse(fencedTopicMonitoringTask.isCancelled());
+        assertTrue((boolean) isFencedField.get(topic));
+        assertTrue((boolean) isClosingOrDeletingField.get(topic));
     }
 
     private ByteBuf getMessageWithMetadata(byte[] data) throws IOException {


### PR DESCRIPTION
### Motivation

The other day, we faced a problem where a topic remained fenced and unavailable. This topic remained unavailable until it was unloaded. The following is the broker log at that time.
```
11:37:55.905 [bookkeeper-ml-workers-OrderedExecutor-77-0] INFO  o.a.b.mledger.impl.OpAddEntry        - [tenant/ns/persistent/topic] Closing ledger 40891546 for being full
11:37:56.208 [pulsar-ordered-OrderedExecutor-0-0-EventThread] ERROR o.a.b.client.MetadataUpdateLoop      - UpdateLoop(ledgerId=40891546,loopId=6ce63876) Error writing metadata to store
11:37:56.209 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.b.mledger.impl.OpAddEntry        - Error when closing ledger 40891546. Status=Error while using ZooKeeper
11:37:56.359 [pulsar-ordered-OrderedExecutor-0-0-EventThread] ERROR o.a.b.mledger.impl.ManagedLedgerImpl - [tenant/ns/persistent/topic] Error creating ledger rc=-9 Error while using ZooKeeper
11:37:56.359 [pulsar-ordered-OrderedExecutor-0-0-EventThread] INFO  o.a.pulsar.broker.service.Producer   - Disconnecting producer: Producer{topic=PersistentTopic{topic=persistent://tenant/ns/topic}, client=/xxx.xxx.xxx.xxx:40646, producerName=pulsar.repl.jp-west, producerId=668}
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] INFO  o.a.pulsar.broker.service.Producer   - Disconnecting producer: Producer{topic=PersistentTopic{topic=persistent://tenant/ns/topic}, client=/xxx.xxx.xxx.xxx:40646, producerName=pulsar.repl.jp-west, producerId=668}
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] INFO  o.a.pulsar.broker.service.Producer   - Disconnecting producer: Producer{topic=PersistentTopic{topic=persistent://tenant/ns/topic}, client=/xxx.xxx.xxx.xxx:40646, producerName=pulsar.repl.jp-west, producerId=668}
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:56.360 [pulsar-ordered-OrderedExecutor-0-0-EventThread] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Failed to persist msg in store: Error while using ZooKeeper
11:37:57.495 [ForkJoinPool.commonPool-worker-51] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40256][persistent://tenant/ns/topic] Creating producer. producerId=668
11:37:58.291 [bookkeeper-ml-workers-OrderedExecutor-77-0] INFO  o.a.b.mledger.impl.ManagedLedgerImpl - [tenant/ns/persistent/topic] End TrimConsumedLedgers. ledgers=2 totalSize=162868668
11:37:58.291 [bookkeeper-ml-workers-OrderedExecutor-77-0] INFO  o.a.b.mledger.impl.ManagedLedgerImpl - [tenant/ns/persistent/topic] Removing ledger 40880508 - size: 82183409
11:37:58.292 [ForkJoinPool.commonPool-worker-20] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40256]-668 persistent://tenant/ns/topic configured with schema false
11:37:58.292 [ForkJoinPool.commonPool-worker-20] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Attempting to add producer to a fenced topic
11:37:58.292 [ForkJoinPool.commonPool-worker-20] ERROR o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40256] Failed to add producer to topic persistent://tenant/ns/topic: Topic is temporarily unavailable
11:37:58.728 [ForkJoinPool.commonPool-worker-75] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40330][persistent://tenant/ns/topic] Creating producer. producerId=668
11:37:58.729 [ForkJoinPool.commonPool-worker-75] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40330]-668 persistent://tenant/ns/topic configured with schema false
11:37:58.729 [ForkJoinPool.commonPool-worker-75] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Attempting to add producer to a fenced topic
11:37:58.729 [ForkJoinPool.commonPool-worker-75] ERROR o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40330] Failed to add producer to topic persistent://tenant/ns/topic: Topic is temporarily unavailable
11:37:59.489 [ForkJoinPool.commonPool-worker-106] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40260][persistent://tenant/ns/topic] Creating producer. producerId=668
11:37:59.489 [ForkJoinPool.commonPool-worker-106] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40260]-668 persistent://tenant/ns/topic configured with schema false
11:37:59.489 [ForkJoinPool.commonPool-worker-106] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Attempting to add producer to a fenced topic
11:37:59.489 [ForkJoinPool.commonPool-worker-106] ERROR o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40260] Failed to add producer to topic persistent://tenant/ns/topic: Topic is temporarily unavailable
11:38:01.062 [ForkJoinPool.commonPool-worker-51] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40248][persistent://tenant/ns/topic] Creating producer. producerId=668
11:38:01.062 [ForkJoinPool.commonPool-worker-51] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40248]-668 persistent://tenant/ns/topic configured with schema false
11:38:01.063 [ForkJoinPool.commonPool-worker-51] WARN  o.a.p.b.s.persistent.PersistentTopic - [persistent://tenant/ns/topic] Attempting to add producer to a fenced topic
11:38:01.063 [ForkJoinPool.commonPool-worker-51] ERROR o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40248] Failed to add producer to topic persistent://tenant/ns/topic: Topic is temporarily unavailable
11:38:04.103 [ForkJoinPool.commonPool-worker-90] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40338][persistent://tenant/ns/topic] Creating producer. producerId=668
11:38:04.104 [ForkJoinPool.commonPool-worker-102] INFO  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:40338]-668 persistent://tenant/ns/topic configured with schema false
```

We were maintaining the ZooKeeper servers, so I think this phenomenon was caused by the shutdown of some ZK servers. However, the causal relationship has not been clarified.

### Modifications

As a workaround, close the topic if it remains fenced for a period of time. Reconnecting from the clients will instantiate a new `PersistentTopic` topic and the topic will back to normal.