### PR TITLE
[C++] Fix flaky tests of KeySharedConsumerTest

### DIFF
--- a/pulsar-client-cpp/tests/KeySharedConsumerTest.cc
+++ b/pulsar-client-cpp/tests/KeySharedConsumerTest.cc
@@ -127,6 +127,13 @@ class KeySharedConsumerTest : public ::testing::Test {
             numTotalMessages += kv.second;
         }
         ASSERT_EQ(numTotalMessages, expectedNumTotalMessages);
+
+        const double expectedMessagesPerConsumer = static_cast<double>(totalMessages) / consumers.size();
+        constexpr double PERCENT_ERROR = 0.50;
+        for (const auto& kv : messagesPerConsumer) {
+            int count = kv.second;
+            ASSERT_LT(fabs(count - expectedMessagesPerConsumer), expectedMessagesPerConsumer * PERCENT_ERROR);
+        }
     }
 
     Client client;

--- a/pulsar-client-cpp/tests/KeySharedConsumerTest.cc
+++ b/pulsar-client-cpp/tests/KeySharedConsumerTest.cc
@@ -89,32 +89,23 @@ class KeySharedConsumerTest : public ::testing::Test {
 
     static void sendCallback(Result result, const MessageId&) { ASSERT_EQ(result, ResultOk); }
 
-    void receiveAndCheckDistribution() {
-        // key is message's ordering key or partitioned key, value is consumer index
-        std::map<std::string, size_t> keyToConsumer;
-        // key is consumer index, value is the number of message received by
-        std::map<size_t, int> messagesPerConsumer;
-        receiveAndCheckDistribution(keyToConsumer, messagesPerConsumer);
-    }
-
-    void receiveAndCheckDistribution(std::map<std::string, size_t>& keyToConsumer,
-                                     std::map<size_t, int>& messagesPerConsumer) {
+    void receiveAndCheckDistribution(int expectedNumTotalMessages) {
+        keyToConsumer.clear();
+        messagesPerConsumer.clear();
         int totalMessages = 0;
 
         for (size_t i = 0; i < consumers.size(); i++) {
             auto& consumer = consumers[i];
-            int messagesForThisConsumer = 0;
             while (true) {
                 Message msg;
-                Result result = consumer.receive(msg, 1000);
+                Result result = consumer.receive(msg, 3000);
                 if (result == ResultTimeout) {
-                    messagesPerConsumer[i] = messagesForThisConsumer;
                     break;
                 }
 
                 ASSERT_EQ(result, ResultOk);
                 totalMessages++;
-                messagesForThisConsumer++;
+                messagesPerConsumer[i]++;
                 ASSERT_EQ(ResultOk, consumer.acknowledge(msg));
 
                 if (msg.hasPartitionKey() || msg.hasOrderingKey()) {
@@ -123,25 +114,30 @@ class KeySharedConsumerTest : public ::testing::Test {
                     if (iter == keyToConsumer.end()) {
                         keyToConsumer[key] = i;
                     } else {
+                        // check messages with the same key will be consumed by the same consumer
                         ASSERT_EQ(iter->second, i);
                     }
                 }
             }
         }
 
-        const double expectedMessagesPerConsumer = static_cast<double>(totalMessages) / consumers.size();
-        constexpr double PERCENT_ERROR = 0.50;
         LOG_INFO("messagesPerConsumer: " << messagesPerConsumer);
+        int numTotalMessages = 0;
         for (const auto& kv : messagesPerConsumer) {
-            int count = kv.second;
-            ASSERT_LT(fabs(count - expectedMessagesPerConsumer), expectedMessagesPerConsumer * PERCENT_ERROR);
+            numTotalMessages += kv.second;
         }
+        ASSERT_EQ(numTotalMessages, expectedNumTotalMessages);
     }
 
     Client client;
     std::vector<Producer> producers;
     std::vector<Consumer> consumers;
     const std::string subName = "SubscriptionName";
+
+    // key is message's ordering key or partitioned key, value is consumer index
+    std::map<std::string, size_t> keyToConsumer;
+    // key is consumer index, value is the number of message received by
+    std::map<size_t, int> messagesPerConsumer;
 };
 
 TEST_F(KeySharedConsumerTest, testNonPartitionedTopic) {
@@ -153,13 +149,14 @@ TEST_F(KeySharedConsumerTest, testNonPartitionedTopic) {
     }
 
     srand(time(nullptr));
-    for (int i = 0; i < 1000; i++) {
+    constexpr int numMessagesPerProducer = 1000;
+    for (int i = 0; i < numMessagesPerProducer; i++) {
         std::string key = std::to_string(rand() % NUMBER_OF_KEYS);
         producers[0].sendAsync(newIntMessage(i, key), sendCallback);
     }
     ASSERT_EQ(ResultOk, producers[0].flush());
 
-    receiveAndCheckDistribution();
+    receiveAndCheckDistribution(numMessagesPerProducer);
 }
 
 TEST_F(KeySharedConsumerTest, testMultiTopics) {
@@ -173,15 +170,16 @@ TEST_F(KeySharedConsumerTest, testMultiTopics) {
     }
 
     srand(time(nullptr));
+    constexpr int numMessagesPerProducer = 1000;
     for (auto& producer : producers) {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < numMessagesPerProducer; i++) {
             std::string key = std::to_string(rand() % NUMBER_OF_KEYS);
             producer.sendAsync(newIntMessage(i, key), sendCallback);
         }
         ASSERT_EQ(ResultOk, producer.flush());
     }
 
-    receiveAndCheckDistribution();
+    receiveAndCheckDistribution(numMessagesPerProducer * 3);
 }
 
 TEST_F(KeySharedConsumerTest, testOrderingKeyPriority) {
@@ -194,7 +192,8 @@ TEST_F(KeySharedConsumerTest, testOrderingKeyPriority) {
     }
 
     srand(time(nullptr));
-    for (int i = 0; i < 1000; i++) {
+    constexpr int numMessagesPerProducer = 1000;
+    for (int i = 0; i < numMessagesPerProducer; i++) {
         int randomInt = rand();
         std::string key = std::to_string(randomInt % NUMBER_OF_KEYS);
         std::string orderingKey = std::to_string((randomInt + 1) % NUMBER_OF_KEYS);
@@ -202,7 +201,7 @@ TEST_F(KeySharedConsumerTest, testOrderingKeyPriority) {
     }
     ASSERT_EQ(ResultOk, producers[0].flush());
 
-    receiveAndCheckDistribution();
+    receiveAndCheckDistribution(numMessagesPerProducer);
 }
 
 TEST_F(KeySharedConsumerTest, testKeyBasedBatching) {
@@ -223,9 +222,7 @@ TEST_F(KeySharedConsumerTest, testKeyBasedBatching) {
         producers[0].sendAsync(newIntMessage(i, "", key.c_str()), sendCallback);
     }
 
-    std::map<std::string, size_t> keyToConsumer;
-    std::map<size_t, int> messagesPerConsumer;
-    receiveAndCheckDistribution(keyToConsumer, messagesPerConsumer);
+    receiveAndCheckDistribution(BATCHING_MAX_MESSAGES);
     // Each consumer should receive 1 batched message for each key
     for (int i = 0; i < NUM_KEYS; i++) {
         ASSERT_EQ(messagesPerConsumer[i], NUM_MESSAGES_PER_KEY);


### PR DESCRIPTION
Fixes #8513 

### Motivation

Tests of `KeySharedConsumerTest` are likely to fail. From the log we can see sometimes the consumer didn't receive all messages.

For example logs in #8513 we can see
- `testMultiTopics`, 3000 messages were sent, but the messages per consumer is `{0 => 0, 1 => 529, 2 => 621}`. Only 1150 messages were received.
- `testOrderingKeyPriority`, 1000 messages were sent, but the messages per consumer is `{0 => 0, 1 => 270, 2 => 264}`. Only 534 messages were received.

It could also be seen in other tests of `KeySharedConsumerTest` when tests are running in CI.

### Modifications

- Increase the receive timeout to make it more likely that consumers can receive all messages.
- Modify `messagesPerConsumer` in each loop instead of only set the key-value when receive timeout to avoid reordering issue.
- Add the check for the total number of received messages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.