### PR TITLE
Support enable WebSocket on Pulsar Proxy.

### DIFF
--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -93,6 +93,14 @@ jobs:
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
-      - name: run integration tests
+      - name: run integration messaging tests
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-messaging.xml -DintegrationTests -DredirectTestOutputToFile=false
+
+      - name: run integration proxy tests
+        if: steps.docs.outputs.changed_only == 'no'
+        run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-proxy.xml -DintegrationTests -DredirectTestOutputToFile=false
+
+      - name: run integration proxy with WebSocket tests
+        if: steps.docs.outputs.changed_only == 'no'
+        run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-proxy-websocket.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -81,6 +81,14 @@ jobs:
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
+      - name: build pulsar image
+        if: steps.docs.outputs.changed_only == 'no'
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+
+      - name: build pulsar-all image
+        if: steps.docs.outputs.changed_only == 'no'
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: build artifacts and docker image
         if: steps.docs.outputs.changed_only == 'no'
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: run integration tests
         if: steps.docs.outputs.changed_only == 'no'

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -216,6 +216,14 @@ tokenAudienceClaim=
 # The token audience stands for this broker. The field `tokenAudienceClaim` of a valid token, need contains this.
 tokenAudience=
 
+### --- WebSocket config variables --- ###
+
+# Enable or disable the WebSocket servlet.
+webSocketServiceEnabled=false
+
+# Name of the cluster to which this broker belongs to
+clusterName=
+
 ### --- Deprecated config variables --- ###
 
 # Deprecated. Use configurationStoreServers

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-websocket</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -534,7 +534,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
     /***** --- WebSocket --- ****/
     @FieldContext(
             category = CATEGORY_WEBSOCKET,
-            doc = "The directory to locate WebSocket servlet"
+            doc = "Enable or disable the WebSocket servlet"
     )
     private boolean webSocketServiceEnabled = false;
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -70,6 +70,8 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private static final String CATEGORY_SASL_AUTH = "SASL Authentication Provider";
     @Category
     private static final String CATEGORY_PLUGIN = "proxy plugin";
+    @Category
+    private static final String CATEGORY_WEBSOCKET = "WebSocket";
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
@@ -528,6 +530,20 @@ public class ProxyConfiguration implements PulsarConfiguration {
             )
         }
     )
