### PR TITLE
[WIP] Remove Python 2 support for Python client

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -198,8 +198,7 @@ if (BUILD_PYTHON_WRAPPER)
         # For python3 the lib name is boost_python3
         set(BOOST_PYTHON_NAME_LIST python36;python37;python38;python3;python3-mt;python-py${BOOST_PYTHON_NAME_POSTFIX};python${BOOST_PYTHON_NAME_POSTFIX}-mt;python${BOOST_PYTHON_NAME_POSTFIX})
     else ()
-        # Regular boost_python
-        set(BOOST_PYTHON_NAME_LIST python;python-mt;python-py27;python27-mt;python27)
+        MESSAGE(FATAL_ERROR "Boost.Python only supports Python3")
     endif ()
 
     foreach (BOOST_PYTHON_NAME IN LISTS BOOST_PYTHON_NAME_LIST)

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -39,10 +39,10 @@ VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
 PYTHON_INCLUDE_DIR="\$(python3 -c \"from distutils.sysconfig import get_python_inc; print(get_python_inc())\")"
 PYTHON_LIBRARY="\$(python3 -c \"import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))\")"
 CMAKE_ARGS="-DPYTHON_INCLUDE_DIR=\"$PYTHON_INCLUDE_DIR\" -DPYTHON_LIBRARY=\"$PYTHON_LIBRARY\" $CMAKE_ARGS"
-COMMAND="cd /pulsar/pulsar-client-cpp
- && apt install -y python3-dev
- && cmake . $CMAKE_ARGS
- && make check-format
+COMMAND="cd /pulsar/pulsar-client-cpp \\
+ && apt install -y python3-dev \\
+ && cmake . $CMAKE_ARGS \\
+ && make check-format \\
  && make -j8"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -36,7 +36,14 @@ echo "---- Build Pulsar C++ client using image $IMAGE (pass <skip-clean> for inc
 docker pull $IMAGE
 
 VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
-COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"
+PYTHON_INCLUDE_DIR="\$(python3 -c \"from distutils.sysconfig import get_python_inc; print(get_python_inc())\")"
+PYTHON_LIBRARY="\$(python3 -c \"import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))\")"
+CMAKE_ARGS="-DPYTHON_INCLUDE_DIR=\"$PYTHON_INCLUDE_DIR\" -DPYTHON_LIBRARY=\"$PYTHON_LIBRARY\" $CMAKE_ARGS"
+COMMAND="cd /pulsar/pulsar-client-cpp
+ && apt install -y python3-dev
+ && cmake . $CMAKE_ARGS
+ && make check-format
+ && make -j8"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -36,10 +36,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 # Newer boost versions don't use the -mt suffix
-if (NOT DEFINED ${Boost_PYTHON27-MT_LIBRARY})
-  set(Boost_PYTHON27-MT_LIBRARY ${Boost_PYTHON27_LIBRARY})
-endif()
-
 if (NOT DEFINED ${Boost_PYTHON37-MT_LIBRARY})
   set(Boost_PYTHON37-MT_LIBRARY ${Boost_PYTHON37_LIBRARY})
 endif()
@@ -50,13 +46,12 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
-                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY}
+                        ${Boost_PYTHON37-MT_LIBRARY}
                         ${Boost_PYTHON34_LIBRARY} ${Boost_PYTHON35_LIBRARY}
                         ${Boost_PYTHON36_LIBRARY} ${Boost_PYTHON38_LIBRARY})
 
 if (APPLE)
     set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS}
-                         ${Boost_PYTHON27-MT_LIBRARY_RELEASE}
                          ${Boost_PYTHON37-MT_LIBRARY_RELEASE}
                          ${Boost_PYTHON38-MT_LIBRARY_RELEASE})
 endif()

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
+                        ${Boost_PYTHON-PY35_LIBRARY}
+                        ${Boost_PYTHON-PY36_LIBRARY}
+                        ${Boost_PYTHON-PY37_LIBRARY}
+                        ${Boost_PYTHON-PY38_LIBRARY}
                         ${Boost_PYTHON37-MT_LIBRARY}
                         ${Boost_PYTHON34_LIBRARY} ${Boost_PYTHON35_LIBRARY}
                         ${Boost_PYTHON36_LIBRARY} ${Boost_PYTHON38_LIBRARY})

--- a/pulsar-client-cpp/python/pkg/osx/vagrant-build.sh
+++ b/pulsar-client-cpp/python/pkg/osx/vagrant-build.sh
@@ -43,14 +43,10 @@ brew link --force boost-python3
 
 make clean
 rm CMakeCache.txt
-PYTHON_INCLUDE_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_path('include'))")
-PYTHON_LIB_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-PYTHON_VERSION=$(python3 -c "import sysconfig; print(sysconfig.get_python_version())")
-PYTHON_LIBRARY="$PYTHON_LIB_DIR/libpython$PYTHON_VERSION.dylib"
 cmake . -DBUILD_TESTS=OFF \
 		-DLINK_STATIC=ON  \
-		-DPYTHON_LIBRARY=$PYTHON_LIBRARY \
-        -DPYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR
+		-DPYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib \
+        -DPYTHON_INCLUDE_DIR=/usr/local/Frameworks/Python.framework/Versions/3.7/include/python3.7m
 make _pulsar -j8
 pushd python
 python3 setup.py bdist_wheel

--- a/pulsar-client-cpp/python/pkg/osx/vagrant-build.sh
+++ b/pulsar-client-cpp/python/pkg/osx/vagrant-build.sh
@@ -35,20 +35,6 @@ cd pulsar/pulsar-client-cpp
 brew link --force boost
 brew link --force protobuf260 || true ## Older images have protobuf 2.6.0 and not linked
 
-# Python 2
-brew unlink python
-brew unlink boost-python3
-brew link --force python@2
-brew link --force boost-python
-
-cmake . -DBUILD_TESTS=OFF \
-		-DLINK_STATIC=ON  \
-		-DPYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib
-make _pulsar -j8
-pushd python
-python2 setup.py bdist_wheel
-popd
-
 #### Python 3
 brew unlink python@2
 brew unlink boost-python
@@ -57,10 +43,14 @@ brew link --force boost-python3
 
 make clean
 rm CMakeCache.txt
+PYTHON_INCLUDE_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_path('include'))")
+PYTHON_LIB_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+PYTHON_VERSION=$(python3 -c "import sysconfig; print(sysconfig.get_python_version())")
+PYTHON_LIBRARY="$PYTHON_LIB_DIR/libpython$PYTHON_VERSION.dylib"
 cmake . -DBUILD_TESTS=OFF \
 		-DLINK_STATIC=ON  \
-		-DPYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib \
-        -DPYTHON_INCLUDE_DIR=/usr/local/Frameworks/Python.framework/Versions/3.7/include/python3.7m
+		-DPYTHON_LIBRARY=$PYTHON_LIBRARY \
+        -DPYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR
 make _pulsar -j8
 pushd python
 python3 setup.py bdist_wheel


### PR DESCRIPTION
Master Issue: #8622 

### Motivation

According to PIP 56, Python 2 should not be supported anymore. But the CMakeLists.txt still try to find include directory and library of Python 2.7 and the vagrant build script still build wheels for Python 2.

### Modifications

- Remove Python 2.7 related find operations in CMakeLists.txt
- Remove Python 2 wheels for OS X vagrant build

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.