### PR TITLE
improve performance of checkPublishRate()

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
@@ -42,11 +42,19 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
     @Override
     public void checkPublishRate() {
         if (this.publishThrottlingEnabled && !publishRateExceeded) {
-            long currentPublishMsgRate = this.currentPublishMsgCount.sum();
-            long currentPublishByteRate = this.currentPublishByteCount.sum();
-            if ((this.publishMaxMessageRate > 0 && currentPublishMsgRate > this.publishMaxMessageRate)
-                    || (this.publishMaxByteRate > 0 && currentPublishByteRate > this.publishMaxByteRate)) {
-                publishRateExceeded = true;
+            if (this.publishMaxByteRate > 0) {
+                long currentPublishByteRate = this.currentPublishByteCount.sum();
+                if (currentPublishByteRate > this.publishMaxByteRate) {
+                    publishRateExceeded = true;
+                    return;
+                }
+            }
+
+            if (this.publishMaxMessageRate > 0) {
+                long currentPublishMsgRate = this.currentPublishMsgCount.sum();
+                if (currentPublishMsgRate > this.publishMaxMessageRate) {
+                    publishRateExceeded = true;
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation

Currently `PublishRateLimiterImpl` is used for broker publisher throttling, and checkPublishRate() is called in high frequency (default is 50ms every time). Each time checkPublishRate() is called, `currentPublishByteCount.sum()` and `currentPublishMsgCount.sum()` are executed. `LongAdder.sum()` will sum all cells in the LongAdder object. 
In case of only byte throttling (or msg count throttling) is enabled, only do the necessary sum operation could improve the performace.

### Modifications
In case of only byte throttling (or msg count throttling) is enabled, only do the necessary sum operation.

### Verifying this change
Already coverd by PublishRateLimiterTest()