### PR TITLE
[Transaction] Add the batch size in transaction ack command.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1167,5 +1167,5 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 ### --- Transaction config variables --- ###
 
 # Enable transaction coordinator in broker
-transactionCoordinatorEnabled=true
+transactionCoordinatorEnabled=false
 transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1844,7 +1844,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TRANSACTION,
             doc = "Enable transaction coordinator in broker"
     )
-    private boolean transactionCoordinatorEnabled = true;
+    private boolean transactionCoordinatorEnabled = false;
 
     @FieldContext(
         category = CATEGORY_TRANSACTION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -435,9 +435,6 @@ public class Consumer {
     private CompletableFuture<Void> individualAckNormal(CommandAck ack, Map<String,Long> properties) {
         List<Position> positionsAcked = new ArrayList<>();
         List<PositionImpl> checkBatchPositions = null;
-        if (isTransactionEnabled()) {
-            checkBatchPositions = new ArrayList<>();
-        }
         for (int i = 0; i < ack.getMessageIdCount(); i++) {
             MessageIdData msgId = ack.getMessageId(i);
             PositionImpl position;
@@ -446,21 +443,9 @@ public class Consumer {
                         SafeCollectionUtils.longListToArray(msgId.getAckSetList()));
                 if (isTransactionEnabled()) {
                     //sync the batch position bit set point, in order to delete the position in pending acks
-                    checkBatchPositions.add(position);
-                    LongPair batchSizePair = this.pendingAcks.get(msgId.getLedgerId(), msgId.getEntryId());
-                    if (batchSizePair == null) {
-                        String error = "Batch position [" + position + "] could not find " +
-                                "it's batch size from consumer pendingAcks!";
-                        log.warn(error);
-                        return FutureUtil.failedFuture(
-                                new BrokerServiceException.NotAllowedException(error));
-                    }
-                    ((PersistentSubscription) subscription)
-                            .syncBatchPositionBitSetForPendingAck(new MutablePair<>(position, batchSizePair.first));
-                    //check if the position can remove from the consumer pending acks.
-                    // the bit set is empty in pending ack handle.
-                    if (((PersistentSubscription) subscription).checkIsCanDeleteConsumerPendingAck(position)) {
-                        removePendingAcks(position);
+                    if (Subscription.isIndividualAckMode(subType)) {
+                        ((PersistentSubscription) subscription)
+                                .syncBatchPositionBitSetForPendingAck(position);
                     }
                 }
             } else {
@@ -473,7 +458,21 @@ public class Consumer {
             checkAckValidationError(ack, position);
         }
         subscription.acknowledgeMessage(positionsAcked, AckType.Individual, properties);
-        return CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        completableFuture.complete(null);
+        if (isTransactionEnabled() && Subscription.isIndividualAckMode(subType)) {
+            completableFuture.whenComplete((v, e) -> positionsAcked.forEach(position -> {
+                //check if the position can remove from the consumer pending acks.
+                // the bit set is empty in pending ack handle.
+                if (((PositionImpl) position).getAckSet() != null) {
+                    if (((PersistentSubscription) subscription)
+                            .checkIsCanDeleteConsumerPendingAck((PositionImpl) position)) {
+                        removePendingAcks((PositionImpl) position);
+                    }
+                }
+            }));
+        }
+        return completableFuture;
     }
 
 
@@ -497,15 +496,11 @@ public class Consumer {
                 position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
             }
 
-            LongPair batchSizePair = this.pendingAcks.get(msgId.getLedgerId(), msgId.getEntryId());
-            if (batchSizePair == null) {
-                String error = "Batch position [" + position + "] could not find " +
-                        "it's batch size from consumer pendingAcks!";
-                log.error(error);
-                return FutureUtil.failedFuture(
-                        new BrokerServiceException.NotAllowedException(error));
+            if (msgId.hasBatchIndex()) {
+                positionsAcked.add(new MutablePair<>(position, msgId.getBatchSize()));
+            } else {
+                positionsAcked.add(new MutablePair<>(position, 0L));
             }
-            positionsAcked.add(new MutablePair<>(position, batchSizePair.first));
 
             checkCanRemovePendingAcksAndHandle(position, msgId);
 
@@ -514,12 +509,17 @@ public class Consumer {
 
         CompletableFuture<Void> completableFuture = transactionIndividualAcknowledge(ack.getTxnidMostBits(),
                 ack.getTxnidLeastBits(), positionsAcked);
-        positionsAcked.forEach(positionLongMutablePair -> {
-            if (((PersistentSubscription) subscription)
-                    .checkIsCanDeleteConsumerPendingAck(positionLongMutablePair.left)) {
-                removePendingAcks(positionLongMutablePair.left);
-            }
-        });
+        if (Subscription.isIndividualAckMode(subType)) {
+            completableFuture.whenComplete((v, e) ->
+                    positionsAcked.forEach(positionLongMutablePair -> {
+                        if (positionLongMutablePair.getLeft().getAckSet() != null) {
+                            if (((PersistentSubscription) subscription)
+                                    .checkIsCanDeleteConsumerPendingAck(positionLongMutablePair.left)) {
+                                removePendingAcks(positionLongMutablePair.left);
+                            }
+                        }
+                    }));
+        }
         return completableFuture;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -467,7 +467,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
                 return;
             }
 
-            if (messagesToRedeliver.size() > 0) {
+            if (messagesToRedeliver != null && messagesToRedeliver.size() > 0) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule replay of {} messages", name, messagesToRedeliver.size());
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -391,7 +391,7 @@ public class PersistentSubscription implements Subscription {
                                                                     List<MutablePair<PositionImpl, Long>> positions) {
         if (pendingAckHandle == null) {
             return FutureUtil.failedFuture(
-                    new TransactionConflictException("Broker does't support Transaction pending ack!"));
+                    new NotAllowedException("Broker does't support Transaction pending ack!"));
         }
 
         return pendingAckHandle.individualAcknowledgeMessage(txnId, positions);
@@ -1050,7 +1050,7 @@ public class PersistentSubscription implements Subscription {
         return cursor;
     }
 
-    public void syncBatchPositionBitSetForPendingAck(MutablePair<PositionImpl, Long> position) {
+    public void syncBatchPositionBitSetForPendingAck(PositionImpl position) {
         this.pendingAckHandle.syncBatchPositionAckSetForTransaction(position);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -53,6 +53,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyE
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionFencedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionInvalidCursorPosition;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandle;
+import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleDisabled;
 import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.broker.service.Consumer;
@@ -71,7 +72,6 @@ import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.transaction.common.exception.TransactionConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +133,7 @@ public class PersistentSubscription implements Subscription {
         if (topic.getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
             this.pendingAckHandle = new PendingAckHandleImpl(this);
         } else {
-            this.pendingAckHandle = null;
+            this.pendingAckHandle = new PendingAckHandleDisabled();
         }
         IS_FENCED_UPDATER.set(this, FALSE);
     }
@@ -389,20 +389,10 @@ public class PersistentSubscription implements Subscription {
 
     public CompletableFuture<Void> transactionIndividualAcknowledge(TxnID txnId,
                                                                     List<MutablePair<PositionImpl, Long>> positions) {
-        if (pendingAckHandle == null) {
-            return FutureUtil.failedFuture(
-                    new NotAllowedException("Broker does't support Transaction pending ack!"));
-        }
-
         return pendingAckHandle.individualAcknowledgeMessage(txnId, positions);
     }
 
     public CompletableFuture<Void> transactionCumulativeAcknowledge(TxnID txnId, List<PositionImpl> positions) {
-        if (pendingAckHandle == null) {
-            return FutureUtil.failedFuture(
-                    new TransactionConflictException("Broker does't support Transaction pending ack!"));
-        }
-
         return pendingAckHandle.cumulativeAcknowledgeMessage(txnId, positions);
     }
 
@@ -1027,9 +1017,6 @@ public class PersistentSubscription implements Subscription {
 
     @Override
     public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction) {
-        if (pendingAckHandle == null) {
-            return FutureUtil.failedFuture(new Exception("Broker does't support Transaction pending ack!"));
-        }
         TxnID txnID = new TxnID(txnidMostBits, txnidLeastBits);
         if (TxnAction.COMMIT.getNumber() == txnAction) {
             return pendingAckHandle.commitTxn(txnID, Collections.emptyMap());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -103,7 +103,7 @@ public interface PendingAckHandle {
      *
      * @param position {@link Position} which position need to sync and carry it batch size
      */
-    void syncBatchPositionAckSetForTransaction(MutablePair<PositionImpl, Long> position);
+    void syncBatchPositionAckSetForTransaction(PositionImpl position);
 
     /**
      * Judge the all ack set point have acked by normal ack and transaction pending ack.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.pendingack.impl;
+
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandle;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.util.FutureUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The disabled implementation of {@link PendingAckHandle}.
+ */
+public class PendingAckHandleDisabled implements PendingAckHandle {
+
+    @Override
+    public CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID,
+                                                                List<MutablePair<PositionImpl, Long>> positions) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public void syncBatchPositionAckSetForTransaction(PositionImpl position) {
+        //no operation
+    }
+
+    @Override
+    public boolean checkIsCanDeleteConsumerPendingAck(PositionImpl position) {
+        return false;
+    }
+
+    @Override
+    public void clearIndividualPosition(Position position) {
+        //no operation
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -85,7 +85,7 @@ public abstract class MockedPulsarServiceBaseTest {
     protected MockZooKeeper mockZooKeeper;
     protected NonClosableMockBookKeeper mockBookKeeper;
     protected boolean isTcpLookup = false;
-    protected final String configClusterName = "test";
+    protected static final String configClusterName = "test";
 
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private ExecutorService bkExecutor;
@@ -95,22 +95,7 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected final void resetConfig() {
-        this.conf = new ServiceConfiguration();
-        this.conf.setAdvertisedAddress("localhost");
-        this.conf.setClusterName(configClusterName);
-        this.conf.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
-        this.conf.setManagedLedgerCacheSizeMB(8);
-        this.conf.setActiveConsumerFailoverDelayTimeMillis(0);
-        this.conf.setDefaultNumberOfNamespaceBundles(1);
-        this.conf.setZookeeperServers("localhost:2181");
-        this.conf.setConfigurationStoreServers("localhost:3181");
-        this.conf.setAllowAutoTopicCreationType("non-partitioned");
-        this.conf.setBrokerServicePort(Optional.of(0));
-        this.conf.setBrokerServicePortTls(Optional.of(0));
-        this.conf.setWebServicePort(Optional.of(0));
-        this.conf.setWebServicePortTls(Optional.of(0));
-        this.conf.setBookkeeperClientExposeStatsToPrometheus(true);
-        this.conf.setNumExecutorThreadPoolSize(5);
+        this.conf = getDefaultConf();
     }
 
     protected final void internalSetup() throws Exception {
@@ -120,6 +105,11 @@ public abstract class MockedPulsarServiceBaseTest {
             lookupUrl = new URI(pulsar.getBrokerServiceUrl());
         }
         pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+    }
+
+    protected final void internalSetup(ServiceConfiguration serviceConfiguration) throws Exception {
+        this.conf = serviceConfiguration;
+        internalSetup();
     }
 
     protected final void internalSetup(boolean isPreciseDispatcherFlowControl) throws Exception {
@@ -401,6 +391,26 @@ public abstract class MockedPulsarServiceBaseTest {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(classObj, fieldValue);
+    }
+
+    protected static ServiceConfiguration getDefaultConf() {
+        ServiceConfiguration configuration = new ServiceConfiguration();
+        configuration.setAdvertisedAddress("localhost");
+        configuration.setClusterName(configClusterName);
+        configuration.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
+        configuration.setManagedLedgerCacheSizeMB(8);
+        configuration.setActiveConsumerFailoverDelayTimeMillis(0);
+        configuration.setDefaultNumberOfNamespaceBundles(1);
+        configuration.setZookeeperServers("localhost:2181");
+        configuration.setConfigurationStoreServers("localhost:3181");
+        configuration.setAllowAutoTopicCreationType("non-partitioned");
+        configuration.setBrokerServicePort(Optional.of(0));
+        configuration.setBrokerServicePortTls(Optional.of(0));
+        configuration.setWebServicePort(Optional.of(0));
+        configuration.setWebServicePortTls(Optional.of(0));
+        configuration.setBookkeeperClientExposeStatsToPrometheus(true);
+        configuration.setNumExecutorThreadPoolSize(5);
+        return configuration;
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -38,6 +39,15 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
 
     public void baseSetup() throws Exception {
         super.internalSetup();
+        baseSetupCommon();
+    }
+
+    public void baseSetup(ServiceConfiguration serviceConfiguration) throws Exception {
+        super.internalSetup(serviceConfiguration);
+        baseSetupCommon();
+    }
+
+    private void baseSetupCommon() throws Exception {
         admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
         admin.tenants().createTenant("prop",
                 new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
@@ -40,7 +41,9 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        super.baseSetup();
+        ServiceConfiguration configuration = getDefaultConf();
+        configuration.setTransactionCoordinatorEnabled(true);
+        super.baseSetup(configuration);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
@@ -70,6 +70,7 @@ public class TransactionMetaStoreTestBase {
             config.setDefaultNumberOfNamespaceBundles(1);
             config.setLoadBalancerEnabled(false);
             config.setAcknowledgmentAtBatchIndexLevelEnabled(true);
+            config.setTransactionCoordinatorEnabled(true);
             configurations[i] = config;
 
             pulsarServices[i] = Mockito.spy(new PulsarService(config));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
@@ -90,6 +90,12 @@ public class ConsumerAckResponseTest extends ProducerConsumerBase {
             Assert.assertTrue(e.getCause() instanceof PulsarClientException.NotAllowedException);
         }
         Message<Integer> message = consumer.receive();
-        consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
+
+        try {
+            consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
+            fail();
+        } catch (ExecutionException e) {
+            Assert.assertTrue(e.getCause() instanceof PulsarClientException.NotAllowedException);
+        }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2396,7 +2396,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         pendingChunckedMessageCount--;
     }
 
-    private CompletableFuture<Void> doAcknowledgeForResponse(MessageId messageId, AckType ackType,
+    private CompletableFuture<Void> doTransactionAcknowledgeForResponse(MessageId messageId, AckType ackType,
                                                              ValidationError validationError,
                                                              Map<String, Long> properties, TxnID txnID) {
         CompletableFuture<Void> callBack = new CompletableFuture<>();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -35,7 +35,6 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -563,7 +562,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         if (txn != null) {
-            return doAcknowledgeForResponse(messageId, ackType, null, properties,
+            return doTransactionAcknowledgeForResponse(messageId, ackType, null, properties,
                     new TxnID(txn.getTxnIdMostBits(), txn.getTxnIdLeastBits()));
         }
 
@@ -2397,8 +2396,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     private CompletableFuture<Void> doTransactionAcknowledgeForResponse(MessageId messageId, AckType ackType,
-                                                             ValidationError validationError,
-                                                             Map<String, Long> properties, TxnID txnID) {
+                                                                        ValidationError validationError,
+                                                                        Map<String, Long> properties, TxnID txnID) {
         CompletableFuture<Void> callBack = new CompletableFuture<>();
         BitSetRecyclable bitSetRecyclable = null;
         long ledgerId;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -1159,6 +1159,10 @@ public final class PulsarApi {
     java.util.List<java.lang.Long> getAckSetList();
     int getAckSetCount();
     long getAckSet(int index);
+    
+    // optional uint64 batch_size = 6;
+    boolean hasBatchSize();
+    long getBatchSize();
   }
   public static final class MessageIdData extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -1249,12 +1253,23 @@ public final class PulsarApi {
       return ackSet_.get(index);
     }
     
+    // optional uint64 batch_size = 6;
+    public static final int BATCH_SIZE_FIELD_NUMBER = 6;
+    private long batchSize_;
+    public boolean hasBatchSize() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    public long getBatchSize() {
+      return batchSize_;
+    }
+    
     private void initFields() {
       ledgerId_ = 0L;
       entryId_ = 0L;
       partition_ = -1;
       batchIndex_ = -1;
       ackSet_ = java.util.Collections.emptyList();;
+      batchSize_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1296,6 +1311,9 @@ public final class PulsarApi {
       for (int i = 0; i < ackSet_.size(); i++) {
         output.writeInt64(5, ackSet_.get(i));
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeUInt64(6, batchSize_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -1328,6 +1346,10 @@ public final class PulsarApi {
         }
         size += dataSize;
         size += 1 * getAckSetList().size();
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(6, batchSize_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -1452,6 +1474,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000008);
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        batchSize_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
       
@@ -1506,6 +1530,10 @@ public final class PulsarApi {
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.ackSet_ = ackSet_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.batchSize_ = batchSize_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -1533,6 +1561,9 @@ public final class PulsarApi {
             ackSet_.addAll(other.ackSet_);
           }
           
+        }
+        if (other.hasBatchSize()) {
+          setBatchSize(other.getBatchSize());
         }
         return this;
       }
@@ -1603,6 +1634,11 @@ public final class PulsarApi {
                 addAckSet(input.readInt64());
               }
               input.popLimit(limit);
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              batchSize_ = input.readUInt64();
               break;
             }
           }
@@ -1736,6 +1772,27 @@ public final class PulsarApi {
       public Builder clearAckSet() {
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        
+        return this;
+      }
+      
+      // optional uint64 batch_size = 6;
+      private long batchSize_ ;
+      public boolean hasBatchSize() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      public long getBatchSize() {
+        return batchSize_;
+      }
+      public Builder setBatchSize(long value) {
+        bitField0_ |= 0x00000020;
+        batchSize_ = value;
+        
+        return this;
+      }
+      public Builder clearBatchSize() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        batchSize_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -1160,9 +1160,9 @@ public final class PulsarApi {
     int getAckSetCount();
     long getAckSet(int index);
     
-    // optional uint64 batch_size = 6;
+    // optional int32 batch_size = 6;
     boolean hasBatchSize();
-    long getBatchSize();
+    int getBatchSize();
   }
   public static final class MessageIdData extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -1253,13 +1253,13 @@ public final class PulsarApi {
       return ackSet_.get(index);
     }
     
-    // optional uint64 batch_size = 6;
+    // optional int32 batch_size = 6;
     public static final int BATCH_SIZE_FIELD_NUMBER = 6;
-    private long batchSize_;
+    private int batchSize_;
     public boolean hasBatchSize() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
-    public long getBatchSize() {
+    public int getBatchSize() {
       return batchSize_;
     }
     
@@ -1269,7 +1269,7 @@ public final class PulsarApi {
       partition_ = -1;
       batchIndex_ = -1;
       ackSet_ = java.util.Collections.emptyList();;
-      batchSize_ = 0L;
+      batchSize_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1312,7 +1312,7 @@ public final class PulsarApi {
         output.writeInt64(5, ackSet_.get(i));
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeUInt64(6, batchSize_);
+        output.writeInt32(6, batchSize_);
       }
     }
     
@@ -1349,7 +1349,7 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeUInt64Size(6, batchSize_);
+          .computeInt32Size(6, batchSize_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -1474,7 +1474,7 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000008);
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
-        batchSize_ = 0L;
+        batchSize_ = 0;
         bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
@@ -1638,7 +1638,7 @@ public final class PulsarApi {
             }
             case 48: {
               bitField0_ |= 0x00000020;
-              batchSize_ = input.readUInt64();
+              batchSize_ = input.readInt32();
               break;
             }
           }
@@ -1776,15 +1776,15 @@ public final class PulsarApi {
         return this;
       }
       
-      // optional uint64 batch_size = 6;
-      private long batchSize_ ;
+      // optional int32 batch_size = 6;
+      private int batchSize_ ;
       public boolean hasBatchSize() {
         return ((bitField0_ & 0x00000020) == 0x00000020);
       }
-      public long getBatchSize() {
+      public int getBatchSize() {
         return batchSize_;
       }
-      public Builder setBatchSize(long value) {
+      public Builder setBatchSize(int value) {
         bitField0_ |= 0x00000020;
         batchSize_ = value;
         
@@ -1792,7 +1792,7 @@ public final class PulsarApi {
       }
       public Builder clearBatchSize() {
         bitField0_ = (bitField0_ & ~0x00000020);
-        batchSize_ = 0L;
+        batchSize_ = 0;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1143,12 +1143,13 @@ public class Commands {
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties) {
-        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError, properties, -1, -1, -1);
+        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
+                properties, -1L, -1L, -1L, -1L);
     }
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
-                                 long txnIdMostBits, long requestId) {
+                                 long txnIdMostBits, long requestId, long batchSize) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
         ackBuilder.setConsumerId(consumerId);
         ackBuilder.setAckType(ackType);
@@ -1158,6 +1159,10 @@ public class Commands {
         if (ackSet != null) {
             messageIdDataBuilder.addAllAckSet(SafeCollectionUtils.longArrayToList(ackSet.toLongArray()));
             ackSet.recycle();
+        }
+
+        if (batchSize >= 0) {
+            messageIdDataBuilder.setBatchSize(batchSize);
         }
         MessageIdData messageIdData = messageIdDataBuilder.build();
         ackBuilder.addMessageId(messageIdData);
@@ -1186,6 +1191,13 @@ public class Commands {
         messageIdDataBuilder.recycle();
         messageIdData.recycle();
         return res;
+    }
+
+    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
+                                 ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
+                                 long txnIdMostBits, long requestId) {
+        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
+                properties, txnIdLeastBits, txnIdMostBits, requestId, -1L);
     }
 
     public static ByteBuf newAckResponse(long requestId, ServerError error, String errorMsg, long consumerId) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1144,12 +1144,12 @@ public class Commands {
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties) {
         return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
-                properties, -1L, -1L, -1L, -1L);
+                properties, -1L, -1L, -1L, -1);
     }
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
-                                 long txnIdMostBits, long requestId, long batchSize) {
+                                 long txnIdMostBits, long requestId, int batchSize) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
         ackBuilder.setConsumerId(consumerId);
         ackBuilder.setAckType(ackType);
@@ -1197,7 +1197,7 @@ public class Commands {
                                  ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
                                  long txnIdMostBits, long requestId) {
         return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
-                properties, txnIdLeastBits, txnIdMostBits, requestId, -1L);
+                properties, txnIdLeastBits, txnIdMostBits, requestId, -1);
     }
 
     public static ByteBuf newAckResponse(long requestId, ServerError error, String errorMsg, long consumerId) {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -60,6 +60,7 @@ message MessageIdData {
     optional int32 partition = 3 [default = -1];
     optional int32 batch_index = 4 [default = -1];
     repeated int64 ack_set = 5;
+    optional uint64 batch_size = 6;
 }
 
 message KeyValue {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -60,7 +60,7 @@ message MessageIdData {
     optional int32 partition = 3 [default = -1];
     optional int32 batch_index = 4 [default = -1];
     repeated int64 ack_set = 5;
-    optional uint64 batch_size = 6;
+    optional int32 batch_size = 6;
 }
 
 message KeyValue {


### PR DESCRIPTION
## Motivation
Now in Failover sub we ack with transaction will not get the batch size from consumer pendingAcks, so we should ack request carry the batch size.

## implement
We ack with transaction will carry the bath size for individual ack delete the consumer pendingAcks.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (yes)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

