### PR TITLE
[Issue 8580][pulsar-common] Set configured TLS protocols to SSLEngine instance

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -174,7 +174,7 @@ public class KeyStoreSSLContext {
     }
 
     private SSLEngine configureSSLEngine(SSLEngine sslEngine) {
-        sslEngine.setEnabledProtocols(sslEngine.getSupportedProtocols());
+        sslEngine.setEnabledProtocols(protocols.toArray(new String[0]));
         sslEngine.setEnabledCipherSuites(sslEngine.getSupportedCipherSuites());
 
         if (this.mode == Mode.SERVER) {


### PR DESCRIPTION
Fixes #8580

### Motivation

See #8580 , some tests fail with newer Java 8 versions that include TLS1.3 protocol. This might also impact the runtime behavior of Pulsar.

### Modifications

Set the configured TLS protocols to the SSLEngine instance.