### PR TITLE
[C++] Fix dangling reference bug in getRandomName 

### DIFF
--- a/pulsar-client-cpp/.gitignore
+++ b/pulsar-client-cpp/.gitignore
@@ -55,6 +55,9 @@ lib*.so*
 .pydevproject
 .idea/
 *.cbp
+*.ninja*
+.clangd/
+compile_commands.json
 
 # doxygen files
 apidocs/

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -28,8 +28,9 @@
 #include "PatternMultiTopicsConsumerImpl.h"
 #include "SimpleLoggerImpl.h"
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
 #include <sstream>
-#include <openssl/sha.h>
 #include <lib/HTTPLookupService.h>
 #include <lib/TopicName.h>
 #include <algorithm>
@@ -45,24 +46,19 @@ namespace pulsar {
 
 static const char hexDigits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                                  '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+static const boost::random::uniform_int_distribution<> hexDigitsDist(0, sizeof(hexDigits));
+static boost::random::mt19937 randomEngine(std::chrono::system_clock::now().time_since_epoch().count());
 
-const std::string generateRandomName() {
-    unsigned char hash[SHA_DIGEST_LENGTH];  // == 20;
-    boost::posix_time::ptime t(boost::posix_time::microsec_clock::universal_time());
-    long nanoSeconds = t.time_of_day().total_nanoseconds();
-    std::stringstream ss;
-    ss << nanoSeconds;
-    SHA1(reinterpret_cast<const unsigned char*>(ss.str().c_str()), ss.str().length(), hash);
+std::string generateRandomName() {
+    const int randomNameLength = 10;
 
-    const int nameLength = 10;
-    std::stringstream hexHash;
-    for (int i = 0; i < nameLength / 2; i++) {
-        hexHash << hexDigits[(hash[i] & 0xF0) >> 4];
-        hexHash << hexDigits[hash[i] & 0x0F];
+    std::string randomName;
+    for(int i = 0; i < randomNameLength; ++i) {
+        randomName += hexDigits[hexDigitsDist(randomEngine)];
     }
-
-    return hexHash.str();
+    return randomName;
 }
+
 typedef std::unique_lock<std::mutex> Lock;
 
 typedef std::vector<std::string> StringList;

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -28,13 +28,12 @@
 #include "PatternMultiTopicsConsumerImpl.h"
 #include "SimpleLoggerImpl.h"
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 #include <sstream>
 #include <lib/HTTPLookupService.h>
 #include <lib/TopicName.h>
 #include <algorithm>
 #include <regex>
+#include <random>
 #include <mutex>
 #ifdef USE_LOG4CXX
 #include "Log4CxxLogger.h"
@@ -46,14 +45,15 @@ namespace pulsar {
 
 static const char hexDigits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                                  '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-static const boost::random::uniform_int_distribution<> hexDigitsDist(0, sizeof(hexDigits));
-static boost::random::mt19937 randomEngine(std::chrono::system_clock::now().time_since_epoch().count());
+static std::uniform_int_distribution<> hexDigitsDist(0, sizeof(hexDigits));
+static std::mt19937 randomEngine =
+    std::mt19937(std::chrono::high_resolution_clock::now().time_since_epoch().count());
 
 std::string generateRandomName() {
     const int randomNameLength = 10;
 
     std::string randomName;
-    for(int i = 0; i < randomNameLength; ++i) {
+    for (int i = 0; i < randomNameLength; ++i) {
         randomName += hexDigits[hexDigitsDist(randomEngine)];
     }
     return randomName;

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -42,7 +42,7 @@ class ReaderImpl;
 typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
 typedef std::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
-const std::string generateRandomName();
+std::string generateRandomName();
 
 class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
    public:


### PR DESCRIPTION
### Motivation

The current `getRandomName` function contains a simple dangling reference bug: when it attempts to return a `const char*` string value from the temporary string returned by the `std::stringstream::str` function.  This sometimes "works" anyway in release mode depending on the platform it's running on, but in debug mode on all the versions of GCC and CLANG I've tried it segfaults.  This makes debugging the c++ client very annoying.

### Modifications

I found the existing method for generating random strings rather obscure, so I both fixed the bug and simplified the code.  I made use of `boost::random` to provide a much more straightforward implementation.  I use this pattern often for random names in my company's production projects, and it works well.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This code is called every time the client subscribes to a topic, so it gets plenty of coverage throughout the tests. I also manually verified that it's working correctly by printing the random names while I was testing.  I've already included this fix in a local build of Pulsar I'm using for a new product at FactSet, and it's working well there.

The CI checks are failing with some error about a website deployment that seems unrelated to the C++ client.  Is this a problem?  Please let me know if I need to do anything special to get those checks to pass.  Thanks!
