### PR TITLE
[Transaction] Guarantee transaction metadata handlers connect

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -71,7 +71,10 @@ public class TransactionMetaStoreHandler extends HandlerState implements Connect
 
     private Timeout requestTimeout;
 
-    public TransactionMetaStoreHandler(long transactionCoordinatorId, PulsarClientImpl pulsarClient, String topic) {
+    private CompletableFuture<Void> connectFuture;
+
+    public TransactionMetaStoreHandler(long transactionCoordinatorId, PulsarClientImpl pulsarClient, String topic,
+                                       CompletableFuture<Void> connectFuture) {
         super(pulsarClient, topic);
         this.transactionCoordinatorId = transactionCoordinatorId;
         this.timeoutQueue = new ConcurrentLinkedQueue<>();
@@ -87,6 +90,7 @@ public class TransactionMetaStoreHandler extends HandlerState implements Connect
                 .create(),
             this);
         this.connectionHandler.grabCnx();
+        this.connectFuture = connectFuture;
     }
 
     @Override
@@ -94,6 +98,7 @@ public class TransactionMetaStoreHandler extends HandlerState implements Connect
         LOG.error("Transaction meta handler with transaction coordinator id {} connection failed.",
             transactionCoordinatorId, exception);
         setState(State.Failed);
+        this.connectFuture.completeExceptionally(exception);
     }
 
     @Override
@@ -105,6 +110,7 @@ public class TransactionMetaStoreHandler extends HandlerState implements Connect
         if (!changeToReadyState()) {
             cnx.channel().close();
         }
+        this.connectFuture.complete(null);
     }
 
     public CompletableFuture<TxnID> newTransactionAsync(long timeout, TimeUnit unit) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -111,7 +111,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
     }
 
     private String getTCAssignTopicName(int partition) {
-        if (partition > 0) {
+        if (partition >= 0) {
             return TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString() + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
         } else {
             return TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString();


### PR DESCRIPTION
### Motivation

Currently, the transaction metadata handlers start with pulsar client start, but the handlers connect with the broker asynchronously, if the client restart, the metadata handler may not be available.

### Modifications

Add the connection future for the metadata handler.

### Verifying this change

This change added tests and can be verified as follows:

  - *org.apache.pulsar.client.impl.TransactionEndToEndTest#txnMetadataHandlerRecoverTest*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