+
+    /***** --- WebSocket --- ****/
+    @FieldContext(
+            category = CATEGORY_WEBSOCKET,
+            doc = "The directory to locate WebSocket servlet"
+    )
+    private boolean webSocketServiceEnabled = false;
+
+    @FieldContext(
+            category = CATEGORY_WEBSOCKET,
+            doc = "Name of the cluster to which this broker belongs to"
+    )
+    private String clusterName;
+
     private Properties properties = new Properties();
 
     public Properties getProperties() {

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -170,6 +170,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -119,7 +119,7 @@ public class TestProxy extends PulsarTestSuite {
 
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
+                .serviceHttpUrl(proxyViaURL.getHttpServiceUrl())
                 .build();
 
         admin.tenants().createTenant(tenant,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -64,9 +64,7 @@ public class TestProxy extends PulsarTestSuite {
             PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
         proxyViaURL = new ProxyContainer(clusterName, "proxy-via-url")
             .withEnv("brokerServiceURL", "pulsar://pulsar-broker-0:6650")
-            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080")
-            .withEnv("webSocketServiceEnabled", "true")
-            .withEnv("clusterName", clusterName);
+            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080");
 
         specBuilder.externalService("proxy-via-url", proxyViaURL);
 
@@ -143,73 +141,6 @@ public class TestProxy extends PulsarTestSuite {
         for (int i = 0; i < 10; i++) {
             // Ensure we the command works even if re-directs happen with a request body
             admin.topics().createSubscription(topic, "test-" + i, MessageId.earliest);
-        }
-    }
-
-    @Test
-    public void testWebSocket() throws Exception {
-
-        final String tenant = "proxy-test-" + randomName(10);
-        final String namespace = tenant + "/ns1";
-
-        @Cleanup
-        PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
-                .build();
-
-        admin.tenants().createTenant(tenant,
-                new TenantInfo(Collections.emptySet(), Collections.singleton(pulsarCluster.getClusterName())));
-
-        admin.namespaces().createNamespace(namespace, Collections.singleton(pulsarCluster.getClusterName()));
-
-        HttpClient httpClient = new HttpClient();
-        WebSocketClient webSocketClient = new WebSocketClient(httpClient);
-        webSocketClient.start();
-        MyWebSocket myWebSocket = new MyWebSocket();
-        Future<Session> sessionFuture =  webSocketClient.connect(myWebSocket,
-                URI.create(pulsarCluster.getHttpServiceUrl().replaceFirst("http", "ws")
-                        + "/ws/v2/producer/persistent/" + namespace + "/my-topic"));
-        sessionFuture.get().getRemote().sendString("{\n" +
-                "  \"payload\": \"SGVsbG8gV29ybGQ=\",\n" +
-                "  \"properties\": {\"key1\": \"value1\", \"key2\": \"value2\"},\n" +
-                "  \"context\": \"1\"\n" +
-                "}");
-
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
-            String response = myWebSocket.getResponse();
-            log.info(response);
-            Assert.assertTrue(response.contains("ok"));
-        });
-    }
-
-    @WebSocket
-    public static class MyWebSocket implements WebSocketListener {
-        Queue<String> incomingMessages = new ArrayBlockingQueue<>(10);
-        @Override
-        public void onWebSocketBinary(byte[] bytes, int i, int i1) {
-        }
-
-        @Override
-        public void onWebSocketText(String s) {
-            incomingMessages.add(s);
-        }
-
-        @Override
-        public void onWebSocketClose(int i, String s) {
-        }
-
-        @Override
-        public void onWebSocketConnect(Session session) {
-
-        }
-
-        @Override
-        public void onWebSocketError(Throwable throwable) {
-
-        }
-
-        public String getResponse() {
-            return incomingMessages.poll();
         }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -119,7 +119,7 @@ public class TestProxy extends PulsarTestSuite {
 
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(pulsarCluster.getPlainTextServiceUrl())
+                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
                 .build();
 
         admin.tenants().createTenant(tenant,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -154,7 +154,7 @@ public class TestProxy extends PulsarTestSuite {
 
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(pulsarCluster.getPlainTextServiceUrl())
+                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
                 .build();
 
         admin.tenants().createTenant(tenant,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -20,7 +20,12 @@ package org.apache.pulsar.tests.integration.proxy;
 
 import static org.testng.Assert.assertEquals;
 
+import java.net.URI;
 import java.util.Collections;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import lombok.Cleanup;
 
@@ -34,6 +39,13 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.tests.integration.containers.ProxyContainer;
 import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import org.slf4j.Logger;
@@ -53,6 +65,7 @@ public class TestProxy extends PulsarTestSuite {
         proxyViaURL = new ProxyContainer(clusterName, "proxy-via-url")
             .withEnv("brokerServiceURL", "pulsar://pulsar-broker-0:6650")
             .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080")
+            .withEnv("webSocketServiceEnabled", "true")
             .withEnv("clusterName", clusterName);
 
         specBuilder.externalService("proxy-via-url", proxyViaURL);
@@ -130,6 +143,73 @@ public class TestProxy extends PulsarTestSuite {
         for (int i = 0; i < 10; i++) {
             // Ensure we the command works even if re-directs happen with a request body
             admin.topics().createSubscription(topic, "test-" + i, MessageId.earliest);
+        }
+    }
+
+    @Test
+    public void testWebSocket() throws Exception {
+
+        final String tenant = "proxy-test-" + randomName(10);
+        final String namespace = tenant + "/ns1";
+
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(pulsarCluster.getPlainTextServiceUrl())
+                .build();
+
+        admin.tenants().createTenant(tenant,
+                new TenantInfo(Collections.emptySet(), Collections.singleton(pulsarCluster.getClusterName())));
+
+        admin.namespaces().createNamespace(namespace, Collections.singleton(pulsarCluster.getClusterName()));
+
+        HttpClient httpClient = new HttpClient();
+        WebSocketClient webSocketClient = new WebSocketClient(httpClient);
+        webSocketClient.start();
+        MyWebSocket myWebSocket = new MyWebSocket();
+        Future<Session> sessionFuture =  webSocketClient.connect(myWebSocket,
+                URI.create(pulsarCluster.getHttpServiceUrl().replaceFirst("http", "ws")
+                        + "/ws/v2/producer/persistent/" + namespace + "/my-topic"));
+        sessionFuture.get().getRemote().sendString("{\n" +
+                "  \"payload\": \"SGVsbG8gV29ybGQ=\",\n" +
+                "  \"properties\": {\"key1\": \"value1\", \"key2\": \"value2\"},\n" +
+                "  \"context\": \"1\"\n" +
+                "}");
+
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            String response = myWebSocket.getResponse();
+            log.info(response);
+            Assert.assertTrue(response.contains("ok"));
+        });
+    }
+
+    @WebSocket
+    public static class MyWebSocket implements WebSocketListener {
+        Queue<String> incomingMessages = new ArrayBlockingQueue<>(10);
+        @Override
+        public void onWebSocketBinary(byte[] bytes, int i, int i1) {
+        }
+
+        @Override
+        public void onWebSocketText(String s) {
+            incomingMessages.add(s);
+        }
+
+        @Override
+        public void onWebSocketClose(int i, String s) {
+        }
+
+        @Override
+        public void onWebSocketConnect(Session session) {
+
+        }
+
+        @Override
+        public void onWebSocketError(Throwable throwable) {
+
+        }
+
+        public String getResponse() {
+            return incomingMessages.poll();
         }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -20,12 +20,7 @@ package org.apache.pulsar.tests.integration.proxy;
 
 import static org.testng.Assert.assertEquals;
 
-import java.net.URI;
 import java.util.Collections;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import lombok.Cleanup;
 
@@ -39,13 +34,6 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.tests.integration.containers.ProxyContainer;
 import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
-import org.awaitility.Awaitility;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.WebSocketListener;
-import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import org.slf4j.Logger;
@@ -64,7 +52,8 @@ public class TestProxy extends PulsarTestSuite {
             PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
         proxyViaURL = new ProxyContainer(clusterName, "proxy-via-url")
             .withEnv("brokerServiceURL", "pulsar://pulsar-broker-0:6650")
-            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080");
+            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080")
+            .withEnv("clusterName", clusterName);
 
         specBuilder.externalService("proxy-via-url", proxyViaURL);
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -31,7 +31,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
-import org.apache.pulsar.tests.integration.containers.ProxyContainer;
 import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.testng.annotations.Test;
@@ -44,19 +43,11 @@ import org.slf4j.LoggerFactory;
  */
 public class TestProxy extends PulsarTestSuite {
     private final static Logger log = LoggerFactory.getLogger(TestProxy.class);
-    private ProxyContainer proxyViaURL;
 
     @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(
             String clusterName,
             PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
-        proxyViaURL = new ProxyContainer(clusterName, "proxy-via-url")
-            .withEnv("brokerServiceURL", "pulsar://pulsar-broker-0:6650")
-            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080")
-            .withEnv("clusterName", clusterName);
-
-        specBuilder.externalService("proxy-via-url", proxyViaURL);
-
         return super.beforeSetupCluster(clusterName, specBuilder);
     }
 
@@ -107,7 +98,7 @@ public class TestProxy extends PulsarTestSuite {
 
     @Test
     public void testProxyWithNoServiceDiscoveryProxyConnectsViaURL() throws Exception {
-        testProxy(proxyViaURL.getPlainTextServiceUrl(), proxyViaURL.getHttpServiceUrl());
+        testProxy(pulsarCluster.getProxy().getPlainTextServiceUrl(), pulsarCluster.getProxy().getHttpServiceUrl());
     }
 
     @Test
@@ -119,7 +110,7 @@ public class TestProxy extends PulsarTestSuite {
 
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder()
-                .serviceHttpUrl(proxyViaURL.getHttpServiceUrl())
+                .serviceHttpUrl(pulsarCluster.getProxy().getHttpServiceUrl())
                 .build();
 
         admin.tenants().createTenant(tenant,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.proxy;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.tests.integration.containers.ProxyContainer;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for proxy.
+ */
+public class TestProxyWithWebSocket extends PulsarTestSuite {
+    private final static Logger log = LoggerFactory.getLogger(TestProxyWithWebSocket.class);
+    private ProxyContainer proxyViaURL;
+
+    @Override
+    protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(
+            String clusterName,
+            PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
+        proxyViaURL = new ProxyContainer(clusterName, "proxy-via-url")
+            .withEnv("brokerServiceURL", "pulsar://pulsar-broker-0:6650")
+            .withEnv("brokerWebServiceURL", "http://pulsar-broker-0:8080")
+            .withEnv("webSocketServiceEnabled", "true")
+            .withEnv("clusterName", clusterName);
+
+        specBuilder.externalService("proxy-via-url", proxyViaURL);
+
+        return super.beforeSetupCluster(clusterName, specBuilder);
+    }
+
+    @Test
+    public void testWebSocket() throws Exception {
+
+        final String tenant = "proxy-test-" + randomName(10);
+        final String namespace = tenant + "/ns1";
+
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(pulsarCluster.getHttpServiceUrl())
+                .build();
+
+        admin.tenants().createTenant(tenant,
+                new TenantInfo(Collections.emptySet(), Collections.singleton(pulsarCluster.getClusterName())));
+
+        admin.namespaces().createNamespace(namespace, Collections.singleton(pulsarCluster.getClusterName()));
+
+        HttpClient httpClient = new HttpClient();
+        WebSocketClient webSocketClient = new WebSocketClient(httpClient);
+        webSocketClient.start();
+        MyWebSocket myWebSocket = new MyWebSocket();
+        Future<Session> sessionFuture =  webSocketClient.connect(myWebSocket,
+                URI.create(pulsarCluster.getHttpServiceUrl().replaceFirst("http", "ws")
+                        + "/ws/v2/producer/persistent/" + namespace + "/my-topic"));
+        sessionFuture.get().getRemote().sendString("{\n" +
+                "  \"payload\": \"SGVsbG8gV29ybGQ=\",\n" +
+                "  \"properties\": {\"key1\": \"value1\", \"key2\": \"value2\"},\n" +
+                "  \"context\": \"1\"\n" +
+                "}");
+
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            String response = myWebSocket.getResponse();
+            log.info(response);
+            Assert.assertTrue(response.contains("ok"));
+        });
+    }
+
+    @WebSocket
+    public static class MyWebSocket implements WebSocketListener {
+        Queue<String> incomingMessages = new ArrayBlockingQueue<>(10);
+        @Override
+        public void onWebSocketBinary(byte[] bytes, int i, int i1) {
+        }
+
+        @Override
+        public void onWebSocketText(String s) {
+            incomingMessages.add(s);
+        }
+
+        @Override
+        public void onWebSocketClose(int i, String s) {
+        }
+
+        @Override
+        public void onWebSocketConnect(Session session) {
+
+        }
+
+        @Override
+        public void onWebSocketError(Throwable throwable) {
+
+        }
+
+        public String getResponse() {
+            return incomingMessages.poll();
+        }
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -132,6 +132,9 @@ public class PulsarCluster {
             .withEnv("zookeeperServers", ZKContainer.NAME)
             .withEnv("configurationStoreServers", CSContainer.NAME + ":" + CS_PORT)
             .withEnv("clusterName", clusterName);
+        if (spec.proxyEnvs != null) {
+            spec.proxyEnvs.forEach(this.proxyContainer::withEnv);
+        }
 
         // create bookies
         bookieContainers.putAll(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
@@ -126,4 +126,9 @@ public class PulsarClusterSpec {
      */
     @Default
     String pulsarTestImage = PulsarContainer.DEFAULT_IMAGE_NAME;
+
+    /**
+     * Specify envs for proxy.
+     */
+    Map<String, String> proxyEnvs;
 }

--- a/tests/integration/src/test/resources/pulsar-messaging.xml
+++ b/tests/integration/src/test/resources/pulsar-messaging.xml
@@ -24,6 +24,8 @@
         <classes>
             <class name="org.apache.pulsar.tests.integration.messaging.PersistentTopicMessagingTest" />
             <class name="org.apache.pulsar.tests.integration.messaging.NonPersistentTopicMessagingTest" />
+            <class name="org.apache.pulsar.tests.integration.proxy.TestProxy" />
+            <class name="org.apache.pulsar.tests.integration.proxy.TestProxyWithWebSocket" />
         </classes>
     </test>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-proxy-websocket.xml
+++ b/tests/integration/src/test/resources/pulsar-proxy-websocket.xml
@@ -19,11 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar (Messaging) Integration Tests" verbose="2" annotations="JDK">
+<suite name="Pulsar (Proxy with WebSocket) Integration Tests" verbose="2" annotations="JDK">
     <test name="messaging-test-suite" preserve-order="true">
         <classes>
-            <class name="org.apache.pulsar.tests.integration.messaging.PersistentTopicMessagingTest" />
-            <class name="org.apache.pulsar.tests.integration.messaging.NonPersistentTopicMessagingTest" />
+            <class name="org.apache.pulsar.tests.integration.proxy.TestProxyWithWebSocket" />
         </classes>
     </test>
 </suite>

--- a/tests/integration/src/test/resources/pulsar-proxy.xml
+++ b/tests/integration/src/test/resources/pulsar-proxy.xml
@@ -19,11 +19,10 @@
 
 -->
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
-<suite name="Pulsar (Messaging) Integration Tests" verbose="2" annotations="JDK">
+<suite name="Pulsar (Proxy) Integration Tests" verbose="2" annotations="JDK">
     <test name="messaging-test-suite" preserve-order="true">
         <classes>
-            <class name="org.apache.pulsar.tests.integration.messaging.PersistentTopicMessagingTest" />
-            <class name="org.apache.pulsar.tests.integration.messaging.NonPersistentTopicMessagingTest" />
+            <class name="org.apache.pulsar.tests.integration.proxy.TestProxy" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Motivation

Support enable WebSocket on Pulsar Proxy.

### Verifying this change

Integration tests added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
