### PR TITLE
Fix the broken rename-netty-native-libs.sh script

### DIFF
--- a/.github/workflows/ci-build-multi-os.yaml
+++ b/.github/workflows/ci-build-multi-os.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: CI - Misc
+name: CI - Build - Multiple - OS
 on:
   pull_request:
     branches:
@@ -31,10 +31,13 @@ env:
 
 jobs:
 
-  license-check:
-    name: License check
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  build:
+    name:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    timeout-minutes: 120
 
     steps:
       - name: Cancel Previous Runs
@@ -62,24 +65,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
       - name: Set up JDK 1.8
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/setup-java@v1
+        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
-      # license check fails with 3.6.2 so we have to downgrade
-      - name: Set up Maven
+      - name: build package
         if: steps.docs.outputs.changed_only == 'no'
-        uses: apache/pulsar-test-infra/setup-maven@master
-        with:
-          maven-version: 3.6.1
-
-      - name: build and check license
-        if: steps.docs.outputs.changed_only == 'no'
-        run: mvn -q -B -ntp -DskipTests license:check install
-
-      - name: license check
-        if: steps.docs.outputs.changed_only == 'no'
-        run: src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz
+        run: mvn clean install -DskipTests

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -33,6 +33,11 @@ jobs:
 
   license-check:
     name: License check
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/src/rename-netty-native-libs.sh
+++ b/src/rename-netty-native-libs.sh
@@ -32,7 +32,14 @@ FILES_TO_RENAME=(
 
 echo "----- Renaming epoll lib in $JAR_PATH ------"
 TMP_DIR=`mktemp -d`
-unzip -q $JAR_PATH -d $TMP_DIR
+CUR_DIR=$(pwd)
+cd ${TMP_DIR}
+# exclude `META-INF/LICENSE`
+unzip -q $JAR_PATH -x "META-INF/LICENSE"
+# include `META-INF/LICENSE` as LICENSE.netty.
+# This approach is to get around the issue that MacOS is not able to recognize the difference between `META-INF/LICENSE` and `META-INF/license/`.
+unzip -p $JAR_PATH META-INF/LICENSE > META-INF/LICENSE.netty
+cd ${CUR_DIR}
 
 pushd $TMP_DIR
 


### PR DESCRIPTION
*Motivation*

The script was broken after we upgraded the `netty-tc-native` version to `2.0.33.Final`.

This change fixes the script to make sure it is able to run on MacOS.

