### PR TITLE
Update gson version to 2.8.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -325,7 +325,7 @@ The Apache Software License, Version 2.0
  * Joda -- org.joda-joda-convert-2.2.1.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.2.jar
  * Gson
-    - com.google.code.gson-gson-2.8.2.jar
+    - com.google.code.gson-gson-2.8.6.jar
     - io.gsonfire-gson-fire-1.8.4.jar
  * Sundrio
     - io.sundr-builder-annotations-0.21.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ flexible messaging model and an intuitive client API.</description>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.18.0</grpc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
-    <gson.version>2.8.2</gson.version>
+    <gson.version>2.8.6</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -431,7 +431,7 @@ The Apache Software License, Version 2.0
     - commons-lang-2.6.jar
     - commons-logging-1.2.jar
   * GSON
-    - gson-2.8.2.jar
+    - gson-2.8.6.jar
   * Jackson
     - jackson-module-parameter-names-2.10.0.jar
     - jackson-module-parameter-names-2.11.1.jar


### PR DESCRIPTION
*Motivation*

Use the same gson version as kubernetes client does to fix version conflict issue.

```
ERROR] testAuthProviderWrongInterface(org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactoryTest)  Time elapsed: 0.07 s  <<< FAILURE!
org.testng.TestException:

The exception was thrown with the wrong message: expected "Function authentication provider.*.must implement KubernetesFunctionAuthProvider" but got "com.google.gson.JsonParser.parseReader(Ljava/io/Reader;)Lcom/google/gson/JsonElement;"
	at org.testng.internal.ExpectedExceptionsHolder.wrongException(ExpectedExceptionsHolder.java:70)
	at org.testng.internal.TestInvoker.considerExceptions(TestInvoker.java:737)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:635)
	at org.testng.internal.TestInvoker.retryFailed(TestInvoker.java:214)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:58)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeLazy(TestNGDirectoryTestSuite.java:123)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:90)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.lang.NoSuchMethodError: com.google.gson.JsonParser.parseReader(Ljava/io/Reader;)Lcom/google/gson/JsonElement;
	at io.kubernetes.client.util.KubeConfig.runExec(KubeConfig.java:330)
	at io.kubernetes.client.util.KubeConfig.tokenViaExecCredential(KubeConfig.java:269)
	at io.kubernetes.client.util.KubeConfig.getAccessToken(KubeConfig.java:231)
	at io.kubernetes.client.util.credentials.KubeconfigAuthentication.<init>(KubeconfigAuthentication.java:46)
	at io.kubernetes.client.util.ClientBuilder.kubeconfig(ClientBuilder.java:276)
	at io.kubernetes.client.util.ClientBuilder.getClientBuilder(ClientBuilder.java:108)
	at io.kubernetes.client.util.ClientBuilder.standard(ClientBuilder.java:87)
	at io.kubernetes.client.util.ClientBuilder.standard(ClientBuilder.java:79)
	at io.kubernetes.client.util.Config.defaultClient(Config.java:113)
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory.setupClient(KubernetesRuntimeFactory.java:339)
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory.initialize(KubernetesRuntimeFactory.java:208)
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactoryTest.createKubernetesRuntimeFactory(KubernetesRuntimeFactoryTest.java:184)
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactoryTest.testAuthProvider(KubernetesRuntimeFactoryTest.java:232)
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactoryTest.testAuthProviderWrongInterface(KubernetesRuntimeFactoryTest.java:243)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

